### PR TITLE
Slim down effects

### DIFF
--- a/modules/effects/arrow-effects-kotlinx-coroutines/build.gradle
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':arrow-data')
     compile project(':arrow-effects')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')

--- a/modules/effects/arrow-effects-reactor/build.gradle
+++ b/modules/effects/arrow-effects-reactor/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':arrow-data')
     compile project(':arrow-effects')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')

--- a/modules/effects/arrow-effects-rx2/build.gradle
+++ b/modules/effects/arrow-effects-rx2/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':arrow-data')
     compile project(':arrow-effects')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')

--- a/modules/effects/arrow-effects/build.gradle
+++ b/modules/effects/arrow-effects/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile project(':arrow-data')
+    compile project(':arrow-typeclasses')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile project(':arrow-annotations')
     kapt project(':arrow-annotations-processor')


### PR DESCRIPTION
I realized `effects` doesn't need 400k extra of unused dependencies.