### PR TITLE
Upgrade Kotlin and kotlinx.coroutines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ buildscript {
         gradleVersionsPluginVersion = '0.17.0'
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = '2.0.7'
-        kotlinVersion = '1.2.20'
+        kotlinVersion = '1.2.31'
         daggerVersion = '2.5'
-        kotlinxCoroutinesVersion = '0.21.2'
+        kotlinxCoroutinesVersion = '0.22.5'
         kotlinxCollectionsImmutableVersion = '0.1'
     }
 


### PR DESCRIPTION
Not requested but required anyways to avoid version conflicts on client projects / libs.
* Upgraded Kotlin to [last stable release](https://github.com/JetBrains/kotlin/releases/tag/v1.2.31).
* Upgraded kotlinx.coroutines to [last version available](https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/0.22.5).

Tests are passing.