### PR TITLE
Prevent Either::map and Either::flatMap creating a new Left

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -106,7 +106,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   inline fun <C> map(crossinline f: (B) -> C): Either<A, C> =
       when (this) {
         is Right -> Right(f(b))
-        is Left -> this as Left<Nothing, C>
+        is Left -> this as Left<A, Nothing>
       }
 
   /**

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -102,8 +102,12 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * Left(12).map { "flower" }  // Result: Left(12)
    * ```
    */
+  @Suppress("UNCHECKED_CAST")
   inline fun <C> map(crossinline f: (B) -> C): Either<A, C> =
-    fold({ Left(it) }, { Right(f(it)) })
+      when (this) {
+        is Right -> Right(f(b))
+        is Left -> this as Left<Nothing, C>
+      }
 
   /**
    * The given function is applied if this is a `Left`.
@@ -222,8 +226,14 @@ fun <R> Right(right: R): Either<Nothing, R> = Either.right(right)
  *
  * @param f The function to bind across [Either.Right].
  */
+@Suppress("UNCHECKED_CAST")
 fun <A, B, C> EitherOf<A, B>.flatMap(f: (B) -> Either<A, C>): Either<A, C> =
-  fix().fold({ Left(it) }, { f(it) })
+  fix().let {
+    when (it) {
+      is Right -> f(it.b)
+      is Left -> it as Left<A, Nothing>
+    }
+  }
 
 /**
  * Returns the value from this [Either.Right] or the given argument if this is a [Either.Left].

--- a/modules/docs/arrow-docs/docs/docs/datatypes/listk/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/listk/README.md
@@ -6,7 +6,7 @@ permalink: /docs/datatypes/listk/
 
 ## ListK
 
-ListK wraps over the platform `List` type to make it a (type constructor)[/docs/patterns/glossary/#type-constructors].
+ListK wraps over the platform `List` type to make it a [type constructor](/docs/patterns/glossary/#type-constructors).
 
 It can be created from Kotlin List type with a convenient `k()` function.
 
@@ -39,7 +39,7 @@ hello.combineK(commaSpace).combineK(world)
 
 The functions `traverse` and `sequence` come from [`Traverse`](/docs/typeclasses/traverse/).
 
-Traversing a list creates a new container (`Kind<F, A>`)[/docs/patterns/glossary/#type-constructors] by combining the result of a function applied to each element:
+Traversing a list creates a new container [`Kind<F, A>`](/docs/patterns/glossary/#type-constructors) by combining the result of a function applied to each element:
 
 ```kotlin:ank
 import arrow.core.*


### PR DESCRIPTION
A number of Either operations could be optimized I think, this is the low-hanging fruit 