### PR TITLE
Allow exception to propagate from fold Success function

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
@@ -81,17 +81,11 @@ sealed class Try<out A> : TryOf<A> {
 
     /**
      * Applies `fa` if this is a `Failure` or `fb` if this is a `Success`.
-     * If `fb` is initially applied and throws an exception,
-     * then `fa` is applied with this exception.
      */
     inline fun <B> fold(fa: (Throwable) -> B, fb: (A) -> B): B =
             when (this) {
                 is Failure -> fa(exception)
-                is Success -> try {
-                    fb(value)
-                } catch (e: Throwable) {
-                    fa(e)
-                }
+                is Success -> fb(value)
             }
 
     abstract fun isFailure(): Boolean

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
@@ -9,7 +9,9 @@ import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.matchers.beTheSameInstanceAs
 import io.kotlintest.matchers.fail
+import io.kotlintest.matchers.should
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldEqual
 import io.kotlintest.matchers.shouldNotBe
@@ -76,8 +78,14 @@ class TryTest : UnitSpec() {
             Success(1).fold({ 2 }, { 3 }) shouldBe 3
         }
 
-        "fold should call left function on Success with exception" {
-            Success(1).fold({ 2 }, { throw Exception() }) shouldBe 2
+        "fold should propagate exception from Success with exception" {
+            Exception().let { ex ->
+                try {
+                    Success(1).fold({ 2 }, { throw ex })
+                } catch (e: Exception) {
+                    ex should beTheSameInstanceAs(e)
+                }
+            }
         }
 
         "getOrDefault returns default if Failure" {


### PR DESCRIPTION
Handling a failed Success as if it was the same as original Failure is not the way it is done in cats. I would argue this makes for a better fold function.
