### PR TITLE
Implementing extension function optionFromNullable()

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -214,3 +214,5 @@ fun <A> Boolean.maybe(f: () -> A): Option<A> =
 fun <A> A.some(): Option<A> = Some(this)
 
 fun <A> none(): Option<A> = None
+
+fun <A> A?.optionFromNullable() : Option<A> = this?.let { Some(it) } ?: None

--- a/modules/docs/arrow-docs/docs/docs/datatypes/option/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/option/README.md
@@ -121,6 +121,11 @@ Arrow also adds syntax to all datatypes so you can easily lift them into the con
 none<String>()
 ```
 
+```kotlin:ank
+val something: String? = null
+something.optionFromNullable()
+```
+
 Arrow contains `Option` instances for many useful typeclasses that allows you to use and transform optional values
 
 [`Functor`]({{ '/docs/typeclasses/functor/' | relative_url }})


### PR DESCRIPTION
Not sure if there is a better way to do this:

```
val something: String? = null
something?.let { Some(it) } ?: None
```

If there is something better or already implemented in arrow this PR can be closed. If not, consider the function that I've implemted:

```
val something: String? = null
something.optionFromNullable()
```

if you want this PR to go forward, please let me know what is the next things need to be done (testing, etc). Do you have some docs with guidelines for contributions? Thanks