### PR TITLE
Removing async laws duplication

### DIFF
--- a/modules/effects/arrow-effects-rx2/src/test/kotlin/arrow/effects/ObservableKWTests.kt
+++ b/modules/effects/arrow-effects-rx2/src/test/kotlin/arrow/effects/ObservableKWTests.kt
@@ -54,11 +54,8 @@ class ObservableKTest : UnitSpec() {
             traverse<ForObservableK>() shouldNotBe null
         }
 
-        testLaws(AsyncLaws.laws(ObservableK.async(), EQ(), EQ()))
-        testLaws(AsyncLaws.laws(ObservableK.async(), EQ(), EQ()))
-        testLaws(AsyncLaws.laws(ObservableK.async(), EQ(), EQ()))
-
         testLaws(
+                AsyncLaws.laws(ObservableK.async(), EQ(), EQ()),
                 FoldableLaws.laws(ObservableK.foldable(), { ObservableK.pure(it) }, Eq.any()),
                 TraverseLaws.laws(ObservableK.traverse(), ObservableK.functor(), { ObservableK.pure(it) }, EQ())
         )


### PR DESCRIPTION
Removing some unnecessary code in `ObservableKTest`