### PR TITLE
IO flatMap perf tweak

### DIFF
--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
@@ -65,7 +65,10 @@ sealed class IO<out A> : IOOf<A> {
   abstract fun <B> map(f: (A) -> B): IO<B>
 
   fun <B> flatMap(f: (A) -> IOOf<B>): IO<B> =
-    Bind(this, { f(it).fix() })
+    when (this) {
+      is Pure -> Suspend { f(this.a).fix() }
+      else -> Bind(this, { f(it).fix() })
+    }
 
   fun continueOn(ctx: CoroutineContext): IO<A> =
     ContinueOn(this, ctx)

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
@@ -67,7 +67,7 @@ sealed class IO<out A> : IOOf<A> {
   fun <B> flatMap(f: (A) -> IOOf<B>): IO<B> =
     when (this) {
       is Pure -> Suspend { f(this.a).fix() }
-      else -> Bind(this, { f(it).fix() })
+      else -> Bind(this) { f(it).fix() }
     }
 
   fun continueOn(ctx: CoroutineContext): IO<A> =


### PR DESCRIPTION
With this small change we gain a ~30% perf improvement on some stupid benchmarks for tailrecM I made.

I'm sure I could shave more by making it abstract, maybe I'll test it tomorrow.