### PR TITLE
Add extra tips for running IO

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/effects/io/README.md
+++ b/modules/docs/arrow-docs/docs/docs/effects/io/README.md
@@ -23,6 +23,8 @@ Running in this context means evaluating the content of an `IO` object, and prop
 
 Note that `IO` objects can be run multiple times, and depending on how they are constructed they will evaluate its content again every time they're run.
 
+The general good practice is to have a single unsafe run call per program, at the entry point. In backend applications or command line tools this can be at the main. For Android apps, specially those before Android 9.0, this could happen per Activity.
+
 ### attempt
 
 Executes and defers the result into a new `IO` that has captured any exceptions inside `Either<Throwable, A>`.
@@ -39,6 +41,8 @@ Takes as a parameter a callback from a result of `Either<Throwable, A>` to a new
 All exceptions that would happen on the function parameter are automatically captured and propagated to the `IO<Unit>` return.
 
 It runs the current `IO` asynchronously, calling the callback parameter on completion and returning its result.
+
+The operation will not yield a result immediately; ultimately to start running the suspended computation you have to evaluate that new instance using an unsafe operator like `unsafeRunAsync` or `unsafeRunSync` for `IO`.
 
 ```kotlin
 IO<Int> { throw RuntimeException("Boom!") }


### PR DESCRIPTION
Requested on gitter, it explains why `runAsync` doesn't start immediately.