### PR TITLE
Semigroup `+` syntax

### DIFF
--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/listk.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/listk.kt
@@ -8,11 +8,12 @@ import arrow.data.*
 import arrow.instance
 import arrow.typeclasses.*
 import arrow.data.combineK as listCombineK
+import kotlin.collections.plus as listPlus
 
 @instance(ListK::class)
 interface ListKSemigroupInstance<A> : Semigroup<ListK<A>> {
   override fun ListK<A>.combine(b: ListK<A>): ListK<A> =
-    (this + b).k()
+    (this.listPlus(b)).k()
 }
 
 @instance(ListK::class)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/set.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/set.kt
@@ -6,10 +6,12 @@ import arrow.data.*
 import arrow.instance
 import arrow.typeclasses.*
 import arrow.data.combineK as setCombineK
+import kotlin.collections.plus as setPlus
 
 @instance(SetK::class)
 interface SetKSemigroupInstance<A> : Semigroup<SetK<A>> {
-  override fun SetK<A>.combine(b: SetK<A>): SetK<A> = (this + b).k()
+  override fun SetK<A>.combine(b: SetK<A>): SetK<A> =
+    (this.setPlus(b)).k()
 }
 
 @instance(SetK::class)

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Semigroup.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Semigroup.kt
@@ -11,6 +11,9 @@ interface Semigroup<A> {
    */
   fun A.combine(b: A): A
 
+  operator fun A.plus(b: A): A =
+    this.combine(b)
+
   fun A.maybeCombine(b: A?): A = Option.fromNullable(b).fold({ this }, { combine(it) })
 
 }

--- a/modules/docs/arrow-docs/docs/docs/typeclasses/semigroup/README.md
+++ b/modules/docs/arrow-docs/docs/docs/typeclasses/semigroup/README.md
@@ -53,4 +53,12 @@ Option.monoid<Int>(Int.semigroup()).run { Option(1).combine(None) }
 
 Many of these types have methods defined directly on them, which allow for such combining, e.g. `+` on `List`, but the value of having a `Semigroup` typeclass available is that these compose.
 
+Additionaly `Semigroup` adds `+` syntax to all types for which a Semigroup instance exists:
+
+```kotlin:ank
+Option.monoid<Int>(Int.semigroup()).run { 
+  Option(1) + Option(2)
+}
+```
+
 Contents partially adapted from [Scala Exercises Cat's Semigroup Tutorial](https://www.scala-exercises.org/cats/semigroup)


### PR DESCRIPTION
Adds `+` to all `A` for which a `Semigroup` instance exists

```kotlin
operator fun A.plus(b: A): A =
  this.combine(b)
```