### PR TITLE
Add cancellation capabilities to IO

### DIFF
--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
@@ -90,6 +90,7 @@ sealed class IO<out A> : IOOf<A> {
   fun unsafeRunAsyncCancellable(onCancel: OnCancel = Silent, cb: (Either<Throwable, A>) -> Unit): Disposable {
     var ab = false
     val cancel = { ab = true }
+    val isCancelled = { ab }
     val onCancelCb =
       when (onCancel) {
         ThrowCancellationException ->
@@ -97,7 +98,7 @@ sealed class IO<out A> : IOOf<A> {
         Silent ->
           { either -> either.fold({ if (!ab && it !is IOCancellationException) cb(either) }, { cb(either) }) }
       }
-    IORunLoop.start(this, onCancelCb) { ab }
+    IORunLoop.start(this, onCancelCb, isCancelled)
     return cancel
   }
 

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -3,6 +3,7 @@ package arrow.effects
 import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
+import arrow.effects.data.internal.IOCancellationException
 import arrow.effects.internal.Platform.ArrayStack
 import arrow.effects.typeclasses.Proc
 import kotlin.coroutines.experimental.Continuation
@@ -16,8 +17,8 @@ private typealias Callback = (Either<Throwable, Any?>) -> Unit
 
 @Suppress("UNCHECKED_CAST")
 internal object IORunLoop {
-  fun <A> start(source: IO<A>, cb: (Either<Throwable, A>) -> Unit): Unit =
-    loop(source, cb as Callback, null, null, null)
+  fun <A> start(source: IO<A>, cb: (Either<Throwable, A>) -> Unit, isCancelled: (() -> Boolean)?): Unit =
+    loop(source, cb as Callback, null, null, null, isCancelled)
 
   fun <A> step(source: IO<A>): IO<A> {
     var currentIO: Current? = source
@@ -35,7 +36,7 @@ internal object IORunLoop {
         is IO.RaiseError -> {
           val errorHandler: IOFrame<Any?, IO<Any?>>? = findErrorHandlerInCallStack(bFirst, bRest)
           when (errorHandler) {
-          // Return case for unhandled errors
+            // Return case for unhandled errors
             null -> return currentIO
             else -> {
               val exception: Throwable = currentIO.exception
@@ -83,7 +84,7 @@ internal object IORunLoop {
           bFirst = { c: Any? -> IO.just(c) }
 
           currentIO = IO.async { cc ->
-            loop(localCont, cc.asyncCallback(currentCC), null, null, null)
+            loop(localCont, cc.asyncCallback(currentCC), null, null, null, null)
           }
         }
         is IO.Map<*, *> -> {
@@ -133,7 +134,7 @@ internal object IORunLoop {
     when {
       bFirst != null || (bRest != null && bRest.isNotEmpty()) ->
         IO.Async { cb ->
-          val rcb = RestartCallback(cb as Callback)
+          val rcb = RestartCallback(cb as Callback, null)
           rcb.prepare(bFirst, bRest)
           register(rcb)
         }
@@ -145,7 +146,8 @@ internal object IORunLoop {
     cb: (Either<Throwable, Any?>) -> Unit,
     rcbRef: RestartCallback?,
     bFirstRef: BindF?,
-    bRestRef: CallStack?): Unit {
+    bRestRef: CallStack?,
+    isCancelled: (() -> Boolean)?): Unit {
     var currentIO: Current? = source
     var bFirst: BindF? = bFirstRef
     var bRest: CallStack? = bRestRef
@@ -156,6 +158,10 @@ internal object IORunLoop {
     var result: Any? = null
 
     do {
+      if (isCancelled?.invoke() == true) {
+        cb(Left(IOCancellationException("User cancellation")))
+        return
+      }
       when (currentIO) {
         is IO.Pure -> {
           result = currentIO.a
@@ -164,7 +170,7 @@ internal object IORunLoop {
         is IO.RaiseError -> {
           val errorHandler: IOFrame<Any?, IO<Any?>>? = findErrorHandlerInCallStack(bFirst, bRest)
           when (errorHandler) {
-          // Return case for unhandled errors
+            // Return case for unhandled errors
             null -> {
               cb(Left(currentIO.exception))
               return
@@ -191,7 +197,7 @@ internal object IORunLoop {
         }
         is IO.Async -> {
           if (rcb == null) {
-            rcb = RestartCallback(cb)
+            rcb = RestartCallback(cb, isCancelled)
           }
           rcb.prepare(bFirst, bRest)
           // Return case for Async operations
@@ -220,7 +226,7 @@ internal object IORunLoop {
           bFirst = { c: Any? -> IO.just(c) }
 
           currentIO = IO.async { cc ->
-            loop(localCont, cc.asyncCallback(currentCC), null, null, null)
+            loop(localCont, cc.asyncCallback(currentCC), null, null, null, isCancelled)
           }
 
         }
@@ -309,7 +315,7 @@ internal object IORunLoop {
     return result
   }
 
-  private data class RestartCallback(val cb: Callback) : Callback {
+  private data class RestartCallback(val cb: Callback, val isCancelled: (() -> Boolean)?) : Callback {
 
     private var canCall = false
     private var bFirst: BindF? = null
@@ -325,17 +331,17 @@ internal object IORunLoop {
       if (canCall) {
         canCall = false
         when (either) {
-          is Either.Left -> loop(IO.RaiseError(either.a), cb, this, bFirst, bRest)
-          is Either.Right -> loop(IO.Pure(either.b), cb, this, bFirst, bRest)
+          is Either.Left -> loop(IO.RaiseError(either.a), cb, this, bFirst, bRest, isCancelled)
+          is Either.Right -> loop(IO.Pure(either.b), cb, this, bFirst, bRest, isCancelled)
         }
       }
     }
 
     companion object {
-      operator fun invoke(cb: Callback): RestartCallback =
+      operator fun invoke(cb: Callback, isCancelled: (() -> Boolean)?): RestartCallback =
         when (cb) {
           is RestartCallback -> cb
-          else -> RestartCallback(cb)
+          else -> RestartCallback(cb, isCancelled)
         }
     }
   }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/data/internal/BindingCancellationException.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/data/internal/BindingCancellationException.kt
@@ -1,5 +1,5 @@
 package arrow.effects.data.internal
 
-import java.util.concurrent.CancellationException as JavaCancellationException
+import arrow.effects.internal.JavaCancellationException
 
 data class BindingCancellationException(override val message: String? = null) : JavaCancellationException()

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/data/internal/IOCancellationException.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/data/internal/IOCancellationException.kt
@@ -1,0 +1,5 @@
+package arrow.effects.data.internal
+
+import arrow.effects.internal.JavaCancellationException
+
+data class IOCancellationException(override val message: String? = null) : JavaCancellationException()

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/Utils.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/Utils.kt
@@ -4,11 +4,13 @@ import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
-import arrow.effects.typeclasses.Duration
 import arrow.effects.IO
+import arrow.effects.typeclasses.Duration
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
+
+typealias JavaCancellationException = java.util.concurrent.CancellationException
 
 object Platform {
 
@@ -36,6 +38,16 @@ object Platform {
     return { a ->
       if (!wasCalled.getAndSet(true)) {
         f(a)
+      }
+    }
+  }
+
+  inline fun onceOnly(crossinline f: () -> Unit): () -> Unit {
+    val wasCalled = AtomicBoolean(false)
+
+    return {
+      if (!wasCalled.getAndSet(true)) {
+        f()
       }
     }
   }

--- a/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
@@ -29,7 +29,7 @@ class IOTest : UnitSpec() {
   }
 
   init {
-    //testLaws(AsyncLaws.laws(IO.async(), EQ(), EQ()))
+    testLaws(AsyncLaws.laws(IO.async(), EQ(), EQ()))
 
     "should defer evaluation until run" {
       var run = false

--- a/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
@@ -7,6 +7,7 @@ import arrow.effects.typeclasses.milliseconds
 import arrow.effects.typeclasses.seconds
 import arrow.test.UnitSpec
 import arrow.test.concurrency.SideEffect
+import arrow.test.laws.AsyncLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.binding
 import io.kotlintest.KTestJUnitRunner

--- a/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
@@ -362,6 +362,15 @@ class IOTest : UnitSpec() {
       }.unsafeRunTimed(2.seconds) shouldBe None
     }
 
+    "unsafeRunAsyncCancellable should not silence IOCancellationException thrown by the user" {
+      IO.async<Either<Throwable, Int>> { cb ->
+        IO(newSingleThreadContext("RunThread")) { throw IOCancellationException("TEST") }
+          .unsafeRunAsyncCancellable(OnCancel.Silent) {
+            cb(it.right())
+          }
+      }.unsafeRunTimed(2.seconds) shouldBe Some(Either.Left(IOCancellationException("TEST")))
+    }
+
     "IO.binding should for comprehend over IO" {
       val result = IO.monad().binding {
         val x = IO.just(1).bind()

--- a/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
@@ -349,7 +349,7 @@ class IOTest : UnitSpec() {
       }.unsafeRunTimed(2.seconds) shouldBe Some(IOCancellationException("User cancellation"))
     }
 
-    "unsafeRunAsyncCancellable should cancel only at operator boundaries" {
+    "unsafeRunAsyncCancellable can cancel only at operator boundaries" {
       IO.async<Unit> { cb ->
         val cancel =
           IO(newSingleThreadContext("RunThread")) { }

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -5,6 +5,6 @@
     <ID>ComplexMethod:FreeApplicative.kt$FreeApplicative$// Beware: smart code @Suppress("UNCHECKED_CAST") fun &lt;G&gt; foldMap(f: FunctionK&lt;F, G&gt;, GA: Applicative&lt;G&gt;): Kind&lt;G, A&gt;</ID>
     <ID>ComplexMethod:tuple.kt$Tuple10EqInstance$override fun Tuple10&lt;A, B, C, D, E, F, G, H, I, J&gt;.eqv(b: Tuple10&lt;A, B, C, D, E, F, G, H, I, J&gt;): Boolean</ID>
     <ID>ComplexMethod:IORunLoop.kt$IORunLoop$fun &lt;A&gt; step(source: IO&lt;A&gt;): IO&lt;A&gt;</ID>
-    <ID>ComplexMethod:IORunLoop.kt$IORunLoop$private fun loop( source: Current, cb: (Either&lt;Throwable, Any?&gt;) -&gt; Unit, rcbRef: RestartCallback?, bFirstRef: BindF?, bRestRef: CallStack?): Unit</ID>
+    <ID>ComplexMethod:IORunLoop.kt$IORunLoop$private fun loop( source: Current, cb: (Either&lt;Throwable, Any?&gt;) -&gt; Unit, rcbRef: RestartCallback?, bFirstRef: BindF?, bRestRef: CallStack?, isCancelled: (() -> Boolean)?): Unit</ID>
   </Whitelist>
 </SmellBaseline>


### PR DESCRIPTION
Make `IO` have a new cancellable runAsync operator that ties into the run loop for cancellation. It improves over the old way of doing it at coroutine (flatMap) boundaries because now we can cancel after every operator call instead.

I'm tempted to make the cancellable asyncRun the default, as it has the same overhead with and without it cc @raulraja for opinion.

With cancellation and parallelism we can build races, which means we can finally have a proper concurrency framework and libraries for Android!