### PR TITLE
Use newThread scheduler to avoid flaky tests on single-core CI machines

### DIFF
--- a/arrow-effects-rx2/src/test/kotlin/arrow/effects/data/FlowableKWTests.kt
+++ b/arrow-effects-rx2/src/test/kotlin/arrow/effects/data/FlowableKWTests.kt
@@ -1,16 +1,16 @@
 package arrow.effects
 
+import arrow.test.UnitSpec
+import arrow.test.laws.AsyncLaws
+import arrow.test.laws.FoldableLaws
+import arrow.test.laws.TraverseLaws
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldNotBe
 import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subscribers.TestSubscriber
 import org.junit.runner.RunWith
-import arrow.test.UnitSpec
-import arrow.test.laws.AsyncLaws
-import arrow.test.laws.FoldableLaws
-import arrow.test.laws.TraverseLaws
-import arrow.typeclasses.*
 import java.util.concurrent.TimeUnit
 
 @RunWith(KTestJUnitRunner::class)
@@ -90,7 +90,7 @@ class FlowableKWTests : UnitSpec() {
             val value: Flowable<Long> = FlowableKW.monadErrorFlat().bindingE {
                 val a = Flowable.timer(2, TimeUnit.SECONDS).k().bind()
                 nextThread = Thread.currentThread()
-                val b = Flowable.just(a).observeOn(Schedulers.io()).k().bind()
+                val b = Flowable.just(a).observeOn(Schedulers.newThread()).k().bind()
                 yields(b)
             }.value()
             val test: TestSubscriber<Long> = value.test()

--- a/arrow-effects-rx2/src/test/kotlin/arrow/effects/data/ObservableKWTests.kt
+++ b/arrow-effects-rx2/src/test/kotlin/arrow/effects/data/ObservableKWTests.kt
@@ -1,16 +1,16 @@
 package arrow.effects
 
+import arrow.test.UnitSpec
+import arrow.test.laws.AsyncLaws
+import arrow.test.laws.FoldableLaws
+import arrow.test.laws.TraverseLaws
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldNotBe
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.schedulers.Schedulers
 import org.junit.runner.RunWith
-import arrow.test.UnitSpec
-import arrow.test.laws.AsyncLaws
-import arrow.test.laws.FoldableLaws
-import arrow.test.laws.TraverseLaws
-import arrow.typeclasses.*
 import java.util.concurrent.TimeUnit
 
 @RunWith(KTestJUnitRunner::class)
@@ -77,7 +77,7 @@ class ObservableKWTest : UnitSpec() {
             val value: Observable<Long> = ObservableKW.monadErrorFlat().bindingE {
                 val a = Observable.timer(2, TimeUnit.SECONDS).k().bind()
                 nextThread = Thread.currentThread()
-                val b = Observable.just(a).observeOn(Schedulers.io()).k().bind()
+                val b = Observable.just(a).observeOn(Schedulers.newThread()).k().bind()
                 yields(b)
             }.value()
             val test: TestObserver<Long> = value.test()


### PR DESCRIPTION
Fix #512