### PR TITLE
Change monad comprehensions to accept any return value

### DIFF
--- a/arrow-docs/docs/docs/datatypes/either/README.md
+++ b/arrow-docs/docs/docs/datatypes/either/README.md
@@ -303,7 +303,7 @@ val httpStatusCode = r.getOrHandle {
     val a = Either.Right(1).bind()
     val b = Either.Right(1 + a).bind()
     val c = Either.Right(1 + b).bind()
-    yields(a + b + c)
+    a + b + c
  }
  // Right(b=6, dummy=kotlin.Unit)
  ```

--- a/arrow-docs/docs/docs/datatypes/eithert/README.md
+++ b/arrow-docs/docs/docs/datatypes/eithert/README.md
@@ -71,7 +71,7 @@ fun getCountryCode(maybePerson : Either<BizError, Person>): Either<BizError, Str
     val person = maybePerson.bind()
     val address = person.address.toEither({ AddressNotFound(person.id) }).bind()
     val country = address.country.toEither({ CountryNotFound(address.id) }).bind()
-    yields(country.code)
+    country.code
   }.ev()
 ```
 
@@ -172,7 +172,7 @@ fun getCountryCode(personId: Int): ObservableKW<Either<BizError, String>> =
             { it.left() },
             { it.code.right() }
         )
-        yields(code)
+        code
       }.ev()
 ```
 
@@ -215,7 +215,7 @@ fun getCountryCode(personId: Int): ObservableKW<Either<BizError, String>> =
       person.address.toEither { AddressNotFound(personId) }
     )).bind()
     val country = EitherT(findCountry(address.id)).bind()
-    yields(country.code)
+    country.code
   }.value()
 ```
 

--- a/arrow-docs/docs/docs/datatypes/ior/README.md
+++ b/arrow-docs/docs/docs/datatypes/ior/README.md
@@ -74,7 +74,7 @@ fun validateUser(name: String, pass: String) =
         Ior.monad<Nel<String>>().binding {
             val username = validateUsername(name).bind()
             val password = validatePassword(pass).bind()
-            yields(User(username, password))
+            User(username, password)
         }.ev()
 ```
 

--- a/arrow-docs/docs/docs/datatypes/option/README.md
+++ b/arrow-docs/docs/docs/datatypes/option/README.md
@@ -152,7 +152,7 @@ Option.monad().binding {
    val a = Some(1).bind()
    val b = Some(1 + a).bind()
    val c = Some(1 + b).bind()
-   yields(a + b + c)
+   a + b + c
 }
 //Some(value=6)
 ```
@@ -162,7 +162,7 @@ Option.monad().binding {
    val x = none<Int>().bind()
    val y = Some(1 + x).bind()
    val z = Some(1 + y).bind()
-   yields(x + y + z)
+   x + y + z
 }
 //None
 ```

--- a/arrow-docs/docs/docs/datatypes/optiont/README.md
+++ b/arrow-docs/docs/docs/datatypes/optiont/README.md
@@ -52,7 +52,7 @@ fun getCountryCode(maybePerson : Option<Person>): Option<String> =
     val address = person.address.bind()
     val country = address.country.bind()
     val code = country.code.bind()
-    yields(code)
+    code
   }.ev()
 ```
 
@@ -148,7 +148,7 @@ fun getCountryCode(personId: Int): ObservableKW<Option<String>> =
           { ObservableKW.raiseError<Country>(NoSuchElementException("...")) },
           { ObservableKW.pure(it) }
         ).bind()
-        yields(country.code)
+        country.code
       }.ev()
 ```
 
@@ -198,7 +198,7 @@ fun getCountryCode(personId: Int): ObservableKW<Option<String>> =
     val address = OptionT(ObservableKW.pure(person.address)).bind()
     val country = OptionT(findCountry(address.id)).bind()
     val code = OptionT(ObservableKW.pure(country.code)).bind()
-    yields(code)
+    code
   }.value().ev()
 ```
 

--- a/arrow-docs/docs/docs/datatypes/sequencekw/README.md
+++ b/arrow-docs/docs/docs/datatypes/sequencekw/README.md
@@ -53,7 +53,7 @@ val positiveEven = positive.filter { it % 2 == 0 }.k()
 SequenceKW.monad().binding {
    val p = positive.bind()
    val pe = positiveEven.bind()
-   yields(p + pe)
+   p + pe
 }.ev().take(5).toList()
 ```
 

--- a/arrow-docs/docs/docs/datatypes/state/README.md
+++ b/arrow-docs/docs/docs/datatypes/state/README.md
@@ -96,7 +96,7 @@ fun stackOperations() = State().monad<Stack>().binding {
     val b = pop().bind()
     val c = pop().bind()
 
-    yields(c)
+    c
 }.ev()
 ```
 

--- a/arrow-docs/docs/docs/datatypes/statet/README.md
+++ b/arrow-docs/docs/docs/datatypes/statet/README.md
@@ -131,7 +131,7 @@ fun stackOperationsS2() = StateT .monad<EitherKindPartial<StackError>, Stack>().
     pushS("a").bind()
     popS().bind()
     val string = popS().bind()
-    yields(string)
+    string
 }.ev()
 
 stackOperationsS2().runM(listOf("hello", "world", "!"))

--- a/arrow-docs/docs/docs/datatypes/try/README.md
+++ b/arrow-docs/docs/docs/datatypes/try/README.md
@@ -164,7 +164,7 @@ Try.monad().binding {
     val b = Try { "4".toInt() }.bind()
     val c = Try { "5".toInt() }.bind()
 
-    yields(a + b + c)
+    a + b + c
 } // Success(value=12)
 ```
 
@@ -174,7 +174,7 @@ Try.monad().binding {
     val b = Try { "4".toInt() }.bind()
     val c = Try { "5".toInt() }.bind()
 
-    yields(a + b + c)
+    a + b + c
 } // Failure(exception=java.lang.NumberFormatException: For input string: "none")
 ```
 
@@ -186,7 +186,7 @@ Try.monadError().bindingCatch {
     val b = "4".toInt()
     val c = "5".toInt()
 
-    yields(a + b + c)
+    a + b + c
 } // Failure(exception=java.lang.NumberFormatException: For input string: "none")
 ```
 

--- a/arrow-docs/docs/docs/effects/async/README.md
+++ b/arrow-docs/docs/docs/effects/async/README.md
@@ -96,7 +96,7 @@ Note that there is no automatic error handling or wrapping of exceptions.
 ```kotlin
 IO.monad().binding {
   val a = bindAsync(IO.async()) { fibonacci(100) }
-  yields(a + 1)
+  a + 1
 }.ev().unsafeRunSync()
 ```
 
@@ -110,14 +110,14 @@ While there is no wrapping of exceptions, the left side of the [`Either`]({{ '/d
 ```kotlin
 IO.monad().binding {
   val a = bindAsync(IO.async()) { fibonacci(100).left() }
-  yields(a + 1)
+  a + 1
 }.ev().unsafeRunSync()
 ```
 
 ```kotlin
 IO.monad().binding {
   val a = bindAsync(IO.async()) { RuntimeException("Boom").right() }
-  yields(a + 1)
+  a + 1
 }.ev().unsafeRunSync()
 ```
 

--- a/arrow-docs/docs/docs/effects/io/README.md
+++ b/arrow-docs/docs/docs/effects/io/README.md
@@ -214,7 +214,7 @@ IO.monad().binding {
         val count = lines.map { it.length }.foldLeft(0) { acc, lineLength -> acc + lineLength }
         count / lines.length
       }
-    yields(average)
+    average
   }
   .ev()
   .attempt()

--- a/arrow-docs/docs/docs/effects/monadsuspend/README.md
+++ b/arrow-docs/docs/docs/effects/monadsuspend/README.md
@@ -51,7 +51,7 @@ val SC = IO.monadSuspend()
 val result = SC.binding {
   println("Print: now")
   val result = pure(1).bind()
-  yields(result + 1)
+  result + 1
 }
 
 //Print: now
@@ -60,7 +60,7 @@ val lazyResult = SC.binding {
   SC.lazy().bind()
   println("Print: lazy")
   val result = eagerIO().bind()
-  yields(result + 1)
+  result + 1
 }
 
 //Nothing here!

--- a/arrow-docs/docs/docs/integrations/kotlinxcoroutines/README.md
+++ b/arrow-docs/docs/docs/integrations/kotlinxcoroutines/README.md
@@ -128,7 +128,7 @@ DeferredKW.monadError().bindingCatch {
 
   val percent = (timelineClick / totalTime * 100).toInt()
 
-  yield(percent)
+  percent
 }.unsafeAttemptSync()
  // Failure(ArithmeticException("/ by zero"))
 ```

--- a/arrow-docs/docs/docs/integrations/kotlinxcoroutines/README.md
+++ b/arrow-docs/docs/docs/integrations/kotlinxcoroutines/README.md
@@ -168,7 +168,7 @@ val (deferred, unsafeCancel) =
     val friendProfiles = userProfile.friends().map { friend ->
         DeferredKW { getProfile(friend.id) }.bind()
     }
-    yields(listOf(userProfile) + friendProfiles)
+    listOf(userProfile) + friendProfiles
   }
 
 deferred.unsafeRunAsync { result ->

--- a/arrow-docs/docs/docs/integrations/rx2/README.md
+++ b/arrow-docs/docs/docs/integrations/rx2/README.md
@@ -141,7 +141,7 @@ val (observable, disposable) =
     val friendProfiles = userProfile.friends().map { friend ->
         bindAsync(observableAsync) { getProfile(friend.id) }
     }
-    yields(listOf(userProfile) + friendProfiles)
+    listOf(userProfile) + friendProfiles
   }
 
 observable.value()

--- a/arrow-docs/docs/docs/integrations/rx2/README.md
+++ b/arrow-docs/docs/docs/integrations/rx2/README.md
@@ -113,7 +113,7 @@ ObservableKW.monadError().bindingCatch {
     end.onNext(Unit)
   }
 
-  yield(percent)
+  percent
 }.ev()
 ```
 

--- a/arrow-docs/docs/docs/patterns/errorhandling/README.md
+++ b/arrow-docs/docs/docs/patterns/errorhandling/README.md
@@ -142,7 +142,7 @@ fun attackOption(): Option<Impacted> =
     val nuke = arm().bind()
     val target = aim().bind()
     val impact = launch(target, nuke).bind()
-    yields(impact)
+    impact
   }.ev()
 
 attackOption()
@@ -199,7 +199,7 @@ fun attackTry(): Try<Impacted> =
     val nuke = arm().bind()
     val target = aim().bind()
     val impact = launch(target, nuke).bind()
-    yields(impact)
+    impact
   }.ev()
 
 attackTry()
@@ -256,7 +256,7 @@ fun attackEither(): Either<NukeException, Impacted> =
     val nuke = arm().bind()
     val target = aim().bind()
     val impact = launch(target, nuke).bind()
-    yields(impact)
+    impact
   }.ev()
 
 attackEither()
@@ -307,7 +307,7 @@ inline fun <reified F> attack(ME:MonadError<F, NukeException> = monadError()):HK
     val nuke = arm<F>().bind()
     val target = aim<F>().bind()
     val impact = launch<F>(target, nuke).bind()
-    yields(impact)
+    impact
   }
 ```
 
@@ -337,7 +337,7 @@ inline fun <reified F> attack(ME:MonadError<F, NukeException> = monadError()):HK
     val nuke = arm<F>().bind()
     val target = aim<F>().bind()
     val impact = launchImpure<F>(target, nuke)
-    yields(impact)
+    impact
   }
 ```
 

--- a/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
+++ b/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
@@ -66,7 +66,6 @@ Arrow uses this capability of the compiler to bring you coroutines-like notation
 
 Every instance of [`Monad`]({{ '/docs/typeclasses/monad' | relative_url }}) contains a method `binding` that receives a suspended function as a parameter.
 This functions must return the last element of the sequence of operations.
-`yields()` is a helper function that takes any one value and constructs a correct return.
 Let's see a minimal example.
 
 ```kotlin:ank

--- a/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
+++ b/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
@@ -75,7 +75,7 @@ import arrow.effects.*
 import arrow.typeclasses.*
 
 IO.monad().binding {
-  yields(1)
+  1
 }.ev().unsafeRunSync()
 ```
 
@@ -85,7 +85,7 @@ In the case of [`IO`]({{ '/docs/effects/io' | relative_url }}), it is immediatel
 ```kotlin
 IO.monad().binding {
   val a = IO.invoke { 1 }
-  yields(a + 1)
+  a + 1
 }.ev().unsafeRunSync()
 // Compiler error: the type of a is IO<Int>, cannot add 1 to it
 ```
@@ -98,14 +98,14 @@ For that we have two flavors of the function `bind()`, which is a function only 
 ```kotlin:ank
 IO.monad().binding {
   val a = IO.invoke { 1 }.bind()
-  yields(a + 1)
+  a + 1
 }.ev().unsafeRunSync()
 ```
 
 ```kotlin:ank
 IO.monad().binding {
   val a = bind { IO.invoke { 1 } }
-  yields(a + 1)
+  a + 1
 }.ev().unsafeRunSync()
 ```
 
@@ -128,7 +128,7 @@ val university: IO<University> =
     val student = getStudentFromDatabase("Bob Roxx").bind()
     val university = getUniversityFromDatabase(student.universityId).bind()
     val dean = getDeanFromDatabase(university.deanId).bind()
-    yields(dean)
+    dean
   }
 ```
 
@@ -142,7 +142,7 @@ fun getNLines(path: FilePath, count: Int): IO<List<String>> =
     if (lines.length < count) {
       IO.raiseError(RuntimeException("File has fewer lines than expected"))
     } else {
-      yields(lines.take(count))
+      lines.take(count)
     }
   }
 ```
@@ -163,7 +163,7 @@ fun getLineLengthAverage(path: FilePath): IO<List<String>> =
     val lines = file.readLines().bind()
     val count = lines.map { it.length }.foldLeft(0) { acc, lineLength -> acc + lineLength }
     val average = count / lines.length
-    yields(average)
+    average
   }
 ```
 
@@ -182,7 +182,7 @@ fun getLineLengthAverage(path: FilePath): IO<List<String>> =
     val lines = file.readLines().bind()
     val count = lines.map { it.length }.foldLeft(0) { acc, lineLength -> acc + lineLength }
     val average = count / lines.length
-    yields(average)
+    average
   }
 ```
 
@@ -214,7 +214,7 @@ fun getLineLengthAverage(path: FilePath): IO<List<String>> =
     
     val count = lines.map { it.length }.foldLeft(0) { acc, lineLength -> acc + lineLength }
     val average = count / lines.length
-    yields(average)
+    average
   }
 ```
 
@@ -239,7 +239,7 @@ val (binding: IO<List<User>>, unsafeCancel: Disposable) =
     val friendProfiles = userProfile.friends().map { friend ->
         bindAsync(ioAsync) { getProfile(friend.id) }
     }
-    yields(listOf(userProfile) + friendProfiles)
+    listOf(userProfile) + friendProfiles
   }
 
 binding.unsafeRunAsync { result ->

--- a/arrow-docs/docs/docs/typeclasses/monadfilter/README.md
+++ b/arrow-docs/docs/docs/typeclasses/monadfilter/README.md
@@ -28,7 +28,7 @@ Option.monadFilter().bindingFilter {
  val b = Option(1).bind()
  val c = a + b
  continueIf(c > 0)
- yields(c)
+ c
 }
 ```
 
@@ -40,7 +40,7 @@ ListKW.monadFilter().bindingFilter {
  val b = listOf(1).k().bind()
  val c = a + b
  continueIf(c > 0)
- yields(c)
+ c
 }
 ```    
 
@@ -52,7 +52,7 @@ Option.monadFilter().bindingFilter {
  val b = Option(1).bind()
  val c = a + b
  continueIf(c < 0)
- yields(c)
+ c
 }
 ```
 
@@ -62,7 +62,7 @@ ListKW.monadFilter().bindingFilter {
  val b = listOf(1).k().bind()
  val c = a + b
  continueIf(c < 0)
- yields(c)
+ c
 }
 ```    
 
@@ -76,8 +76,7 @@ When `bindWithFilter` is satisfied the computation continues
 Option.monadFilter().bindingFilter {
  val a = Option(1).bind()
  val b = Option(1).bindWithFilter { it == a } //continues
- val c = a + b
- yields(c)
+ a + b
 }
 ```
 
@@ -85,8 +84,7 @@ Option.monadFilter().bindingFilter {
 ListKW.monadFilter().bindingFilter {
  val a = listOf(1).k().bind()
  val b = listOf(1).k().bindWithFilter { it == a } //continues
- val c = a + b
- yields(c)
+ a + b
 }
 ```
 
@@ -96,8 +94,7 @@ When `bindWithFilter` returns `false` the computation short circuits yielding th
 Option.monadFilter().bindingFilter {
  val a = Option(0).bind()
  val b = Option(1).bindWithFilter { it == a } //short circuits because a is 0
- val c = a + b
- yields(c)
+ a + b
 }
 ```   
 
@@ -105,7 +102,6 @@ Option.monadFilter().bindingFilter {
 ListKW.monadFilter().bindingFilter {
  val a = listOf(0).k().bind()
  val b = listOf(1).k().bindWithFilter { it == a } //short circuits because a is 0
- val c = a + b
- yields(c)
+ a + b
 }
 ```

--- a/arrow-effects/src/main/kotlin/arrow/effects/MonadSuspend.kt
+++ b/arrow-effects/src/main/kotlin/arrow/effects/MonadSuspend.kt
@@ -46,8 +46,9 @@ inline fun <reified F, A> (() -> Either<Throwable, A>).deferUnsafe(SC: MonadSusp
  * This operation is cancellable by calling invoke on the [Disposable] return.
  * If [Disposable.invoke] is called the binding result will become a lifted [BindingCancellationException].
  */
-fun <F, B> MonadSuspend<F>.bindingCancellable(c: suspend MonadSuspendCancellableContinuation<F, *>.() -> HK<F, B>): Tuple2<HK<F, B>, Disposable> {
+fun <F, B> MonadSuspend<F>.bindingCancellable(c: suspend MonadSuspendCancellableContinuation<F, *>.() -> B): Tuple2<HK<F, B>, Disposable> {
     val continuation = MonadSuspendCancellableContinuation<F, B>(this)
-    c.startCoroutine(continuation, continuation)
+    val wrapReturn: suspend MonadSuspendCancellableContinuation<F, *>.() -> HK<F, B> = { pure(c()) }
+    wrapReturn.startCoroutine(continuation, continuation)
     return continuation.returnedMonad() toT continuation.disposable()
 }

--- a/arrow-free/src/main/kotlin/arrow/free/StackSafeMonadContinuations.kt
+++ b/arrow-free/src/main/kotlin/arrow/free/StackSafeMonadContinuations.kt
@@ -40,7 +40,7 @@ open class StackSafeMonadContinuation<F, A>(M: Monad<F>, override val context: C
     @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b"))
     infix fun <B> yields(b: B): B = b
 
-    @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b"))
+    @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b()"))
     infix fun <B> yields(b: () -> B): B = b()
 }
 

--- a/arrow-mtl/src/main/kotlin/arrow/mtl/MonadFilter.kt
+++ b/arrow-mtl/src/main/kotlin/arrow/mtl/MonadFilter.kt
@@ -1,7 +1,9 @@
 package arrow.mtl
 
-import arrow.*
+import arrow.HK
+import arrow.TC
 import arrow.core.Option
+import arrow.typeclass
 import arrow.typeclasses.Monad
 import kotlin.coroutines.experimental.startCoroutine
 
@@ -19,8 +21,9 @@ interface MonadFilter<F> : Monad<F>, FunctorFilter<F>, TC {
  * A coroutine is initiated and inside [MonadContinuation] suspended yielding to [flatMap]. Once all the flatMap binds are completed
  * the underlying monad is returned from the act of executing the coroutine
  */
-fun <F, B> MonadFilter<F>.bindingFilter(c: suspend MonadFilterContinuation<F, *>.() -> HK<F, B>): HK<F, B> {
+fun <F, B> MonadFilter<F>.bindingFilter(c: suspend MonadFilterContinuation<F, *>.() -> B): HK<F, B> {
     val continuation = MonadFilterContinuation<F, B>(this)
-    c.startCoroutine(continuation, continuation)
+    val wrapReturn: suspend MonadFilterContinuation<F, *>.() -> HK<F, B> = { pure(c()) }
+    wrapReturn.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()
 }

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
@@ -32,8 +32,9 @@ interface Monad<F> : Applicative<F>, TC {
  * A coroutine is initiated and suspended inside [MonadErrorContinuation] yielding to [Monad.flatMap]. Once all the flatMap binds are completed
  * the underlying monad is returned from the act of executing the coroutine
  */
-fun <F, B> Monad<F>.binding(c: suspend MonadContinuation<F, *>.() -> HK<F, B>): HK<F, B> {
+fun <F, B> Monad<F>.binding(c: suspend MonadContinuation<F, *>.() -> B): HK<F, B> {
     val continuation = MonadContinuation<F, B>(this)
-    c.startCoroutine(continuation, continuation)
+    val wrapReturn: suspend MonadContinuation<F, *>.() -> HK<F, B> = { pure(c()) }
+    wrapReturn.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()
 }

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
@@ -86,6 +86,6 @@ open class MonadContinuation<F, A>(M: Monad<F>, override val context: CoroutineC
     @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b"))
     fun <B> yields(b: B): B = b
 
-    @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b"))
+    @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b()"))
     fun <B> yields(b: () -> B): B = b()
 }

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
@@ -83,7 +83,9 @@ open class MonadContinuation<F, A>(M: Monad<F>, override val context: CoroutineC
         COROUTINE_SUSPENDED
     }
 
-    infix fun <B> yields(b: B): HK<F, B> = yields { b }
+    @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b"))
+    fun <B> yields(b: B): B = b
 
-    infix fun <B> yields(b: () -> B): HK<F, B> = pure(b())
+    @Deprecated("Yielding in comprehensions isn't required anymore", ReplaceWith("b"))
+    fun <B> yields(b: () -> B): B = b()
 }

--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
@@ -24,8 +24,9 @@ interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F>, TC {
  * This one operates over [MonadError] instances that can support [Throwable] in their error type automatically lifting
  * errors as failed computations in their monadic context and not letting exceptions thrown as the regular monad binding does.
  */
-fun <F, B> MonadError<F, Throwable>.bindingCatch(c: suspend MonadErrorContinuation<F, *>.() -> HK<F, B>): HK<F, B> {
+fun <F, B> MonadError<F, Throwable>.bindingCatch(c: suspend MonadErrorContinuation<F, *>.() -> B): HK<F, B> {
     val continuation = MonadErrorContinuation<F, B>(this)
-    c.startCoroutine(continuation, continuation)
+    val wrapReturn: suspend MonadErrorContinuation<F, *>.() -> HK<F, B> = { pure(c()) }
+    wrapReturn.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()
 }


### PR DESCRIPTION
This PR removes the need to use `yields()` in comprehensions to form a correct value. Instead we take the return value from the block and lift it using `pure()`.

A deprecation path has been added for yields() that replaces the call with the first parameter, as users were not meant to use the return value anyway.