### PR TITLE
Generate all static and extensions methods in Type class Syntax

### DIFF
--- a/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monoid.kt
+++ b/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monoid.kt
@@ -10,14 +10,14 @@ interface Monoid<A> : Semigroup<A>, TC {
     fun empty(): A
 
     /**
-     * Combine an array of [A] values.
-     */
-    fun combineAll(vararg elems: A): A = combineAll(elems.asList())
-
-    /**
      * Combine a collection of [A] values.
      */
     fun combineAll(elems: Collection<A>): A =
             if (elems.isEmpty()) empty() else elems.reduce { a, b -> combine(a, b) }
 
 }
+
+/**
+ * Combine an array of [A] values.
+ */
+fun <A> Monoid<A>.combineAll(vararg elems: A): A = combineAll(elems.asList())


### PR DESCRIPTION
Auto derived from the Monoid syntax:
```kotlin
interface MonoidSyntax<A> {

  val monoid: Monoid<A>

  fun kotlin.collections.Collection<A>.`combineAll`(dummy: Unit = Unit): A =
    monoid.`combineAll`(this)

  fun `empty`(): A =
    monoid.`empty`()
}
```