### PR TITLE
Use `val` instead of `fun` in syntax generation for type class syntax

### DIFF
--- a/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
+++ b/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassFileGenerator.kt
@@ -66,10 +66,10 @@ data class SyntaxFunctionSignature(
             when (hkArgs) {
                 is HKArgs.None -> ""
                 is HKArgs.First -> {
-                    val thisArgs = listOf("this" to "") + args.drop(1)
-                    "${typeClass.simpleName.decapitalize()}().__name__(${thisArgs.joinToString(", ") { it.first }})"
+                    val thisArgs = listOf("this" to "") + args.drop(1).dropLast(1)
+                    "${typeClass.simpleName.decapitalize()}.__name__(${thisArgs.joinToString(", ") { it.first }})"
                 }
-                is HKArgs.Unknown -> "${typeClass.simpleName.decapitalize()}().$name(${args.joinToString(", ") { it.first }})"
+                is HKArgs.Unknown -> "${typeClass.simpleName.decapitalize()}.$name(${args.joinToString(", ") { it.first }})"
             }
 
     companion object {
@@ -82,7 +82,7 @@ data class SyntaxFunctionSignature(
                 val argName = nameResolver.getString(it.name)
                 val argType = it.type.extractFullName(typeClass.clazz, failOnGeneric = false)
                 argName to argType
-            }
+            } + listOf("dummy" to "Unit = Unit")
             val abstractReturnType = f.returnType.extractFullName(typeClass.clazz, failOnGeneric = false)
             val isAbstract = f.modality == ProtoBuf.Modality.ABSTRACT
             return SyntaxFunctionSignature(
@@ -146,7 +146,7 @@ class TypeclassFileGenerator(
         return """
             |interface ${tc.simpleName}Syntax${tc.expandedTypeArgs(false)} {
             |
-            |  fun ${tc.simpleName.decapitalize()}(): ${tc.simpleName}${tc.expandedTypeArgs(false)}
+            |  val ${tc.simpleName.decapitalize()}: ${tc.simpleName}${tc.expandedTypeArgs(false)}
             |
             |  ${delegatedFunctions.joinToString("\n\n  ")}
             |}


### PR DESCRIPTION
This makes the encoding on Tagless classes easier by activating the syntax based on the injected property:

```kotlin
class Service1<F> @Inject constructor(
        override val functor: Functor<F> //here functor is provided to `FunctorSyntax` via override
) : FunctorSyntax<F> {
    fun s1(a: HK<F, Int>): HK<F, Int> = a.map { it + 1 }
}
```

This PR also solves erasure issues related to classes in cases such as `Functor#map` vs `HK<F, A>.map` generated extension by providing a dummy extra argument where it's definition after erasure is no longer equivalent.