### PR TITLE
Moves `Try` to `arrow-core` 

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
@@ -1,9 +1,7 @@
-package arrow.data
+package arrow.core
 
 import arrow.*
-import arrow.core.*
 import arrow.legacy.*
-import arrow.typeclasses.Applicative
 
 typealias Failure<A> = Try.Failure<A>
 typealias Success<A> = Try.Success<A>
@@ -49,9 +47,6 @@ sealed class Try<out A> : TryOf<A> {
 
     @Deprecated(DeprecatedUnsafeAccess, ReplaceWith("getOrElse { ifEmpty }"))
     operator fun invoke() = get()
-
-    fun <G, B> traverse(f: (A) -> Kind<G, B>, GA: Applicative<G>): Kind<G, Try<B>> =
-            this.fix().fold({ GA.pure(raise(it)) }, { GA.map(f(it), { Try { it } }) })
 
     fun <B> ap(ff: TryOf<(A) -> B>): Try<B> = ff.fix().flatMap { f -> map(f) }.fix()
 

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/StateTTests.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/StateTTests.kt
@@ -2,6 +2,9 @@ package arrow.data
 
 import arrow.Kind
 import arrow.core.ForId
+import arrow.core.ForTry
+import arrow.core.Try
+import arrow.core.monad
 import arrow.mtl.instances.StateTMonadStateInstance
 import arrow.mtl.monadState
 import arrow.test.UnitSpec
@@ -16,7 +19,7 @@ import org.junit.runner.RunWith
 @RunWith(KTestJUnitRunner::class)
 class StateTTests : UnitSpec() {
 
-    val M: StateTMonadStateInstance<ForTry, Int> = StateT.monadState<ForTry, Int>(Try.monad())
+    val M: StateTMonadStateInstance<ForTry, Int> = StateT.monadState(Try.monad())
 
     val EQ: Eq<StateTOf<ForTry, Int, Int>> = Eq { a, b ->
         a.runM(1, Try.monad()) == b.runM(1, Try.monad())

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
@@ -1,5 +1,6 @@
 package arrow.data
 
+import arrow.core.*
 import arrow.syntax.applicative.map
 import arrow.test.UnitSpec
 import arrow.test.laws.EqLaws

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/ValidatedTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/ValidatedTest.kt
@@ -1,13 +1,10 @@
 package arrow.data
 
+import arrow.core.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.fail
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldNotBe
-import arrow.core.Left
-import arrow.core.None
-import arrow.core.Right
-import arrow.core.Some
 import arrow.instances.*
 import arrow.syntax.applicative.map
 import arrow.syntax.validated.valid

--- a/modules/core/arrow-examples/src/test/kotlin/arrow/DataTypeExamples.kt
+++ b/modules/core/arrow-examples/src/test/kotlin/arrow/DataTypeExamples.kt
@@ -119,7 +119,7 @@ class DataTypeExamples : FreeSpec() { init {
             val gain = Try { playLottery(99) }
             gain.recover { 0 } shouldBe Try.Success(0)
 
-            gain.recoverWith { Try { playLottery(42)} } shouldBe Try.Success(1000)
+            gain.recoverWith { Try { playLottery(42) } } shouldBe Try.Success(1000)
         }
 
         "Fold" {

--- a/modules/core/arrow-instances/src/main/kotlin/arrow/instances/try.kt
+++ b/modules/core/arrow-instances/src/main/kotlin/arrow/instances/try.kt
@@ -1,9 +1,7 @@
 package arrow.instances
 
 import arrow.Kind
-import arrow.core.Either
-import arrow.core.Eval
-import arrow.data.*
+import arrow.core.*
 import arrow.instance
 import arrow.typeclasses.*
 
@@ -100,6 +98,9 @@ interface TryFoldableInstance : Foldable<ForTry> {
     override fun <A, B> foldRight(fa: TryOf<A>, lb: Eval<B>, f: kotlin.Function2<A, Eval<B>, Eval<B>>): Eval<B> =
             fa.fix().foldRight(lb, f)
 }
+
+fun <A, B, G> Try<A>.traverse(f: (A) -> Kind<G, B>, GA: Applicative<G>): Kind<G, Try<B>> =
+        this.fix().fold({ GA.pure(Try.raise(it)) }, { GA.map(f(it), { Try { it } }) })
 
 @instance(Try::class)
 interface TryTraverseInstance : Traverse<ForTry> {

--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/try/try.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/try/try.kt
@@ -1,9 +1,6 @@
 package arrow.syntax.`try`
 
 import arrow.core.*
-import arrow.data.Try
-import arrow.data.applicative
-import arrow.data.fix
 import arrow.syntax.applicative.tupled
 
 @Deprecated(DeprecatedAmbiguity, ReplaceWith("Try { body }.toOption()"))

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadSuspendLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadSuspendLaws.kt
@@ -4,8 +4,8 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
-import arrow.data.Try
-import arrow.data.recover
+import arrow.core.Try
+import arrow.core.recover
 import arrow.effects.MonadSuspend
 import arrow.effects.bindingCancellable
 import arrow.effects.data.internal.BindingCancellationException

--- a/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/try.kt
+++ b/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/try.kt
@@ -1,6 +1,6 @@
 package arrow.dagger.instances
 
-import arrow.data.*
+import arrow.core.*
 import arrow.typeclasses.*
 import dagger.Module
 import dagger.Provides

--- a/modules/dagger/arrow-dagger/src/test/kotlin/arrow/dagger/instances/tests/instances.kt
+++ b/modules/dagger/arrow-dagger/src/test/kotlin/arrow/dagger/instances/tests/instances.kt
@@ -1,9 +1,6 @@
 package arrow.dagger.instances.tests
 
-import arrow.core.EitherPartialOf
-import arrow.core.ForEval
-import arrow.core.ForId
-import arrow.core.ForOption
+import arrow.core.*
 import arrow.dagger.instances.*
 import arrow.data.*
 import arrow.typeclasses.*

--- a/modules/docs/arrow-docs/docs/docs/datatypes/try/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/try/README.md
@@ -59,7 +59,7 @@ However, we could use `Try` to retrieve the computation result in a much cleaner
 
 ```kotlin:ank
 import arrow.*
-import arrow.data.*
+import arrow.core.*
 
 val lotteryTry = Try { getLotteryNumbers() }
 lotteryTry

--- a/modules/docs/arrow-docs/src/main/java/arrow/debug/debug.kt
+++ b/modules/docs/arrow-docs/src/main/java/arrow/debug/debug.kt
@@ -1,7 +1,7 @@
 package arrow.debug
 
 import arrow.TC
-import arrow.data.Try
+import arrow.core.Try
 import arrow.effects.Async
 import arrow.effects.Effect
 import arrow.effects.MonadSuspend

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKW.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKW.kt
@@ -1,7 +1,7 @@
 package arrow.effects
 
 import arrow.core.*
-import arrow.data.Try
+import arrow.core.Try
 import arrow.deriving
 import arrow.higherkind
 import arrow.typeclasses.Applicative

--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/instances/try.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/instances/try.kt
@@ -1,8 +1,8 @@
 package arrow.optics.instances
 
-import arrow.data.Try
-import arrow.data.TryOf
-import arrow.data.traverse
+import arrow.core.Try
+import arrow.core.TryOf
+import arrow.core.traverse
 import arrow.instance
 import arrow.optics.Traversal
 import arrow.optics.typeclasses.Each

--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/std/try.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/std/try.kt
@@ -2,10 +2,6 @@ package arrow.optics
 
 import arrow.core.*
 import arrow.data.*
-import arrow.optics.Iso
-import arrow.optics.PIso
-import arrow.optics.PPrism
-import arrow.optics.Prism
 import arrow.syntax.validated.*
 
 /**

--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/std/validated.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/std/validated.kt
@@ -2,10 +2,8 @@ package arrow.optics
 
 import arrow.core.*
 import arrow.data.*
-import arrow.data.Failure
-import arrow.data.Success
-import arrow.optics.Iso
-import arrow.optics.PIso
+import arrow.core.Failure
+import arrow.core.Success
 
 /**
  * [PIso] that defines equality between [Validated] and [Either]

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/OptionalTest.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/OptionalTest.kt
@@ -1,12 +1,6 @@
 package arrow.optics
 
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.eq
-import arrow.core.foldable
-import arrow.core.getOrElse
-import arrow.data.Try
-import arrow.data.applicative
+import arrow.core.*
 import arrow.data.k
 import arrow.syntax.collections.firstOption
 import arrow.syntax.either.left

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/instances/EachInstanceTest.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/instances/EachInstanceTest.kt
@@ -5,7 +5,7 @@ import arrow.core.EitherPartialOf
 import arrow.core.Option
 import arrow.data.ListK
 import arrow.data.MapK
-import arrow.data.Try
+import arrow.core.Try
 import arrow.optics.typeclasses.each
 import arrow.test.UnitSpec
 import arrow.test.generators.genEither

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/std/ValidatedInstancesTest.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/std/ValidatedInstancesTest.kt
@@ -3,9 +3,8 @@ package arrow.optics
 import arrow.core.Either
 import arrow.core.applicative
 import arrow.core.fix
-import arrow.data.Try
+import arrow.core.Try
 import arrow.data.applicative
-import arrow.data.fix
 import arrow.syntax.either.right
 import arrow.test.UnitSpec
 import arrow.test.generators.*


### PR DESCRIPTION
Since `Try` is a popular used data type along with other core ones like `Option` we are moving it to `arrow-core` with the intent of reducing the need for users to depend on `arrow-data` if they don't plan on using other more advanced data types.