### PR TITLE
Remove unnecessary inline in core

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -94,11 +94,11 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * ```
    */
   @Suppress("UNCHECKED_CAST")
-  inline fun <C> map(crossinline f: (B) -> C): Either<A, C> =
-      when (this) {
-        is Right -> Right(f(b))
-        is Left -> this
-      }
+  fun <C> map(f: (B) -> C): Either<A, C> =
+    when (this) {
+      is Right -> Right(f(b))
+      is Left -> this
+    }
 
   /**
    * The given function is applied if this is a `Left`.
@@ -109,13 +109,13 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * Left(12).mapLeft { "flower" }  // Result: Left("flower)
    * ```
    */
-  inline fun <C> mapLeft(crossinline f: (A) -> C): Either<C, B> =
+  fun <C> mapLeft(f: (A) -> C): Either<C, B> =
     fold({ Left(f(it)) }, { Right(it) })
 
   /**
    * Map over Left and Right of this Either
    */
-  inline fun <C, D> bimap(crossinline leftOperation: (A) -> C, crossinline rightOperation: (B) -> D): Either<C, D> =
+  fun <C, D> bimap(leftOperation: (A) -> C, rightOperation: (B) -> D): Either<C, D> =
     fold({ Left(leftOperation(it)) }, { Right(rightOperation(it)) })
 
   /**
@@ -131,7 +131,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * left.exists { it > 10 }      // Result: false
    * ```
    */
-  inline fun exists(crossinline predicate: (B) -> Boolean): Boolean =
+  fun exists(predicate: (B) -> Boolean): Boolean =
     fold({ false }, { predicate(it) })
 
   /**
@@ -229,7 +229,7 @@ fun <A, B, C> EitherOf<A, B>.flatMap(f: (B) -> Either<A, C>): Either<A, C> =
  * Left(12).getOrElse(17)  // Result: 17
  * ```
  */
-inline fun <B> EitherOf<*, B>.getOrElse(crossinline default: () -> B): B =
+fun <B> EitherOf<*, B>.getOrElse(default: () -> B): B =
   fix().fold({ default() }, ::identity)
 
 /**
@@ -241,8 +241,8 @@ inline fun <B> EitherOf<*, B>.getOrElse(crossinline default: () -> B): B =
  * Left(12).orNull()  // Result: null
  * ```
  */
-inline fun <B> EitherOf<*, B>.orNull(): B? =
-    getOrElse { null }
+fun <B> EitherOf<*, B>.orNull(): B? =
+  getOrElse { null }
 
 /**
  * Returns the value from this [Either.Right] or allows clients to transform [Either.Left] to [Either.Right] while providing access to
@@ -254,7 +254,7 @@ inline fun <B> EitherOf<*, B>.orNull(): B? =
  * Left(12).getOrHandle { it + 5 } // Result: 17
  * ```
  */
-inline fun <A, B> EitherOf<A, B>.getOrHandle(crossinline default: (A) -> B): B =
+fun <A, B> EitherOf<A, B>.getOrHandle(default: (A) -> B): B =
   fix().fold({ default(it) }, ::identity)
 
 /**
@@ -273,7 +273,7 @@ inline fun <A, B> EitherOf<A, B>.getOrHandle(crossinline default: (A) -> B): B =
  * left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
  * ```
  */
-inline fun <A, B> EitherOf<A, B>.filterOrElse(crossinline predicate: (B) -> Boolean, crossinline default: () -> A): Either<A, B> =
+fun <A, B> EitherOf<A, B>.filterOrElse(predicate: (B) -> Boolean, default: () -> A): Either<A, B> =
   fix().fold({ Left(it) }, { if (predicate(it)) Right(it) else Left(default()) })
 
 /**
@@ -303,7 +303,7 @@ fun <A, B> EitherOf<A, B>.combineK(y: EitherOf<A, B>): Either<A, B> =
   }
 
 @Deprecated(DeprecatedAmbiguity, ReplaceWith("Try { body }.toEither()"))
-inline fun <T> eitherTry(body: () -> T): Either<Throwable, T> = try {
+fun <T> eitherTry(body: () -> T): Either<Throwable, T> = try {
   Right(body())
 } catch (t: Throwable) {
   Left(t)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Id.kt
@@ -7,15 +7,15 @@ fun <A> IdOf<A>.value(): A = this.fix().value
 @higherkind
 data class Id<out A>(val value: A) : IdOf<A> {
 
-  inline fun <B> map(f: (A) -> B): Id<B> = Id(f(value))
+  fun <B> map(f: (A) -> B): Id<B> = Id(f(value))
 
-  inline fun <B> flatMap(f: (A) -> IdOf<B>): Id<B> = f(value).fix()
+  fun <B> flatMap(f: (A) -> IdOf<B>): Id<B> = f(value).fix()
 
   fun <B> foldLeft(initial: B, operation: (B, A) -> B): B = operation(initial, this.fix().value)
 
   fun <B> foldRight(initial: Eval<B>, operation: (A, Eval<B>) -> Eval<B>): Eval<B> = operation(this.fix().value, initial)
 
-  fun <B> coflatMap(f: (IdOf<A>) -> B): Id<B> = this.fix().map({ f(this) })
+  fun <B> coflatMap(f: (IdOf<A>) -> B): Id<B> = this.fix().map { f(this) }
 
   fun extract(): A = this.fix().value
 

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -66,9 +66,9 @@ sealed class Option<out A> : OptionOf<A> {
    * @param f the function to apply
    * @see flatMap
    */
-  inline fun <B> map(crossinline f: (A) -> B): Option<B> = fold({ None }, { a -> Some(f(a)) })
+  fun <B> map(f: (A) -> B): Option<B> = fold({ None }, { a -> Some(f(a)) })
 
-  inline fun <P1, R> map(p1: Option<P1>, crossinline f: (A, P1) -> R): Option<R> = if (isEmpty()) {
+  fun <P1, R> map(p1: Option<P1>, f: (A, P1) -> R): Option<R> = if (isEmpty()) {
     None
   } else {
     p1.map { pp1 -> f(get(), pp1) }
@@ -99,7 +99,7 @@ sealed class Option<out A> : OptionOf<A> {
    *
    *  @param predicate the predicate used for testing.
    */
-  inline fun filter(crossinline predicate: Predicate<A>): Option<A> =
+  fun filter(predicate: Predicate<A>): Option<A> =
     fold({ None }, { a -> if (predicate(a)) Some(a) else None })
 
   /**
@@ -108,7 +108,7 @@ sealed class Option<out A> : OptionOf<A> {
    *
    * @param predicate the predicate used for testing.
    */
-  inline fun filterNot(crossinline predicate: Predicate<A>): Option<A> = fold({ None }, { a -> if (!predicate(a)) Some(a) else None })
+  fun filterNot(predicate: Predicate<A>): Option<A> = fold({ None }, { a -> if (!predicate(a)) Some(a) else None })
 
   /**
    * Returns true if this option is nonempty '''and''' the predicate
@@ -117,7 +117,7 @@ sealed class Option<out A> : OptionOf<A> {
    *
    * @param predicate the predicate to test
    */
-  inline fun exists(crossinline predicate: Predicate<A>): Boolean = fold({ false }, { a -> predicate(a) })
+  fun exists(predicate: Predicate<A>): Boolean = fold({ false }, { a -> predicate(a) })
 
   /**
    * Returns true if this option is empty '''or''' the predicate
@@ -125,10 +125,10 @@ sealed class Option<out A> : OptionOf<A> {
    *
    * @param p the predicate to test
    */
-  inline fun forall(crossinline p: Predicate<A>): Boolean = fold({ true }, p)
+  fun forall(p: Predicate<A>): Boolean = fold({ true }, p)
 
   @Deprecated(DeprecatedUnsafeAccess, ReplaceWith("fold({ Unit }, f)"))
-  inline fun forEach(f: (A) -> Unit) {
+  fun forEach(f: (A) -> Unit) {
     if (nonEmpty()) f(get())
   }
 

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
@@ -52,17 +52,17 @@ sealed class Try<out A> : TryOf<A> {
   /**
    * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
    */
-  inline fun <B> flatMap(crossinline f: (A) -> TryOf<B>): Try<B> = fold({ raise(it) }, { f(it).fix() })
+   fun <B> flatMap( f: (A) -> TryOf<B>): Try<B> = fold({ raise(it) }, { f(it).fix() })
 
   /**
    * Maps the given function to the value from this `Success` or returns this if this is a `Failure`.
    */
-  inline fun <B> map(crossinline f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
+   fun <B> map( f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
 
   /**
    * Converts this to a `Failure` if the predicate is not satisfied.
    */
-  inline fun filter(crossinline p: Predicate<A>): Try<A> =
+   fun filter( p: Predicate<A>): Try<A> =
     fold(
       { Failure(it) },
       { if (p(it)) Success(it) else Failure(TryException.PredicateException("Predicate does not hold for $it")) }

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
@@ -52,17 +52,17 @@ sealed class Try<out A> : TryOf<A> {
   /**
    * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
    */
-   fun <B> flatMap( f: (A) -> TryOf<B>): Try<B> = fold({ raise(it) }, { f(it).fix() })
+  fun <B> flatMap(f: (A) -> TryOf<B>): Try<B> = fold({ raise(it) }, { f(it).fix() })
 
   /**
    * Maps the given function to the value from this `Success` or returns this if this is a `Failure`.
    */
-   fun <B> map( f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
+  fun <B> map(f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
 
   /**
    * Converts this to a `Failure` if the predicate is not satisfied.
    */
-   fun filter( p: Predicate<A>): Try<A> =
+  fun filter(p: Predicate<A>): Try<A> =
     fold(
       { Failure(it) },
       { if (p(it)) Success(it) else Failure(TryException.PredicateException("Predicate does not hold for $it")) }

--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/function/pipe.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/function/pipe.kt
@@ -2,6 +2,8 @@ package arrow.syntax.function
 
 infix inline fun <P1, R> P1.pipe(t: (P1) -> R): R = t(this)
 
+infix inline fun <P1, R> P1.pipeLazy(crossinline t: (P1) -> R): () -> R = { t(this) }
+
 infix inline fun <P1, P2, R> P1.pipe2(crossinline t: (P1, P2) -> R): (P2) -> R = { p2 -> t(this, p2) }
 
 infix inline fun <P1, P2, P3, R> P1.pipe3(crossinline t: (P1, P2, P3) -> R): (P2, P3) -> R = { p2, p3 -> t(this, p2, p3) }


### PR DESCRIPTION
cc #966 && @trevorsummerssmith

When we started with the lib we liked inlines and crossinline because we thought it'd be efficient. It turned out to be a bytecode bloat instead, and it comes with bad interactions with coroutines.

This PR removes a bunch of gratuitous inline identifiers. I'm keeping the fold and constructor ones for now as they're mostly harmless.