### PR TITLE
Minor typo fix

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
+++ b/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
@@ -108,7 +108,7 @@ IO.monad().binding {
 }.fix().unsafeRunSync()
 ```
 
-What `bind()` does is use the rest of the sequential operations as the function you'd normally past to `flatMap`.
+What `bind()` does is use the rest of the sequential operations as the function you'd normally pass to `flatMap`.
 The equivalent code without using comprehensions would look like:
 
 ```kotlin:ank


### PR DESCRIPTION
I think 'pass' works better than 'past' here.