### PR TITLE
Bump ank version to 0.6.2-SNAPSHOT after the renamening

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build #:arrow-docs:runAnk
+  - ./gradlew clean build :arrow-docs:runAnk
   - ./gradlew codeCoverageReport
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - ./deploy-scripts/deploy.sh
 
-#deploy:
-#  provider: pages
-#  skip_cleanup: true
-#  github_token: $GITHUB_TOKEN
-#  local_dir: modules/docs/arrow-docs/build/site
-#  on:
-#    branch: master
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: modules/docs/arrow-docs/build/site
+  on:
+    branch: master

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
 
     repositories {
         jcenter()
+        maven { url 'https://oss.jfrog.org/oss-snapshot-local/' }
         maven { url 'https://jitpack.io' }
         maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
         maven { url "https://dl.bintray.com/jetbrains/markdown/" }
@@ -39,7 +40,7 @@ buildscript {
         classpath "com.github.ben-manes:gradle-versions-plugin:$gradleVersionsPluginVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
-        classpath 'io.arrow-kt:ank-gradle-plugin:0.6.1'
+        classpath 'io.arrow-kt:ank-gradle-plugin:0.6.2-SNAPSHOT'
         classpath 'org.ajoberstar:gradle-git-publish:0.3.2'
     }
 }
@@ -49,6 +50,7 @@ apply from: 'detekt.gradle.kts'
 allprojects {
     repositories {
         jcenter()
+        maven { url 'https://oss.jfrog.org/oss-snapshot-local/' }
         maven { url 'https://kotlin.bintray.com/kotlinx' }
         maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
         maven { url "http://dl.bintray.com/arrow-kt/arrow-kt" }

--- a/modules/docs/arrow-docs/build.gradle
+++ b/modules/docs/arrow-docs/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'ank-gradle-plugin'
 apply plugin: 'org.ajoberstar.git-publish'
 
 dependencies {
-    compile 'io.arrow-kt:ank-core:0.6.1'
+    compile 'io.arrow-kt:ank-core:0.6.2-SNAPSHOT'
     compile project(':arrow-syntax')
     compile project(':arrow-effects')
     compile project(':arrow-effects-rx2')

--- a/modules/docs/arrow-docs/docs/docs/optics/each/README.md
+++ b/modules/docs/arrow-docs/docs/docs/optics/each/README.md
@@ -17,14 +17,14 @@ import arrow.data.*
 import arrow.optics.*
 import arrow.optics.typeclasses.*
 
-val each: Each<ListKWKind<Int>, Int> = Each.fromTraverse(ListKW.traverse())
+val each: Each<ListKOf<Int>, Int> = Each.fromTraverse(ListK.traverse())
 
-val listTraversal: Traversal<ListKWKind<Int>, Int> = each.each()
+val listTraversal: Traversal<ListKOf<Int>, Int> = each.each()
 
 listTraversal.lastOption(listOf(1, 2, 3).k())
 ```
 ```kotlin:ank
-listTraversal.lastOption(ListKW.empty())
+listTraversal.lastOption(ListK.empty())
 ```
 
 #### Creating your own `Each` instances
@@ -39,8 +39,8 @@ See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | rela
 
 The following datatypes in Arrow provide instances that adhere to the `Each` typeclass.
 
-- [MapKW]({{ '/docs/datatypes/mapkw' | relative_url }})
-- [ListKW]({{ '/docs/datatypes/listkw' | relative_url }})
+- [MapK]({{ '/docs/datatypes/mapk' | relative_url }})
+- [ListK]({{ '/docs/datatypes/listk' | relative_url }})
 - [Option]({{ '/docs/datatypes/option' | relative_url }})
 - [Try]({{ '/docs/datatypes/try' | relative_url }})
 - [Either]({{ '/docs/datatypes/either' | relative_url }})

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,8 +76,8 @@ project(":arrow-recursion").projectDir = file("modules/recursion-schemes/arrow-r
 
 /** Docs **/
 
-//include(":arrow-docs")
-//project(":arrow-docs").projectDir = file("modules/docs/arrow-docs")
+include(":arrow-docs")
+project(":arrow-docs").projectDir = file("modules/docs/arrow-docs")
 
 /** Optics **/
 


### PR DESCRIPTION
- Bumps ank version to `0.6.2-SNAPSHOT` after the renamening https://github.com/arrow-kt/arrow/pull/671

👀 @pakoito @raulraja 