### PR TITLE
Arrow 0.7 War Room, day 2

### DIFF
--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/boolean.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/boolean.kt
@@ -1,0 +1,29 @@
+package arrow.instances
+
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Show
+
+interface BooleanShowInstance: Show<Boolean> {
+  override fun Boolean.show(): String =
+    this.toString()
+}
+
+interface BooleanEqInstance : Eq<Boolean> {
+  override fun Boolean.eqv(b: Boolean): Boolean = this == b
+}
+
+// FIXME
+//fun Boolean.Companion.show(): Show<Boolean> =
+//  object : BooleanShowInstance {}
+//
+//fun Boolean.Companion.eq(): Eq<Boolean> =
+//  object : BooleanEqInstance {}
+
+object BooleanInstances {
+
+  fun show(): Show<Boolean> =
+    object : BooleanShowInstance {}
+
+  fun eq(): Eq<Boolean> =
+    object : BooleanEqInstance {}
+}

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/char.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/char.kt
@@ -2,6 +2,12 @@ package arrow.instances
 
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Order
+import arrow.typeclasses.Show
+
+interface CharShowInstance: Show<Char> {
+  override fun Char.show(): String =
+    this.toString()
+}
 
 interface CharEqInstance : Eq<Char> {
   override fun Char.eqv(b: Char): Boolean = this == b
@@ -23,6 +29,9 @@ interface CharOrderInstance : Order<Char> {
 
   override fun Char.neqv(b: Char): Boolean = this != b
 }
+
+fun Char.Companion.show(): Show<Char> =
+  object : CharShowInstance {}
 
 fun Char.Companion.eq(): Eq<Char> =
   object : CharEqInstance {}

--- a/modules/docs/arrow-docs/docs/_data/menu.yml
+++ b/modules/docs/arrow-docs/docs/_data/menu.yml
@@ -56,6 +56,9 @@ options:
       - title: Intro
         url: /docs/datatypes/intro/
 
+      - title: Basic Types
+        url: /docs/datatypes/basic/
+
       - title: Option
         url: /docs/datatypes/option/
 

--- a/modules/docs/arrow-docs/docs/docs/datatypes/basic/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/basic/README.md
@@ -1,0 +1,54 @@
+---
+layout: docs
+title: Basic Types
+permalink: /docs/datatypes/basic/
+---
+
+## Basic Types
+
+Arrow provides [typeclass]({{ '/docs/patterns/glossary/' | relative_url }}) instances for several platform types.
+These instances are available in the module `arrow-instances`.
+
+### Numbers
+
+- [`Show`]({{ '/docs/typeclasses/show/' | relative_url }})
+
+- [`Eq`]({{ '/docs/typeclasses/eq/' | relative_url }})
+
+- [`Order`]({{ '/docs/typeclasses/order/' | relative_url }})
+
+- [`Semigroup`]({{ '/docs/typeclasses/semigroup/' | relative_url }})
+
+- [`Monoid`]({{ '/docs/typeclasses/monoid/' | relative_url }})
+
+### String
+
+- [`Show`]({{ '/docs/typeclasses/show/' | relative_url }})
+
+- [`Eq`]({{ '/docs/typeclasses/eq/' | relative_url }})
+
+- [`Order`]({{ '/docs/typeclasses/order/' | relative_url }})
+
+- [`Semigroup`]({{ '/docs/typeclasses/semigroup/' | relative_url }})
+
+- [`Monoid`]({{ '/docs/typeclasses/monoid/' | relative_url }})
+
+- [`FilterIndex`]({{ '/docs/optics/filterindex/' | relative_url }})
+
+- [`Index`]({{ '/docs/optics/index/' | relative_url }})
+
+### Boolean
+
+Note that because Boolean doesn't have a companion object you'll find these in `BooleanInstances`.
+
+- [`Show`]({{ '/docs/typeclasses/show/' | relative_url }})
+
+- [`Eq`]({{ '/docs/typeclasses/eq/' | relative_url }})
+
+### Char
+
+- [`Show`]({{ '/docs/typeclasses/show/' | relative_url }})
+
+- [`Eq`]({{ '/docs/typeclasses/eq/' | relative_url }})
+
+- [`Order`]({{ '/docs/typeclasses/order/' | relative_url }})


### PR DESCRIPTION
Tasklist, prioritised (X means completed): https://pastebin.com/ptLHjwQu

## Code
 
- [x] Move invoke functions inside typeclasses
- [x] Make sure that all typeclass requirements are the first parameter in data types
- [ ] Make sure that all typeclasses are implemented as extfuns on Kind, except for the constructors
- [ ] All existing KDocs match their method signature
- [x] Get https://github.com/arrow-kt/arrow/pull/669 in
- [x]  2 spaces everywhere
- [x] Remove unnecessary labels this@blabla
- [ ] BONUS: Add KDocs at will
- [ ] BONUS IF YOU WANT TO MAKE PACO HAPPY: everything that's an expression body starts on the next line EXCEPT methods that start with `TYPECLASS.run {`. Those stay on the same line.
- [x] Relocate `Const` to avoid `free` dependencies on `optics` and `mtl` modules
 
## Docs
 
- [x] Redo the typeclass intro doc
- [x] Redo the glossary
- [ ] Write a section on Dependency Injection for new typeclass encodign
- [ ] List typeclasses available for platform types
- [x] All datatypes list the typeclasses they implement an instance for
- [ ] All typeclasses list the datatypes they're implemented for
- [x] Re-read all the typeclasses and see if they make sense with the new encoding
- [ ] Re-read all code examples in datatypes and see if they make sense with the new encoding
- [ ] Syntax sections only where necessary: Option, Either, Try, IO...
- [x] Review examples is Kleisli, as they apparently don't compile
- [ ] Add shapeless license?
- [ ] BONUS: List which module (core/data) each datatype belongs to
- [ ] BONUS: easy docs, i.e. ListK, MapK, SortedMapK
- [ ] BONUS: Docs on funKtionale helpers
- [x] Uberto's findings (COMPLETED): https://pastebin.com/kwbUEuDW