### PR TITLE
AwaitAll for Traverse Deferred<T>

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         kotlinTestVersion = '2.0.7'
         kotlinVersion = '1.2.41'
         daggerVersion = '2.15'
-        kotlinxCoroutinesVersion = '0.22.5'
+        kotlinxCoroutinesVersion = '0.23.3'
         kotlinxCollectionsImmutableVersion = '0.1'
     }
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/build.gradle
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     kaptTest project(':arrow-annotations-processor')
     compileOnly project(':arrow-annotations-processor')
     testCompileOnly project(':arrow-annotations-processor')
+    testCompile project(':arrow-instances-data')
     testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
     testCompile project(':arrow-test')
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -1,8 +1,12 @@
 package arrow.effects
 
+import arrow.Kind
 import arrow.core.*
+import arrow.data.fix
+import arrow.data.sequence
 import arrow.effects.typeclasses.Proc
 import arrow.higherkind
+import arrow.typeclasses.Traverse
 import kotlinx.coroutines.experimental.*
 import kotlin.coroutines.experimental.CoroutineContext
 
@@ -110,3 +114,7 @@ fun <A> DeferredKOf<A>.unsafeRunAsync(cb: (Either<Throwable, A>) -> Unit): Unit 
   }
 
 suspend fun <A> DeferredKOf<A>.await(): A = this.fix().await()
+
+suspend fun <F, A> Kind<F, DeferredKOf<A>>.awaitAll(T: Traverse<F>): Kind<F, A> = T.run {
+    this@awaitAll.sequence(DeferredK.applicative()).await()
+}

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/test/kotlin/arrow/effects/DeferredTest.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/test/kotlin/arrow/effects/DeferredTest.kt
@@ -1,13 +1,18 @@
 package arrow.effects
 
 import arrow.Kind
+import arrow.core.*
+import arrow.data.*
 import arrow.test.UnitSpec
 import arrow.test.generators.genIntSmall
 import arrow.test.laws.AsyncLaws
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Functor
+import arrow.typeclasses.Traverse
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.fail
 import io.kotlintest.matchers.shouldBe
+import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import kotlinx.coroutines.experimental.CoroutineStart
 import kotlinx.coroutines.experimental.Unconfined
@@ -18,6 +23,10 @@ import org.junit.runner.RunWith
 class DeferredKTest : UnitSpec() {
   fun <A> EQ(): Eq<Kind<ForDeferredK, A>> = Eq { a, b ->
     a.unsafeAttemptSync() == b.unsafeAttemptSync()
+  }
+
+  suspend fun <F, A> checkAwaitAll(FF: Functor<F>, T: Traverse<F>, v: Kind<F, A>) = FF.run {
+    v.map { DeferredK { it } }.awaitAll(T) == v
   }
 
   init {
@@ -125,6 +134,17 @@ class DeferredKTest : UnitSpec() {
         fail("${throwable.message}")
       } catch (throwable: Throwable) {
         // Success
+      }
+    }
+
+    "awaitAll called on a Traverse instance of Kind<F, DeferredK<T>> should return a Traverse instance of Kind<F, T>" {
+      forAll(Gen.string(), Gen.list(Gen.string())) { x, xs ->
+        runBlocking {
+          checkAwaitAll(ListK.functor(), ListK.traverse(), xs.k()) &&
+          checkAwaitAll(NonEmptyList.functor(), NonEmptyList.traverse(), NonEmptyList(x, xs)) &&
+          checkAwaitAll(Option.functor(), Option.traverse(), Option.just(x)) &&
+          checkAwaitAll(Try.functor(), Try.traverse(), Try.just(x))
+        }
       }
     }
   }


### PR DESCRIPTION
For #884, 
This adds awaitAll to any F<DeferredK<T>> that returns F<T> where F has a traverse instance 