### PR TITLE
Generate isos up to arity 22

### DIFF
--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/optics/IsosFileGenerator.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/optics/IsosFileGenerator.kt
@@ -11,7 +11,7 @@ class IsosFileGenerator(
 
   private val filePrefix = "isos"
   private val tuple = "arrow.core.Tuple"
-  private val letters = ('a'..'j').toList()
+  private val letters = ('a'..'v').toList()
 
   fun generate() = buildIsos(annotatedList)
 

--- a/modules/core/arrow-annotations-processor/src/main/java/arrow/optics/OpticsProcessor.kt
+++ b/modules/core/arrow-annotations-processor/src/main/java/arrow/optics/OpticsProcessor.kt
@@ -102,10 +102,10 @@ class OptikalProcessor : AbstractProcessor() {
     (element.kotlinMetadata as? KotlinClassMetadata)?.data?.classProto?.isDataClass == true -> {
       val properties = element.getConstructorTypesNames().zip(element.getConstructorParamNames(), Target.Companion::invoke)
 
-      if (properties.size > 10) {
+      if (properties.size > 22) {
         logW("""
           |Cannot generate arrow.optics.Iso for ${element.enclosingElement}.${element.simpleName}.
-          |Iso generation is supported up to 10 constructor parameters is supported
+          |Iso generation is supported up to 22 constructor parameters.
           """)
         null
       } else AnnotatedOptic(element as TypeElement, element.getClassData(), properties)


### PR DESCRIPTION
With arrow-generic we can now support the generation of `Iso` up to Tuple22.