### PR TITLE
@typeclass and Tagless Final support for Arrow

### DIFF
--- a/arrow-annotations-processor/src/main/java/arrow/higherkinds/HigherKindsProcessor.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/higherkinds/HigherKindsProcessor.kt
@@ -28,6 +28,7 @@ class HigherKindsProcessor : AbstractProcessor() {
                 .map { element ->
                     when (element.kind) {
                         ElementKind.CLASS -> processClass(element as TypeElement)
+                        ElementKind.INTERFACE -> processClass(element as TypeElement)
                         else -> knownError("$higherKindsAnnotationName can only be used on classes")
                     }
                 }

--- a/arrow-annotations-processor/src/main/java/arrow/tc/AnnotatedTypeclass.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/AnnotatedTypeclass.kt
@@ -1,0 +1,8 @@
+package arrow.tc
+
+import arrow.common.utils.ClassOrPackageDataWrapper
+import javax.lang.model.element.TypeElement
+
+class AnnotatedTypeclass(
+        val classElement: TypeElement,
+        val classOrPackageProto: ClassOrPackageDataWrapper)

--- a/arrow-annotations-processor/src/main/java/arrow/tc/AnnotationInfo.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/AnnotationInfo.kt
@@ -1,0 +1,7 @@
+package arrow.tc
+
+import arrow.typeclass
+
+val typeClassAnnotationKClass = typeclass::class
+val typeClassAnnotationClass = typeClassAnnotationKClass.java
+val typeClassAnnotationName = "@" + typeClassAnnotationClass.simpleName

--- a/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
@@ -3,9 +3,7 @@ package arrow.tc
 import arrow.common.Package
 import arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.typeConstraints
-import org.jetbrains.kotlin.serialization.ProtoBuf
 import java.io.File
-import javax.lang.model.element.Name
 
 data class Typeclass(
         val `package`: Package,

--- a/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
@@ -1,0 +1,68 @@
+package arrow.tc
+
+import arrow.common.Package
+import arrow.common.utils.ClassOrPackageDataWrapper
+import arrow.common.utils.typeConstraints
+import org.jetbrains.kotlin.serialization.ProtoBuf
+import java.io.File
+import javax.lang.model.element.Name
+
+data class Typeclass(
+        val `package`: Package,
+        val target: AnnotatedTypeclass
+) {
+    val clazz = target.classOrPackageProto as ClassOrPackageDataWrapper.Class
+    val typeArgs: List<String> = target.classOrPackageProto.typeParameters.map { target.classOrPackageProto.nameResolver.getString(it.name) }
+    fun expandedTypeArgs(reified: Boolean = false): String =
+            if (target.classOrPackageProto.typeParameters.isNotEmpty()) {
+                target.classOrPackageProto.typeParameters.joinToString(
+                        prefix = "<",
+                        separator = ", ",
+                        transform = {
+                            val name = target.classOrPackageProto.nameResolver.getString(it.name)
+                            if (reified) "reified $name" else name
+                        },
+                        postfix = ">"
+                )
+            } else {
+                ""
+            }
+    val typeConstraints = target.classOrPackageProto.typeConstraints()
+    val name: String = clazz.nameResolver.getString(clazz.classProto.fqName).replace("/", ".")
+    val simpleName = name.substringAfterLast(".")
+}
+
+class TypeclassFileGenerator(
+        private val generatedDir: File,
+        annotatedList: List<AnnotatedTypeclass>
+) {
+
+    private val typeclasses: List<Typeclass> = annotatedList.map { Typeclass(it.classOrPackageProto.`package`, it) }
+
+    /**
+     * Main entry point for higher kinds extension generation
+     */
+    fun generate() {
+        typeclasses.forEachIndexed { _, tc ->
+            val elementsToGenerate = listOf(genLookup(tc))
+            val source: String = elementsToGenerate.joinToString(prefix = "package ${tc.`package`}\n\n", separator = "\n", postfix = "\n")
+            val file = File(generatedDir, typeClassAnnotationClass.simpleName + ".${tc.target.classElement.qualifiedName}.kt")
+            file.writeText(source)
+        }
+    }
+
+    /*
+    inline fun <reified F> monad(): Monad<F> = instance(InstanceParametrizedType(Monad::class.java, listOf(typeLiteral<F>())))
+     */
+
+    private fun genLookup(tc: Typeclass): String {
+        val typeLiterals = tc.typeArgs.map { "typeLiteral<$it>()" }
+        return """
+            |import arrow.*
+            |
+            |inline fun ${tc.expandedTypeArgs(true)} ${tc.simpleName.decapitalize()}(): ${tc.name}${tc.expandedTypeArgs()} =
+            |  instance(InstanceParametrizedType(${tc.name}::class.java, listOf(${typeLiterals.joinToString(",")})))
+            |""".trimMargin()
+    }
+
+}

--- a/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
@@ -1,0 +1,47 @@
+package arrow.tc
+
+import com.google.auto.service.AutoService
+import arrow.common.utils.AbstractProcessor
+import arrow.common.utils.knownError
+import java.io.File
+import javax.annotation.processing.Processor
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.TypeElement
+
+@AutoService(Processor::class)
+class TypeclassesProcessor : AbstractProcessor() {
+
+    private val annotatedList: MutableList<AnnotatedTypeclass> = mutableListOf<AnnotatedTypeclass>()
+
+    override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
+
+    override fun getSupportedAnnotationTypes(): Set<String> = setOf(typeClassAnnotationClass.canonicalName)
+
+    /**
+     * Processor entry point
+     */
+    override fun onProcess(annotations: Set<TypeElement>, roundEnv: RoundEnvironment) {
+        annotatedList += roundEnv
+                .getElementsAnnotatedWith(typeClassAnnotationClass)
+                .map { element ->
+                    when (element.kind) {
+                        ElementKind.CLASS -> processClass(element as TypeElement)
+                        ElementKind.INTERFACE -> processClass(element as TypeElement)
+                        else -> knownError("${typeClassAnnotationName}AnnotationName can only be used on classes")
+                    }
+                }
+
+        if (roundEnv.processingOver()) {
+            val generatedDir = File(this.generatedDir!!, typeClassAnnotationClass.simpleName).also { it.mkdirs() }
+            TypeclassFileGenerator(generatedDir, annotatedList).generate()
+        }
+    }
+
+    private fun processClass(element: TypeElement): AnnotatedTypeclass {
+        val proto = getClassOrPackageDataWrapper(element)
+        return AnnotatedTypeclass(element, proto)
+    }
+
+}

--- a/arrow-annotations/src/main/java/arrow/Typeclass.kt
+++ b/arrow-annotations/src/main/java/arrow/Typeclass.kt
@@ -217,7 +217,10 @@ private fun reifyRawParameterizedType(carrier: InstanceParametrizedType, classif
             InstanceParametrizedType(classifier.rawType, listOf(carrier.actualTypeArguments[index + 1]))
         } else if (classifier.actualTypeArguments.any { it is TypeVariable<*> }) {
             val nestedTypes = resolveNestedTypes(carrier.actualTypeArguments.toList())
-            InstanceParametrizedType(classifier.rawType, listOf(nestedTypes[index]))
+            if (index < nestedTypes.size)
+                InstanceParametrizedType(classifier.rawType, listOf(nestedTypes[index]))
+            else
+                InstanceParametrizedType(classifier.rawType, nestedTypes)
         } else {
             InstanceParametrizedType(classifier, classifier.actualTypeArguments.filterNotNull())
         }

--- a/arrow-annotations/src/main/java/arrow/typeclass.kt
+++ b/arrow-annotations/src/main/java/arrow/typeclass.kt
@@ -1,7 +1,5 @@
 package arrow
 
-import kotlin.reflect.KClass
-
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented

--- a/arrow-annotations/src/main/java/arrow/typeclass.kt
+++ b/arrow-annotations/src/main/java/arrow/typeclass.kt
@@ -1,0 +1,8 @@
+package arrow
+
+import kotlin.reflect.KClass
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+@MustBeDocumented
+annotation class typeclass()

--- a/arrow-effects/src/main/kotlin/arrow/effects/typeclass/Async.kt
+++ b/arrow-effects/src/main/kotlin/arrow/effects/typeclass/Async.kt
@@ -9,11 +9,10 @@ import arrow.core.Right
 typealias Proc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
 
 /** The context required to run an asynchronous computation. **/
+@typeclass
 interface AsyncContext<out F> : Typeclass {
     fun <A> runAsync(fa: Proc<A>): HK<F, A>
 }
-
-inline fun <reified F> asyncContext(): AsyncContext<F> = instance(InstanceParametrizedType(AsyncContext::class.java, listOf(typeLiteral<F>())))
 
 inline fun <F, A> runAsync(AC: AsyncContext<F>, crossinline f: () -> A): HK<F, A> =
         AC.runAsync { ff: (Either<Throwable, A>) -> Unit ->

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/FunctorFilter.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/FunctorFilter.kt
@@ -4,6 +4,7 @@ import arrow.*
 import arrow.core.*
 import arrow.typeclasses.Functor
 
+@typeclass
 interface FunctorFilter<F> : Functor<F>, Typeclass {
 
     /**
@@ -29,5 +30,3 @@ interface FunctorFilter<F> : Functor<F>, Typeclass {
     fun <A> filter(fa: HK<F, A>, f: (A) -> Boolean): HK<F, A> =
             mapFilter(fa, { a -> if (f(a)) Some(a) else None })
 }
-
-inline fun <reified F> functorFilter(): FunctorFilter<F> = instance(InstanceParametrizedType(FunctorFilter::class.java, listOf(typeLiteral<F>())))

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/MonadCombine.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/MonadCombine.kt
@@ -7,6 +7,7 @@ import arrow.typeclasses.*
 /**
  * The combination of a Monad with a MonoidK
  */
+@typeclass
 interface MonadCombine<F> : MonadFilter<F>, Alternative<F>, Typeclass {
 
     fun <G, A> unite(fga: HK<F, HK<G, A>>, FG: Foldable<G>): HK<F, A> =
@@ -18,8 +19,6 @@ interface MonadCombine<F> : MonadFilter<F>, Alternative<F>, Typeclass {
         return Tuple2(asep, bsep)
     }
 }
-
-inline fun <reified F> monadCombine(): MonadCombine<F> = instance(InstanceParametrizedType(MonadCombine::class.java, listOf(typeLiteral<F>())))
 
 inline fun <F, reified G, A> MonadCombine<F>.uniteF(fga: HK<F, HK<G, A>>, FG: Foldable<G> = foldable()) = unite(fga, FG)
 

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/MonadFilter.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/MonadFilter.kt
@@ -5,6 +5,7 @@ import arrow.core.Option
 import arrow.typeclasses.Monad
 import kotlin.coroutines.experimental.startCoroutine
 
+@typeclass
 interface MonadFilter<F> : Monad<F>, FunctorFilter<F>, Typeclass {
 
     fun <A> empty(): HK<F, A>
@@ -23,5 +24,3 @@ fun <F, B> MonadFilter<F>.bindingFilter(c: suspend MonadFilterContinuation<F, *>
     c.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()
 }
-
-inline fun <reified F> monadFilter(): MonadFilter<F> = instance(InstanceParametrizedType(MonadFilter::class.java, listOf(typeLiteral<F>())))

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/MonadReader.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/MonadReader.kt
@@ -3,6 +3,7 @@ package arrow.mtl
 import arrow.*
 import arrow.typeclasses.Monad
 
+@typeclass
 interface MonadReader<F, D> : Monad<F> {
     /** Get the environment */
     fun ask(): HK<F, D>
@@ -17,6 +18,3 @@ interface MonadReader<F, D> : Monad<F> {
 inline fun <reified F, A, reified D> HK<F, A>.local(FT: MonadReader<F, D> = monadReader(), noinline f: (D) -> D): HK<F, A> = FT.local(f, this)
 
 inline fun <reified F, A, reified D> ((D) -> A).reader(FT: MonadReader<F, D> = monadReader()): HK<F, A> = FT.reader(this)
-
-inline fun <reified F, reified D> monadReader(): MonadReader<F, D> =
-        instance(InstanceParametrizedType(MonadReader::class.java, listOf(typeLiteral<F>(), typeLiteral<D>())))

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/MonadState.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/MonadState.kt
@@ -4,6 +4,7 @@ import arrow.*
 import arrow.core.Tuple2
 import arrow.typeclasses.Monad
 
+@typeclass
 interface MonadState<F, S> : Monad<F>, Typeclass {
 
     fun <A> state(f: (S) -> Tuple2<S, A>): HK<F, A> = flatMap(get(), { s -> f(s).let { (a, b) -> map(set(a), { b }) } })
@@ -16,6 +17,3 @@ interface MonadState<F, S> : Monad<F>, Typeclass {
 
     fun <A> inspect(f: (S) -> A): HK<F, A> = map(get(), f)
 }
-
-inline fun <reified F, reified S> monadState(): MonadState<F, S> =
-        instance(InstanceParametrizedType(MonadState::class.java, listOf(typeLiteral<F>(), typeLiteral<S>())))

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/MonadWriter.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/MonadWriter.kt
@@ -5,6 +5,7 @@ import arrow.core.Tuple2
 import arrow.typeclasses.Monad
 
 /** A monad that support monoidal accumulation (e.g. logging List<String>) */
+@typeclass
 interface MonadWriter<F, W> : Monad<F>, Typeclass {
 
     /** Lift a writer action into the effect */
@@ -30,6 +31,3 @@ interface MonadWriter<F, W> : Monad<F>, Typeclass {
         inline fun <reified F, reified W> invoke(MWF: MonadWriter<F, W> = monadWriter()) = MWF
     }
 }
-
-inline fun <reified F, reified W> monadWriter(): MonadWriter<F, W> = instance(
-        InstanceParametrizedType(MonadWriter::class.java, listOf(typeLiteral<F>(), typeLiteral<W>())))

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/TraverseFilter.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/TraverseFilter.kt
@@ -7,6 +7,7 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.applicative
 
+@typeclass
 interface TraverseFilter<F> : Traverse<F>, FunctorFilter<F>, Typeclass {
 
     fun <G, A, B> traverseFilter(fa: HK<F, A>, f: (A) -> HK<G, Option<B>>, GA: Applicative<G>): HK<G, HK<F, B>>
@@ -25,5 +26,3 @@ inline fun <reified F, reified G, A, B> HK<F, A>.traverseFilter(
         FT: TraverseFilter<F> = traverseFilter<F>(),
         GA: Applicative<G> = applicative<G>(),
         noinline f: (A) -> HK<G, Option<B>>): HK<G, HK<F, B>> = FT.traverseFilter(this, f, GA)
-
-inline fun <reified F> traverseFilter(): TraverseFilter<F> = instance(InstanceParametrizedType(TraverseFilter::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Alternative.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Alternative.kt
@@ -2,6 +2,5 @@ package arrow.typeclasses
 
 import arrow.*
 
+@typeclass
 interface Alternative<F> : Applicative<F>, MonoidK<F>, Typeclass
-
-inline fun <reified F> alternative(): Alternative<F> = instance(InstanceParametrizedType(Alternative::class.java, listOf(F::class.java)))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Applicative.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Applicative.kt
@@ -6,6 +6,7 @@ import arrow.*
 import arrow.core.Eval
 import arrow.core.Tuple2
 
+@typeclass
 interface Applicative<F> : Functor<F>, Typeclass {
 
     fun <A> pure(a: A): HK<F, A>
@@ -20,5 +21,3 @@ interface Applicative<F> : Functor<F>, Typeclass {
 
     fun <A, B, Z> map2Eval(fa: HK<F, A>, fb: Eval<HK<F, B>>, f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> = fb.map { fc -> map2(fa, fc, f) }
 }
-
-inline fun <reified F> applicative(): Applicative<F> = instance(InstanceParametrizedType(Applicative::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ApplicativeError.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ApplicativeError.kt
@@ -5,6 +5,7 @@ import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
 
+@typeclass
 interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
 
     fun <A> raiseError(e: E): HK<F, A>
@@ -27,6 +28,3 @@ interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
                 raiseError<A>(recover(t))
             }
 }
-
-inline fun <reified F, reified E> applicativeError(): ApplicativeError<F, E> =
-        instance(InstanceParametrizedType(ApplicativeError::class.java, listOf(typeLiteral<F>(), typeLiteral<E>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Bifoldable.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Bifoldable.kt
@@ -3,6 +3,7 @@ package arrow.typeclasses
 import arrow.*
 import arrow.core.Eval
 
+@typeclass
 interface Bifoldable<F> : Typeclass {
 
     fun <A, B, C> bifoldLeft(fab: HK2<F, A, B>, c: C, f: (C, A) -> C, g: (C, B) -> C): C
@@ -15,5 +16,3 @@ interface Bifoldable<F> : Typeclass {
 
 inline fun <F, A, B, reified C> Bifoldable<in F>.bifoldMap(MC: Monoid<C> = monoid(), fab: HK2<F, A, B>, noinline f: (A) -> C, noinline g: (B) -> C) =
         bifoldMap(fab, f, g, MC)
-
-inline fun <reified F> bifoldable(): Bifoldable<F> = instance(InstanceParametrizedType(Bifoldable::class.java, listOf(F::class.java)))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Bimonad.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Bimonad.kt
@@ -2,9 +2,5 @@ package arrow.typeclasses
 
 import arrow.*
 
-/**
- * The combination of monad and comonad
- */
+@typeclass
 interface Bimonad<F> : Monad<F>, Comonad<F>, Typeclass
-
-inline fun <reified F> bimonad(): Bimonad<F> = instance(InstanceParametrizedType(Bimonad::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Comonad.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Comonad.kt
@@ -9,6 +9,7 @@ import kotlin.coroutines.experimental.intrinsics.suspendCoroutineOrReturn
 /**
  * The dual of monads, used to extract values from F
  */
+@typeclass
 interface Comonad<F> : Functor<F>, Typeclass {
 
     fun <A, B> coflatMap(fa: HK<F, A>, f: (HK<F, A>) -> B): HK<F, B>
@@ -54,5 +55,3 @@ fun <F, B : Any> Comonad<F>.cobinding(c: suspend ComonadContinuation<F, *>.() ->
     c.startCoroutine(continuation, continuation)
     return continuation.returnedMonad
 }
-
-inline fun <reified F> comonad(): Comonad<F> = instance(InstanceParametrizedType(Comonad::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Eq.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Eq.kt
@@ -1,15 +1,13 @@
 package arrow.typeclasses
 
-import arrow.InstanceParametrizedType
-import arrow.Typeclass
-import arrow.instance
-import arrow.typeLiteral
+import arrow.*
 
 /**
  * A type class used to determine equality between 2 instances of the same type [F] in a type safe way.
  *
  * @see <a href="http://arrow-kt.io/docs/typeclasses/eq/">Eq documentation</a>
  */
+@typeclass
 interface Eq<in F> : Typeclass {
 
     /**
@@ -57,10 +55,3 @@ interface Eq<in F> : Typeclass {
         }
     }
 }
-
-/**
- * Method to lookup instance of [Eq] for a type [F].
- *
- * @return [Eq] instance for type [F].
- */
-inline fun <reified F> eq(): Eq<F> = instance(InstanceParametrizedType(Eq::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -14,6 +14,7 @@ import arrow.core.Eval.Companion.always
  *
  * Beyond these it provides many other useful methods related to folding over F<A> values.
  */
+@typeclass
 interface Foldable<F> : Typeclass {
 
     /**
@@ -183,5 +184,3 @@ inline fun <reified F, A> Foldable<F>.size(MB: Monoid<Long> = monoid(), fa: HK<F
  */
 inline fun <F, reified G, A, B> Foldable<F>.foldM(fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>, MG: Monad<G> = monad()): HK<G, B> =
         foldLeft(fa, MG.pure(z), { gb, a -> MG.flatMap(gb) { f(it, a) } })
-
-inline fun <reified F> foldable(): Foldable<F> = instance(InstanceParametrizedType(Foldable::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -3,6 +3,7 @@ package arrow.typeclasses
 import arrow.*
 import arrow.core.Tuple2
 
+@typeclass
 interface Functor<F> : Typeclass {
 
     fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>
@@ -25,5 +26,3 @@ interface Functor<F> : Typeclass {
 }
 
 fun <F, B, A : B> Functor<F>.widen(fa: HK<F, A>): HK<F, B> = fa
-
-inline fun <reified F> functor(): Functor<F> = instance(InstanceParametrizedType(Functor::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Inject.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Inject.kt
@@ -8,6 +8,7 @@ import arrow.core.FunctionK
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
  */
+@typeclass
 interface Inject<F, G> : Typeclass {
 
     fun inj(): FunctionK<F, G>
@@ -15,5 +16,3 @@ interface Inject<F, G> : Typeclass {
     fun <A> invoke(fa: HK<F, A>): HK<G, A> = inj()(fa)
 
 }
-
-inline fun <reified F, reified G> inject(): Inject<F, G> = instance(InstanceParametrizedType(Inject::class.java, listOf(typeLiteral<F>(), typeLiteral<G>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
@@ -5,6 +5,7 @@ import arrow.core.Either
 import arrow.core.Eval
 import kotlin.coroutines.experimental.startCoroutine
 
+@typeclass
 interface Monad<F> : Applicative<F>, Typeclass {
 
     fun <A, B> flatMap(fa: HK<F, A>, f: (A) -> HK<F, B>): HK<F, B>
@@ -34,5 +35,3 @@ fun <F, B> Monad<F>.binding(c: suspend MonadContinuation<F, *>.() -> HK<F, B>): 
     c.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()
 }
-
-inline fun <reified F> monad(): Monad<F> = instance(InstanceParametrizedType(Monad::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
@@ -3,6 +3,7 @@ package arrow.typeclasses
 import arrow.*
 import kotlin.coroutines.experimental.startCoroutine
 
+@typeclass
 interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F>, Typeclass {
 
     fun <A> ensure(fa: HK<F, A>, error: () -> E, predicate: (A) -> Boolean): HK<F, A> =
@@ -26,6 +27,3 @@ fun <F, B> MonadError<F, Throwable>.bindingE(c: suspend MonadErrorContinuation<F
     c.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()
 }
-
-inline fun <reified F, reified E> monadError(): MonadError<F, E> =
-        instance(InstanceParametrizedType(MonadError::class.java, listOf(typeLiteral<F>(), typeLiteral<E>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monoid.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monoid.kt
@@ -2,6 +2,7 @@ package arrow.typeclasses
 
 import arrow.*
 
+@typeclass
 interface Monoid<A> : Semigroup<A>, Typeclass {
     /**
      * A zero value for this A
@@ -20,5 +21,3 @@ interface Monoid<A> : Semigroup<A>, Typeclass {
             if (elems.isEmpty()) empty() else elems.reduce { a, b -> combine(a, b) }
 
 }
-
-inline fun <reified A> monoid(): Monoid<A> = instance(InstanceParametrizedType(Monoid::class.java, listOf(typeLiteral<A>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonoidK.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonoidK.kt
@@ -8,6 +8,7 @@ import arrow.*
  * MonoidK<F> allows two F<A> values to be combined, for any A. It also means that for any A, there
  * is an "empty" F<A> value.
  */
+@typeclass
 interface MonoidK<F> : SemigroupK<F>, Typeclass {
 
     /**
@@ -22,5 +23,3 @@ interface MonoidK<F> : SemigroupK<F>, Typeclass {
         override fun combine(a: HK<F, A>, b: HK<F, A>): HK<F, A> = this@MonoidK.combineK(a, b)
     }
 }
-
-inline fun <reified F> monoidK(): MonoidK<F> = instance(InstanceParametrizedType(MonoidK::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Order.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Order.kt
@@ -1,10 +1,7 @@
 package arrow.typeclasses
 
-import arrow.InstanceParametrizedType
-import arrow.Typeclass
+import arrow.*
 import arrow.core.Tuple2
-import arrow.instance
-import arrow.typeLiteral
 
 /**
  * The [Order] type class is used to define a total ordering on some type [F] and is defined by being able to fully determine order between two instances.
@@ -14,6 +11,7 @@ import arrow.typeLiteral
  * @see [Eq]
  * @see <a href="http://arrow-kt.io/docs/typeclasses/order/">Order documentation</a>
  */
+@typeclass
 interface Order<F> : Eq<F>, Typeclass {
 
     /**
@@ -118,10 +116,3 @@ interface Order<F> : Eq<F>, Typeclass {
     }
 
 }
-
-/**
- * Method to lookup instance of [Order] for a type [F].
- *
- * @return [Order] instance for type [F].
- */
-inline fun <reified F> order(): Order<F> = instance(InstanceParametrizedType(Order::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Reducible.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Reducible.kt
@@ -14,6 +14,7 @@ import arrow.core.*
  *  - reduceLeftTo(fa)(f)(g) eagerly reduces with an additional mapping function
  *  - reduceRightTo(fa)(f)(g) lazily reduces with an additional mapping function
  */
+@typeclass
 interface Reducible<F> : Foldable<F>, Typeclass {
 
     /**
@@ -67,8 +68,6 @@ inline fun <F, reified G, A> Reducible<F>.reduceK(fga: HK<F, HK<G, A>>, SGKG: Se
  */
 inline fun <F, A, reified B> Reducible<F>.reduceMap(fa: HK<F, A>, noinline f: (A) -> B, SB: Semigroup<B> = semigroup()): B =
         reduceLeftTo(fa, f, { b, a -> SB.combine(b, f(a)) })
-
-inline fun <reified F> reducible(): Reducible<F> = instance(InstanceParametrizedType(Reducible::class.java, listOf(typeLiteral<F>())))
 
 /**
  * This class defines a Reducible<F> in terms of a Foldable<G> together with a split method, F<A> -> (A, G<A>).

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Semigroup.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Semigroup.kt
@@ -1,11 +1,9 @@
 package arrow.typeclasses
 
-import arrow.InstanceParametrizedType
-import arrow.Typeclass
+import arrow.*
 import arrow.core.Option
-import arrow.instance
-import arrow.typeLiteral
 
+@typeclass
 interface Semigroup<A> : Typeclass {
     /**
      * Combine two [A] values.
@@ -15,5 +13,3 @@ interface Semigroup<A> : Typeclass {
     fun maybeCombine(a: A, b: A?): A = Option.fromNullable(b).fold({ a }, { this.combine(a, it) })
 
 }
-
-inline fun <reified A> semigroup(): Semigroup<A> = instance(InstanceParametrizedType(Semigroup::class.java, listOf(typeLiteral<A>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/SemigroupK.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/SemigroupK.kt
@@ -2,6 +2,7 @@ package arrow.typeclasses
 
 import arrow.*
 
+@typeclass
 interface SemigroupK<F> : Typeclass {
 
     /**
@@ -17,5 +18,3 @@ interface SemigroupK<F> : Typeclass {
                 combineK(a, b)
     }
 }
-
-inline fun <reified F> semigroupK(): SemigroupK<F> = instance(InstanceParametrizedType(SemigroupK::class.java, listOf(typeLiteral<F>())))

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Traverse.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Traverse.kt
@@ -6,6 +6,7 @@ import arrow.core.*
 /**
  * Traverse, also known as Traversable. Traversal over a structure with an effect.
  */
+@typeclass
 interface Traverse<F> : Functor<F>, Foldable<F>, Typeclass {
 
     /**
@@ -27,5 +28,3 @@ applicative(), FM: Monad<F> = monad()): HK<G, HK<F, B>> = GA.map(traverse(fa, f,
  * Thread all the G effects through the F structure to invert the structure from F<G<A>> to G<F<A>>.
  */
 inline fun <F, reified G, A> Traverse<F>.sequence(fga: HK<F, HK<G, A>>, GA: Applicative<G> = applicative()): HK<G, HK<F, A>> = sequence(GA, fga)
-
-inline fun <reified F> traverse(): Traverse<F> = instance(InstanceParametrizedType(Traverse::class.java, listOf(typeLiteral<F>())))


### PR DESCRIPTION
This is my happy new year PR! :tada: 

This PR makes some fixes to the typeclass discovery lookup which enables applications built on a purely functional tagless final style and introduces `@typeclass` which is used to remove the boilerplate generated when declaring typeclass factories.  

With this changes you can define now in Arrow full abstract polymorphic applications decoupled from their run-time in Kotlin with minimal boilerplate such as:
```kotlin
package test

import arrow.*
import arrow.core.*
import arrow.typeclasses.*

/** abstract Tagless Final Program **/
@typeclass
interface Service1<F> : Typeclass {
    fun A(): Applicative<F>
    fun op1(): HK<F, Int> = A().pure(1)
}

@typeclass
interface Service2<F> : Typeclass {
    fun A(): Applicative<F>
    fun op2(): HK<F, Int> = A().pure(1)

}

@typeclass
interface App<F> : Typeclass {
    fun M(): Monad<F>
    fun service1(): Service1<F>
    fun service2(): Service2<F>

    fun program(): HK<F, Int> = M().binding {
        val a = service1().op1().bind()
        val b = service2().op2().bind()
        yields(a + b)
    }
}

/** Evidences over Option **/

@instance(Option::class)
interface OptionService1Instance<F> : Service1<F>

@instance(Option::class)
interface OptionService2Instance<F> : Service2<F>

@instance(Option::class)
interface OptionAppInstance<F> : App<F>

fun main(args: Array<String>): Unit {
    val result: Option<Int> = app<OptionHK>().program().ev()
    println(result)
}
```