### PR TITLE
EitherT: add .value()

### DIFF
--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/EitherT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/EitherT.kt
@@ -10,6 +10,8 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 
+fun <F, A, B> EitherTOf<F, A, B>.value() = fix().value
+
 /**
  * [EitherT]`<F, A, B>` is a light wrapper on an `F<`[Either]`<A, B>>` with some
  * convenient methods for working with this nested structure.


### PR DESCRIPTION
Adds `.value()` shorthand for `.fix().value`, similar to what Id currently has.