### PR TITLE
Remove references to bindAsync

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/effects/async/README.md
+++ b/modules/docs/arrow-docs/docs/docs/effects/async/README.md
@@ -80,46 +80,6 @@ IO.async()
 > never() exists to test datatypes that can handle non-termination.
 For example, IO has unsafeRunTimed that runs never() safely.
 
-### Syntax available inside Monad Comprehensions
-
-All the syntax functions are geared towards using `Async` inside [Monad Comprehension]({{ '/docs/patterns/monad_comprehensions' | relative_url }})
-to create blocks of code to be run asynchronously.
-
-#### binding#bindAsync
-
-Runs a function parameter in the Async passed as a parameter,
-and then awaits for the result before continuing the execution.
-
-Note that there is no automatic error handling or wrapping of exceptions.
-
-```kotlin
-IO.monad().binding {
-  val a = bindAsync(IO.async()) { fibonacci(100) }
-  a + 1
-}.fix().unsafeRunSync()
-```
-
-#### binding#bindAsyncUnsafe
-
-Runs a function parameter in the Async passed as a parameter,
-and then awaits for the result before continuing the execution.
-
-While there is no wrapping of exceptions, the left side of the [`Either`]({{ '/docs/datatypes/either' | relative_url }}) represents an error in the execution.
-
-```kotlin
-IO.monad().binding {
-  val a = bindAsync(IO.async()) { fibonacci(100).left() }
-  a + 1
-}.fix().unsafeRunSync()
-```
-
-```kotlin
-IO.monad().binding {
-  val a = bindAsync(IO.async()) { RuntimeException("Boom").right() }
-  a + 1
-}.fix().unsafeRunSync()
-```
-
 ### Laws
 
 Arrow provides `AsyncLaws` in the form of test cases for internal verification of lawful instances and third party apps creating their own `Async` instances.

--- a/modules/docs/arrow-docs/docs/docs/integrations/rx2/README.md
+++ b/modules/docs/arrow-docs/docs/docs/integrations/rx2/README.md
@@ -139,7 +139,7 @@ val (observable, disposable) =
   ObservableK.monadDefer().bindingCancellable {
     val userProfile = Observable.create { getUserProfile("123") }
     val friendProfiles = userProfile.friends().map { friend ->
-        bindAsync(observableAsync) { getProfile(friend.id) }
+        bindDefer { getProfile(friend.id) }
     }
     listOf(userProfile) + friendProfiles
   }

--- a/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
+++ b/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
@@ -234,9 +234,9 @@ As cleanup is important in these restricted environments, any instance of [`Mona
 ```kotlin
 val (binding: IO<List<User>>, unsafeCancel: Disposable) =
   ioSync.bindingCancellable {
-    val userProfile = bindAsync(ioAsync) { getUserProfile("123") }
+    val userProfile = bindDefer { getUserProfile("123") }
     val friendProfiles = userProfile.friends().map { friend ->
-        bindAsync(ioAsync) { getProfile(friend.id) }
+        bindDefer { getProfile(friend.id) }
     }
     listOf(userProfile) + friendProfiles
   }


### PR DESCRIPTION
Leftovers from the last refactor to comprehensions.