### PR TITLE
Invariant F in Kinds

### DIFF
--- a/modules/core/arrow-annotations/src/main/java/arrow/hks.kt
+++ b/modules/core/arrow-annotations/src/main/java/arrow/hks.kt
@@ -1,6 +1,6 @@
 package arrow
 
-interface Kind<out F, out A>
+interface Kind<F, out A>
 
 typealias Kind2<F, A, B> = Kind<Kind<F, A>, B>
 


### PR DESCRIPTION
Forces F in Kind to be invariant. As Witness types are not expected to be inherited from, covariance is pointless.