### PR TITLE
Rename MonadSuspendLaws to MonadDeferLaws

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.experimental.newSingleThreadContext
 
 object AsyncLaws {
   inline fun <F> laws(AC: Async<F>, EQ: Eq<Kind<F, Int>>, EQ_EITHER: Eq<Kind<F, Either<Throwable, Int>>>, EQERR: Eq<Kind<F, Int>> = EQ): List<Law> =
-    MonadSuspendLaws.laws(AC, EQERR, EQ_EITHER, EQ) + listOf(
+    MonadDeferLaws.laws(AC, EQERR, EQ_EITHER, EQ) + listOf(
       Law("Async Laws: success equivalence") { AC.asyncSuccess(EQ) },
       Law("Async Laws: error equivalence") { AC.asyncError(EQERR) },
       Law("Async Laws: continueOn jumps threads") { AC.continueOn(EQ) },

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
@@ -13,7 +13,7 @@ import io.kotlintest.properties.forAll
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.newSingleThreadContext
 
-object MonadSuspendLaws {
+object MonadDeferLaws {
   inline fun <F> laws(SC: MonadDefer<F>, EQ: Eq<Kind<F, Int>>, EQ_EITHER: Eq<Kind<F, Either<Throwable, Int>>>, EQERR: Eq<Kind<F, Int>> = EQ): List<Law> =
     MonadErrorLaws.laws(SC, EQERR, EQ_EITHER, EQ) + listOf(
       Law("Sync bind: binding blocks") { SC.asyncBind(EQ) },

--- a/modules/effects/arrow-effects-rx2/src/test/kotlin/arrow/effects/MaybeKTests.kt
+++ b/modules/effects/arrow-effects-rx2/src/test/kotlin/arrow/effects/MaybeKTests.kt
@@ -46,7 +46,7 @@ class MaybeKTests : UnitSpec() {
       FoldableLaws.laws(MaybeK.foldable(), { MaybeK.just(it) }, Eq.any()),
       MonadErrorLaws.laws(MaybeK.monadError(), EQ(), EQ(), EQ()),
       ApplicativeErrorLaws.laws(MaybeK.applicativeError(), EQ(), EQ(), EQ()),
-      MonadSuspendLaws.laws(MaybeK.monadDefer(), EQ(), EQ(), EQ()),
+      MonadDeferLaws.laws(MaybeK.monadDefer(), EQ(), EQ(), EQ()),
       AsyncLaws.laws(MaybeK.async(), EQ(), EQ(), EQ()),
       AsyncLaws.laws(MaybeK.effect(), EQ(), EQ(), EQ())
     )

--- a/modules/effects/arrow-effects-rx2/src/test/kotlin/arrow/effects/SingleKTests.kt
+++ b/modules/effects/arrow-effects-rx2/src/test/kotlin/arrow/effects/SingleKTests.kt
@@ -44,7 +44,7 @@ class SingleKTests : UnitSpec() {
       MonadLaws.laws(SingleK.monad(), EQ()),
       MonadErrorLaws.laws(SingleK.monadError(), EQ(), EQ(), EQ()),
       ApplicativeErrorLaws.laws(SingleK.applicativeError(), EQ(), EQ(), EQ()),
-      MonadSuspendLaws.laws(SingleK.monadDefer(), EQ(), EQ(), EQ()),
+      MonadDeferLaws.laws(SingleK.monadDefer(), EQ(), EQ(), EQ()),
       AsyncLaws.laws(SingleK.async(), EQ(), EQ(), EQ()),
       AsyncLaws.laws(SingleK.effect(), EQ(), EQ(), EQ())
     )


### PR DESCRIPTION
Rename MonadSuspendLaws to MonadDeferLaws (including file name)

Fixes #993 