### PR TITLE
Flipped infix Applicative::ap (#1000)

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -306,8 +306,12 @@ inline fun <A, B> EitherOf<A, B?>.leftIfNull(crossinline default: () -> A): Eith
 fun <A, B> EitherOf<A, B>.contains(elem: B): Boolean =
   fix().fold({ false }, { it == elem })
 
-fun <A, B, C> EitherOf<A, B>.ap(ff: EitherOf<A, (B) -> C>): Either<A, C> =
+fun <A, B, C> EitherOf<A, B>.apPipe(ff: EitherOf<A, (B) -> C>): Either<A, C> =
   ff.fix().flatMap { f -> fix().map(f) }.fix()
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B, C> EitherOf<A, (B) -> C>.ap(fb: EitherOf<A, B>): Either<A, C> =
+  fb.apPipe(this)
 
 fun <A, B> EitherOf<A, B>.combineK(y: EitherOf<A, B>): Either<A, B> =
   when (this) {

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Eval.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Eval.kt
@@ -157,7 +157,7 @@ sealed class Eval<out A> : EvalOf<A> {
 
   fun <B> map(f: (A) -> B): Eval<B> = flatMap { a -> Now(f(a)) }
 
-  fun <B> ap(ff: EvalOf<(A) -> B>): Eval<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: EvalOf<(A) -> B>): Eval<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
   fun <B> flatMap(f: (A) -> EvalOf<B>): Eval<B> =
@@ -268,3 +268,6 @@ sealed class Eval<out A> : EvalOf<A> {
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> EvalOf<(A) -> B>.ap(fa: EvalOf<A>): Eval<B> = fa.fix().apPipe(this)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Function0.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Function0.kt
@@ -16,7 +16,7 @@ data class Function0<out A>(internal val f: () -> A) : Function0Of<A> {
 
   fun <B> coflatMap(f: (Function0Of<A>) -> B): Function0<B> = { f(this) }.k()
 
-  fun <B> ap(ff: Function0Of<(A) -> B>): Function0<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: Function0Of<(A) -> B>): Function0<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   fun extract(): A = f()
 
@@ -36,3 +36,7 @@ data class Function0<out A>(internal val f: () -> A) : Function0Of<A> {
 
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> Function0Of<(A) -> B>.ap(fa: Function0Of<A>): Function0<B> =
+  fa.fix().apPipe(this)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Function1.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Function1.kt
@@ -13,7 +13,8 @@ class Function1<I, out O>(val f: (I) -> O) : Function1Of<I, O> {
 
   fun <B> flatMap(f: (O) -> Function1Of<I, B>): Function1<I, B> = { p: I -> f(this.f(p))(p) }.k()
 
-  fun <B> ap(ff: Function1Of<I, (O) -> B>): Function1<I, B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: Function1Of<I, (O) -> B>): Function1<I, B> =
+    ff.fix().flatMap { f -> map(f) }.fix()
 
   fun local(f: (I) -> I): Function1<I, O> = f.andThen { this(it) }.k()
 
@@ -38,3 +39,7 @@ class Function1<I, out O>(val f: (I) -> O) : Function1Of<I, O> {
     fun <I> id(): Function1<I, I> = Function1(::identity)
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <I, O, B> Function1Of<I, (O) -> B>.ap(fo: Function1Of<I, O>): Function1<I, B> =
+  fo.fix().apPipe(this)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Id.kt
@@ -19,7 +19,7 @@ data class Id<out A>(val value: A) : IdOf<A> {
 
   fun extract(): A = this.fix().value
 
-  fun <B> ap(ff: IdOf<(A) -> B>): Id<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: IdOf<(A) -> B>): Id<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   companion object {
 
@@ -34,3 +34,6 @@ data class Id<out A>(val value: A) : IdOf<A> {
     fun <A> just(a: A): Id<A> = Id(a)
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> IdOf<(A) -> B>.ap(fa: IdOf<A>): Id<B> = fa.fix().apPipe(this)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -90,7 +90,7 @@ sealed class Option<out A> : OptionOf<A> {
       is Some -> f(t).fix()
     }
 
-  fun <B> ap(ff: OptionOf<(A) -> B>): Option<B> =
+  fun <B> apPipe(ff: OptionOf<(A) -> B>): Option<B> =
     ff.fix().flatMap { this.fix().map(it) }
 
   /**
@@ -211,3 +211,6 @@ fun <A> Boolean.maybe(f: () -> A): Option<A> =
 fun <A> A.some(): Option<A> = Some(this)
 
 fun <A> none(): Option<A> = None
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> OptionOf<(A) -> B>.ap(fa: OptionOf<A>): Option<B> = fa.fix().apPipe(this)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Try.kt
@@ -47,7 +47,7 @@ sealed class Try<out A> : TryOf<A> {
   @Deprecated(DeprecatedUnsafeAccess, ReplaceWith("getOrElse { ifEmpty }"))
   operator fun invoke() = get()
 
-  fun <B> ap(ff: TryOf<(A) -> B>): Try<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: TryOf<(A) -> B>): Try<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   /**
    * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
@@ -240,3 +240,6 @@ inline fun <A, B> TryOf<A>.transform(ifSuccess: (A) -> TryOf<B>, ifFailure: (Thr
 fun <A> (() -> A).try_(): Try<A> = Try(this)
 
 fun <T> TryOf<TryOf<T>>.flatten(): Try<T> = fix().flatMap(::identity)
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> TryOf<(A) -> B>.ap(fa: TryOf<A>): Try<B> = fa.fix().apPipe(this)

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/TupleN.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/TupleN.kt
@@ -10,7 +10,7 @@ data class Tuple2<out A, out B>(val a: A, val b: B) : Tuple2Of<A, B> {
   fun <C, D> bimap(fl: (A) -> C, fr: (B) -> D) =
     fl(a) toT fr(b)
 
-  fun <C> ap(f: Tuple2Of<*, (B) -> C>) =
+  fun <C> apPipe(f: Tuple2Of<*, (B) -> C>) =
     map(f.fix().b)
 
   fun <C> flatMap(f: (B) -> Tuple2Of<@UnsafeVariance A, C>) =
@@ -32,6 +32,10 @@ data class Tuple2<out A, out B>(val a: A, val b: B) : Tuple2Of<A, B> {
 
   companion object
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B, C> Tuple2Of<*, (B) -> C>.ap(fb: Tuple2Of<A, B>): Tuple2<A, C> =
+  fb.fix().apPipe(this)
 
 @higherkind
 data class Tuple3<out A, out B, out C>(val a: A, val b: B, val c: C) : Tuple3Of<A, B, C> {

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/EitherT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/EitherT.kt
@@ -104,5 +104,12 @@ data class EitherT<F, A, B>(val value: Kind<F, Either<A, B>>) : EitherTOf<F, A, 
     })
   }
 
-  fun <C> ap(MF: Monad<F>, ff: EitherTOf<F, A, (B) -> C>): EitherT<F, A, C> = ff.fix().flatMap(MF) { f -> map(MF, f) }
+  fun <C> apPipe(MF: Monad<F>, ff: EitherTOf<F, A, (B) -> C>): EitherT<F, A, C> =
+    ff.fix().flatMap(MF) { f -> map(MF, f) }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <F, A, B, C> EitherTOf<F, A, (B) -> C>.ap(
+  MF: Monad<F>,
+  fb: EitherTOf<F, A, B>
+): EitherT<F, A, C> = fb.fix().apPipe(MF, this)

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/Ior.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/Ior.kt
@@ -326,8 +326,12 @@ fun <A, B, D> Ior<A, B>.flatMap(SG: Semigroup<A>, f: (B) -> Ior<A, D>): Ior<A, D
   }
 )
 
-fun <A, B, D> Ior<A, B>.ap(SG: Semigroup<A>, ff: IorOf<A, (B) -> D>): Ior<A, D> =
-  ff.fix().flatMap(SG) { f -> map(f) }
+fun <A, B, D> IorOf<A, B>.apPipe(SG: Semigroup<A>, ff: IorOf<A, (B) -> D>): Ior<A, D> =
+  ff.fix().flatMap(SG) { f -> fix().map(f) }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <A, B, D> IorOf<A, (B) -> D>.ap(SG: Semigroup<A>, fb: IorOf<A, B>): Ior<A, D> =
+  fb.apPipe(SG, this)
 
 inline fun <A, B> Ior<A, B>.getOrElse(crossinline default: () -> B): B = fold({ default() }, ::identity, { _, b -> b })
 

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/Kleisli.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/Kleisli.kt
@@ -32,8 +32,8 @@ class Kleisli<F, D, A>(val run: KleisliFun<F, D, A>) : KleisliOf<F, D, A>, Kleis
    * @param ff function with the [Kleisli] context.
    * @param AF [Applicative] for the context [F].
    */
-  fun <B> ap(AF: Applicative<F>, ff: KleisliOf<F, D, (A) -> B>): Kleisli<F, D, B> =
-    AF.run { Kleisli { run(it).ap(ff.fix().run(it)) } }
+  fun <B> apPipe(AF: Applicative<F>, ff: KleisliOf<F, D, (A) -> B>): Kleisli<F, D, B> =
+    AF.run { Kleisli { run(it).apPipe(ff.fix().run(it)) } }
 
   /**
    * Map the end of the arrow [A] to [B] given a function [f].
@@ -153,6 +153,12 @@ class Kleisli<F, D, A>(val run: KleisliFun<F, D, A>) : KleisliOf<F, D, A>, Kleis
 
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <F, D, A, B> KleisliOf<F, D, (A) -> B>.ap(
+  AF: Applicative<F>,
+  fa: KleisliOf<F, D, A>
+): Kleisli<F, D, B> = fa.fix().apPipe(AF, this)
 
 /**
  * Flatten nested [Kleisli] arrows.

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/ListK.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/ListK.kt
@@ -22,7 +22,7 @@ data class ListK<out A>(val list: List<A>) : ListKOf<A>, List<A> by list {
     return Eval.defer { loop(this.fix()) }
   }
 
-  fun <B> ap(ff: ListKOf<(A) -> B>): ListK<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: ListKOf<(A) -> B>): ListK<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   fun <G, B> traverse(GA: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, ListK<B>> =
     foldRight(Eval.always { GA.just(emptyList<B>().k()) }) { a, eval ->
@@ -70,6 +70,9 @@ data class ListK<out A>(val list: List<A>) : ListKOf<A>, List<A> by list {
   }
 
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> ListKOf<(A) -> B>.ap(fa: ListKOf<A>): ListK<B> = fa.fix().apPipe(this)
 
 fun <A> ListKOf<A>.combineK(y: ListKOf<A>): ListK<A> =
   (fix().list + y.fix().list).k()

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/MapK.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/MapK.kt
@@ -21,12 +21,12 @@ data class MapK<K, out A>(val map: Map<K, A>) : MapKOf<K, A>, Map<K, A> by map {
     if (fb.value().isEmpty()) Eval.now(emptyMap<K, Z>().k())
     else fb.map { b -> this.map2(b, f) }
 
-  fun <B> ap(ff: MapK<K, (A) -> B>): MapK<K, B> =
-    ff.flatMap { this.map(it) }
+  fun <B> apPipe(ff: MapKOf<K, (A) -> B>): MapK<K, B> =
+    ff.fix().flatMap { this.map(it) }
 
-  fun <B, Z> ap2(f: MapK<K, (A, B) -> Z>, fb: MapK<K, B>): Map<K, Z> =
-    f.map.flatMap { (k, f) ->
-      this.flatMap { a -> fb.flatMap { b -> mapOf(Tuple2(k, f(a, b))).k() } }
+  fun <B, Z> apPipe2(f: MapKOf<K, (A, B) -> Z>, fb: MapKOf<K, B>): MapK<K, Z> =
+    f.fix().map.flatMap { (k, f) ->
+      this.flatMap { a -> fb.fix().flatMap { b -> mapOf(Tuple2(k, f(a, b))).k() } }
         .getOption(k).map { Tuple2(k, it) }.k().asIterable()
     }.k()
 
@@ -58,6 +58,14 @@ fun <K, A> Option<Tuple2<K, A>>.k(): MapK<K, A> =
     is Some -> mapOf(this.t).k()
     is None -> emptyMap<K, A>().k()
   }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <K, A, B> MapKOf<K, (A) -> B>.ap(fa: MapKOf<K, A>): MapK<K, B> =
+  fa.fix().apPipe(this)
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <K, A, B, Z> MapKOf<K, (A, B) -> Z>.ap2(fa: MapKOf<K, A>, fb: MapKOf<K, B>): MapK<K, Z> =
+  fa.fix().apPipe2(this, fb)
 
 inline fun <K, V, G> MapKOf<K, Kind<G, V>>.sequence(GA: Applicative<G>): Kind<G, MapK<K, V>> =
   fix().traverse(GA, ::identity)

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/NonEmptyList.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/NonEmptyList.kt
@@ -31,7 +31,8 @@ class NonEmptyList<out A> private constructor(
 
   fun <B> flatMap(f: (A) -> NonEmptyListOf<B>): NonEmptyList<B> = f(head).fix() + tail.flatMap { f(it).fix().all }
 
-  fun <B> ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
+    ff.fix().flatMap { f -> map(f) }.fix()
 
   operator fun plus(l: NonEmptyList<@UnsafeVariance A>): NonEmptyList<A> = NonEmptyList(all + l.all)
 
@@ -123,6 +124,10 @@ class NonEmptyList<out A> private constructor(
 }
 
 fun <A> A.nel(): NonEmptyList<A> = NonEmptyList.of(this)
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B, C> NonEmptyListOf<(A) -> B>.ap(fa: NonEmptyListOf<A>): NonEmptyList<B> =
+  fa.fix().apPipe(this)
 
 inline fun <A, G> NonEmptyListOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, NonEmptyList<A>> =
   fix().traverse(GA, ::identity)

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/Reader.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/Reader.kt
@@ -80,7 +80,20 @@ fun <D, A, B> Reader<D, A>.flatMap(f: (A) -> Reader<D, B>): Reader<D, B> = flatM
  *
  * @param ff function that maps [A] to [B] within the [Reader] context.
  */
-fun <D, A, B> Reader<D, A>.ap(ff: ReaderOf<D, (A) -> B>): Reader<D, B> = ap(IdBimonad, ff)
+fun <D, A, B> ReaderOf<D, A>.apPipe(ff: ReaderOf<D, (A) -> B>): Reader<D, B> =
+  fix().apPipe(IdBimonad, ff)
+
+/**
+ * Apply this function which operates within the context of [Reader] to a value in the context of
+ * [Reader].
+ *
+ * Version of [apPipe] with flipped receiver and parameter.
+ *
+ * @param fa value that is mapped to [B] by this function within the [Reader] context.
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <D, A, B> ReaderOf<D, (A) -> B>.ap(fa: ReaderOf<D, A>): ReaderOf<D, B> =
+  fa.apPipe(this)
 
 /**
  * Zip with another [Reader].

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/SequenceK.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/SequenceK.kt
@@ -15,7 +15,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
 
   fun <B> flatMap(f: (A) -> SequenceKOf<B>): SequenceK<B> = this.fix().sequence.flatMap { f(it).fix().sequence }.k()
 
-  fun <B> ap(ff: SequenceKOf<(A) -> B>): SequenceK<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> apPipe(ff: SequenceKOf<(A) -> B>): SequenceK<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   fun <B> map(f: (A) -> B): SequenceK<B> = this.fix().sequence.map(f).k()
 
@@ -76,6 +76,10 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
 
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> SequenceKOf<(A) -> B>.ap(fa: SequenceKOf<A>): SequenceK<B> =
+  fa.fix().apPipe(this)
 
 fun <A> SequenceKOf<A>.combineK(y: SequenceKOf<A>): SequenceK<A> = (fix().sequence + y.fix().sequence).k()
 

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/SortedMapK.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/SortedMapK.kt
@@ -25,8 +25,8 @@ data class SortedMapK<A : Comparable<A>, B>(val map: SortedMap<A, B>) : SortedMa
     if (fc.value().isEmpty()) Eval.now(sortedMapOf<A, Z>().k())
     else fc.map { c -> this.map2(c, f) }
 
-  fun <C> ap(ff: SortedMapK<A, (B) -> C>): SortedMapK<A, C> =
-    ff.flatMap { this.map(it) }
+  fun <C> apPipe(ff: SortedMapKOf<A, (B) -> C>): SortedMapK<A, C> =
+    ff.fix().flatMap { this.map(it) }
 
   fun <C, Z> ap2(f: SortedMapK<A, (B, C) -> Z>, fc: SortedMapK<A, C>): SortedMap<A, Z> =
     f.map.flatMap { (k, f) ->
@@ -62,6 +62,11 @@ fun <A : Comparable<A>, B> Option<Tuple2<A, B>>.k(): SortedMapK<A, B> = this.fol
   { sortedMapOf<A, B>().k() },
   { mapEntry -> sortedMapOf<A, B>(mapEntry.a to mapEntry.b).k() }
 )
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A : Comparable<A>, B, C> SortedMapKOf<A, (B) -> C>.ap(
+  fa: SortedMapKOf<A, B>
+): SortedMapK<A, C> = fa.fix().apPipe(this)
 
 inline fun <K : Comparable<K>, V, G> SortedMapKOf<K, Kind<G, V>>.sequence(GA: Applicative<G>): Kind<G, SortedMapK<K, V>> =
   fix().traverse(GA, ::identity)

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/StateT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/StateT.kt
@@ -200,7 +200,7 @@ class StateT<F, S, A>(
    * @param ff function with the [StateT] context.
    * @param MF [Monad] for the context [F].
    */
-  fun <B> ap(MF: Monad<F>, ff: StateTOf<F, S, (A) -> B>): StateT<F, S, B> =
+  fun <B> apPipe(MF: Monad<F>, ff: StateTOf<F, S, (A) -> B>): StateT<F, S, B> =
     ff.fix().map2(MF, this) { f, a -> f(a) }
 
   /**
@@ -301,6 +301,12 @@ class StateT<F, S, A>(
     run(MF, s).map { it.a }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <F, S, A, B> StateTOf<F, S, (A) -> B>.ap(
+  MF: Monad<F>,
+  fa: StateTOf<F, S, A>
+): StateT<F, S, B> = fa.fix().apPipe(MF, this)
 
 /**
  * Wrap the function with [StateT].

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/WriterT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/WriterT.kt
@@ -95,8 +95,11 @@ data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, 
 
   fun swap(MF: Monad<F>): WriterT<F, A, W> = transform(MF) { it.b toT it.a }
 
-  fun <B> ap(MF: Monad<F>, SG: Semigroup<W>, ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
-    ff.fix().flatMap(MF, SG) { map(MF, it) }
+  fun <B> apPipe(
+    MF: Monad<F>,
+    SG: Semigroup<W>,
+    ff: WriterTOf<F, W, (A) -> B>
+  ): WriterT<F, W, B> = ff.fix().flatMap(MF, SG) { map(MF, it) }
 
   fun <B> flatMap(MF: Monad<F>, SG: Semigroup<W>, f: (A) -> WriterT<F, W, B>): WriterT<F, W, B> = MF.run {
     WriterT(value.flatMap { value -> f(value.b).value.map { SG.run { it.a.combine(value.a) } toT it.b } })
@@ -118,3 +121,10 @@ data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, 
     WriterT(value.combineK(y.fix().value))
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <F, W, A, B> WriterTOf<F, W, (A) -> B>.ap(
+  MF: Monad<F>,
+  SG: Semigroup<W>,
+  fa: WriterTOf<F, W, A>
+): WriterT<F, W, B> = fa.fix().apPipe(MF, SG, this)

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/ValidatedTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/ValidatedTest.kt
@@ -136,14 +136,14 @@ class ValidatedTest : UnitSpec() {
       Invalid(10).findValid(plusIntSemigroup) { Invalid(5) } shouldBe Invalid(15)
     }
 
-    "ap should return Valid(f(a)) if both are Valid" {
-      Valid(10).ap<Int, Int, Int>(plusIntSemigroup, Valid({ a -> a + 5 })) shouldBe Valid(15)
+    "apPipe should return Valid(f(a)) if both are Valid" {
+      Valid(10).apPipe<Int, Int, Int>(plusIntSemigroup, Valid({ a -> a + 5 })) shouldBe Valid(15)
     }
 
-    "ap should return first Invalid found if is unique or combine both in otherwise" {
-      Invalid(10).ap<Int, Int, Int>(plusIntSemigroup, Valid({ a -> a + 5 })) shouldBe Invalid(10)
-      Valid(10).ap<Int, Int, Int>(plusIntSemigroup, Invalid(5)) shouldBe Invalid(5)
-      Invalid(10).ap<Int, Int, Int>(plusIntSemigroup, Invalid(5)) shouldBe Invalid(15)
+    "apPipe should return first Invalid found if is unique or combine both in otherwise" {
+      Invalid(10).apPipe<Int, Int, Int>(plusIntSemigroup, Valid({ a -> a + 5 })) shouldBe Invalid(10)
+      Valid(10).apPipe<Int, Int, Int>(plusIntSemigroup, Invalid(5)) shouldBe Invalid(5)
+      Invalid(10).apPipe<Int, Int, Int>(plusIntSemigroup, Invalid(5)) shouldBe Invalid(15)
     }
 
     data class MyException(val msg: String) : Exception()

--- a/modules/core/arrow-data/src/test/kotlin/arrow/free/FreeApplicativeTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/free/FreeApplicativeTest.kt
@@ -61,9 +61,9 @@ class FreeApplicativeTest : UnitSpec() {
       val loops = 10000
       val start = 333
       val r = FreeApplicative.liftF(NonEmptyList.of(start))
-      val rr = (1..loops).toList().fold(r) { v, _ -> v.ap(FreeApplicative.liftF(NonEmptyList.of({ a: Int -> a + 1 }))) }
+      val rr = (1..loops).toList().fold(r) { v, _ -> v.apPipe(FreeApplicative.liftF(NonEmptyList.of({ a: Int -> a + 1 }))) }
       rr.foldK(NonEmptyList.applicative()) shouldBe NonEmptyList.of(start + loops)
-      val rx = (1..loops).toList().foldRight(r) { _, v -> v.ap(FreeApplicative.liftF(NonEmptyList.of({ a: Int -> a + 1 }))) }
+      val rx = (1..loops).toList().foldRight(r) { _, v -> v.apPipe(FreeApplicative.liftF(NonEmptyList.of({ a: Int -> a + 1 }))) }
       rx.foldK(NonEmptyList.applicative()) shouldBe NonEmptyList.of(start + loops)
     }
   }

--- a/modules/core/arrow-free/src/main/kotlin/arrow/free/Free.kt
+++ b/modules/core/arrow-free/src/main/kotlin/arrow/free/Free.kt
@@ -34,8 +34,8 @@ sealed class Free<S, out A> : FreeOf<S, A> {
         override fun <A> just(a: A): Free<F, A> =
           Companion.just(a)
 
-        override fun <A, B> Kind<FreePartialOf<F>, A>.ap(ff: Kind<FreePartialOf<F>, (A) -> B>): Free<F, B> =
-          applicative.run { ap(ff).fix() }
+        override fun <A, B> FreeOf<F, A>.apPipe(ff: FreeOf<F, (A) -> B>): Free<F, B> =
+          applicative.run { apPipe(ff).fix() }
       }
   }
 
@@ -61,7 +61,12 @@ fun <S, A, B> FreeOf<S, A>.map(f: (A) -> B): Free<S, B> = flatMap { Free.Pure<S,
 
 fun <S, A, B> FreeOf<S, A>.flatMap(f: (A) -> Free<S, B>): Free<S, B> = Free.FlatMapped(this.fix(), f)
 
-fun <S, A, B> FreeOf<S, A>.ap(ff: FreeOf<S, (A) -> B>): Free<S, B> = ff.fix().flatMap { f -> map(f = f) }.fix()
+fun <S, A, B> FreeOf<S, A>.apPipe(ff: FreeOf<S, (A) -> B>): Free<S, B> =
+  ff.fix().flatMap { f -> map(f = f) }.fix()
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <S, A, B> FreeOf<S, (A) -> B>.ap(fa: FreeOf<S, A>): Free<S, B> =
+  fa.apPipe(this)
 
 @Suppress("UNCHECKED_CAST")
 tailrec fun <S, A> Free<S, A>.step(): Free<S, A> =

--- a/modules/core/arrow-free/src/main/kotlin/arrow/free/instances/free.kt
+++ b/modules/core/arrow-free/src/main/kotlin/arrow/free/instances/free.kt
@@ -9,7 +9,7 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
-import arrow.free.ap as freeAp
+import arrow.free.apPipe as freeApPipe
 import arrow.free.flatMap as freeFlatMap
 import arrow.free.map as freeMap
 
@@ -28,8 +28,8 @@ interface FreeApplicativeInstance<S> : FreeFunctorInstance<S>, Applicative<FreeP
   override fun <A, B> Kind<FreePartialOf<S>, A>.map(f: (A) -> B): Free<S, B> =
     fix().freeMap(f)
 
-  override fun <A, B> Kind<FreePartialOf<S>, A>.ap(ff: Kind<FreePartialOf<S>, (A) -> B>): Free<S, B> =
-    fix().freeAp(ff)
+  override fun <A, B> Kind<FreePartialOf<S>, A>.apPipe(ff: Kind<FreePartialOf<S>, (A) -> B>): Free<S, B> =
+    fix().freeApPipe(ff)
 }
 
 @instance(Free::class)
@@ -38,8 +38,8 @@ interface FreeMonadInstance<S> : FreeApplicativeInstance<S>, Monad<FreePartialOf
   override fun <A, B> Kind<FreePartialOf<S>, A>.map(f: (A) -> B): Free<S, B> =
     fix().freeMap(f)
 
-  override fun <A, B> Kind<FreePartialOf<S>, A>.ap(ff: Kind<FreePartialOf<S>, (A) -> B>): Free<S, B> =
-    fix().freeAp(ff)
+  override fun <A, B> Kind<FreePartialOf<S>, A>.apPipe(ff: Kind<FreePartialOf<S>, (A) -> B>): Free<S, B> =
+    fix().freeApPipe(ff)
 
   override fun <A, B> Kind<FreePartialOf<S>, A>.flatMap(f: (A) -> Kind<FreePartialOf<S>, B>): Free<S, B> =
     fix().freeFlatMap { f(it).fix() }

--- a/modules/core/arrow-free/src/main/kotlin/arrow/free/instances/freeaplicative.kt
+++ b/modules/core/arrow-free/src/main/kotlin/arrow/free/instances/freeaplicative.kt
@@ -20,8 +20,8 @@ interface FreeApplicativeFunctorInstance<S> : Functor<FreeApplicativePartialOf<S
 interface FreeApplicativeApplicativeInstance<S> : FreeApplicativeFunctorInstance<S>, Applicative<FreeApplicativePartialOf<S>> {
   override fun <A> just(a: A): FreeApplicative<S, A> = FreeApplicative.just(a)
 
-  override fun <A, B> Kind<FreeApplicativePartialOf<S>, A>.ap(ff: Kind<FreeApplicativePartialOf<S>, (A) -> B>): FreeApplicative<S, B> =
-    fix().ap(ff.fix())
+  override fun <A, B> Kind<FreeApplicativePartialOf<S>, A>.apPipe(ff: Kind<FreeApplicativePartialOf<S>, (A) -> B>): FreeApplicative<S, B> =
+    fix().apPipe(ff.fix())
 
   override fun <A, B> Kind<FreeApplicativePartialOf<S>, A>.map(f: (A) -> B): FreeApplicative<S, B> = fix().map(f)
 }

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
@@ -4,7 +4,7 @@ import arrow.Kind
 import arrow.core.Eval
 import arrow.instance
 import arrow.typeclasses.*
-import arrow.typeclasses.ap as constAp
+import arrow.typeclasses.apPipe as constApPipe
 import arrow.typeclasses.combine as combineAp
 
 @instance(Const::class)
@@ -23,8 +23,8 @@ interface ConstApplicativeInstance<A> : Applicative<ConstPartialOf<A>> {
     override fun SA(): Monoid<A> = MA()
   }.empty().fix()
 
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.ap(ff: Kind<ConstPartialOf<A>, (T) -> U>): Const<A, U> =
-    constAp(MA(), ff)
+  override fun <T, U> Kind<ConstPartialOf<A>, T>.apPipe(ff: Kind<ConstPartialOf<A>, (T) -> U>): Const<A, U> =
+    constApPipe(MA(), ff)
 }
 
 @instance(Const::class)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/either.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/either.kt
@@ -5,7 +5,7 @@ import arrow.Kind2
 import arrow.core.*
 import arrow.instance
 import arrow.typeclasses.*
-import arrow.core.ap as eitherAp
+import arrow.core.apPipe as eitherApPipe
 import arrow.core.combineK as eitherCombineK
 import arrow.core.flatMap as eitherFlatMap
 import arrow.instances.traverse as eitherTraverse
@@ -63,8 +63,8 @@ interface EitherApplicativeInstance<L> : EitherFunctorInstance<L>, Applicative<E
 
   override fun <A, B> Kind<EitherPartialOf<L>, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
 
-  override fun <A, B> Kind<EitherPartialOf<L>, A>.ap(ff: Kind<EitherPartialOf<L>, (A) -> B>): Either<L, B> =
-    fix().eitherAp(ff)
+  override fun <A, B> Kind<EitherPartialOf<L>, A>.apPipe(ff: Kind<EitherPartialOf<L>, (A) -> B>): Either<L, B> =
+    fix().eitherApPipe(ff)
 }
 
 @instance(Either::class)
@@ -72,8 +72,8 @@ interface EitherMonadInstance<L> : EitherApplicativeInstance<L>, Monad<EitherPar
 
   override fun <A, B> Kind<EitherPartialOf<L>, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
 
-  override fun <A, B> Kind<EitherPartialOf<L>, A>.ap(ff: Kind<EitherPartialOf<L>, (A) -> B>): Either<L, B> =
-    fix().eitherAp(ff)
+  override fun <A, B> Kind<EitherPartialOf<L>, A>.apPipe(ff: Kind<EitherPartialOf<L>, (A) -> B>): Either<L, B> =
+    fix().eitherApPipe(ff)
 
   override fun <A, B> Kind<EitherPartialOf<L>, A>.flatMap(f: (A) -> Kind<EitherPartialOf<L>, B>): Either<L, B> =
     fix().eitherFlatMap { f(it).fix() }

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/eval.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/eval.kt
@@ -13,8 +13,8 @@ interface EvalFunctorInstance : Functor<ForEval> {
 
 @instance(Eval::class)
 interface EvalApplicativeInstance : Applicative<ForEval> {
-  override fun <A, B> Kind<ForEval, A>.ap(ff: Kind<ForEval, (A) -> B>): Eval<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForEval, A>.apPipe(ff: Kind<ForEval, (A) -> B>): Eval<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForEval, A>.map(f: (A) -> B): Eval<B> =
     fix().map(f)
@@ -25,8 +25,8 @@ interface EvalApplicativeInstance : Applicative<ForEval> {
 
 @instance(Eval::class)
 interface EvalMonadInstance : Monad<ForEval> {
-  override fun <A, B> Kind<ForEval, A>.ap(ff: Kind<ForEval, (A) -> B>): Eval<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForEval, A>.apPipe(ff: Kind<ForEval, (A) -> B>): Eval<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForEval, A>.flatMap(f: (A) -> Kind<ForEval, B>): Eval<B> =
     fix().flatMap(f)
@@ -55,8 +55,8 @@ interface EvalComonadInstance : Comonad<ForEval> {
 
 @instance(Eval::class)
 interface EvalBimonadInstance : Bimonad<ForEval> {
-  override fun <A, B> Kind<ForEval, A>.ap(ff: Kind<ForEval, (A) -> B>): Eval<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForEval, A>.apPipe(ff: Kind<ForEval, (A) -> B>): Eval<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForEval, A>.flatMap(f: (A) -> Kind<ForEval, B>): Eval<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function0.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function0.kt
@@ -13,8 +13,8 @@ interface Function0FunctorInstance : Functor<ForFunction0> {
 
 @instance(Function0::class)
 interface Function0ApplicativeInstance : Applicative<ForFunction0> {
-  override fun <A, B> Kind<ForFunction0, A>.ap(ff: Kind<ForFunction0, (A) -> B>): Function0<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForFunction0, A>.apPipe(ff: Kind<ForFunction0, (A) -> B>): Function0<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForFunction0, A>.map(f: (A) -> B): Function0<B> =
     fix().map(f)
@@ -25,8 +25,8 @@ interface Function0ApplicativeInstance : Applicative<ForFunction0> {
 
 @instance(Function0::class)
 interface Function0MonadInstance : Monad<ForFunction0> {
-  override fun <A, B> Kind<ForFunction0, A>.ap(ff: Kind<ForFunction0, (A) -> B>): Function0<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForFunction0, A>.apPipe(ff: Kind<ForFunction0, (A) -> B>): Function0<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForFunction0, A>.flatMap(f: (A) -> Kind<ForFunction0, B>): Function0<B> =
     fix().flatMap(f)
@@ -55,8 +55,8 @@ interface Function0ComonadInstance : Comonad<ForFunction0> {
 
 @instance(Function0::class)
 interface Function0BimonadInstance : Bimonad<ForFunction0> {
-  override fun <A, B> Kind<ForFunction0, A>.ap(ff: Kind<ForFunction0, (A) -> B>): Function0<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForFunction0, A>.apPipe(ff: Kind<ForFunction0, (A) -> B>): Function0<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForFunction0, A>.flatMap(f: (A) -> Kind<ForFunction0, B>): Function0<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function1.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function1.kt
@@ -31,8 +31,8 @@ interface Function1ApplicativeInstance<I> : Function1FunctorInstance<I>, Applica
   override fun <A, B> Kind<Function1PartialOf<I>, A>.map(f: (A) -> B): Function1<I, B> =
     fix().map(f)
 
-  override fun <A, B> Kind<Function1PartialOf<I>, A>.ap(ff: Kind<Function1PartialOf<I>, (A) -> B>): Function1<I, B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<Function1PartialOf<I>, A>.apPipe(ff: Kind<Function1PartialOf<I>, (A) -> B>): Function1<I, B> =
+    fix().apPipe(ff)
 }
 
 @instance(Function1::class)
@@ -41,8 +41,8 @@ interface Function1MonadInstance<I> : Function1ApplicativeInstance<I>, Monad<Fun
   override fun <A, B> Kind<Function1PartialOf<I>, A>.map(f: (A) -> B): Function1<I, B> =
     fix().map(f)
 
-  override fun <A, B> Kind<Function1PartialOf<I>, A>.ap(ff: Kind<Function1PartialOf<I>, (A) -> B>): Function1<I, B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<Function1PartialOf<I>, A>.apPipe(ff: Kind<Function1PartialOf<I>, (A) -> B>): Function1<I, B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<Function1PartialOf<I>, A>.flatMap(f: (A) -> Kind<Function1PartialOf<I>, B>): Function1<I, B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
@@ -29,8 +29,8 @@ interface IdFunctorInstance : Functor<ForId> {
 
 @instance(Id::class)
 interface IdApplicativeInstance : Applicative<ForId> {
-  override fun <A, B> Kind<ForId, A>.ap(ff: Kind<ForId, (A) -> B>): Id<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForId, A>.apPipe(ff: Kind<ForId, (A) -> B>): Id<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForId, A>.map(f: (A) -> B): Id<B> =
     fix().map(f)
@@ -41,8 +41,8 @@ interface IdApplicativeInstance : Applicative<ForId> {
 
 @instance(Id::class)
 interface IdMonadInstance : Monad<ForId> {
-  override fun <A, B> Kind<ForId, A>.ap(ff: Kind<ForId, (A) -> B>): Id<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForId, A>.apPipe(ff: Kind<ForId, (A) -> B>): Id<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForId, A>.flatMap(f: (A) -> Kind<ForId, B>): Id<B> =
     fix().flatMap(f)
@@ -71,8 +71,8 @@ interface IdComonadInstance : Comonad<ForId> {
 
 @instance(Id::class)
 interface IdBimonadInstance : Bimonad<ForId> {
-  override fun <A, B> Kind<ForId, A>.ap(ff: Kind<ForId, (A) -> B>): Id<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForId, A>.apPipe(ff: Kind<ForId, (A) -> B>): Id<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForId, A>.flatMap(f: (A) -> Kind<ForId, B>): Id<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/option.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/option.kt
@@ -76,8 +76,8 @@ interface OptionFunctorInstance : Functor<ForOption> {
 
 @instance(Option::class)
 interface OptionApplicativeInstance : Applicative<ForOption> {
-  override fun <A, B> Kind<ForOption, A>.ap(ff: Kind<ForOption, (A) -> B>): Option<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForOption, A>.apPipe(ff: Kind<ForOption, (A) -> B>): Option<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForOption, A>.map(f: (A) -> B): Option<B> =
     fix().map(f)
@@ -88,8 +88,8 @@ interface OptionApplicativeInstance : Applicative<ForOption> {
 
 @instance(Option::class)
 interface OptionMonadInstance : Monad<ForOption> {
-  override fun <A, B> Kind<ForOption, A>.ap(ff: Kind<ForOption, (A) -> B>): Option<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForOption, A>.apPipe(ff: Kind<ForOption, (A) -> B>): Option<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForOption, A>.flatMap(f: (A) -> Kind<ForOption, B>): Option<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/try.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/try.kt
@@ -87,8 +87,8 @@ interface TryFunctorInstance : Functor<ForTry> {
 
 @instance(Try::class)
 interface TryApplicativeInstance : Applicative<ForTry> {
-  override fun <A, B> Kind<ForTry, A>.ap(ff: Kind<ForTry, (A) -> B>): Try<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForTry, A>.apPipe(ff: Kind<ForTry, (A) -> B>): Try<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForTry, A>.map(f: (A) -> B): Try<B> =
     fix().map(f)
@@ -99,8 +99,8 @@ interface TryApplicativeInstance : Applicative<ForTry> {
 
 @instance(Try::class)
 interface TryMonadInstance : Monad<ForTry> {
-  override fun <A, B> Kind<ForTry, A>.ap(ff: Kind<ForTry, (A) -> B>): Try<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForTry, A>.apPipe(ff: Kind<ForTry, (A) -> B>): Try<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForTry, A>.flatMap(f: (A) -> Kind<ForTry, B>): Try<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/tuple.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/tuple.kt
@@ -25,8 +25,8 @@ interface Tuple2ApplicativeInstance<F> : Tuple2FunctorInstance<F>, Applicative<T
   override fun <A, B> Kind<Tuple2PartialOf<F>, A>.map(f: (A) -> B) =
     fix().map(f)
 
-  override fun <A, B> Kind<Tuple2PartialOf<F>, A>.ap(ff: Kind<Tuple2PartialOf<F>, (A) -> B>) =
-    fix().ap(ff.fix())
+  override fun <A, B> Kind<Tuple2PartialOf<F>, A>.apPipe(ff: Kind<Tuple2PartialOf<F>, (A) -> B>) =
+    fix().apPipe(ff.fix())
 
   override fun <A> just(a: A) =
     MF().empty() toT a
@@ -37,8 +37,8 @@ interface Tuple2MonadInstance<F> : Tuple2ApplicativeInstance<F>, Monad<Tuple2Par
   override fun <A, B> Kind<Tuple2PartialOf<F>, A>.map(f: (A) -> B) =
     fix().map(f)
 
-  override fun <A, B> Kind<Tuple2PartialOf<F>, A>.ap(ff: Kind<Tuple2PartialOf<F>, (A) -> B>) =
-    fix().ap(ff)
+  override fun <A, B> Kind<Tuple2PartialOf<F>, A>.apPipe(ff: Kind<Tuple2PartialOf<F>, (A) -> B>) =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<Tuple2PartialOf<F>, A>.flatMap(f: (A) -> Kind<Tuple2PartialOf<F>, B>) =
     fix().flatMap { f(it).fix() }

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/eithert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/eithert.kt
@@ -23,16 +23,16 @@ interface EitherTApplicativeInstance<F, L> : EitherTFunctorInstance<F, L>, Appli
 
   override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.map(f: (A) -> B): EitherT<F, L, B> = fix().map(MF()) { f(it) }
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.ap(ff: Kind<EitherTPartialOf<F, L>, (A) -> B>): EitherT<F, L, B> =
-    fix().ap(MF(), ff)
+  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.apPipe(ff: Kind<EitherTPartialOf<F, L>, (A) -> B>): EitherT<F, L, B> =
+    fix().apPipe(MF(), ff)
 }
 
 interface EitherTMonadInstance<F, L> : EitherTApplicativeInstance<F, L>, Monad<EitherTPartialOf<F, L>> {
 
   override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.map(f: (A) -> B): EitherT<F, L, B> = fix().map(MF()) { f(it) }
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.ap(ff: Kind<EitherTPartialOf<F, L>, (A) -> B>): EitherT<F, L, B> =
-    fix().ap(MF(), ff)
+  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.apPipe(ff: Kind<EitherTPartialOf<F, L>, (A) -> B>): EitherT<F, L, B> =
+    fix().apPipe(MF(), ff)
 
   override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.flatMap(f: (A) -> Kind<EitherTPartialOf<F, L>, B>): EitherT<F, L, B> = fix().flatMap(MF()) { f(it).fix() }
 

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/ior.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/ior.kt
@@ -28,8 +28,8 @@ interface IorApplicativeInstance<L> : IorFunctorInstance<L>, Applicative<IorPart
 
   override fun <A, B> Kind<IorPartialOf<L>, A>.map(f: (A) -> B): Ior<L, B> = fix().map(f)
 
-  override fun <A, B> Kind<IorPartialOf<L>, A>.ap(ff: Kind<IorPartialOf<L>, (A) -> B>): Ior<L, B> =
-    fix().ap(SL(), ff)
+  override fun <A, B> Kind<IorPartialOf<L>, A>.apPipe(ff: Kind<IorPartialOf<L>, (A) -> B>): Ior<L, B> =
+    fix().apPipe(SL(), ff)
 }
 
 @instance(Ior::class)
@@ -40,8 +40,8 @@ interface IorMonadInstance<L> : IorApplicativeInstance<L>, Monad<IorPartialOf<L>
   override fun <A, B> Kind<IorPartialOf<L>, A>.flatMap(f: (A) -> Kind<IorPartialOf<L>, B>): Ior<L, B> =
     fix().flatMap(SL()) { f(it).fix() }
 
-  override fun <A, B> Kind<IorPartialOf<L>, A>.ap(ff: Kind<IorPartialOf<L>, (A) -> B>): Ior<L, B> =
-    fix().ap(SL(), ff)
+  override fun <A, B> Kind<IorPartialOf<L>, A>.apPipe(ff: Kind<IorPartialOf<L>, (A) -> B>): Ior<L, B> =
+    fix().apPipe(SL(), ff)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> IorOf<L, Either<A, B>>): Ior<L, B> =
     Ior.tailRecM(a, f, SL())

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/kleisli.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/kleisli.kt
@@ -24,8 +24,8 @@ interface KleisliApplicativeInstance<F, D> : KleisliFunctorInstance<F, D>, Appli
   override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.map(f: (A) -> B): Kleisli<F, D, B> =
     fix().map(FF(), f)
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.ap(ff: Kind<KleisliPartialOf<F, D>, (A) -> B>): Kleisli<F, D, B> =
-    fix().ap(FF(), ff)
+  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.apPipe(ff: Kind<KleisliPartialOf<F, D>, (A) -> B>): Kleisli<F, D, B> =
+    fix().apPipe(FF(), ff)
 
   override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.product(fb: Kind<KleisliPartialOf<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
     Kleisli { FF().run { fix().run(it).product(fb.fix().run(it)) } }
@@ -42,8 +42,8 @@ interface KleisliMonadInstance<F, D> : KleisliApplicativeInstance<F, D>, Monad<K
   override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.flatMap(f: (A) -> Kind<KleisliPartialOf<F, D>, B>): Kleisli<F, D, B> =
     fix().flatMap(FF(), f.andThen { it.fix() })
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.ap(ff: Kind<KleisliPartialOf<F, D>, (A) -> B>): Kleisli<F, D, B> =
-    fix().ap(FF(), ff)
+  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.apPipe(ff: Kind<KleisliPartialOf<F, D>, (A) -> B>): Kleisli<F, D, B> =
+    fix().apPipe(FF(), ff)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> KleisliOf<F, D, Either<A, B>>): Kleisli<F, D, B> =
     Kleisli.tailRecM(FF(), a, f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/listk.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/listk.kt
@@ -45,8 +45,8 @@ interface ListKFunctorInstance : Functor<ForListK> {
 
 @instance(ListK::class)
 interface ListKApplicativeInstance : Applicative<ForListK> {
-  override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForListK, A>.apPipe(ff: Kind<ForListK, (A) -> B>): ListK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForListK, A>.map(f: (A) -> B): ListK<B> =
     fix().map(f)
@@ -60,8 +60,8 @@ interface ListKApplicativeInstance : Applicative<ForListK> {
 
 @instance(ListK::class)
 interface ListKMonadInstance : Monad<ForListK> {
-  override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForListK, A>.apPipe(ff: Kind<ForListK, (A) -> B>): ListK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForListK, A>.flatMap(f: (A) -> Kind<ForListK, B>): ListK<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/nonemptylist.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/nonemptylist.kt
@@ -38,8 +38,8 @@ interface NonEmptyListFunctorInstance : Functor<ForNonEmptyList> {
 
 @instance(NonEmptyList::class)
 interface NonEmptyListApplicativeInstance : Applicative<ForNonEmptyList> {
-  override fun <A, B> Kind<ForNonEmptyList, A>.ap(ff: Kind<ForNonEmptyList, (A) -> B>): NonEmptyList<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForNonEmptyList, A>.apPipe(ff: Kind<ForNonEmptyList, (A) -> B>): NonEmptyList<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForNonEmptyList, A>.map(f: (A) -> B): NonEmptyList<B> =
     fix().map(f)
@@ -50,8 +50,8 @@ interface NonEmptyListApplicativeInstance : Applicative<ForNonEmptyList> {
 
 @instance(NonEmptyList::class)
 interface NonEmptyListMonadInstance : Monad<ForNonEmptyList> {
-  override fun <A, B> Kind<ForNonEmptyList, A>.ap(ff: Kind<ForNonEmptyList, (A) -> B>): NonEmptyList<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForNonEmptyList, A>.apPipe(ff: Kind<ForNonEmptyList, (A) -> B>): NonEmptyList<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForNonEmptyList, A>.flatMap(f: (A) -> Kind<ForNonEmptyList, B>): NonEmptyList<B> =
     fix().flatMap(f)
@@ -80,8 +80,8 @@ interface NonEmptyListComonadInstance : Comonad<ForNonEmptyList> {
 
 @instance(NonEmptyList::class)
 interface NonEmptyListBimonadInstance : Bimonad<ForNonEmptyList> {
-  override fun <A, B> Kind<ForNonEmptyList, A>.ap(ff: Kind<ForNonEmptyList, (A) -> B>): NonEmptyList<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForNonEmptyList, A>.apPipe(ff: Kind<ForNonEmptyList, (A) -> B>): NonEmptyList<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForNonEmptyList, A>.flatMap(f: (A) -> Kind<ForNonEmptyList, B>): NonEmptyList<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/optiont.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/optiont.kt
@@ -27,8 +27,8 @@ interface OptionTApplicativeInstance<F> : OptionTFunctorInstance<F>, Applicative
 
   override fun <A, B> Kind<OptionTPartialOf<F>, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(FF(), f)
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.ap(ff: Kind<OptionTPartialOf<F>, (A) -> B>): OptionT<F, B> =
-    fix().ap(FF(), ff)
+  override fun <A, B> Kind<OptionTPartialOf<F>, A>.apPipe(ff: Kind<OptionTPartialOf<F>, (A) -> B>): OptionT<F, B> =
+    fix().apPipe(FF(), ff)
 }
 
 @instance(OptionT::class)
@@ -38,8 +38,8 @@ interface OptionTMonadInstance<F> : OptionTApplicativeInstance<F>, Monad<OptionT
 
   override fun <A, B> Kind<OptionTPartialOf<F>, A>.flatMap(f: (A) -> Kind<OptionTPartialOf<F>, B>): OptionT<F, B> = fix().flatMap(FF()) { f(it).fix() }
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.ap(ff: Kind<OptionTPartialOf<F>, (A) -> B>): OptionT<F, B> =
-    fix().ap(FF(), ff)
+  override fun <A, B> Kind<OptionTPartialOf<F>, A>.apPipe(ff: Kind<OptionTPartialOf<F>, (A) -> B>): OptionT<F, B> =
+    fix().apPipe(FF(), ff)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> OptionTOf<F, Either<A, B>>): OptionT<F, B> =
     OptionT.tailRecM(FF(), a, f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/sequence.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/sequence.kt
@@ -47,8 +47,8 @@ interface SequenceKFunctorInstance : Functor<ForSequenceK> {
 
 @instance(SequenceK::class)
 interface SequenceKApplicativeInstance : Applicative<ForSequenceK> {
-  override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForSequenceK, A>.apPipe(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForSequenceK, A>.map(f: (A) -> B): SequenceK<B> =
     fix().map(f)
@@ -62,8 +62,8 @@ interface SequenceKApplicativeInstance : Applicative<ForSequenceK> {
 
 @instance(SequenceK::class)
 interface SequenceKMonadInstance : Monad<ForSequenceK> {
-  override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForSequenceK, A>.apPipe(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForSequenceK, A>.flatMap(f: (A) -> Kind<ForSequenceK, B>): SequenceK<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/statet.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/statet.kt
@@ -27,8 +27,8 @@ interface StateTApplicativeInstance<F, S> : StateTFunctorInstance<F, S>, Applica
   override fun <A> just(a: A): StateT<F, S, A> =
     StateT(FF().just({ s: S -> FF().just(Tuple2(s, a)) }))
 
-  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.ap(ff: Kind<StateTPartialOf<F, S>, (A) -> B>): StateT<F, S, B> =
-    fix().ap(FF(), ff)
+  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.apPipe(ff: Kind<StateTPartialOf<F, S>, (A) -> B>): StateT<F, S, B> =
+    fix().apPipe(FF(), ff)
 
   override fun <A, B> Kind<StateTPartialOf<F, S>, A>.product(fb: Kind<StateTPartialOf<F, S>, B>): StateT<F, S, Tuple2<A, B>> =
     fix().product(FF(), fb.fix())
@@ -47,7 +47,7 @@ interface StateTMonadInstance<F, S> : StateTApplicativeInstance<F, S>, Monad<Sta
   override fun <A, B> tailRecM(a: A, f: (A) -> StateTOf<F, S, Either<A, B>>): StateT<F, S, B> =
     StateT.tailRecM(FF(), a, f)
 
-  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.ap(ff: Kind<StateTPartialOf<F, S>, (A) -> B>): StateT<F, S, B> =
+  override fun <A, B> Kind<StateTPartialOf<F, S>, A>.apPipe(ff: Kind<StateTPartialOf<F, S>, (A) -> B>): StateT<F, S, B> =
     ff.fix().map2(FF(), fix()) { f, a -> f(a) }
 
 }

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/validated.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/validated.kt
@@ -21,7 +21,7 @@ interface ValidatedApplicativeInstance<E> : ValidatedFunctorInstance<E>, Applica
 
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.map(f: (A) -> B): Validated<E, B> = fix().map(f)
 
-  override fun <A, B> Kind<ValidatedPartialOf<E>, A>.ap(ff: Kind<ValidatedPartialOf<E>, (A) -> B>): Validated<E, B> = fix().ap(SE(), ff.fix())
+  override fun <A, B> Kind<ValidatedPartialOf<E>, A>.apPipe(ff: Kind<ValidatedPartialOf<E>, (A) -> B>): Validated<E, B> = fix().apPipe(SE(), ff.fix())
 
 }
 

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
@@ -27,8 +27,8 @@ interface WriterTApplicativeInstance<F, W> : Applicative<WriterTPartialOf<F, W>>
   override fun <A> just(a: A): WriterTOf<F, W, A> =
     WriterT(FF().just(MM().empty() toT a))
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.ap(ff: Kind<WriterTPartialOf<F, W>, (A) -> B>): WriterT<F, W, B> =
-    fix().ap(FF(), MM(), ff)
+  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.apPipe(ff: Kind<WriterTPartialOf<F, W>, (A) -> B>): WriterT<F, W, B> =
+    fix().apPipe(FF(), MM(), ff)
 
   override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.map(f: (A) -> B): WriterT<F, W, B> =
     fix().map(FF()) { f(it) }
@@ -46,8 +46,8 @@ interface WriterTMonadInstance<F, W> : WriterTApplicativeInstance<F, W>, Monad<W
   override fun <A, B> tailRecM(a: A, f: (A) -> Kind<WriterTPartialOf<F, W>, Either<A, B>>): WriterT<F, W, B> =
     WriterT.tailRecM(FF(), a, f)
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.ap(ff: Kind<WriterTPartialOf<F, W>, (A) -> B>): WriterT<F, W, B> =
-    fix().ap(FF(), MM(), ff)
+  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.apPipe(ff: Kind<WriterTPartialOf<F, W>, (A) -> B>): WriterT<F, W, B> =
+    fix().apPipe(FF(), MM(), ff)
 }
 
 @instance(WriterT::class)

--- a/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/instances/listk.kt
+++ b/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/instances/listk.kt
@@ -21,8 +21,8 @@ interface ListKMonadCombineInstance : MonadCombine<ForListK> {
   override fun <A, B> Kind<ForListK, A>.mapFilter(f: (A) -> Option<B>): ListK<B> =
     fix().mapFilter(f)
 
-  override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForListK, A>.apPipe(ff: Kind<ForListK, (A) -> B>): ListK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForListK, A>.flatMap(f: (A) -> Kind<ForListK, B>): ListK<B> =
     fix().flatMap(f)
@@ -60,8 +60,8 @@ interface ListKMonadFilterInstance : MonadFilter<ForListK> {
   override fun <A, B> Kind<ForListK, A>.mapFilter(f: (A) -> Option<B>): ListK<B> =
     fix().mapFilter(f)
 
-  override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForListK, A>.apPipe(ff: Kind<ForListK, (A) -> B>): ListK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForListK, A>.flatMap(f: (A) -> Kind<ForListK, B>): ListK<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/instances/option.kt
+++ b/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/instances/option.kt
@@ -47,8 +47,8 @@ interface OptionMonadFilterInstance : MonadFilter<ForOption> {
   override fun <A> empty(): Option<A> =
     Option.empty()
 
-  override fun <A, B> Kind<ForOption, A>.ap(ff: Kind<ForOption, (A) -> B>): Option<B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForOption, A>.apPipe(ff: Kind<ForOption, (A) -> B>): Option<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForOption, A>.flatMap(f: (A) -> Kind<ForOption, B>): Option<B> =
     fix().flatMap(f)

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AlternativeLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AlternativeLaws.kt
@@ -22,7 +22,7 @@ object AlternativeLaws {
 
   fun <F> Alternative<F>.alternativeRightAbsorption(cff: (Int) -> Kind<F, (Int) -> Int>, EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genConstructor2(Gen.int(), cff)) { fa: Kind<F, (Int) -> Int> ->
-      empty<Int>().ap(fa).equalUnderTheLaw(empty(), EQ)
+      empty<Int>().apPipe(fa).equalUnderTheLaw(empty(), EQ)
     }
 
   fun <F> Alternative<F>.alternativeLeftDistributivity(cf: (Int) -> Kind<F, Int>, EQ: Eq<Kind<F, Int>>): Unit =
@@ -36,6 +36,6 @@ object AlternativeLaws {
                                                         EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genConstructor(Gen.int(), cf), genConstructor2(Gen.int(), cff), genConstructor2(Gen.int(), cff)
     ) { fa: Kind<F, Int>, ff: Kind<F, (Int) -> Int>, fg: Kind<F, (Int) -> Int> ->
-      fa.ap(ff.combineK(fg)).equalUnderTheLaw(fa.ap(ff).combineK(fa.ap(fg)), EQ)
+      fa.apPipe(ff.combineK(fg)).equalUnderTheLaw(fa.apPipe(ff).combineK(fa.apPipe(fg)), EQ)
     }
 }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ApplicativeLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ApplicativeLaws.kt
@@ -13,7 +13,7 @@ object ApplicativeLaws {
 
   inline fun <F> laws(A: Applicative<F>, EQ: Eq<Kind<F, Int>>): List<Law> =
     FunctorLaws.laws(A, EQ) + listOf(
-      Law("Applicative Laws: ap identity") { A.apIdentity(EQ) },
+      Law("Applicative Laws: apPipe identity") { A.apIdentity(EQ) },
       Law("Applicative Laws: homomorphism") { A.homomorphism(EQ) },
       Law("Applicative Laws: interchange") { A.interchange(EQ) },
       Law("Applicative Laws: map derived") { A.mapDerived(EQ) },
@@ -23,22 +23,22 @@ object ApplicativeLaws {
 
   fun <F> Applicative<F>.apIdentity(EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
-      fa.ap(just({ n: Int -> n })).equalUnderTheLaw(fa, EQ)
+      fa.apPipe(just({ n: Int -> n })).equalUnderTheLaw(fa, EQ)
     }
 
   fun <F> Applicative<F>.homomorphism(EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genFunctionAToB<Int, Int>(Gen.int()), Gen.int()) { ab: (Int) -> Int, a: Int ->
-      just(a).ap(just(ab)).equalUnderTheLaw(just(ab(a)), EQ)
+      just(a).apPipe(just(ab)).equalUnderTheLaw(just(ab(a)), EQ)
     }
 
   fun <F> Applicative<F>.interchange(EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genApplicative(genFunctionAToB<Int, Int>(Gen.int()), this), Gen.int()) { fa: Kind<F, (Int) -> Int>, a: Int ->
-      just(a).ap(fa).equalUnderTheLaw(fa.ap(just({ x: (Int) -> Int -> x(a) })), EQ)
+      just(a).apPipe(fa).equalUnderTheLaw(fa.apPipe(just({ x: (Int) -> Int -> x(a) })), EQ)
     }
 
   fun <F> Applicative<F>.mapDerived(EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genApplicative(Gen.int(), this), genFunctionAToB<Int, Int>(Gen.int())) { fa: Kind<F, Int>, f: (Int) -> Int ->
-      fa.map(f).equalUnderTheLaw(fa.ap(just(f)), EQ)
+      fa.map(f).equalUnderTheLaw(fa.apPipe(just(f)), EQ)
     }
 
   fun <F> Applicative<F>.cartesianBuilderMap(EQ: Eq<Kind<F, Int>>): Unit =

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/TraverseLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/TraverseLaws.kt
@@ -65,10 +65,10 @@ object TraverseLaws {
         override fun <A> just(a: A): Kind<TIF, A> =
           TIC(Id(a) toT Id(a))
 
-        override fun <A, B> Kind<TIF, A>.ap(ff: Kind<TIF, (A) -> B>): Kind<TIF, B> {
+        override fun <A, B> Kind<TIF, A>.apPipe(ff: Kind<TIF, (A) -> B>): Kind<TIF, B> {
           val (fam, fan) = fix().ti
           val (fm, fn) = ff.fix().ti
-          return TIC(Id.applicative().run { fam.ap(fm) toT fan.ap(fn) })
+          return TIC(Id.applicative().run { fam.apPipe(fm) toT fan.apPipe(fn) })
         }
 
       }

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Applicative.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Applicative.kt
@@ -11,12 +11,14 @@ interface Applicative<F> : Functor<F> {
 
   fun <A> A.just(dummy: Unit = Unit): Kind<F, A> = just(this)
 
-  fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B>
+  fun <A, B> Kind<F, A>.apPipe(ff: Kind<F, (A) -> B>): Kind<F, B>
+
+  infix fun <A, B> Kind<F, (A) -> B>.ap(fa: Kind<F, A>): Kind<F, B> = fa.apPipe(this)
 
   fun <A, B> Kind<F, A>.product(fb: Kind<F, B>): Kind<F, Tuple2<A, B>> =
-    fb.ap(this.map { a: A -> { b: B -> Tuple2(a, b) } })
+    fb.apPipe(this.map { a: A -> { b: B -> Tuple2(a, b) } })
 
-  override fun <A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B> = ap(just(f))
+  override fun <A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B> = apPipe(just(f))
 
   fun <A, B, Z> Kind<F, A>.map2(fb: Kind<F, B>, f: (Tuple2<A, B>) -> Z): Kind<F, Z> = product(fb).map(f)
 

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Composed.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Composed.kt
@@ -167,15 +167,15 @@ interface ComposedApplicative<F, G> : Applicative<Nested<F, G>>, ComposedFunctor
   override fun G(): Applicative<G>
 
   override fun <A, B> NestedType<F, G, A>.map(f: (A) -> B): Kind<Nested<F, G>, B> =
-    ap(just(f))
+    apPipe(just(f))
 
   override fun <A> just(a: A): NestedType<F, G, A> = F().just(G().just(a)).nest()
 
-  override fun <A, B> NestedType<F, G, A>.ap(ff: Kind<Nested<F, G>, (A) -> B>): Kind<Nested<F, G>, B> =
-    F().run { unnest().ap(ff.unnest().map { gfa: Kind<G, (A) -> B> -> { ga: Kind<G, A> -> G().run { ga.ap(gfa) } } }) }.nest()
+  override fun <A, B> NestedType<F, G, A>.apPipe(ff: Kind<Nested<F, G>, (A) -> B>): Kind<Nested<F, G>, B> =
+    F().run { unnest().apPipe(ff.unnest().map { gfa: Kind<G, (A) -> B> -> { ga: Kind<G, A> -> G().run { ga.apPipe(gfa) } } }) }.nest()
 
   fun <A, B> UnnestedType<F, G, A>.apC(ff: Kind<F, Kind<G, (A) -> B>>): Kind<F, Kind<G, B>> =
-    nest().ap(ff.nest()).unnest()
+    nest().apPipe(ff.nest()).unnest()
 
   companion object {
     operator fun <F, G> invoke(FF: Applicative<F>, GF: Applicative<G>)

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Const.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Const.kt
@@ -24,7 +24,11 @@ data class Const<A, out T>(val value: A) : ConstOf<A, T> {
 
 fun <A, T> ConstOf<A, T>.combine(SG: Semigroup<A>, that: ConstOf<A, T>): Const<A, T> = Const(SG.run { value().combine(that.value()) })
 
-fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Const<A, U> = ff.fix().retag<U>().combine(SG, fix().retag())
+fun <A, T, U> ConstOf<A, T>.apPipe(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Const<A, U> = ff.fix().retag<U>().combine(SG, fix().retag())
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <A, T, U> ConstOf<A, (T) -> U>.ap(SG: Semigroup<A>, fa: ConstOf<A, T>): Const<A, U> =
+  fa.apPipe(SG, this)
 
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =
   fix().traverse(GA, ::identity)

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Monad.kt
@@ -16,7 +16,7 @@ interface Monad<F> : Applicative<F> {
   override fun <A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B> =
     flatMap { a -> just(f(a)) }
 
-  override fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B> =
+  override fun <A, B> Kind<F, A>.apPipe(ff: Kind<F, (A) -> B>): Kind<F, B> =
     ff.flatMap { f -> this.map(f) }
 
   fun <A> Kind<F, Kind<F, A>>.flatten(): Kind<F, A> =

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/internal.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/internal/internal.kt
@@ -17,8 +17,8 @@ val IdBimonad: Bimonad<ForId> = object : Bimonad<ForId> {
   override fun <A> just(a: A): Kind<ForId, A> =
     Id(a)
 
-  override fun <A, B> Kind<ForId, A>.ap(ff: Kind<ForId, (A) -> B>): Kind<ForId, B> =
-    fix().ap(ff)
+  override fun <A, B> Kind<ForId, A>.apPipe(ff: Kind<ForId, (A) -> B>): Kind<ForId, B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForId, A>.map(f: (A) -> B): Kind<ForId, B> =
     fix().map(f)

--- a/modules/docs/arrow-docs/docs/docs/datatypes/kleisli/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/kleisli/README.md
@@ -57,7 +57,7 @@ val optionIntDoubleKleisli = Kleisli { str: String ->
   if (str.toCharArray().all { it.isDigit() }) Some(intToDouble) else None
 }
 
-optionIntKleisli.ap(Option.applicative(), optionIntDoubleKleisli).fix().run("1")
+optionIntKleisli.apPipe(Option.applicative(), optionIntDoubleKleisli).fix().run("1")
 ```
 
 #### Map

--- a/modules/docs/arrow-docs/docs/docs/datatypes/listk/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/listk/README.md
@@ -75,7 +75,7 @@ Or you can apply a list of transformations using `ap` from [`Applicative`](/docs
 import arrow.instances.*
 ForListK extensions {
   listOf(1, 2, 3).k()
-    .ap(listOf({ x: Int -> x + 10}, { x: Int -> x * 2}).k())
+    .apPipe(listOf({ x: Int -> x + 10}, { x: Int -> x * 2}).k())
 }
 ```
 

--- a/modules/docs/arrow-docs/docs/docs/datatypes/sequencek/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/sequencek/README.md
@@ -45,7 +45,7 @@ Applying a sequence of functions to a sequence:
 import arrow.instances.*
 ForSequenceK extensions {
   sequenceOf(1, 2, 3).k()
-    .ap(sequenceOf({ x: Int -> x + 1}, { x: Int -> x * 2}).k())
+    .apPipe(sequenceOf({ x: Int -> x + 1}, { x: Int -> x * 2}).k())
     .toList() 
 }
 ```

--- a/modules/docs/arrow-docs/docs/docs/typeclasses/applicative/README.md
+++ b/modules/docs/arrow-docs/docs/docs/typeclasses/applicative/README.md
@@ -62,14 +62,26 @@ It lifts a value into the computational context of a type constructor.
 Option.just(1) // Some(1)
 ```
 
-#### Kind<F, A>#ap
+#### Kind<F, A>#apPipe
 
 Apply a function inside the type constructor's context
 
-`fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B>`
+`fun <A, B> Kind<F, A>.apPipe(ff: Kind<F, (A) -> B>): Kind<F, B>`
 
 ```kotlin:ank
-Option.applicative().run { Some(1).ap(Some({ n: Int -> n + 1 })) }
+Option.applicative().run { Some(1).apPipe(Some({ n: Int -> n + 1 })) }
+```
+
+#### Kind<F, (A) -> B>#ap
+
+Apply a function inside the type constructor's context
+
+`infix fun <A, B> Kind<F, (A) -> B>.ap(fa: Kind<F, A>): Kind<F, B>`
+
+This is an infix version of `Kind<F, A>#apPipe` with its argument and receiver flipped in order to allow for more idiomatic usage with curried functions.
+
+```kotlin:ank
+Option.applicative().run { pure(::Profile.curried()) ap profileService() ap phoneService() ap addressService() }
 ```
 
 #### Other combinators

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -19,7 +19,7 @@ data class DeferredK<out A>(val deferred: Deferred<A>) : DeferredKOf<A>, Deferre
   fun <B> map(f: (A) -> B): DeferredK<B> =
     flatMap { a: A -> just(f(a)) }
 
-  fun <B> ap(fa: DeferredKOf<(A) -> B>): DeferredK<B> =
+  fun <B> apPipe(fa: DeferredKOf<(A) -> B>): DeferredK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> DeferredKOf<B>): DeferredK<B> =
@@ -89,6 +89,10 @@ data class DeferredK<out A>(val deferred: Deferred<A>) : DeferredKOf<A>, Deferre
       }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> DeferredKOf<(A) -> B>.ap(fa: DeferredKOf<A>): DeferredK<B> =
+  fa.fix().apPipe(this)
 
 fun <A> DeferredKOf<A>.handleErrorWith(f: (Throwable) -> DeferredK<A>): DeferredK<A> =
   async(Unconfined, CoroutineStart.LAZY) {

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -26,8 +26,8 @@ interface DeferredKApplicativeInstance : Applicative<ForDeferredK> {
   override fun <A> just(a: A): DeferredK<A> =
     DeferredK.just(a)
 
-  override fun <A, B> DeferredKOf<A>.ap(ff: DeferredKOf<(A) -> B>): DeferredK<B> =
-    fix().ap(ff)
+  override fun <A, B> DeferredKOf<A>.apPipe(ff: DeferredKOf<(A) -> B>): DeferredK<B> =
+    fix().apPipe(ff)
 }
 
 @instance(DeferredK::class)
@@ -41,8 +41,8 @@ interface DeferredKMonadInstance : Monad<ForDeferredK> {
   override fun <A, B> tailRecM(a: A, f: (A) -> DeferredKOf<Either<A, B>>): DeferredK<B> =
     DeferredK.tailRecM(a, f)
 
-  override fun <A, B> DeferredKOf<A>.ap(ff: DeferredKOf<(A) -> B>): DeferredK<B> =
-    fix().ap(ff)
+  override fun <A, B> DeferredKOf<A>.apPipe(ff: DeferredKOf<(A) -> B>): DeferredK<B> =
+    fix().apPipe(ff)
 
   override fun <A> just(a: A): DeferredK<A> =
     DeferredK.just(a)

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxK.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxK.kt
@@ -20,7 +20,7 @@ data class FluxK<A>(val flux: Flux<A>) : FluxKOf<A>, FluxKKindedJ<A> {
   fun <B> map(f: (A) -> B): FluxK<B> =
       flux.map(f).k()
 
-  fun <B> ap(fa: FluxKOf<(A) -> B>): FluxK<B> =
+  fun <B> apPipe(fa: FluxKOf<(A) -> B>): FluxK<B> =
       flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> FluxKOf<B>): FluxK<B> =
@@ -115,6 +115,9 @@ data class FluxK<A>(val flux: Flux<A>) : FluxKOf<A>, FluxKKindedJ<A> {
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> FluxKOf<(A) -> B>.ap(fa: FluxKOf<A>): FluxK<B> = fa.fix().apPipe(this)
 
 inline fun <A, G> FluxKOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, FluxK<A>> =
     fix().traverse(GA, ::identity)

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxKInstances.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxKInstances.kt
@@ -22,8 +22,8 @@ interface FluxKApplicativeInstance : Applicative<ForFluxK> {
   override fun <A> just(a: A): FluxK<A> =
       FluxK.just(a)
 
-  override fun <A, B> FluxKOf<A>.ap(ff: FluxKOf<(A) -> B>): FluxK<B> =
-      fix().ap(ff)
+  override fun <A, B> FluxKOf<A>.apPipe(ff: FluxKOf<(A) -> B>): FluxK<B> =
+      fix().apPipe(ff)
 
   override fun <A, B> Kind<ForFluxK, A>.map(f: (A) -> B): FluxK<B> =
       fix().map(f)
@@ -31,8 +31,8 @@ interface FluxKApplicativeInstance : Applicative<ForFluxK> {
 
 @instance(FluxK::class)
 interface FluxKMonadInstance : Monad<ForFluxK> {
-  override fun <A, B> FluxKOf<A>.ap(ff: FluxKOf<(A) -> B>): FluxK<B> =
-      fix().ap(ff)
+  override fun <A, B> FluxKOf<A>.apPipe(ff: FluxKOf<(A) -> B>): FluxK<B> =
+      fix().apPipe(ff)
 
   override fun <A, B> Kind<ForFluxK, A>.flatMap(f: (A) -> Kind<ForFluxK, B>): FluxK<B> =
       fix().flatMap(f)

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoK.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoK.kt
@@ -20,7 +20,7 @@ data class MonoK<A>(val mono: Mono<A>) : MonoKOf<A>, MonoKKindedJ<A> {
   fun <B> map(f: (A) -> B): MonoK<B> =
       mono.map(f).k()
 
-  fun <B> ap(fa: MonoKOf<(A) -> B>): MonoK<B> =
+  fun <B> apPipe(fa: MonoKOf<(A) -> B>): MonoK<B> =
       flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> MonoKOf<B>): MonoK<B> =
@@ -68,3 +68,6 @@ data class MonoK<A>(val mono: Mono<A>) : MonoKOf<A>, MonoKKindedJ<A> {
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> MonoKOf<(A) -> B>.ap(fa: MonoKOf<A>): MonoK<B> = fa.fix().apPipe(this)

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoKInstances.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoKInstances.kt
@@ -18,8 +18,8 @@ interface MonoKFunctorInstance : Functor<ForMonoK> {
 
 @instance(MonoK::class)
 interface MonoKApplicativeInstance : Applicative<ForMonoK> {
-  override fun <A, B> MonoKOf<A>.ap(ff: MonoKOf<(A) -> B>): MonoK<B> =
-      fix().ap(ff)
+  override fun <A, B> MonoKOf<A>.apPipe(ff: MonoKOf<(A) -> B>): MonoK<B> =
+      fix().apPipe(ff)
 
   override fun <A, B> Kind<ForMonoK, A>.map(f: (A) -> B): MonoK<B> =
       fix().map(f)
@@ -30,8 +30,8 @@ interface MonoKApplicativeInstance : Applicative<ForMonoK> {
 
 @instance(MonoK::class)
 interface MonoKMonadInstance : Monad<ForMonoK> {
-  override fun <A, B> MonoKOf<A>.ap(ff: MonoKOf<(A) -> B>): MonoK<B> =
-      fix().ap(ff)
+  override fun <A, B> MonoKOf<A>.apPipe(ff: MonoKOf<(A) -> B>): MonoK<B> =
+      fix().apPipe(ff)
 
   override fun <A, B> MonoKOf<A>.flatMap(f: (A) -> Kind<ForMonoK, B>): MonoK<B> =
       fix().flatMap(f)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableK.kt
@@ -21,7 +21,7 @@ data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKi
   fun <B> map(f: (A) -> B): FlowableK<B> =
     flowable.map(f).k()
 
-  fun <B> ap(fa: FlowableKOf<(A) -> B>): FlowableK<B> =
+  fun <B> apPipe(fa: FlowableKOf<(A) -> B>): FlowableK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> FlowableKOf<B>): FlowableK<B> =
@@ -171,6 +171,10 @@ data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKi
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> FlowableKOf<(A) -> B>.ap(fa: FlowableKOf<A>): FlowableK<B> =
+  fa.fix().apPipe(this)
 
 inline fun <A, G> FlowableKOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, FlowableK<A>> =
   fix().traverse(GA, ::identity)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableKInstances.kt
@@ -20,8 +20,8 @@ interface FlowableKFunctorInstance : Functor<ForFlowableK> {
 
 @instance(FlowableK::class)
 interface FlowableKApplicativeInstance : Applicative<ForFlowableK> {
-  override fun <A, B> FlowableKOf<A>.ap(ff: FlowableKOf<(A) -> B>): FlowableK<B> =
-    fix().ap(ff)
+  override fun <A, B> FlowableKOf<A>.apPipe(ff: FlowableKOf<(A) -> B>): FlowableK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForFlowableK, A>.map(f: (A) -> B): FlowableK<B> =
     fix().map(f)
@@ -32,8 +32,8 @@ interface FlowableKApplicativeInstance : Applicative<ForFlowableK> {
 
 @instance(FlowableK::class)
 interface FlowableKMonadInstance : Monad<ForFlowableK> {
-  override fun <A, B> FlowableKOf<A>.ap(ff: FlowableKOf<(A) -> B>): FlowableK<B> =
-    fix().ap(ff)
+  override fun <A, B> FlowableKOf<A>.apPipe(ff: FlowableKOf<(A) -> B>): FlowableK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> FlowableKOf<A>.flatMap(f: (A) -> Kind<ForFlowableK, B>): FlowableK<B> =
     fix().flatMap(f)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeK.kt
@@ -18,7 +18,7 @@ data class MaybeK<A>(val maybe: Maybe<A>) : MaybeKOf<A>, MaybeKKindedJ<A> {
   fun <B> map(f: (A) -> B): MaybeK<B> =
     maybe.map(f).k()
 
-  fun <B> ap(fa: MaybeKOf<(A) -> B>): MaybeK<B> =
+  fun <B> apPipe(fa: MaybeKOf<(A) -> B>): MaybeK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> MaybeKOf<B>): MaybeK<B> =
@@ -85,3 +85,6 @@ data class MaybeK<A>(val maybe: Maybe<A>) : MaybeKOf<A>, MaybeKKindedJ<A> {
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> MaybeKOf<(A) -> B>.ap(fa: MaybeKOf<A>): MaybeK<B> = fa.fix().apPipe(this)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeKInstances.kt
@@ -19,8 +19,8 @@ interface MaybeKFunctorInstance : Functor<ForMaybeK> {
 
 @instance(MaybeK::class)
 interface MaybeKApplicativeInstance : Applicative<ForMaybeK> {
-  override fun <A, B> MaybeKOf<A>.ap(ff: MaybeKOf<(A) -> B>): MaybeK<B> =
-    fix().ap(ff)
+  override fun <A, B> MaybeKOf<A>.apPipe(ff: MaybeKOf<(A) -> B>): MaybeK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForMaybeK, A>.map(f: (A) -> B): MaybeK<B> =
     fix().map(f)
@@ -31,8 +31,8 @@ interface MaybeKApplicativeInstance : Applicative<ForMaybeK> {
 
 @instance(MaybeK::class)
 interface MaybeKMonadInstance : Monad<ForMaybeK> {
-  override fun <A, B> MaybeKOf<A>.ap(ff: MaybeKOf<(A) -> B>): MaybeK<B> =
-    fix().ap(ff)
+  override fun <A, B> MaybeKOf<A>.apPipe(ff: MaybeKOf<(A) -> B>): MaybeK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> MaybeKOf<A>.flatMap(f: (A) -> Kind<ForMaybeK, B>): MaybeK<B> =
     fix().flatMap(f)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableK.kt
@@ -20,7 +20,7 @@ data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, Obs
   fun <B> map(f: (A) -> B): ObservableK<B> =
     observable.map(f).k()
 
-  fun <B> ap(fa: ObservableKOf<(A) -> B>): ObservableK<B> =
+  fun <B> apPipe(fa: ObservableKOf<(A) -> B>): ObservableK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> ObservableKOf<B>): ObservableK<B> =
@@ -115,6 +115,10 @@ data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, Obs
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> ObservableKOf<(A) -> B>.ap(fa: ObservableKOf<A>): ObservableK<B> =
+  fa.fix().apPipe(this)
 
 inline fun <A, G> ObservableKOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, ObservableK<A>> =
   fix().traverse(GA, ::identity)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableKInstances.kt
@@ -19,8 +19,8 @@ interface ObservableKFunctorInstance : Functor<ForObservableK> {
 
 @instance(ObservableK::class)
 interface ObservableKApplicativeInstance : Applicative<ForObservableK> {
-  override fun <A, B> ObservableKOf<A>.ap(ff: ObservableKOf<(A) -> B>): ObservableK<B> =
-    fix().ap(ff)
+  override fun <A, B> ObservableKOf<A>.apPipe(ff: ObservableKOf<(A) -> B>): ObservableK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForObservableK, A>.map(f: (A) -> B): ObservableK<B> =
     fix().map(f)
@@ -31,8 +31,8 @@ interface ObservableKApplicativeInstance : Applicative<ForObservableK> {
 
 @instance(ObservableK::class)
 interface ObservableKMonadInstance : Monad<ForObservableK> {
-  override fun <A, B> ObservableKOf<A>.ap(ff: ObservableKOf<(A) -> B>): ObservableK<B> =
-    fix().ap(ff)
+  override fun <A, B> ObservableKOf<A>.apPipe(ff: ObservableKOf<(A) -> B>): ObservableK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForObservableK, A>.flatMap(f: (A) -> Kind<ForObservableK, B>): ObservableK<B> =
     fix().flatMap(f)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleK.kt
@@ -20,7 +20,7 @@ data class SingleK<A>(val single: Single<A>) : SingleKOf<A>, SingleKKindedJ<A> {
   fun <B> map(f: (A) -> B): SingleK<B> =
     single.map(f).k()
 
-  fun <B> ap(fa: SingleKOf<(A) -> B>): SingleK<B> =
+  fun <B> apPipe(fa: SingleKOf<(A) -> B>): SingleK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
   fun <B> flatMap(f: (A) -> SingleKOf<B>): SingleK<B> =
@@ -69,3 +69,6 @@ data class SingleK<A>(val single: Single<A>) : SingleKOf<A>, SingleKKindedJ<A> {
     }
   }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> SingleKOf<(A) -> B>.ap(fa: SingleKOf<A>): SingleK<B> = fa.fix().apPipe(this)

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleKInstances.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleKInstances.kt
@@ -18,8 +18,8 @@ interface SingleKFunctorInstance : Functor<ForSingleK> {
 
 @instance(SingleK::class)
 interface SingleKApplicativeInstance : Applicative<ForSingleK> {
-  override fun <A, B> SingleKOf<A>.ap(ff: SingleKOf<(A) -> B>): SingleK<B> =
-    fix().ap(ff)
+  override fun <A, B> SingleKOf<A>.apPipe(ff: SingleKOf<(A) -> B>): SingleK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> Kind<ForSingleK, A>.map(f: (A) -> B): SingleK<B> =
     fix().map(f)
@@ -30,8 +30,8 @@ interface SingleKApplicativeInstance : Applicative<ForSingleK> {
 
 @instance(SingleK::class)
 interface SingleKMonadInstance : Monad<ForSingleK> {
-  override fun <A, B> SingleKOf<A>.ap(ff: SingleKOf<(A) -> B>): SingleK<B> =
-    fix().ap(ff)
+  override fun <A, B> SingleKOf<A>.apPipe(ff: SingleKOf<(A) -> B>): SingleK<B> =
+    fix().apPipe(ff)
 
   override fun <A, B> SingleKOf<A>.flatMap(f: (A) -> Kind<ForSingleK, B>): SingleK<B> =
     fix().flatMap(f)

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IO.kt
@@ -166,8 +166,11 @@ sealed class IO<out A> : IOOf<A> {
   }
 }
 
-fun <A, B> IOOf<A>.ap(ff: IOOf<(A) -> B>): IO<B> =
+fun <A, B> IOOf<A>.apPipe(ff: IOOf<(A) -> B>): IO<B> =
   fix().flatMap { a -> ff.fix().map { it(a) } }
+
+@Suppress("NOTHING_TO_INLINE")
+inline infix fun <A, B> IOOf<(A) -> B>.ap(fa: IOOf<A>): IO<B> = fa.apPipe(this)
 
 fun <A> IOOf<A>.handleErrorWith(f: (Throwable) -> IOOf<A>): IO<A> =
   IO.Bind(fix(), IOFrame.errorHandler(f))

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IOInstances.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/IOInstances.kt
@@ -9,7 +9,7 @@ import arrow.effects.typeclasses.Proc
 import arrow.instance
 import arrow.typeclasses.*
 import kotlin.coroutines.experimental.CoroutineContext
-import arrow.effects.ap as ioAp
+import arrow.effects.apPipe as ioApPipe
 import arrow.effects.handleErrorWith as ioHandleErrorWith
 
 @instance(IO::class)
@@ -26,8 +26,8 @@ interface IOApplicativeInstance : Applicative<ForIO> {
   override fun <A> just(a: A): IO<A> =
     IO.just(a)
 
-  override fun <A, B> Kind<ForIO, A>.ap(ff: IOOf<(A) -> B>): IO<B> =
-    fix().ioAp(ff)
+  override fun <A, B> Kind<ForIO, A>.apPipe(ff: IOOf<(A) -> B>): IO<B> =
+    fix().ioApPipe(ff)
 }
 
 @instance(IO::class)


### PR DESCRIPTION
Implementation of https://github.com/arrow-kt/arrow/issues/1000

Renames old Applicative::ap to apPipe and introduces an infix version
with flipped receiver and parameter under the old name
