### PR TITLE
Adding utility method to Duration

### DIFF
--- a/arrow-effects/src/main/kotlin/arrow/effects/data/Duration.kt
+++ b/arrow-effects/src/main/kotlin/arrow/effects/data/Duration.kt
@@ -9,7 +9,12 @@ data class Duration(val amount: Long, val timeUnit: TimeUnit) {
         // Actually limited to 9223372036854775807 days, so unless you are very patient, it is unlimited ;-)
         val INFINITE = Duration(amount = Long.MAX_VALUE, timeUnit = TimeUnit.DAYS)
     }
+
+    operator fun times(i: Int) = Duration(amount * i, timeUnit)
+
 }
+
+operator fun Int.times(d: Duration) = d * this
 
 val Long.days: Duration
     get() = Duration(this, TimeUnit.DAYS)

--- a/arrow-effects/src/main/kotlin/arrow/effects/data/Duration.kt
+++ b/arrow-effects/src/main/kotlin/arrow/effects/data/Duration.kt
@@ -12,6 +12,15 @@ data class Duration(val amount: Long, val timeUnit: TimeUnit) {
 
     operator fun times(i: Int) = Duration(amount * i, timeUnit)
 
+    operator fun plus(d: Duration): Duration = run {
+        val comp = timeUnit.compareTo(d.timeUnit)
+        when {
+            comp == 0 -> Duration(amount + d.amount, timeUnit) // Same unit
+            comp < 0 -> this + Duration(timeUnit.convert(d.amount, d.timeUnit), timeUnit) // Convert to same unit then add
+            else -> d + this // Swap this and d to add to the smaller unit
+        }
+    }
+
 }
 
 operator fun Int.times(d: Duration) = d * this

--- a/arrow-effects/src/test/kotlin/arrow/effects/data/DurationTest.kt
+++ b/arrow-effects/src/test/kotlin/arrow/effects/data/DurationTest.kt
@@ -1,0 +1,36 @@
+package arrow.effects.data
+
+import arrow.effects.Duration
+import arrow.test.UnitSpec
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+/**
+ *
+ */
+@RunWith(KTestJUnitRunner::class)
+class DurationTest : UnitSpec() {
+
+    init {
+        "plus should be commutative" {
+            forAll(Gen.long(), TimeUnitGen(), Gen.long(), TimeUnitGen()) { i: Long, u: TimeUnit, j: Long, v: TimeUnit ->
+                val a = Duration(i, u)
+                val b = Duration(j, v)
+                a + b == b + a
+            }
+        }
+    }
+
+}
+
+private class TimeUnitGen : Gen<TimeUnit> {
+
+    companion object {
+        val units = TimeUnit.values()
+    }
+
+    override fun generate(): TimeUnit = units[Gen.choose(0, units.size -1).generate()]
+}

--- a/arrow-effects/src/test/kotlin/arrow/effects/data/DurationTest.kt
+++ b/arrow-effects/src/test/kotlin/arrow/effects/data/DurationTest.kt
@@ -2,6 +2,7 @@ package arrow.effects.data
 
 import arrow.effects.Duration
 import arrow.test.UnitSpec
+import arrow.test.generators.TimeUnitGen
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -24,13 +25,4 @@ class DurationTest : UnitSpec() {
         }
     }
 
-}
-
-private class TimeUnitGen : Gen<TimeUnit> {
-
-    companion object {
-        val units = TimeUnit.values()
-    }
-
-    override fun generate(): TimeUnit = units[Gen.choose(0, units.size -1).generate()]
 }

--- a/arrow-effects/src/test/kotlin/arrow/effects/data/DurationTest.kt
+++ b/arrow-effects/src/test/kotlin/arrow/effects/data/DurationTest.kt
@@ -2,12 +2,11 @@ package arrow.effects.data
 
 import arrow.effects.Duration
 import arrow.test.UnitSpec
-import arrow.test.generators.TimeUnitGen
+import arrow.test.generators.genIntSmall
+import arrow.test.generators.genTimeUnit
 import io.kotlintest.KTestJUnitRunner
-import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
-import java.util.concurrent.TimeUnit
 
 /**
  *
@@ -17,9 +16,9 @@ class DurationTest : UnitSpec() {
 
     init {
         "plus should be commutative" {
-            forAll(Gen.long(), TimeUnitGen(), Gen.long(), TimeUnitGen()) { i: Long, u: TimeUnit, j: Long, v: TimeUnit ->
-                val a = Duration(i, u)
-                val b = Duration(j, v)
+            forAll(genIntSmall(), genTimeUnit(), genIntSmall(), genTimeUnit()) { i, u, j, v ->
+                val a = Duration(i.toLong(), u)
+                val b = Duration(j.toLong(), v)
                 a + b == b + a
             }
         }

--- a/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -149,11 +149,8 @@ fun <K, V> genMap(genK: Gen<K>, genV: Gen<V>): Gen<Map<K, V>> =
 fun <K, V> genMapKW(genK: Gen<K>, genV: Gen<V>): Gen<MapKW<K, V>> =
         Gen.create { Gen.list(genK).generate().map { it to genV.generate() }.toMap().k() }
 
-class TimeUnitGen : Gen<TimeUnit> {
-
-    companion object {
-        val units = TimeUnit.values()
-    }
-
-    override fun generate(): TimeUnit = units[Gen.choose(0, units.size -1).generate()]
+fun genTimeUnit(): Gen<TimeUnit> = object : Gen<TimeUnit> {
+    val units = TimeUnit.values()
+    val random = Gen.choose(0, units.size -1)
+    override fun generate(): TimeUnit = units[random.generate()]
 }

--- a/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -6,6 +6,7 @@ import arrow.typeclasses.applicative
 import arrow.core.*
 import arrow.data.*
 import io.kotlintest.properties.Gen
+import java.util.concurrent.TimeUnit
 
 inline fun <reified F, A> genApplicative(valueGen: Gen<A>, AP: Applicative<F> = applicative<F>()): Gen<HK<F, A>> =
         object : Gen<HK<F, A>> {
@@ -147,3 +148,12 @@ fun <K, V> genMap(genK: Gen<K>, genV: Gen<V>): Gen<Map<K, V>> =
 
 fun <K, V> genMapKW(genK: Gen<K>, genV: Gen<V>): Gen<MapKW<K, V>> =
         Gen.create { Gen.list(genK).generate().map { it to genV.generate() }.toMap().k() }
+
+class TimeUnitGen : Gen<TimeUnit> {
+
+    companion object {
+        val units = TimeUnit.values()
+    }
+
+    override fun generate(): TimeUnit = units[Gen.choose(0, units.size -1).generate()]
+}


### PR DESCRIPTION
Overloading the * operator to multiply a duration. Not sure it is really relevant to have it in Arrow though.