### PR TITLE
Add `compareTo` overload for `Order`

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/OrderLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/OrderLaws.kt
@@ -22,7 +22,8 @@ object OrderLaws {
       Law("Order law: totality order") { O.totalityOrder(fGen) },
       Law("Order law: compare order") { O.compareOrder(fGen) },
       Law("Order law: min order") { O.minOrder(fGen) },
-      Law("Order law: max order") { O.maxOrder(fGen) }
+      Law("Order law: max order") { O.maxOrder(fGen) },
+      Law("Order law: operator compareTo delegates to compare order") { O.operatorCompareToOrder(fGen) }
     )
 
   fun <F> Order<F>.reflexitivityEq(fGen: Gen<F>) =

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/OrderLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/OrderLaws.kt
@@ -103,4 +103,9 @@ object OrderLaws {
       else if (c == 0) (m == x) && (m == y)
       else m == x
     }
+
+  fun <F> Order<F>.operatorCompareToOrder(fGen: Gen<F>): Unit =
+    forAll(fGen, fGen) { x, y ->
+      x.compare(y) == x.compareTo(y)
+    }
 }

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Order.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Order.kt
@@ -24,6 +24,9 @@ interface Order<F> : Eq<F> {
    */
   fun F.compare(b: F): Int
 
+  /** Kotlin operator overload */
+  operator fun F.compareTo(b: F): Int = compare(b)
+
   /** @see [Eq.eqv] */
   override fun F.eqv(b: F): Boolean = this.compare(b) == 0
 

--- a/modules/docs/arrow-docs/docs/docs/typeclasses/order/README.md
+++ b/modules/docs/arrow-docs/docs/docs/typeclasses/order/README.md
@@ -33,6 +33,12 @@ import arrow.instances.*
 Int.order().run { 1.compare(2) }
 ```
 
+Additionaly, `Order` overloads operators `>`, `<`, `<=` and `>=` following the kotlin `compareTo` convention for every type for each an exists an `Order` instance.
+
+```kotlin:ank
+Int.order().run { 1 > 2 }
+```  
+
 #### F#lte / F#lt
 
 Lesser than or equal to defines total order in a set, it compares two elements and returns true if they're equal or the first is lesser than the second.


### PR DESCRIPTION
This pull-request provides `compareTo` operators for all `Order` instances as described in #729.
There are two more operators mentioned in #729:

* Equality operator (`==`, `!=`) for `Eq` instances  - _it is impossible to implement that as extension function, because member functions always shadow extensions and equals is defined for every object in Kotlin (because of Java legacy)_
* Plus operator (`+`) for `Semigroup` instances - _already added in #768 _

It seems that all three items of issue would resolved after this PR is merged, so it will close #729 