### PR TITLE
Adding a cond method on Either companion object

### DIFF
--- a/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -193,6 +193,8 @@ import arrow.legacy.*
             }
         }
 
+        fun <L, R> cond(test: Boolean, r: () -> R, l: () -> L): Either<L, R> = if (test) right(r()) else left(l())
+
     }
 }
 

--- a/arrow-data/src/test/kotlin/arrow/data/EitherTest.kt
+++ b/arrow-data/src/test/kotlin/arrow/data/EitherTest.kt
@@ -88,6 +88,12 @@ class EitherTest : UnitSpec() {
             }
         }
 
+        "cond should create right instance only if test is true" {
+            forAll{t: Boolean, i: Int, s: String ->
+                val expected = if (t) Right(i) else Left(s)
+                Either.cond(t, { i }, { s }) == expected
+            }
+        }
 
     }
 }

--- a/arrow-docs/docs/docs/datatypes/either/README.md
+++ b/arrow-docs/docs/docs/datatypes/either/README.md
@@ -232,6 +232,16 @@ val x = "hello".left()
 x.getOrElse { 7 }
 ```
 
+For creating Either instance based on a predicate, use `Either.cond()` method : 
+
+```kotlin:ank
+Either.cond(true, { 42 }, { "Error" })
+```
+
+```kotlin:ank
+Either.cond(false, { 42 }, { "Error" })
+```
+
 Another operation is `fold`. This operation will extract the value from the Either, or provide a default if the value is `Left`
  
  ```kotlin:ank


### PR DESCRIPTION
This mimic the [Scala stdlib](https://www.scala-lang.org/api/current/scala/util/Either$.html#cond[A,B](test:Boolean,right:=%3EB,left:=%3EA):scala.util.Either[A,B]). 
Shall we make the t parameter a thunk too ? 