### PR TITLE
Kotlin 1.3 migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ buildscript {
         gradleVersionsPluginVersion = '0.17.0'
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = '2.0.7'
-        kotlinVersion = '1.2.51'
+        kotlinVersion = '1.3-M2'
         daggerVersion = '2.15'
-        kotlinxCoroutinesVersion = '0.23.3'
+        kotlinxCoroutinesVersion = '0.25.0'
         kotlinxCollectionsImmutableVersion = '0.1'
         kotlinPoetVersion='1.0.0-RC1'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         kotlinTestVersion = '2.0.7'
         kotlinVersion = '1.3-M2'
         daggerVersion = '2.15'
-        kotlinxCoroutinesVersion = '0.25.0'
+        kotlinxCoroutinesVersion = '0.25.1-eap13'
         kotlinxCollectionsImmutableVersion = '0.1'
         kotlinPoetVersion='1.0.0-RC1'
     }

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Continuation.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Continuation.kt
@@ -1,0 +1,11 @@
+package arrow.core
+
+interface Continuation<in T> : kotlin.coroutines.Continuation<T> {
+  fun resume(value: T)
+
+  fun resumeWithException(exception: Throwable)
+
+  override fun resumeWith(result: SuccessOrFailure<T>) =
+    result.fold(::resume, ::resumeWithException)
+
+}

--- a/modules/core/arrow-free/src/main/kotlin/arrow/free/StackSafeMonadContinuations.kt
+++ b/modules/core/arrow-free/src/main/kotlin/arrow/free/StackSafeMonadContinuations.kt
@@ -1,7 +1,7 @@
 package arrow.free
 
 import arrow.Kind
-import arrow.typeclasses.Continuation
+import arrow.core.Continuation
 import arrow.typeclasses.Monad
 import arrow.typeclasses.stateStack
 import kotlin.coroutines.*

--- a/modules/core/arrow-free/src/main/kotlin/arrow/free/StackSafeMonadContinuations.kt
+++ b/modules/core/arrow-free/src/main/kotlin/arrow/free/StackSafeMonadContinuations.kt
@@ -4,7 +4,6 @@ import arrow.Kind
 import arrow.typeclasses.Continuation
 import arrow.typeclasses.Monad
 import arrow.typeclasses.stateStack
-import arrow.typeclasses.success
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
@@ -33,7 +32,7 @@ open class StackSafeMonadContinuation<F, A>(M: Monad<F>, override val context: C
     val labelHere = c.stateStack // save the whole coroutine stack labels
     returnedMonad = m().flatMap { z ->
       c.stateStack = labelHere
-      c.resumeWith(z.success())
+      c.resumeWith(SuccessOrFailure.success(z))
       returnedMonad
     }
     COROUTINE_SUSPENDED

--- a/modules/core/arrow-generic/build.gradle
+++ b/modules/core/arrow-generic/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     compile project(':arrow-typeclasses')
     compile project(':arrow-core')

--- a/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/typeclasses/MonadFilter.kt
+++ b/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/typeclasses/MonadFilter.kt
@@ -3,7 +3,7 @@ package arrow.mtl.typeclasses
 import arrow.Kind
 import arrow.core.Option
 import arrow.typeclasses.Monad
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.startCoroutine
 
 interface MonadFilter<F> : Monad<F>, FunctorFilter<F> {
 

--- a/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/typeclasses/MonadFilterContinuation.kt
+++ b/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/typeclasses/MonadFilterContinuation.kt
@@ -2,9 +2,9 @@ package arrow.mtl.typeclasses
 
 import arrow.Kind
 import arrow.typeclasses.MonadContinuation
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.EmptyCoroutineContext
-import kotlin.coroutines.experimental.RestrictsSuspension
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.RestrictsSuspension
 
 @RestrictsSuspension
 open class MonadFilterContinuation<F, A>(val MF: MonadFilter<F>, override val context: CoroutineContext = EmptyCoroutineContext) :

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/concurrency/CoroutineDispatchers.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/concurrency/CoroutineDispatchers.kt
@@ -1,7 +1,7 @@
 package arrow.test.concurrency
 
-import kotlinx.coroutines.experimental.CoroutineDispatcher
-import kotlinx.coroutines.experimental.asCoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ThreadPoolExecutor

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
@@ -11,7 +11,7 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.binding
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
-import kotlinx.coroutines.experimental.newSingleThreadContext
+import kotlinx.coroutines.newSingleThreadContext
 
 object AsyncLaws {
   inline fun <F> laws(AC: Async<F>, EQ: Eq<Kind<F, Int>>, EQ_EITHER: Eq<Kind<F, Either<Throwable, Int>>>, EQERR: Eq<Kind<F, Int>> = EQ): List<Law> =

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadLaws.kt
@@ -15,7 +15,7 @@ import arrow.typeclasses.Monad
 import arrow.typeclasses.binding
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
-import kotlinx.coroutines.experimental.newSingleThreadContext
+import kotlinx.coroutines.newSingleThreadContext
 
 object MonadLaws {
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadSuspendLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadSuspendLaws.kt
@@ -10,8 +10,8 @@ import arrow.test.generators.genIntSmall
 import arrow.test.generators.genThrowable
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.forAll
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.newSingleThreadContext
+import kotlinx.coroutines.CommonPool
+import kotlinx.coroutines.newSingleThreadContext
 
 object MonadSuspendLaws {
   inline fun <F> laws(SC: MonadDefer<F>, EQ: Eq<Kind<F, Int>>, EQ_EITHER: Eq<Kind<F, Either<Throwable, Int>>>, EQERR: Eq<Kind<F, Int>> = EQ): List<Law> =

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Comonad.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Comonad.kt
@@ -1,6 +1,7 @@
 package arrow.typeclasses
 
 import arrow.Kind
+import arrow.core.Continuation
 import arrow.core.identity
 import java.io.Serializable
 import kotlin.coroutines.*

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Comonad.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Comonad.kt
@@ -3,9 +3,9 @@ package arrow.typeclasses
 import arrow.Kind
 import arrow.core.identity
 import java.io.Serializable
-import kotlin.coroutines.experimental.*
-import kotlin.coroutines.experimental.intrinsics.COROUTINE_SUSPENDED
-import kotlin.coroutines.experimental.intrinsics.suspendCoroutineOrReturn
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 
 /**
  * The dual of monads, used to extract values from F
@@ -34,7 +34,7 @@ open class ComonadContinuation<F, A : Any>(CM: Comonad<F>, override val context:
 
   suspend fun <B> Kind<F, B>.fix(): B = extract { this }
 
-  suspend fun <B> extract(m: () -> Kind<F, B>): B = suspendCoroutineOrReturn { c ->
+  suspend fun <B> extract(m: () -> Kind<F, B>): B = suspendCoroutineUninterceptedOrReturn { c ->
     val labelHere = c.stateStack // save the whole coroutine stack labels
     returnedMonad = m().coflatMap { x: Kind<F, B> ->
       c.stateStack = labelHere

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ContinuationUtils.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ContinuationUtils.kt
@@ -2,9 +2,7 @@ package arrow.typeclasses
 
 import kotlin.coroutines.Continuation
 
-private val coroutineImplClass by lazy { Class.forName("kotlin.coroutines.jvm.internal.CoroutineImpl") }
-
-private val labelField by lazy { coroutineImplClass.getDeclaredField("label").apply { isAccessible = true } }
+private val coroutineImplClass by lazy { Class.forName("kotlin.coroutines.jvm.internal.BaseContinuationImpl") }
 
 private val completionField by lazy { coroutineImplClass.getDeclaredField("completion").apply { isAccessible = true } }
 
@@ -15,7 +13,7 @@ private var <T> Continuation<T>.completion: Continuation<*>?
 var <T> Continuation<T>.stateStack: List<Map<String, *>>
   get() {
     if (!coroutineImplClass.isInstance(this)) return emptyList()
-    val resultForThis = (this.javaClass.declaredFields + labelField)
+    val resultForThis = (this.javaClass.declaredFields)
       .associate { it.isAccessible = true; it.name to it.get(this@stateStack) }
       .let(::listOf)
     val resultForCompletion = completion?.stateStack
@@ -24,7 +22,7 @@ var <T> Continuation<T>.stateStack: List<Map<String, *>>
   set(value) {
     if (!coroutineImplClass.isInstance(this)) return
     val mapForThis = value.first()
-    (this.javaClass.declaredFields + labelField).forEach {
+    (this.javaClass.declaredFields).forEach {
       if (it.name in mapForThis) {
         it.isAccessible = true
         val fieldValue = mapForThis[it.name]

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ContinuationUtils.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ContinuationUtils.kt
@@ -1,8 +1,8 @@
 package arrow.typeclasses
 
-import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.Continuation
 
-private val coroutineImplClass by lazy { Class.forName("kotlin.coroutines.experimental.jvm.internal.CoroutineImpl") }
+private val coroutineImplClass by lazy { Class.forName("kotlin.coroutines.jvm.internal.CoroutineImpl") }
 
 private val labelField by lazy { coroutineImplClass.getDeclaredField("label").apply { isAccessible = true } }
 

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
@@ -5,7 +5,7 @@ import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Tuple2
 import arrow.core.identity
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.startCoroutine
 
 interface Monad<F> : Applicative<F> {
 

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
@@ -2,9 +2,9 @@ package arrow.typeclasses
 
 import arrow.Kind
 import java.util.concurrent.CountDownLatch
-import kotlin.coroutines.experimental.*
-import kotlin.coroutines.experimental.intrinsics.COROUTINE_SUSPENDED
-import kotlin.coroutines.experimental.intrinsics.suspendCoroutineOrReturn
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 
 interface BindingInContextContinuation<in T> : Continuation<T> {
   fun await(): Throwable?
@@ -52,7 +52,7 @@ open class MonadContinuation<F, A>(M: Monad<F>, override val context: CoroutineC
   suspend fun <B> (() -> B).bindIn(context: CoroutineContext): B =
     bindIn(context, this)
 
-  open suspend fun <B> bind(m: () -> Kind<F, B>): B = suspendCoroutineOrReturn { c ->
+  open suspend fun <B> bind(m: () -> Kind<F, B>): B = suspendCoroutineUninterceptedOrReturn { c ->
     val labelHere = c.stateStack // save the whole coroutine stack labels
     returnedMonad = m().flatMap { x: B ->
       c.stateStack = labelHere
@@ -62,7 +62,7 @@ open class MonadContinuation<F, A>(M: Monad<F>, override val context: CoroutineC
     COROUTINE_SUSPENDED
   }
 
-  open suspend fun <B> bindIn(context: CoroutineContext, m: () -> B): B = suspendCoroutineOrReturn { c ->
+  open suspend fun <B> bindIn(context: CoroutineContext, m: () -> B): B = suspendCoroutineUninterceptedOrReturn { c ->
     val labelHere = c.stateStack // save the whole coroutine stack labels
     val monadCreation: suspend () -> Kind<F, A> = {
       just(m()).flatMap { xx: B ->

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadContinuations.kt
@@ -1,6 +1,7 @@
 package arrow.typeclasses
 
 import arrow.Kind
+import arrow.core.Continuation
 import java.util.concurrent.CountDownLatch
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
@@ -1,7 +1,7 @@
 package arrow.typeclasses
 
 import arrow.Kind
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.startCoroutine
 
 interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F> {
 

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadErrorContinuations.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadErrorContinuations.kt
@@ -1,8 +1,8 @@
 package arrow.typeclasses
 
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.EmptyCoroutineContext
-import kotlin.coroutines.experimental.RestrictsSuspension
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.RestrictsSuspension
 
 @RestrictsSuspension
 open class MonadErrorContinuation<F, A>(val ME: MonadError<F, Throwable>, override val context: CoroutineContext = EmptyCoroutineContext) :

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/Continuation.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/Continuation.kt
@@ -15,3 +15,6 @@ inline fun <A> A.success(): SuccessOrFailure<A> =
 
 inline fun <A> Throwable.failure(): SuccessOrFailure<A> =
   SuccessOrFailure.failure(this)
+
+inline fun <A, B> SuccessOrFailure<A>.flatMap(f: (A) -> SuccessOrFailure<B>): SuccessOrFailure<B> =
+  fold(f, { it.failure() })

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/Continuation.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/Continuation.kt
@@ -9,12 +9,3 @@ interface Continuation<in T> : kotlin.coroutines.Continuation<T> {
     result.fold(::resume, ::resumeWithException)
 
 }
-
-inline fun <A> A.success(): SuccessOrFailure<A> =
-  SuccessOrFailure.success(this)
-
-inline fun <A> Throwable.failure(): SuccessOrFailure<A> =
-  SuccessOrFailure.failure(this)
-
-inline fun <A, B> SuccessOrFailure<A>.flatMap(f: (A) -> SuccessOrFailure<B>): SuccessOrFailure<B> =
-  fold(f, { it.failure() })

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/Continuation.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/Continuation.kt
@@ -1,0 +1,17 @@
+package arrow.typeclasses
+
+interface Continuation<in T> : kotlin.coroutines.Continuation<T> {
+  fun resume(value: T)
+
+  fun resumeWithException(exception: Throwable)
+
+  override fun resumeWith(result: SuccessOrFailure<T>) =
+    result.fold(::resume, ::resumeWithException)
+
+}
+
+inline fun <A> A.success(): SuccessOrFailure<A> =
+  SuccessOrFailure.success(this)
+
+inline fun <A> Throwable.failure(): SuccessOrFailure<A> =
+  SuccessOrFailure.failure(this)

--- a/modules/docs/arrow-docs/docs/docs/generic/product/README.md
+++ b/modules/docs/arrow-docs/docs/docs/generic/product/README.md
@@ -135,7 +135,7 @@ ForTry extensions {
 
 ```kotlin:ank
 import arrow.effects.*
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.async
 
 val asyncBalance: DeferredK<Int> = async { 1000 }.k()
 val asyncAvailable: DeferredK<Int> = async { 900 }.k()

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -6,7 +6,7 @@ import arrow.effects.typeclasses.Proc
 import arrow.higherkind
 import arrow.typeclasses.Traverse
 import kotlinx.coroutines.experimental.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Deferred<A>.k(): DeferredK<A> =
   DeferredK(this)

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -8,7 +8,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 import arrow.effects.handleErrorWith as deferredHandleErrorWith
 import arrow.effects.runAsync as deferredRunAsync
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/test/kotlin/arrow/effects/DeferredTest.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/test/kotlin/arrow/effects/DeferredTest.kt
@@ -14,9 +14,9 @@ import io.kotlintest.matchers.fail
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
-import kotlinx.coroutines.experimental.CoroutineStart
-import kotlinx.coroutines.experimental.Unconfined
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Unconfined
+import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/CoroutineContextReactorScheduler.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/CoroutineContextReactorScheduler.kt
@@ -1,6 +1,6 @@
 package arrow.effects
 
-import arrow.typeclasses.Continuation
+import arrow.core.Continuation
 import reactor.core.Disposable
 import reactor.core.scheduler.Scheduler
 import kotlin.coroutines.CoroutineContext

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/CoroutineContextReactorScheduler.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/CoroutineContextReactorScheduler.kt
@@ -2,9 +2,9 @@ package arrow.effects
 
 import reactor.core.Disposable
 import reactor.core.scheduler.Scheduler
-import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.startCoroutine
 
 object CoroutineContextReactorScheduler {
   private interface NonCancellableContinuation : Continuation<Unit>, Disposable

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/CoroutineContextReactorScheduler.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/CoroutineContextReactorScheduler.kt
@@ -1,8 +1,8 @@
 package arrow.effects
 
+import arrow.typeclasses.Continuation
 import reactor.core.Disposable
 import reactor.core.scheduler.Scheduler
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
 

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxK.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxK.kt
@@ -8,7 +8,7 @@ import arrow.higherkind
 import arrow.typeclasses.Applicative
 import reactor.core.publisher.Flux
 import reactor.core.publisher.FluxSink
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Flux<A>.k(): FluxK<A> = FluxK(this)
 

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxKInstances.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxKInstances.kt
@@ -9,7 +9,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 @instance(FluxK::class)
 interface FluxKFunctorInstance : Functor<ForFluxK> {

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoK.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoK.kt
@@ -8,7 +8,7 @@ import arrow.effects.typeclasses.Proc
 import arrow.higherkind
 import reactor.core.publisher.Mono
 import reactor.core.publisher.MonoSink
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Mono<A>.k(): MonoK<A> = MonoK(this)
 

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoKInstances.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoKInstances.kt
@@ -8,7 +8,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 @instance(MonoK::class)
 interface MonoKFunctorInstance : Functor<ForMonoK> {

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/CoroutineContextRx2Scheduler.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/CoroutineContextRx2Scheduler.kt
@@ -4,9 +4,9 @@ import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
 import io.reactivex.internal.disposables.EmptyDisposable
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.startCoroutine
 
 object CoroutineContextRx2Scheduler {
   private interface NonCancellableContinuation : Continuation<Unit>, Disposable

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/CoroutineContextRx2Scheduler.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/CoroutineContextRx2Scheduler.kt
@@ -1,10 +1,10 @@
 package arrow.effects
 
+import arrow.typeclasses.Continuation
 import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
 import io.reactivex.internal.disposables.EmptyDisposable
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
 

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/CoroutineContextRx2Scheduler.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/CoroutineContextRx2Scheduler.kt
@@ -1,6 +1,6 @@
 package arrow.effects
 
-import arrow.typeclasses.Continuation
+import arrow.core.Continuation
 import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
 import io.reactivex.internal.disposables.EmptyDisposable

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableK.kt
@@ -9,7 +9,7 @@ import arrow.typeclasses.Applicative
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.FlowableEmitter
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Flowable<A>.k(): FlowableK<A> = FlowableK(this)
 

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableKInstances.kt
@@ -10,7 +10,7 @@ import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
 import io.reactivex.BackpressureStrategy
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 @instance(FlowableK::class)
 interface FlowableKFunctorInstance : Functor<ForFlowableK> {

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeK.kt
@@ -6,7 +6,7 @@ import arrow.effects.typeclasses.Proc
 import arrow.higherkind
 import io.reactivex.Maybe
 import io.reactivex.MaybeEmitter
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Maybe<A>.k(): MaybeK<A> = MaybeK(this)
 

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeKInstances.kt
@@ -9,7 +9,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 @instance(MaybeK::class)
 interface MaybeKFunctorInstance : Functor<ForMaybeK> {

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableK.kt
@@ -8,7 +8,7 @@ import arrow.higherkind
 import arrow.typeclasses.Applicative
 import io.reactivex.Observable
 import io.reactivex.ObservableEmitter
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Observable<A>.k(): ObservableK<A> = ObservableK(this)
 

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableKInstances.kt
@@ -9,7 +9,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 @instance(ObservableK::class)
 interface ObservableKFunctorInstance : Functor<ForObservableK> {

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleK.kt
@@ -8,7 +8,7 @@ import arrow.effects.typeclasses.Proc
 import arrow.higherkind
 import io.reactivex.Single
 import io.reactivex.SingleEmitter
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A> Single<A>.k(): SingleK<A> = SingleK(this)
 

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleKInstances.kt
@@ -8,7 +8,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 @instance(SingleK::class)
 interface SingleKFunctorInstance : Functor<ForSingleK> {

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
@@ -12,7 +12,7 @@ import arrow.effects.typeclasses.Disposable
 import arrow.effects.typeclasses.Duration
 import arrow.effects.typeclasses.Proc
 import arrow.higherkind
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 enum class OnCancel { ThrowCancellationException, Silent }
 

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IOInstances.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IOInstances.kt
@@ -8,7 +8,7 @@ import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 import arrow.effects.ap as ioAp
 import arrow.effects.handleErrorWith as ioHandleErrorWith
 

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IOParallel.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IOParallel.kt
@@ -4,7 +4,7 @@ import arrow.core.Tuple2
 import arrow.core.Tuple3
 import arrow.effects.internal.parMap2
 import arrow.effects.internal.parMap3
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 fun <A, B, C> IO.Companion.parallelMapN(ctx: CoroutineContext, ioA: IO<A>, ioB: IO<B>, f: (A, B) -> C): IO<C> =
   IO.async(IO.effect().parMap2(ctx, ioA, ioB, f /* see parMap2 notes on this parameter */) { it.fix().unsafeRunSync() })

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -6,7 +6,7 @@ import arrow.core.Right
 import arrow.effects.data.internal.IOCancellationException
 import arrow.effects.internal.Platform.ArrayStack
 import arrow.effects.typeclasses.Proc
-import arrow.typeclasses.Continuation
+import arrow.core.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
 

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -6,9 +6,9 @@ import arrow.core.Right
 import arrow.effects.data.internal.IOCancellationException
 import arrow.effects.internal.Platform.ArrayStack
 import arrow.effects.typeclasses.Proc
-import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.startCoroutine
+import arrow.typeclasses.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.startCoroutine
 
 private typealias Current = IOOf<Any?>
 private typealias BindF = (Any?) -> IO<Any?>

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
@@ -5,8 +5,6 @@ import arrow.core.*
 import arrow.effects.typeclasses.Effect
 import arrow.effects.typeclasses.Proc
 import arrow.typeclasses.Continuation as AContinuation
-import arrow.typeclasses.failure
-import arrow.typeclasses.success
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.startCoroutine
@@ -19,14 +17,14 @@ internal fun <F, A, B, C> Effect<F>.parMap2(ctx: CoroutineContext, ioA: Kind<F, 
   val a: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioA.map { it.left() }.runAsync {
-        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
+        it.fold({ invoke { ca.resumeWith(SuccessOrFailure.failure(it)) } }, { invoke { ca.resumeWith(SuccessOrFailure.success(it)) } })
       })
     }
   }
   val b: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioB.map { it.right() }.runAsync {
-        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
+        it.fold({ invoke { ca.resumeWith(SuccessOrFailure.failure(it)) } }, { invoke { ca.resumeWith(SuccessOrFailure.success(it)) } })
       })
     }
   }
@@ -45,21 +43,21 @@ internal fun <F, A, B, C, D> Effect<F>.parMap3(ctx: CoroutineContext, ioA: Kind<
   val a: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioA.map { Treither.Left<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
+        it.fold({ invoke { ca.resumeWith(SuccessOrFailure.failure(it)) } }, { invoke { ca.resumeWith(SuccessOrFailure.success(it)) } })
       })
     }
   }
   val b: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioB.map { Treither.Middle<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
+        it.fold({ invoke { ca.resumeWith(SuccessOrFailure.failure(it)) } }, { invoke { ca.resumeWith(SuccessOrFailure.success(it)) } })
       })
     }
   }
   val c: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioC.map { Treither.Right<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
+        it.fold({ invoke { ca.resumeWith(SuccessOrFailure.failure(it)) } }, { invoke { ca.resumeWith(SuccessOrFailure.success(it)) } })
       })
     }
   }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
@@ -4,10 +4,13 @@ import arrow.Kind
 import arrow.core.*
 import arrow.effects.typeclasses.Effect
 import arrow.effects.typeclasses.Proc
-import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.startCoroutine
-import kotlin.coroutines.experimental.suspendCoroutine
+import arrow.typeclasses.Continuation as AContinuation
+import arrow.typeclasses.failure
+import arrow.typeclasses.success
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
 
 /* See par3 */
 internal fun <F, A, B, C> Effect<F>.parMap2(ctx: CoroutineContext, ioA: Kind<F, A>, ioB: Kind<F, B>, f: (A, B) -> C,
@@ -16,14 +19,14 @@ internal fun <F, A, B, C> Effect<F>.parMap2(ctx: CoroutineContext, ioA: Kind<F, 
   val a: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioA.map { it.left() }.runAsync {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
       })
     }
   }
   val b: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioB.map { it.right() }.runAsync {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
       })
     }
   }
@@ -42,21 +45,21 @@ internal fun <F, A, B, C, D> Effect<F>.parMap3(ctx: CoroutineContext, ioA: Kind<
   val a: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioA.map { Treither.Left<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
       })
     }
   }
   val b: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioB.map { Treither.Middle<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
       })
     }
   }
   val c: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioC.map { Treither.Right<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ invoke { ca.resumeWith(it.failure()) } }, { invoke { ca.resumeWith(it.success()) } })
       })
     }
   }
@@ -66,8 +69,8 @@ internal fun <F, A, B, C, D> Effect<F>.parMap3(ctx: CoroutineContext, ioA: Kind<
   c.startCoroutine(triCont)
 }
 
-private fun <A, B, C> parContinuation(ctx: CoroutineContext, f: (A, B) -> C, cc: Continuation<C>): Continuation<Either<A, B>> =
-  object : Continuation<Either<A, B>> {
+private fun <A, B, C> parContinuation(ctx: CoroutineContext, f: (A, B) -> C, cc: AContinuation<C>): AContinuation<Either<A, B>> =
+  object : AContinuation<Either<A, B>> {
     override val context: CoroutineContext = ctx
 
     var intermediate: Tuple2<A?, B?> = null toT null
@@ -94,8 +97,8 @@ private fun <A, B, C> parContinuation(ctx: CoroutineContext, f: (A, B) -> C, cc:
     }
   }
 
-private fun <A, B, C, D> triContinuation(ctx: CoroutineContext, f: (A, B, C) -> D, cc: Continuation<D>): Continuation<Treither<A, B, C>> =
-  object : Continuation<Treither<A, B, C>> {
+private fun <A, B, C, D> triContinuation(ctx: CoroutineContext, f: (A, B, C) -> D, cc: AContinuation<D>): AContinuation<Treither<A, B, C>> =
+  object : AContinuation<Treither<A, B, C>> {
     override val context: CoroutineContext = ctx
 
     var intermediate: Tuple3<A?, B?, C?> = Tuple3(null, null, null)
@@ -147,8 +150,8 @@ private sealed class Treither<out A, out B, out C> {
   abstract fun <D> fold(fa: (A) -> D, fb: (B) -> D, fc: (C) -> D): D
 }
 
-private fun <A> asyncIOContinuation(ctx: CoroutineContext, cc: (Either<Throwable, A>) -> Unit): Continuation<A> =
-  object : Continuation<A> {
+private fun <A> asyncIOContinuation(ctx: CoroutineContext, cc: (Either<Throwable, A>) -> Unit): AContinuation<A> =
+  object : AContinuation<A> {
     override val context: CoroutineContext = ctx
 
     override fun resume(value: A) {

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
@@ -4,7 +4,7 @@ import arrow.Kind
 import arrow.core.*
 import arrow.effects.typeclasses.Effect
 import arrow.effects.typeclasses.Proc
-import arrow.typeclasses.Continuation as AContinuation
+import arrow.core.Continuation as AContinuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.startCoroutine

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Async.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Async.kt
@@ -3,7 +3,7 @@ package arrow.effects.typeclasses
 import arrow.Kind
 import arrow.core.Either
 import arrow.typeclasses.MonadContinuation
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 /** An asynchronous computation that might fail. **/
 typealias Proc<A> = ((Either<Throwable, A>) -> Unit) -> Unit

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
@@ -6,7 +6,7 @@ import arrow.core.Tuple2
 import arrow.core.toT
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclasses.MonadError
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.startCoroutine
 
 /** The context required to defer evaluating a safe computation. **/
 interface MonadDefer<F> : MonadError<F, Throwable> {

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
@@ -6,6 +6,7 @@ import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclasses.MonadErrorContinuation
 import arrow.typeclasses.bindingCatch
 import arrow.typeclasses.stateStack
+import arrow.typeclasses.success
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -42,7 +43,7 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
       if (cancelled.get()) {
         throw BindingCancellationException()
       }
-      c.resumeWith(SuccessOrFailure.success(x))
+      c.resumeWith(x.success())
       returnedMonad
     }
     COROUTINE_SUSPENDED
@@ -61,7 +62,7 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
         if (cancelled.get()) {
           throw BindingCancellationException()
         }
-        c.resumeWith(SuccessOrFailure.success(xx))
+        c.resumeWith(xx.success())
         returnedMonad
       }
     }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
@@ -7,12 +7,12 @@ import arrow.typeclasses.MonadErrorContinuation
 import arrow.typeclasses.bindingCatch
 import arrow.typeclasses.stateStack
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.EmptyCoroutineContext
-import kotlin.coroutines.experimental.RestrictsSuspension
-import kotlin.coroutines.experimental.intrinsics.COROUTINE_SUSPENDED
-import kotlin.coroutines.experimental.intrinsics.suspendCoroutineOrReturn
-import kotlin.coroutines.experimental.startCoroutine
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.RestrictsSuspension
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.startCoroutine
 
 typealias Disposable = () -> Unit
 
@@ -35,20 +35,20 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
   suspend fun <B> bindDeferUnsafe(f: () -> Either<Throwable, B>): B =
     deferUnsafe(f).bind()
 
-  override suspend fun <B> bind(m: () -> Kind<F, B>): B = suspendCoroutineOrReturn { c ->
+  override suspend fun <B> bind(m: () -> Kind<F, B>): B = suspendCoroutineUninterceptedOrReturn { c ->
     val labelHere = c.stateStack // save the whole coroutine stack labels
     returnedMonad = m().flatMap { x: B ->
       c.stateStack = labelHere
       if (cancelled.get()) {
         throw BindingCancellationException()
       }
-      c.resume(x)
+      c.resumeWith(SuccessOrFailure.success(x))
       returnedMonad
     }
     COROUTINE_SUSPENDED
   }
 
-  override suspend fun <B> bindIn(context: CoroutineContext, m: () -> B): B = suspendCoroutineOrReturn { c ->
+  override suspend fun <B> bindIn(context: CoroutineContext, m: () -> B): B = suspendCoroutineUninterceptedOrReturn { c ->
     val labelHere = c.stateStack // save the whole coroutine stack labels
     val monadCreation: suspend () -> Kind<F, A> = {
       val datatype = try {
@@ -61,7 +61,7 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
         if (cancelled.get()) {
           throw BindingCancellationException()
         }
-        c.resume(xx)
+        c.resumeWith(SuccessOrFailure.success(xx))
         returnedMonad
       }
     }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
@@ -6,7 +6,6 @@ import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclasses.MonadErrorContinuation
 import arrow.typeclasses.bindingCatch
 import arrow.typeclasses.stateStack
-import arrow.typeclasses.success
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -43,7 +42,7 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
       if (cancelled.get()) {
         throw BindingCancellationException()
       }
-      c.resumeWith(x.success())
+      c.resumeWith(SuccessOrFailure.success(x))
       returnedMonad
     }
     COROUTINE_SUSPENDED
@@ -62,7 +61,7 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
         if (cancelled.get()) {
           throw BindingCancellationException()
         }
-        c.resumeWith(xx.success())
+        c.resumeWith(SuccessOrFailure.success(xx))
         returnedMonad
       }
     }

--- a/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects/src/test/kotlin/arrow/effects/IOTest.kt
@@ -14,7 +14,7 @@ import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.fail
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldEqual
-import kotlinx.coroutines.experimental.newSingleThreadContext
+import kotlinx.coroutines.newSingleThreadContext
 import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)


### PR DESCRIPTION
This PR migrates the lib to stable coroutines.

~~It's currently blocked on a version of `kotlinx.coroutines` on the new stack, to test.~~

~~Testing low level machinery...~~

All working now!