### PR TITLE
Replace rest of usages of `kotlin-stdlib-jre7` with `kotlin-stdlib-jdk7`

### DIFF
--- a/arrow-core/build.gradle
+++ b/arrow-core/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     kapt project(':arrow-annotations-processor')
     kaptTest project(':arrow-annotations-processor')

--- a/arrow-data/build.gradle
+++ b/arrow-data/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-typeclasses')
     kapt project(':arrow-annotations-processor')

--- a/arrow-effects-kotlinx-coroutines/build.gradle
+++ b/arrow-effects-kotlinx-coroutines/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':arrow-data')
     compile project(':arrow-effects')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     kapt project(':arrow-annotations-processor')
     kaptTest project(':arrow-annotations-processor')

--- a/arrow-effects-rx2/build.gradle
+++ b/arrow-effects-rx2/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':arrow-data')
     compile project(':arrow-effects')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     kapt project(':arrow-annotations-processor')
     kaptTest project(':arrow-annotations-processor')

--- a/arrow-effects/build.gradle
+++ b/arrow-effects/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':arrow-data')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     kapt project(':arrow-annotations-processor')
     kaptTest project(':arrow-annotations-processor')

--- a/arrow-examples/build.gradle
+++ b/arrow-examples/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     testCompile project(':arrow-test')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
 }
 

--- a/arrow-free/build.gradle
+++ b/arrow-free/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-data')
     compile project(':arrow-instances')

--- a/arrow-instances/build.gradle
+++ b/arrow-instances/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-typeclasses')
     compile project(':arrow-data')

--- a/arrow-kindedj/build.gradle
+++ b/arrow-kindedj/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testCompile project(':arrow-test')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/arrow-mtl/build.gradle
+++ b/arrow-mtl/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-instances')
     compile project(':arrow-free')

--- a/arrow-syntax/build.gradle
+++ b/arrow-syntax/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-data')
     compile project(':arrow-instances')

--- a/arrow-typeclasses/build.gradle
+++ b/arrow-typeclasses/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-core')
     kapt project(':arrow-annotations-processor')

--- a/arrow-validation/build.gradle
+++ b/arrow-validation/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testCompile project(':arrow-test')
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
 }
 


### PR DESCRIPTION
This is a followup to the missed libraries in ce99db67b595314942d585ef6aec3d27eef2e1c5.
See https://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages