### PR TITLE
Fix Syntax Diamond Inheritance Issues

### DIFF
--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/common/utils/ProcessorUtils.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/common/utils/ProcessorUtils.kt
@@ -38,6 +38,21 @@ interface ProcessorUtils : KotlinMetadataUtils {
 
     fun ProtoBuf.Function.overrides(o: ProtoBuf.Function): Boolean = false
 
+    fun ClassOrPackageDataWrapper.Class.declaredTypeClassInterfaces(
+            typeTable: TypeTable): List<ClassOrPackageDataWrapper> {
+        val interfaces = this.classProto.supertypes(typeTable).map {
+            it.extractFullName(this, failOnGeneric = false)
+        }.filter {
+                    it != "`arrow`.`TC`"
+                }
+        return interfaces.map { i ->
+            val className = i.removeBackticks().substringBefore("<")
+            val typeClassElement = elementUtils.getTypeElement(className)
+            val parentInterface = getClassOrPackageDataWrapper(typeClassElement)
+            parentInterface as ClassOrPackageDataWrapper.Class
+        }
+    }
+
     fun recurseTypeclassInterfaces(
             current: ClassOrPackageDataWrapper.Class,
             typeTable: TypeTable,

--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/AnnotatedTypeclass.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/tc/AnnotatedTypeclass.kt
@@ -7,4 +7,5 @@ class AnnotatedTypeclass(
         val classElement: TypeElement,
         val classOrPackageProto: ClassOrPackageDataWrapper,
         val superTypes: List<ClassOrPackageDataWrapper.Class>,
+        val diamondTypes: List<ClassOrPackageDataWrapper.Class>,
         val syntax : Boolean)

--- a/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/MonadCombine.kt
+++ b/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/MonadCombine.kt
@@ -7,7 +7,7 @@ import arrow.typeclasses.*
 /**
  * The combination of a Monad with a MonoidK
  */
-@typeclass
+@typeclass(syntax = false)
 interface MonadCombine<F> : MonadFilter<F>, Alternative<F>, TC {
 
     fun <G, A> unite(fga: Kind<F, Kind<G, A>>, FG: Foldable<G>): Kind<F, A> =
@@ -23,3 +23,33 @@ interface MonadCombine<F> : MonadFilter<F>, Alternative<F>, TC {
 inline fun <F, reified G, A> MonadCombine<F>.uniteF(fga: Kind<F, Kind<G, A>>, FG: Foldable<G> = foldable()) = unite(fga, FG)
 
 inline fun <F, reified G, A, B> MonadCombine<F>.separateF(fgab: Kind<F, Kind2<G, A, B>>, BFG: Bifoldable<G> = bifoldable()) = separate(fgab, BFG)
+
+interface MonadCombineSyntax<F> : MonadFilterSyntax<F>, AlternativeSyntax<F> {
+
+    fun monadCombine(): MonadCombine<F>
+
+    override fun monadFilter(): MonadFilter<F> = monadCombine()
+
+    override fun alternative(): Alternative<F> = monadCombine()
+
+    override fun monad(): Monad<F> = monadCombine()
+
+    override fun applicative(): Applicative<F> = monadCombine()
+
+    override fun functor(): Functor<F> = monadCombine()
+
+    override fun functorFilter(): FunctorFilter<F> = monadCombine()
+
+    override fun monoidK(): MonoidK<F> = monadCombine()
+
+    override fun semigroupK(): SemigroupK<F> = monadCombine()
+
+    fun <G, A, B> Kind<F, Kind2<G, A, B>>.`separate`(dummy: Unit = Unit, BFG: Bifoldable<G>): Tuple2<Kind<F, A>, Kind<F, B>> =
+            this@MonadCombineSyntax.monadCombine().`separate`(this, BFG)
+
+    fun <G, A> Kind<F, Kind<G, A>>.`unite`(dummy: Unit = Unit, FG: Foldable<G>): Kind<F, A> =
+            this@MonadCombineSyntax.monadCombine().`unite`(this, FG)
+
+    override fun <A> empty(dummy: Unit): Kind<F, A> =
+            this@MonadCombineSyntax.monadCombine().`empty`()
+}

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/Async.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/Async.kt
@@ -4,15 +4,39 @@ import arrow.Kind
 import arrow.TC
 import arrow.core.Either
 import arrow.typeclass
+import arrow.typeclasses.*
 
         /** An asynchronous computation that might fail. **/
 typealias Proc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
 
 /** The context required to run an asynchronous computation that may fail. **/
-@typeclass
+@typeclass(syntax = false)
 interface Async<F> : MonadSuspend<F>, TC {
     fun <A> async(fa: Proc<A>): Kind<F, A>
 
     fun <A> never(): Kind<F, A> =
             async { }
+}
+
+interface AsyncSyntax<F> : MonadSuspendSyntax<F> {
+
+    fun async(): Async<F>
+
+    override fun monadSuspend(): MonadSuspend<F> = async()
+
+    override fun monadError(): MonadError<F, Throwable> = async()
+
+    override fun applicativeError(): ApplicativeError<F, Throwable> = async()
+
+    override fun applicative(): Applicative<F> = async()
+
+    override fun functor(): Functor<F> = async()
+
+    override fun monad(): Monad<F> = async()
+
+    fun <A> Proc<A>.`async`(dummy: Unit = Unit): Kind<F, A> =
+            this@AsyncSyntax.async().`async`(this)
+
+    fun <A> `never`(dummy: Unit = Unit): Kind<F, A> =
+            this@AsyncSyntax.async().`never`()
 }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/Effect.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/Effect.kt
@@ -4,8 +4,31 @@ import arrow.Kind
 import arrow.TC
 import arrow.core.Either
 import arrow.typeclass
+import arrow.typeclasses.*
 
-@typeclass
+@typeclass(syntax = false)
 interface Effect<F> : Async<F>, TC {
     fun <A> runAsync(fa: Kind<F, A>, cb: (Either<Throwable, A>) -> Kind<F, Unit>): Kind<F, Unit>
+}
+
+interface EffectSyntax<F> : AsyncSyntax<F> {
+
+    fun effect(): Effect<F>
+
+    override fun async() : Async <F> = effect()
+
+    override fun monadSuspend() : MonadSuspend <F> = effect()
+
+    override fun monadError() : MonadError<F, Throwable> = effect()
+
+    override fun applicativeError() : ApplicativeError<F, Throwable> = effect()
+
+    override fun applicative() : Applicative<F> = effect()
+
+    override fun functor() : Functor<F> = effect()
+
+    override fun monad() : Monad<F> = effect()
+
+    fun <A> Kind<F, A>.`runAsync`(dummy: Unit = Unit, cb: kotlin.Function1<arrow.core.Either<kotlin.Throwable, A>, arrow.Kind<F, kotlin.Unit>>): Kind<F, kotlin.Unit> =
+            this@EffectSyntax.effect().`runAsync`(this, cb)
 }


### PR DESCRIPTION
Fix for Syntax derivation so we cna solve some of the diamond related issues caused by subtyping when generating Syntax type classes.
A type class such as `MonadErrorSyntax` know now it has to `override fun applicative(): Applicative` as this appears both in the `MonadSyntax` and `ApplicativeError` declarations.

Codegen looks like:

```kotlin
interface MonadErrorSyntax<F, E> : arrow.typeclasses.ApplicativeErrorSyntax<F, E>, arrow.typeclasses.MonadSyntax<F> {

  fun monadError(): MonadError<F, E>

  override fun applicativeError() : arrow.typeclasses.ApplicativeError <F, E> = monadError()

  override fun monad() : arrow.typeclasses.Monad <F> = monadError()

  override fun applicative() : arrow.typeclasses.Applicative <F> = monadError()

  override fun functor() : arrow.typeclasses.Functor <F> = monadError()

  fun <A> arrow.Kind<F, A>.`ensure`(dummy: Unit = Unit, error: kotlin.Function0<E>, predicate: kotlin.Function1<A, kotlin.Boolean>): arrow.Kind<F, A> =
    this@MonadErrorSyntax.monadError().`ensure`(this, error, predicate)
}

```