### PR TITLE
Inject method to restore scroll position after focus into searchbar

### DIFF
--- a/modules/docs/arrow-docs/docs/_includes/_doc-wrapper.html
+++ b/modules/docs/arrow-docs/docs/_includes/_doc-wrapper.html
@@ -1,7 +1,7 @@
 <div id="doc-wrapper">
     <div class="doc-header">
         <div class="search-wrapper">
-          <input id="docsearch" class="search" placeholder="Search documentation..." type="search" autofocus="autofocus">
+          <input id="docsearch" class="search" placeholder="Search documentation..." type="search">
         </div>
         <a target="_blank"
           href="{{site.data.commons.github_repository}}/edit/master/modules/docs/arrow-docs/docs{{page.url | replace: '_', ''}}README.md">

--- a/modules/docs/arrow-docs/docs/js/functions.js
+++ b/modules/docs/arrow-docs/docs/js/functions.js
@@ -13,8 +13,17 @@
     $(document).ready(function() {
 
         // To focus the searchbar on load. Autofocus won't work since, in the end,
-        // the input is injected externally by the Algolia autocomplete.js library
+        // the input is injected externally by the Algolia autocomplete.js library.
+        // There is native way to focus an element without scrolling the view into it,
+        // but it's not possible to detect current engine's support in a clean way (yet).
+        // https://github.com/heycam/webidl/issues/107#issuecomment-399910305
+        var actualPosition = window.scrollY;
         document.querySelector(docsearchInputId).focus();
+        // Hijacking the event loop order, since the focus() will trigger
+        // internally an scroll that goes to the event loop
+        setTimeout(function() {
+          window.scroll(window.scrollX, actualPosition);
+        }, 0);
 
         // Following functions are related to the sidebar nav
         // Show and hide the sidebar


### PR DESCRIPTION
* Inject method to restore scroll position after focus into searchbar

   It's kind of hacky, but it's probably our best shot until a way to detect feature options in JS engines is available.

   More info on:
https://github.com/heycam/webidl/issues/107#issuecomment-399910305

This fixes #906 