### PR TITLE
Add @Deprecated annotations on boolean instances

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/boolean.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/boolean.kt
@@ -1,3 +1,4 @@
 package arrow.core
 
+@Deprecated(DeprecatedAmbiguity, ReplaceWith("Boolean"))
 object BooleanInstances

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/boolean.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/boolean.kt
@@ -1,6 +1,7 @@
 package arrow.instances
 
 import arrow.core.BooleanInstances
+import arrow.core.DeprecatedAmbiguity
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Show
 
@@ -20,8 +21,10 @@ interface BooleanEqInstance : Eq<Boolean> {
 //fun Boolean.Companion.eq(): Eq<Boolean> =
 //  object : BooleanEqInstance {}
 
+@Deprecated(DeprecatedAmbiguity, ReplaceWith("Boolean.show()"))
 fun BooleanInstances.show(): Show<Boolean> =
   object : BooleanShowInstance {}
 
+@Deprecated(DeprecatedAmbiguity, ReplaceWith("Boolean.eq()"))
 fun BooleanInstances.eq(): Eq<Boolean> =
   object : BooleanEqInstance {}


### PR DESCRIPTION
* Add @Deprecated annotation on arrow-core BooleanInstances
* Add @Deprecated annotation on arrow-instances-core boolean show and eq
functions

Closes #943 