### PR TITLE
Auto-generate Syntax for Type Classes

### DIFF
--- a/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
@@ -110,11 +110,9 @@ class TypeclassFileGenerator(
 
     private val typeclasses: List<Typeclass> = annotatedList.map { Typeclass(it.classOrPackageProto.`package`, it) }
 
-    private fun functionSignatures(typeClass: Typeclass): List<SyntaxFunctionSignature> {
-        return typeClass.target.classOrPackageProto.functionList.map {
+    private fun functionSignatures(typeClass: Typeclass): List<SyntaxFunctionSignature> = typeClass.target.classOrPackageProto.functionList.map {
             SyntaxFunctionSignature.from("arrow.HK", typeClass, it)
         }.filter { it.hkArgs == HKArgs.First }
-    }
 
     /**
      * Main entry point for higher kinds extension generation

--- a/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
@@ -2,7 +2,12 @@ package arrow.tc
 
 import arrow.common.Package
 import arrow.common.utils.ClassOrPackageDataWrapper
+import arrow.common.utils.extractFullName
+import arrow.common.utils.removeBackticks
 import arrow.common.utils.typeConstraints
+import arrow.derive.HKArgs
+import me.eugeniomarletti.kotlin.metadata.modality
+import org.jetbrains.kotlin.serialization.ProtoBuf
 import java.io.File
 
 data class Typeclass(
@@ -25,9 +30,77 @@ data class Typeclass(
             } else {
                 ""
             }
+
     val typeConstraints = target.classOrPackageProto.typeConstraints()
     val name: String = clazz.nameResolver.getString(clazz.classProto.fqName).replace("/", ".")
     val simpleName = name.substringAfterLast(".")
+}
+
+data class SyntaxFunctionSignature(
+        val typeClass: Typeclass,
+        val tparams: List<String>,
+        val name: String,
+        val args: List<Pair<String, String>>,
+        val retType: String,
+        val hkArgs: HKArgs,
+        val receiverType: String,
+        val isAbstract: Boolean
+
+) {
+
+    fun generate(): String {
+        val typeParamsS = tparams.joinToString(prefix = "<`", separator = "`, `", postfix = "`>")
+        val argsS = args.drop(1).map { "${it.first}: ${it.second}" }.joinToString(prefix = "(`", separator = "`, `", postfix = "`)")
+        return """|fun $typeParamsS ${receiver()}__name__$argsS: $retType =
+                  |    ${implBody()}""".removeBackticks().replace("__name__", "`$name`").trimMargin()
+    }
+
+    fun receiver(): String =
+            when (hkArgs) {
+                is HKArgs.None -> ""
+                is HKArgs.First -> "${args[0].second}."
+                is HKArgs.Unknown -> ""
+            }
+
+    fun implBody(): String =
+            when (hkArgs) {
+                is HKArgs.None -> ""
+                is HKArgs.First -> {
+                    val thisArgs = listOf("this" to "") + args.drop(1)
+                    "${typeClass.simpleName.decapitalize()}().__name__(${thisArgs.joinToString(", ") { it.first }})"
+                }
+                is HKArgs.Unknown -> "${typeClass.simpleName.decapitalize()}().$name(${args.joinToString(", ") { it.first }})"
+            }
+
+    companion object {
+
+        fun from(receiverType: String, typeClass: Typeclass, f: ProtoBuf.Function): SyntaxFunctionSignature {
+            val nameResolver = typeClass.clazz.nameResolver
+            val typeParams = f.typeParameterList.map { nameResolver.getString(it.name) }
+            val typeClassAbstractKind = nameResolver.getString(typeClass.clazz.typeParameters[0].name)
+            val args = f.valueParameterList.map {
+                val argName = nameResolver.getString(it.name)
+                val argType = it.type.extractFullName(typeClass.clazz, failOnGeneric = false)
+                argName to argType
+            }
+            val abstractReturnType = f.returnType.extractFullName(typeClass.clazz, failOnGeneric = false)
+            val isAbstract = f.modality == ProtoBuf.Modality.ABSTRACT
+            return SyntaxFunctionSignature(
+                    typeClass = typeClass,
+                    tparams = typeParams,
+                    name = nameResolver.getString(f.name),
+                    args = args,
+                    retType = abstractReturnType,
+                    hkArgs = when {
+                        f.valueParameterList.isEmpty() -> HKArgs.None
+                        nameResolver.getString(f.getValueParameter(0).type.className).startsWith("arrow/HK") -> HKArgs.First
+                        else -> HKArgs.Unknown
+                    },
+                    receiverType = receiverType,
+                    isAbstract = isAbstract
+            )
+        }
+    }
 }
 
 class TypeclassFileGenerator(
@@ -37,12 +110,18 @@ class TypeclassFileGenerator(
 
     private val typeclasses: List<Typeclass> = annotatedList.map { Typeclass(it.classOrPackageProto.`package`, it) }
 
+    private fun functionSignatures(typeClass: Typeclass): List<SyntaxFunctionSignature> {
+        return typeClass.target.classOrPackageProto.functionList.map {
+            SyntaxFunctionSignature.from("arrow.HK", typeClass, it)
+        }.filter { it.hkArgs == HKArgs.First }
+    }
+
     /**
      * Main entry point for higher kinds extension generation
      */
     fun generate() {
         typeclasses.forEachIndexed { _, tc ->
-            val elementsToGenerate = listOf(genLookup(tc))
+            val elementsToGenerate = listOf(genLookup(tc), genSyntax(tc))
             val source: String = elementsToGenerate.joinToString(prefix = "package ${tc.`package`}\n\n", separator = "\n", postfix = "\n")
             val file = File(generatedDir, typeClassAnnotationClass.simpleName + ".${tc.target.classElement.qualifiedName}.kt")
             file.writeText(source)
@@ -60,6 +139,19 @@ class TypeclassFileGenerator(
             |
             |inline fun ${tc.expandedTypeArgs(true)} ${tc.simpleName.decapitalize()}(): ${tc.name}${tc.expandedTypeArgs()} =
             |  instance(InstanceParametrizedType(${tc.name}::class.java, listOf(${typeLiterals.joinToString(",")})))
+            |""".trimMargin()
+    }
+
+    private fun genSyntax(tc: Typeclass): String {
+        val delegatedFunctions: List<String> = functionSignatures(tc).map { it.generate() }
+
+        return """
+            |interface ${tc.simpleName}Syntax${tc.expandedTypeArgs(false)} {
+            |
+            |  fun ${tc.simpleName.decapitalize()}(): ${tc.simpleName}${tc.expandedTypeArgs(false)}
+            |
+            |  ${delegatedFunctions.joinToString("\n\n  ")}
+            |}
             |""".trimMargin()
     }
 


### PR DESCRIPTION
For a type class such as:
```kotlin
@typeclass
interface Functor<F> : TC {

    fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B>

    fun <A, B> lift(f: (A) -> B): (HK<F, A>) -> HK<F, B> =
            { fa: HK<F, A> ->
                map(fa, f)
            }

    fun <A> void(fa: HK<F, A>): HK<F, Unit> = map(fa, { _ -> Unit })

    fun <A, B> fproduct(fa: HK<F, A>, f: (A) -> B): HK<F, Tuple2<A, B>> = map(fa, { a -> Tuple2(a, f(a)) })

    fun <A, B> `as`(fa: HK<F, A>, b: B): HK<F, B> = map(fa, { _ -> b })

    fun <A, B> tupleLeft(fa: HK<F, A>, b: B): HK<F, Tuple2<B, A>> = map(fa, { a -> Tuple2(b, a) })

    fun <A, B> tupleRight(fa: HK<F, A>, b: B): HK<F, Tuple2<A, B>> = map(fa, { a -> Tuple2(a, b) })

}
```
It generates all it's syntax facilities:

```kotlin
interface FunctorSyntax<F> {

  fun functor(): Functor<F>

  fun <A, B> arrow.HK<F, A>.`as`(b: B): arrow.HK<F, B> =
    functor().`as`(this, b)

  fun <A, B> arrow.HK<F, A>.`fproduct`(f: kotlin.Function1<A, B>): arrow.HK<F, arrow.core.Tuple2<A, B>> =
    functor().`fproduct`(this, f)

  fun <A, B> arrow.HK<F, A>.`map`(f: kotlin.Function1<A, B>): arrow.HK<F, B> =
    functor().`map`(this, f)

  fun <A, B> arrow.HK<F, A>.`tupleLeft`(b: B): arrow.HK<F, arrow.core.Tuple2<B, A>> =
    functor().`tupleLeft`(this, b)

  fun <A, B> arrow.HK<F, A>.`tupleRight`(b: B): arrow.HK<F, arrow.core.Tuple2<A, B>> =
    functor().`tupleRight`(this, b)

  fun <A> arrow.HK<F, A>.`void`(): arrow.HK<F, kotlin.Unit> =
    functor().`void`(this)
}

```

Which makes it easy to include at call sites for example in abstract contexts like F bound algebras in tagless final:

```kotlin
class Service<F> @Inject constructor(
  override val functor: Functor<F>
): FunctorSyntax<F> by functor {
  fun <A, B> doStuff(fa: HK<F, A>, f: (A) -> B): HK<F, B> = fa.map(f) 
}
```
`fa.map(f)` here is valid because of the inherited `FunctorSyntax<F>`, otherwise we would have to use `functor` directly `functor.map(fa, f)`