### PR TITLE
Make ApplicativeError#catch have bias to the right

### DIFF
--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ApplicativeError.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ApplicativeError.kt
@@ -26,7 +26,7 @@ interface ApplicativeError<F, E> : Applicative<F> {
   fun <A> fromEither(fab: Either<E, A>): Kind<F, A> =
     fab.fold({ raiseError<A>(it) }, { just(it) })
 
-  fun <A> catch(f: () -> A, recover: (Throwable) -> E): Kind<F, A> =
+  fun <A> catch(recover: (Throwable) -> E, f: () -> A): Kind<F, A> =
     try {
       just(f())
     } catch (t: Throwable) {
@@ -34,5 +34,5 @@ interface ApplicativeError<F, E> : Applicative<F> {
     }
 
   fun <A> ApplicativeError<F, Throwable>.catch(f: () -> A): Kind<F, A> =
-    catch(f, ::identity)
+    catch(::identity, f)
 }

--- a/modules/docs/arrow-docs/docs/docs/typeclasses/applicativeerror/README.md
+++ b/modules/docs/arrow-docs/docs/docs/typeclasses/applicativeerror/README.md
@@ -111,11 +111,11 @@ Constructor function. It takes two function parameters. The first is a generator
 `catch()` runs the generator function to generate a success datatype, and if it throws an exception it uses the error mapping function to create a new failure datatype.
 
 ```kotlin:ank
-eitherAE.catch({ 1 } ,::identity)
+eitherAE.catch(::identity) { 1 }
 ```
 
 ```kotlin:ank
-eitherAE.catch({ throw RuntimeException("Boom") } ,::identity)
+eitherAE.catch(::identity) { throw RuntimeException("Boom") }
 ```
 
 ### Laws


### PR DESCRIPTION
It makes sense with our right-bias policy, and the lambda sugar makes more sense in the operation rather than the transformation.