### PR TITLE
[Spitballing] More user friendly Optional constructor

### DIFF
--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/Optional.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/Optional.kt
@@ -67,6 +67,12 @@ interface POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
       override fun set(s: S, b: B): T = set(b)(s)
     }
 
+    operator fun <S, A> invoke(get: (S) -> Option<A>, set: (A, S) -> S): Optional<S, A> = object: Optional<S, A> {
+      override fun getOrModify(s: S): Either<S, A> = get(s).toEither { s }
+
+      override fun set(s: S, b: A): S = set(b, s)
+    }
+
     /**
      * Invoke operator overload to create a [POptional] of type `S` with focus `A`.
      * Can also be used to construct [Optional]

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/TestDomain.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/TestDomain.kt
@@ -3,6 +3,7 @@ package arrow.optics
 import arrow.core.Left
 import arrow.core.Right
 import arrow.core.identity
+import arrow.core.toOption
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 
@@ -82,11 +83,11 @@ internal val userLens: Lens<User, Token> = Lens(
 )
 
 internal val optionalHead: Optional<List<Int>, Int> = Optional(
-  { it.firstOrNull()?.let(::Right) ?: it.let(::Left) },
-  { int -> { list -> listOf(int) + if (list.size > 1) list.drop(1) else emptyList() } }
+  { it.firstOrNull().toOption() },
+  { int, list -> listOf(int) + if (list.size > 1) list.drop(1) else emptyList() }
 )
 
 internal val defaultHead: Optional<Int, Int> = Optional(
-  { it.let(::Right) },
-  { ::identity }
+  { it.toOption() },
+  { a: Int, _ : Int -> a }
 )


### PR DESCRIPTION
I think most new user will use non-polymorphic Optional, but constructor still forces them to use Either which is not intuitive in that context. My idea is to introduce new constructor `(S) -> Option<A>`. Unfortunatelly due to type erasure, we can't have Function1 as second parameter, so I've added Function2, which also is frankly more user friendly.

note: after this change defaultHead was throwing type inference errors.
![image](https://user-images.githubusercontent.com/1307829/42177614-a131218a-7e2d-11e8-80b9-cfbc8bc91303.png)
