### PR TITLE
Adding integration for Retrofit

### DIFF
--- a/modules/integrations/arrow-integrations-retrofit-adapter/build.gradle
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+    def retrofitVersion = "2.4.0"
+
+    compile project(':arrow-effects')
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    compile project(':arrow-annotations')
+    compile "com.squareup.retrofit2:retrofit:2.4.0"
+    kapt project(':arrow-annotations-processor')
+    kaptTest project(':arrow-annotations-processor')
+    compileOnly project(':arrow-annotations-processor')
+    testCompileOnly project(':arrow-annotations-processor')
+    testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
+    testCompile project(':arrow-test')
+    testCompile "com.squareup.retrofit2:converter-gson:${retrofitVersion}"
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.10'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    testCompile project(':arrow-effects-rx2')
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply plugin: 'kotlin-kapt'

--- a/modules/integrations/arrow-integrations-retrofit-adapter/build.gradle
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/build.gradle
@@ -9,10 +9,8 @@ dependencies {
     kaptTest project(':arrow-annotations-processor')
     compileOnly project(':arrow-annotations-processor')
     testCompileOnly project(':arrow-annotations-processor')
-    testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"
     testCompile project(':arrow-test')
     testCompile "com.squareup.retrofit2:converter-gson:${retrofitVersion}"
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.10'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testCompile project(':arrow-effects-rx2')
 }

--- a/modules/integrations/arrow-integrations-retrofit-adapter/gradle.properties
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow-Integrations-Retrofit-Adapter
+POM_ARTIFACT_ID=arrow-integration-retrofit-adapter
+POM_PACKAGING=jar

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/Async2CallAdapterFactory.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/Async2CallAdapterFactory.kt
@@ -1,0 +1,38 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.effects.IO
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class Async2CallAdapterFactory : CallAdapter.Factory() {
+
+  companion object {
+    fun create() = Async2CallAdapterFactory()
+  }
+
+  override fun get(returnType: Type, annotations: Array<Annotation>, retrofit: Retrofit): CallAdapter<*, *>? {
+    val rawType = CallAdapter.Factory.getRawType(returnType)
+
+    if (returnType !is ParameterizedType) {
+      val name = parseTypeName(returnType)
+      throw IllegalArgumentException("Return type must be parameterized as " +
+        "$name<Foo> or $name<out Foo>")
+    }
+
+    val effectType = CallAdapter.Factory.getParameterUpperBound(0, returnType)
+
+    return when (rawType) {
+      IO::class.java -> IO2CallAdapter<Type>(effectType)
+      CallK::class.java -> CallKind2CallAdapter<Type>(effectType)
+      else -> null
+    }
+  }
+}
+
+private fun parseTypeName(type: Type) =
+  type.typeName
+    .split(".")
+    .last()
+

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/CallK.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/CallK.kt
@@ -1,0 +1,33 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.Kind
+import arrow.effects.typeclasses.Async
+import arrow.effects.typeclasses.MonadDefer
+import arrow.typeclasses.MonadError
+import retrofit2.Call
+import retrofit2.HttpException
+import retrofit2.Response
+
+data class CallK<R>(val call: Call<R>) {
+  fun <F> async(async: Async<F>): Kind<F, R> =
+    async.async { proc -> call.enqueue(ResponseCallback(proc)) }
+
+  fun <F> defer(defer: MonadDefer<F>): Kind<F, R> =
+    defer {
+      handleResponse(call.execute())
+    }
+
+  fun <F> catch(defer: MonadError<F, Throwable>): Kind<F, R> =
+    defer.run {
+      catch {
+        handleResponse(call.execute())
+      }
+    }
+}
+
+private fun <R> handleResponse(response: Response<R>) =
+  if (response.isSuccessful) {
+    response.body() ?: throw IllegalStateException("The request returned a null body")
+  } else {
+    throw HttpException(response)
+  }

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/CallKind2CallAdapter.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/CallKind2CallAdapter.kt
@@ -1,0 +1,11 @@
+package arrow.integrations.retrofit.adapter
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class CallKind2CallAdapter<R>(private val type: Type) : CallAdapter<R, CallK<R>> {
+  override fun adapt(call: Call<R>): CallK<R> = CallK(call)
+
+  override fun responseType(): Type = type
+}

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/IO2CallAdapter.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/IO2CallAdapter.kt
@@ -1,0 +1,12 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.effects.IO
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class IO2CallAdapter<R>(private val type: Type) : CallAdapter<R, IO<R>> {
+  override fun adapt(call: Call<R>): IO<R> = IO.async { proc -> call.enqueue(ResponseCallback(proc)) }
+
+  override fun responseType(): Type = type
+}

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/ResponseCallback.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow.integrations.retrofit.adapter/ResponseCallback.kt
@@ -1,0 +1,28 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.HttpException
+import retrofit2.Response
+
+class ResponseCallback<R>(private val proc: (Either<Throwable, R>) -> Unit) : Callback<R> {
+  override fun onResponse(call: Call<R>, response: Response<R>) {
+    if (response.isSuccessful) {
+      val body = response.body()
+      if (body != null) {
+        proc(body.right())
+      } else {
+        proc(IllegalStateException("The request returned a null body").left())
+      }
+    } else {
+      proc(HttpException(response).left())
+    }
+  }
+
+  override fun onFailure(call: Call<R>, throwable: Throwable) {
+    proc(throwable.left())
+  }
+}

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ApiClientTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ApiClientTest.kt
@@ -1,0 +1,13 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.effects.IO
+import retrofit2.http.GET
+
+interface ApiClientTest {
+
+  @GET("test")
+  fun test(): CallK<String>
+
+  @GET("testIO")
+  fun testIO(): IO<String>
+}

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ApiClientTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ApiClientTest.kt
@@ -1,13 +1,14 @@
 package arrow.integrations.retrofit.adapter
 
 import arrow.effects.IO
+import arrow.integrations.retrofit.adapter.mock.ResponseMock
 import retrofit2.http.GET
 
 interface ApiClientTest {
 
   @GET("test")
-  fun test(): CallK<String>
+  fun test(): CallK<ResponseMock>
 
   @GET("testIO")
-  fun testIO(): IO<String>
+  fun testIO(): IO<ResponseMock>
 }

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/Async2CallAdapterFactoryTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/Async2CallAdapterFactoryTest.kt
@@ -1,0 +1,50 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.effects.IO
+import arrow.test.UnitSpec
+import com.google.common.reflect.TypeToken
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import org.junit.runner.RunWith
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+private val NO_ANNOTATIONS = emptyArray<Annotation>()
+
+@RunWith(KTestJUnitRunner::class)
+class Async2CallAdapterFactoryTest : UnitSpec() {
+  private val retrofit = Retrofit.Builder()
+    .baseUrl("http://localhost:1")
+    .addConverterFactory(GsonConverterFactory.create())
+    .addCallAdapterFactory(Async2CallAdapterFactory.create())
+    .build()
+
+  private val factory = Async2CallAdapterFactory.create()
+
+  init {
+    "Non Async Class should return null" {
+      factory.get(object : TypeToken<List<String>>() {}.type, NO_ANNOTATIONS, retrofit) shouldBe null
+    }
+
+    "Non parametrized type should throw exception" {
+      val exceptionList = shouldThrow<IllegalArgumentException> {
+        factory.get(List::class.java, NO_ANNOTATIONS, retrofit)
+      }
+      exceptionList.message shouldBe "Return type must be parameterized as List<Foo> or List<out Foo>"
+
+      val exceptionIO = shouldThrow<IllegalArgumentException> {
+        factory.get(IO::class.java, NO_ANNOTATIONS, retrofit)
+      }
+      exceptionIO.message shouldBe "Return type must be parameterized as IO<Foo> or IO<out Foo>"
+    }
+
+    "Should work for all types" {
+      factory.get(object : TypeToken<IO<String>>() {}.type, NO_ANNOTATIONS, retrofit)!!
+        .responseType() shouldBe String::class.java
+      factory.get(object : TypeToken<CallK<String>>() {}.type, NO_ANNOTATIONS, retrofit)!!
+        .responseType() shouldBe String::class.java
+    }
+  }
+}

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/Async2CallAdapterFactoryTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/Async2CallAdapterFactoryTest.kt
@@ -1,12 +1,13 @@
 package arrow.integrations.retrofit.adapter
 
 import arrow.effects.IO
+import arrow.integrations.retrofit.adapter.retrofit.retrofit
 import arrow.test.UnitSpec
 import com.google.common.reflect.TypeToken
 import io.kotlintest.KTestJUnitRunner
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.matchers.shouldThrow
+import okhttp3.HttpUrl
 import org.junit.runner.RunWith
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -15,11 +16,7 @@ private val NO_ANNOTATIONS = emptyArray<Annotation>()
 
 @RunWith(KTestJUnitRunner::class)
 class Async2CallAdapterFactoryTest : UnitSpec() {
-  private val retrofit = Retrofit.Builder()
-    .baseUrl("http://localhost:1")
-    .addConverterFactory(GsonConverterFactory.create())
-    .addCallAdapterFactory(Async2CallAdapterFactory.create())
-    .build()
+  private val retrofit = retrofit(HttpUrl.parse("http://localhost:1")!!)
 
   private val factory = Async2CallAdapterFactory.create()
 

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
@@ -1,0 +1,61 @@
+package arrow.integrations.retrofit.adapter
+
+import arrow.effects.IO
+import arrow.effects.ObservableK
+import arrow.effects.async
+import arrow.effects.fix
+import arrow.effects.monadDefer
+import arrow.integrations.retrofit.adapter.retrofit.retrofit
+import arrow.test.UnitSpec
+import io.kotlintest.KTestJUnitRunner
+import okhttp3.HttpUrl
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class ProcCallBackTest : UnitSpec() {
+  private val server = MockWebServer().apply {
+    enqueue(MockResponse().setBody("\"hello, world!\"").setResponseCode(200))
+    enqueue(MockResponse().setBody("\"hello, world!\"").setResponseCode(200))
+    enqueue(MockResponse().setBody("\"hello, world!\"").setResponseCode(200))
+    start()
+  }
+
+  private val baseUrl: HttpUrl = server.url("/")
+
+  init {
+
+    "should be able to parse answer with ForIO" {
+      val result = retrofit(baseUrl)
+        .create(ApiClientTest::class.java)
+        .test()
+        .async(IO.async())
+        .fix()
+        .unsafeRunSync()
+
+      assertEquals(result, "hello, world!")
+    }
+
+    "should be able to parse answer with ForObservableK" {
+      retrofit(baseUrl)
+        .create(ApiClientTest::class.java)
+        .test()
+        .defer(ObservableK.monadDefer())
+        .fix()
+        .observable
+        .test()
+        .assertValue("hello, world!")
+    }
+
+    "should be able to parse answer with IO" {
+      val result = retrofit(baseUrl)
+        .create(ApiClientTest::class.java)
+        .testIO()
+        .unsafeRunSync()
+
+      assertEquals(result, "hello, world!")
+    }
+  }
+}

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
@@ -5,6 +5,7 @@ import arrow.effects.ObservableK
 import arrow.effects.async
 import arrow.effects.fix
 import arrow.effects.monadDefer
+import arrow.integrations.retrofit.adapter.mock.ResponseMock
 import arrow.integrations.retrofit.adapter.retrofit.retrofit
 import arrow.test.UnitSpec
 import io.kotlintest.KTestJUnitRunner
@@ -17,9 +18,9 @@ import org.junit.runner.RunWith
 @RunWith(KTestJUnitRunner::class)
 class ProcCallBackTest : UnitSpec() {
   private val server = MockWebServer().apply {
-    enqueue(MockResponse().setBody("\"hello, world!\"").setResponseCode(200))
-    enqueue(MockResponse().setBody("\"hello, world!\"").setResponseCode(200))
-    enqueue(MockResponse().setBody("\"hello, world!\"").setResponseCode(200))
+    enqueue(MockResponse().setBody("{\"response\":  \"hello, world!\"}").setResponseCode(200))
+    enqueue(MockResponse().setBody("{\"response\":  \"hello, world!\"}").setResponseCode(200))
+    enqueue(MockResponse().setBody("{\"response\":  \"hello, world!\"}").setResponseCode(200))
     start()
   }
 
@@ -28,34 +29,33 @@ class ProcCallBackTest : UnitSpec() {
   init {
 
     "should be able to parse answer with ForIO" {
-      val result = retrofit(baseUrl)
-        .create(ApiClientTest::class.java)
+      val result = createApiClientTest(baseUrl)
         .test()
         .async(IO.async())
         .fix()
         .unsafeRunSync()
 
-      assertEquals(result, "hello, world!")
+      assertEquals(result, ResponseMock("hello, world!"))
     }
 
     "should be able to parse answer with ForObservableK" {
-      retrofit(baseUrl)
-        .create(ApiClientTest::class.java)
+      createApiClientTest(baseUrl)
         .test()
         .defer(ObservableK.monadDefer())
         .fix()
         .observable
         .test()
-        .assertValue("hello, world!")
+        .assertValue(ResponseMock("hello, world!"))
     }
 
     "should be able to parse answer with IO" {
-      val result = retrofit(baseUrl)
-        .create(ApiClientTest::class.java)
+      val result = createApiClientTest(baseUrl)
         .testIO()
         .unsafeRunSync()
 
-      assertEquals(result, "hello, world!")
+      assertEquals(result, ResponseMock("hello, world!"))
     }
   }
 }
+
+private fun createApiClientTest(baseUrl: HttpUrl) = retrofit(baseUrl).create(ApiClientTest::class.java)

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/mock/ResponseMock.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/mock/ResponseMock.kt
@@ -1,0 +1,3 @@
+package arrow.integrations.retrofit.adapter.mock
+
+data class ResponseMock(val response: String)

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/retrofit/Retrofit.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/retrofit/Retrofit.kt
@@ -1,0 +1,18 @@
+package arrow.integrations.retrofit.adapter.retrofit
+
+import arrow.integrations.retrofit.adapter.Async2CallAdapterFactory
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+private fun provideOkHttpClient(): OkHttpClient =
+  OkHttpClient.Builder().build()
+
+private fun configRetrofit(retrofitBuilder: Retrofit.Builder) =
+  retrofitBuilder
+    .addCallAdapterFactory(Async2CallAdapterFactory.create())
+    .client(provideOkHttpClient())
+
+private fun getRetrofitBuilderDefaults(baseUrl: HttpUrl) = Retrofit.Builder().baseUrl(baseUrl)
+
+fun retrofit(baseUrl: HttpUrl): Retrofit = configRetrofit(getRetrofitBuilderDefaults(baseUrl)).build()

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/retrofit/Retrofit.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/retrofit/Retrofit.kt
@@ -4,6 +4,7 @@ import arrow.integrations.retrofit.adapter.Async2CallAdapterFactory
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 
 private fun provideOkHttpClient(): OkHttpClient =
   OkHttpClient.Builder().build()
@@ -11,6 +12,7 @@ private fun provideOkHttpClient(): OkHttpClient =
 private fun configRetrofit(retrofitBuilder: Retrofit.Builder) =
   retrofitBuilder
     .addCallAdapterFactory(Async2CallAdapterFactory.create())
+    .addConverterFactory(GsonConverterFactory.create())
     .client(provideOkHttpClient())
 
 private fun getRetrofitBuilderDefaults(baseUrl: HttpUrl) = Retrofit.Builder().baseUrl(baseUrl)

--- a/settings.gradle
+++ b/settings.gradle
@@ -60,6 +60,10 @@ include {
             _ 'effects-reactor'
         }
 
+        integrations {
+            _ 'integrations-retrofit-adapter'
+        }
+
         folder('recursion-schemes') {
             _ 'recursion'
         }


### PR DESCRIPTION
This PR is a adapter for Arrow's Async classes. 

Example of use:

```
interface ApiClientTest {
  @GET("test")
  fun test(): CallK<ResponseMock>

  @GET("testIO")
  fun testIO(): IO<ResponseMock>
}
```

Using this plugin, it will be possible to set IO as a return type for a endpoint. It will be also possible the set CallK to create polymorphic return types that can be concretised in a latter moment.