### PR TITLE
Specify z-index for code snippets to avoid them clashing with sidebar

### DIFF
--- a/modules/docs/arrow-docs/docs/_sass/components/_code.scss
+++ b/modules/docs/arrow-docs/docs/_sass/components/_code.scss
@@ -18,6 +18,7 @@ p, ul {
   font-family: $code-font-family !important;
   font-size: 0.8rem !important;
   @include border-radius (3px);
+  z-index: 0;
 }
 
 .hljs {

--- a/modules/docs/arrow-docs/docs/css/arrow.css
+++ b/modules/docs/arrow-docs/docs/css/arrow.css
@@ -847,7 +847,8 @@ p code, ul code {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   -ms-border-radius: 3px;
-  -o-border-radius: 3px; }
+  -o-border-radius: 3px;
+  z-index: 0; }
 
 .hljs {
   display: block;


### PR DESCRIPTION
* Specify z-index for code snippets to avoid them clashing with sidebar.



We spotted a problem on the snippets conflicting with the open sidebar on mobile layouts.

![screenshot_20181017-010608](https://user-images.githubusercontent.com/7753447/47073627-fd813c80-d1f8-11e8-9def-5625b89839d5.png)

![captura de pantalla de 2018-10-17 10-56-51](https://user-images.githubusercontent.com/7753447/47074796-6ec1ef00-d1fb-11e8-8e29-1b84d81085fc.png)


This change fixes it.
