### PR TITLE
remove private val dummy from Left and Right

### DIFF
--- a/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -151,7 +151,7 @@ import arrow.legacy.*
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
     @Suppress("DataClassPrivateConstructor")
-    data class Left<out A, out B>  @PublishedApi internal constructor(val a: A) : Either<A, B>() {
+    data class Left<out A, out B> @PublishedApi internal constructor(val a: A) : Either<A, B>() {
         override val isLeft = true
         override val isRight = false
 
@@ -164,7 +164,7 @@ import arrow.legacy.*
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
     @Suppress("DataClassPrivateConstructor")
-    data class Right<out A, out B>  @PublishedApi internal constructor(val b: B) : Either<A, B>() {
+    data class Right<out A, out B> @PublishedApi internal constructor(val b: B) : Either<A, B>() {
         override val isLeft = false
         override val isRight = true
 

--- a/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -151,7 +151,7 @@ import arrow.legacy.*
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
     @Suppress("DataClassPrivateConstructor")
-    data class Left<out A, out B> private constructor(val a: A) : Either<A, B>() {
+    data class Left<out A, out B>  @PublishedApi internal constructor(val a: A) : Either<A, B>() {
         override val isLeft = true
         override val isRight = false
 
@@ -164,7 +164,7 @@ import arrow.legacy.*
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
     @Suppress("DataClassPrivateConstructor")
-    data class Right<out A, out B> private constructor(val b: B) : Either<A, B>() {
+    data class Right<out A, out B>  @PublishedApi internal constructor(val b: B) : Either<A, B>() {
         override val isLeft = false
         override val isRight = true
 

--- a/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -150,24 +150,24 @@ import arrow.legacy.*
     /**
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
-    data class Left<out A, out B>(val a: A, private val dummy: Unit) : Either<A, B>() {
+    data class Left<out A, out B>(val a: A) : Either<A, B>() {
         override val isLeft = true
         override val isRight = false
 
         companion object {
-            inline operator fun <A> invoke(a: A): Either<A, Nothing> = Left(a, Unit)
+            inline operator fun <A> invoke(a: A): Either<A, Nothing> = Left(a)
         }
     }
 
     /**
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
-    data class Right<out A, out B>(val b: B, private val dummy: Unit) : Either<A, B>() {
+    data class Right<out A, out B>(val b: B) : Either<A, B>() {
         override val isLeft = false
         override val isRight = true
 
         companion object {
-            inline operator fun <B> invoke(b: B): Either<Nothing, B> = Right(b, Unit)
+            inline operator fun <B> invoke(b: B): Either<Nothing, B> = Right(b)
         }
     }
 

--- a/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -150,7 +150,8 @@ import arrow.legacy.*
     /**
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
-    data class Left<out A, out B>(val a: A) : Either<A, B>() {
+    @Suppress("DataClassPrivateConstructor")
+    data class Left<out A, out B> private constructor(val a: A) : Either<A, B>() {
         override val isLeft = true
         override val isRight = false
 
@@ -162,7 +163,8 @@ import arrow.legacy.*
     /**
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
-    data class Right<out A, out B>(val b: B) : Either<A, B>() {
+    @Suppress("DataClassPrivateConstructor")
+    data class Right<out A, out B> private constructor(val b: B) : Either<A, B>() {
         override val isLeft = false
         override val isRight = true
 


### PR DESCRIPTION
I removed the private property dummy from Left and Right, I do not really see why they would be required.