### PR TITLE
fix slug in deploy scripts

### DIFF
--- a/deploy-scripts/deploy_common.sh
+++ b/deploy-scripts/deploy_common.sh
@@ -2,7 +2,7 @@
 . $(dirname $0)/deploy_functions.sh
 set -e
 
-SLUG="arrow/arrow"
+SLUG="arrow-kt/arrow"
 JDK="oraclejdk8"
 BRANCH="master"
 VERSION_NAME=$(getProperty "VERSION_NAME")


### PR DESCRIPTION
Currently, the travis ci after success step is failing: 
> Failed release deployment: wrong repository. Expected 'arrow/arrow' but was 'arrow-kt/arrow'.

let's fix the slug in order to be able to release again.
