### PR TITLE
Auto gen type class syntax inheritance in typeclass generation

### DIFF
--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/instances/InstanceProcessor.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/instances/InstanceProcessor.kt
@@ -1,9 +1,9 @@
 package arrow.instances
 
-import com.google.auto.service.AutoService
 import arrow.common.utils.AbstractProcessor
 import arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.knownError
+import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.serialization.deserialization.TypeTable
 import java.io.File
 import javax.annotation.processing.Processor

--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/AnnotatedTypeclass.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/AnnotatedTypeclass.kt
@@ -5,4 +5,6 @@ import javax.lang.model.element.TypeElement
 
 class AnnotatedTypeclass(
         val classElement: TypeElement,
-        val classOrPackageProto: ClassOrPackageDataWrapper)
+        val classOrPackageProto: ClassOrPackageDataWrapper,
+        val superTypes: List<ClassOrPackageDataWrapper.Class>,
+        val syntax : Boolean)

--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
@@ -1,10 +1,9 @@
 package arrow.tc
 
-import arrow.common.messager.logW
-import com.google.auto.service.AutoService
 import arrow.common.utils.AbstractProcessor
 import arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.knownError
+import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.serialization.deserialization.TypeTable
 import java.io.File
 import javax.annotation.processing.Processor

--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
@@ -1,8 +1,11 @@
 package arrow.tc
 
+import arrow.common.messager.logW
 import com.google.auto.service.AutoService
 import arrow.common.utils.AbstractProcessor
+import arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.knownError
+import org.jetbrains.kotlin.serialization.deserialization.TypeTable
 import java.io.File
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
@@ -40,8 +43,19 @@ class TypeclassesProcessor : AbstractProcessor() {
     }
 
     private fun processClass(element: TypeElement): AnnotatedTypeclass {
-        val proto = getClassOrPackageDataWrapper(element)
-        return AnnotatedTypeclass(element, proto)
+        val proto = getClassOrPackageDataWrapper(element) as ClassOrPackageDataWrapper.Class
+        val typeTable = TypeTable(proto.classProto.typeTable)
+        val superTypes: List<ClassOrPackageDataWrapper.Class> =
+                recurseTypeclassInterfaces(proto, typeTable, emptyList()).map { it as ClassOrPackageDataWrapper.Class }
+        val syntax = element.annotationMirrors.flatMap { am ->
+            am.elementValues.entries.filter {
+                "syntax" == it.key.simpleName.toString()
+            }.map {
+                        logW("${it.key.simpleName} = ${it.value}")
+                        it.value.toString().toBoolean()
+                    }
+        }.firstOrNull() ?: true
+        return AnnotatedTypeclass(element, proto, superTypes, syntax)
     }
 
 }

--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/TypeclassProcessor.kt
@@ -50,10 +50,7 @@ class TypeclassesProcessor : AbstractProcessor() {
         val syntax = element.annotationMirrors.flatMap { am ->
             am.elementValues.entries.filter {
                 "syntax" == it.key.simpleName.toString()
-            }.map {
-                        logW("${it.key.simpleName} = ${it.value}")
-                        it.value.toString().toBoolean()
-                    }
+            }.map { it.value.toString().toBoolean() }
         }.firstOrNull() ?: true
         return AnnotatedTypeclass(element, proto, superTypes, syntax)
     }

--- a/modules/core/arrow-annotations/src/main/java/arrow/typeclass.kt
+++ b/modules/core/arrow-annotations/src/main/java/arrow/typeclass.kt
@@ -3,7 +3,7 @@ package arrow
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
-annotation class typeclass()
+annotation class typeclass(val syntax: Boolean = true)
 
 /**
  * Marker trait that all Functional typeclasses such as Monad, Functor, etc... must implement to be considered

--- a/modules/dagger/arrow-dagger-effects/src/main/kotlin/arrow.dagger.effects.instances/syntax.kt
+++ b/modules/dagger/arrow-dagger-effects/src/main/kotlin/arrow.dagger.effects.instances/syntax.kt
@@ -1,0 +1,8 @@
+package arrow.dagger.effects.instances
+
+import arrow.effects.*
+import javax.inject.Inject
+
+class DaggerMonadSuspendSyntaxInstance<F> @Inject constructor(val monadSuspend: MonadSuspend<F>) : MonadSuspendSyntax<F> {
+    override fun monadSuspend(): MonadSuspend<F> = monadSuspend
+}

--- a/modules/dagger/arrow-dagger-effects/src/main/kotlin/arrow.dagger.effects.instances/syntax.kt
+++ b/modules/dagger/arrow-dagger-effects/src/main/kotlin/arrow.dagger.effects.instances/syntax.kt
@@ -6,3 +6,11 @@ import javax.inject.Inject
 class DaggerMonadSuspendSyntaxInstance<F> @Inject constructor(val monadSuspend: MonadSuspend<F>) : MonadSuspendSyntax<F> {
     override fun monadSuspend(): MonadSuspend<F> = monadSuspend
 }
+
+class DaggerAsyncSyntaxInstance<F> @Inject constructor(val async: Async<F>) : AsyncSyntax<F> {
+    override fun async(): Async<F> = async
+}
+
+class DaggerEffectSyntaxInstance<F> @Inject constructor(val effect: Effect<F>) : EffectSyntax<F> {
+    override fun effect(): Effect<F> = effect
+}

--- a/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/syntax.kt
+++ b/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/syntax.kt
@@ -1,0 +1,72 @@
+package arrow.dagger.instances
+
+import arrow.typeclasses.*
+import javax.inject.Inject
+
+class DaggerEqSyntaxInstance<F> @Inject constructor(val eq: Eq<F>) : EqSyntax<F> {
+    override fun eq(): Eq<F> = eq
+}
+
+class DaggerOrderSyntaxInstance<F> @Inject constructor(val order: Order<F>) : OrderSyntax<F> {
+    override fun order(): Order<F> = order
+}
+
+class DaggerFunctorSyntaxInstance<F> @Inject constructor(val functor: Functor<F>) : FunctorSyntax<F> {
+    override fun functor(): Functor<F> = functor
+}
+
+class DaggerApplicativeSyntaxInstance<F> @Inject constructor(val applicative: Applicative<F>) : ApplicativeSyntax<F> {
+    override fun applicative(): Applicative<F> = applicative
+}
+
+class DaggerMonadSyntaxInstance<F> @Inject constructor(val monad: Monad<F>) : MonadSyntax<F> {
+    override fun monad(): Monad<F> = monad
+}
+
+class DaggerFoldableSyntaxInstance<F> @Inject constructor(val foldable: Foldable<F>) : FoldableSyntax<F> {
+    override fun foldable(): Foldable<F> = foldable
+}
+
+class DaggerTraverseSyntaxInstance<F> @Inject constructor(val traverse: Traverse<F>) : TraverseSyntax<F> {
+    override fun traverse(): Traverse<F> = traverse
+}
+
+class DaggerAlternativeSyntaxInstance<F> @Inject constructor(val alternative: Alternative<F>) : AlternativeSyntax<F> {
+    override fun alternative(): Alternative<F> = alternative
+}
+
+class DaggerApplicativeErrorSyntaxInstance<F, E> @Inject constructor(val applicativeError: ApplicativeError<F, E>) : ApplicativeErrorSyntax<F, E> {
+    override fun applicativeError(): ApplicativeError<F, E> = applicativeError
+}
+
+class DaggerBimonadSyntaxInstance<F> @Inject constructor(val bimonad: Bimonad<F>) : BimonadSyntax<F> {
+    override fun bimonad(): Bimonad<F> = bimonad
+}
+
+class DaggerComonadSyntaxInstance<F> @Inject constructor(val comonad: Comonad<F>) : ComonadSyntax<F> {
+    override fun comonad(): Comonad<F> = comonad
+}
+
+class DaggerInjectSyntaxInstance<F, G> @Inject constructor(val inject: arrow.typeclasses.Inject<F, G>) : InjectSyntax<F, G> {
+    override fun inject(): arrow.typeclasses.Inject<F, G> = inject
+}
+
+class DaggerMonaderrorSyntaxInstance<F, E> @Inject constructor(val monadError: MonadError<F, E>) : MonadErrorSyntax<F, E> {
+    override fun monadError(): MonadError<F, E> = monadError
+}
+
+class DaggerSemigroupSyntaxInstance<A> @Inject constructor(val semigroup: Semigroup<A>) : SemigroupSyntax<A> {
+    override fun semigroup(): Semigroup<A> = semigroup
+}
+
+class DaggerSemigroupKSyntaxInstance<F> @Inject constructor(val semigroupK: SemigroupK<F>) : SemigroupKSyntax<F> {
+    override fun semigroupK(): SemigroupK<F> = semigroupK
+}
+
+class DaggerMonoidKSyntaxInstance<F> @Inject constructor(val monoidK: MonoidK<F>) : MonoidKSyntax<F> {
+    override fun monoidK(): MonoidK<F> = monoidK
+}
+
+class DaggerReducibleSyntaxInstance<F> @Inject constructor(val reducible: Reducible<F>) : ReducibleSyntax<F> {
+    override fun reducible(): Reducible<F> = reducible
+}

--- a/modules/docs/arrow-docs/docs/docs/quickstart/blogs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/quickstart/blogs/README.md
@@ -14,7 +14,7 @@ A rundown of all the features included in the library.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/IL5XzaCMKpQ?rel=0" frameborder="0" allowfullscreen></iframe>
 
-Lambda World, Cadiz, Nov '17
+Lambda World, Cadiz, Nov '17 - version 0.3.11
 
 ### Kotlin for the Pragmatic Functionalist
 
@@ -22,7 +22,7 @@ An introduction to Arrow and the enhancements it brings to Kotlin's standard lib
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/s9oMED6ZikQ?rel=0" frameborder="0" allowfullscreen></iframe>
 
-KotlinConf, San Francisco, Nov '17
+KotlinConf, San Francisco, Nov '17 - version 0.3.11
 
 ### Architectures Using Functional Programming Concepts
 
@@ -30,7 +30,7 @@ Introductory talk to Functional architectures to be built on top of Arrow.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/qI1ctQ0293o?rel=0" frameborder="0" allowfullscreen></iframe>
 
-KotlinConf, San Francisco, Nov '17
+KotlinConf, San Francisco, Nov '17 - version 0.3.11
 
 ### Building a DSL... in Kotlin
  
@@ -38,7 +38,7 @@ KotlinConf, San Francisco, Nov '17
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kr8iWE4Jfhc" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
 
- droidconSF, San Francisco, Nov '17
+ droidconSF, San Francisco, Nov '17 - version 0.3.11
  
 ### Functional approach to Android architecture using Kotlin
  
@@ -46,7 +46,7 @@ KotlinConf, San Francisco, Nov '17
  
 <iframe width="560" height="315" src="https://www.youtube.com/embed/qGef3sFAIxU" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
  
- Mobilization 7, Łódź, Oct '17
+ Mobilization 7, Łódź, Oct '17 - version 0.3.11
 
 ### Functional Programming in Kotlin
 

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/MonadSuspend.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/MonadSuspend.kt
@@ -8,10 +8,11 @@ import arrow.core.toT
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclass
 import arrow.typeclasses.MonadError
+import arrow.typeclasses.MonadErrorSyntax
 import kotlin.coroutines.experimental.startCoroutine
 
 /** The context required to defer evaluating a safe computation. **/
-@typeclass
+@typeclass(syntax = false)
 interface MonadSuspend<F> : MonadError<F, Throwable>, TC {
     fun <A> suspend(fa: () -> Kind<F, A>): Kind<F, A>
 
@@ -28,6 +29,25 @@ interface MonadSuspend<F> : MonadError<F, Throwable>, TC {
 
     fun <A> deferUnsafe(f: () -> Either<Throwable, A>): Kind<F, A> =
             suspend { f().fold({ raiseError<A>(it) }, { pure(it) }) }
+}
+
+interface MonadSuspendSyntax<F> : MonadErrorSyntax<F, Throwable> {
+
+    fun monadSuspend(): MonadSuspend<F>
+
+    override fun monadError() : MonadError <F, Throwable> = monadSuspend()
+
+    fun <A> kotlin.Function0<arrow.core.Either<kotlin.Throwable, A>>.`deferUnsafe`(dummy: Unit = Unit): arrow.Kind<F, A> =
+            this@MonadSuspendSyntax.monadSuspend().`deferUnsafe`(this)
+
+    fun <A> kotlin.Function0<A>.`invoke`(dummy: Unit = Unit): arrow.Kind<F, A> =
+            this@MonadSuspendSyntax.monadSuspend().`invoke`(this)
+
+    fun `lazy`(): arrow.Kind<F, kotlin.Unit> =
+            this@MonadSuspendSyntax.monadSuspend().`lazy`()
+
+    fun <A> kotlin.Function0<arrow.Kind<F, A>>.`suspend`(dummy: Unit = Unit): arrow.Kind<F, A> =
+            this@MonadSuspendSyntax.monadSuspend().`suspend`(this)
 }
 
 inline fun <reified F, A> (() -> A).defer(SC: MonadSuspend<F> = monadSuspend()): Kind<F, A> = SC(this)


### PR DESCRIPTION
`@typeclass` can now derive syntax instances that extend each other to eliminate all implementation boilerplate. This PR also include the relevant Dagger classes that can be directly injected. Docs will come after testing in a real project as I'm still adjusting the flexibility of this technique.

Auto generated from the `Applicative` Type class:
```kotlin
interface ApplicativeSyntax<F> : arrow.typeclasses.FunctorSyntax<F> {

  fun applicative(): Applicative<F>

  override fun functor() : arrow.typeclasses.Functor <F> = applicative()

  fun <A, B> arrow.Kind<F, A>.`ap`(dummy: Unit = Unit, ff: arrow.Kind<F, kotlin.Function1<A, B>>): arrow.Kind<F, B> =
    this@ApplicativeSyntax.applicative().`ap`(this, ff)

  fun <A, B, Z> arrow.Kind<F, A>.`map2`(dummy: Unit = Unit, fb: arrow.Kind<F, B>, f: kotlin.Function1<arrow.core.Tuple2<A, B>, Z>): arrow.Kind<F, Z> =
    this@ApplicativeSyntax.applicative().`map2`(this, fb, f)

  fun <A, B, Z> arrow.Kind<F, A>.`map2Eval`(dummy: Unit = Unit, fb: arrow.core.Eval<arrow.Kind<F, B>>, f: kotlin.Function1<arrow.core.Tuple2<A, B>, Z>): arrow.core.Eval<arrow.Kind<F, Z>> =
    this@ApplicativeSyntax.applicative().`map2Eval`(this, fb, f)

  fun <A, B> arrow.Kind<F, A>.`product`(dummy: Unit = Unit, fb: arrow.Kind<F, B>): arrow.Kind<F, arrow.core.Tuple2<A, B>> =
    this@ApplicativeSyntax.applicative().`product`(this, fb)

  fun <A> A.`pure`(dummy: Unit = Unit): arrow.Kind<F, A> =
    this@ApplicativeSyntax.applicative().`pure`(this)
}
```