### PR TITLE
Try's success/failure extfuns 

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
@@ -239,4 +239,8 @@ inline fun <A, B> TryOf<A>.transform(ifSuccess: (A) -> TryOf<B>, ifFailure: (Thr
 
 fun <A> (() -> A).try_(): Try<A> = Try(this)
 
+fun <A> A.success(): Try<A> = Success(this)
+
+fun <A> Throwable.failure(): Try<A> = Failure(this)
+
 fun <T> TryOf<TryOf<T>>.flatten(): Try<T> = fix().flatMap(::identity)

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
@@ -331,11 +331,12 @@ class TryTest : UnitSpec() {
     }
 
     "success" {
-      "1".toInt().success() shouldBe success
+      10.success() shouldBe success
     }
 
     "failure" {
-      NumberFormatException().failure<Int>() shouldBe failure
+      val ex = NumberFormatException()
+      ex.failure<Int>() shouldBe Failure(ex)
     }
 
     "flatten" {

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/TryTest.kt
@@ -330,6 +330,14 @@ class TryTest : UnitSpec() {
       failure.transform({ Try { it.toString() } }) { Try { "NaN" } }.get() shouldBe "NaN"
     }
 
+    "success" {
+      "1".toInt().success() shouldBe success
+    }
+
+    "failure" {
+      NumberFormatException().failure<Int>() shouldBe failure
+    }
+
     "flatten" {
       (Try { success }.flatten().isSuccess()) shouldBe true
       (Try { failure }.flatten().isFailure()) shouldBe true


### PR DESCRIPTION
Added `success` and `failure` extfuns to `Try` datatype.
Added tests for `success` and `failure` to `TryTest`

It fixes #1009 

Let me know if there's something to change

