### PR TITLE
Improve Eval.Compute.value performance

### DIFF
--- a/arrow-core/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/Eval.kt
@@ -188,7 +188,7 @@ sealed class Eval<out A> : EvalKind<A> {
 
         override fun value(): A {
             var curr: Eval<A> = this
-            var fs: List<(Any?) -> Eval<A>> = listOf()
+            var fs: MutableList<(Any?) -> Eval<A>> = mutableListOf()
 
             loop@ while (true) {
                 when (curr) {
@@ -200,7 +200,8 @@ sealed class Eval<out A> : EvalKind<A> {
                                     val inStartFun: (Any?) -> Eval<A> = { cc.run(it) }
                                     val outStartFun: (Any?) -> Eval<A> = { currComp.run(it) }
                                     curr = cc.start<A>()
-                                    fs = listOf(inStartFun, outStartFun) + fs
+                                    fs.add(0, outStartFun)
+                                    fs.add(0, inStartFun)
                                 }
                                 else -> {
                                     curr = currComp.run(cc.value())
@@ -211,7 +212,7 @@ sealed class Eval<out A> : EvalKind<A> {
                     else ->
                         if (fs.isNotEmpty()) {
                             curr = fs[0](curr.value())
-                            fs = fs.drop(1)
+                            fs.removeAt(0)
                         } else {
                             break@loop
                         }


### PR DESCRIPTION
Currently, Eval.Compute.value is implemented using a mutable reference to an immutable list. This PR replaces it with a mutable reference to a mutable list, which greatly increases performance.

Tested using the following factorial implementation:
```kotlin
fun factorial(i: Int): Eval<Int> = when (i) {
    0 -> Eval.One
    else -> Eval.defer { factorial(i - 1) }.map { it * i }
}
```

With the old implementation, factorial 0..2000 takes ~13 seconds on my laptop. With the new implementation, it takes ~0.5 seconds.