### PR TITLE
Update README

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/patterns/monads/README.md
+++ b/modules/docs/arrow-docs/docs/docs/patterns/monads/README.md
@@ -371,7 +371,7 @@ In Arrow terms, a Monad is an interface with two operations: a constructor `just
 interface Monad<F>: Applicative<F>, Functor<F> {
     fun <A> just (instance: A): Kind<F, A>
 
-    fun <A, B> Kind<F, A>.flatMap(f: (A) ->  Kind<F, B>)
+    fun <A, B> Kind<F, A>.flatMap(f: (A) ->  Kind<F, B>) : Kind<F, B>
 }
 ```
 


### PR DESCRIPTION
'It's important that `flatMaps`'s argument returns `Kind<F, B>`' but return type in flatmap function of Monad interface was forgotten.