### PR TITLE
improve error message on incompatible jdk version

### DIFF
--- a/arrow-annotations-processor/build.gradle
+++ b/arrow-annotations-processor/build.gradle
@@ -1,4 +1,5 @@
 import org.gradle.internal.jvm.Jvm
+import org.gradle.api.GradleException
 
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
@@ -13,7 +14,12 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "com.google.testing.compile:compile-testing:0.13"
     testCompile fileTree(dir: './src/test/libs', includes: ['*.jar'])
-    testCompile files(Jvm.current().getToolsJar())
+    def toolsJar = Jvm.current().getToolsJar()
+
+    if (!toolsJar)
+        throw new GradleException("tools.jar not found at your JAVA_HOME dir ${Jvm.current().getJavaHome().getAbsolutePath()}.\n" +
+                "Building with a JRE or JDK9 is currently not supported.")
+    testCompile files(toolsJar)
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
without this change the build just fails with a NullPointerException.