### PR TITLE
Adding Iterable Extensions that returns Option

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -202,14 +202,14 @@ fun <A> none(): Option<A> = None
 
 fun <T> Iterable<T>.firstOrNone(): Option<T> = this.firstOrNull().toOption()
 
-inline fun <T> Iterable<T>.firstOrNone(predicate: (T) -> Boolean): Option<T> = this.firstOrNull(predicate).toOption()
+fun <T> Iterable<T>.firstOrNone(predicate: (T) -> Boolean): Option<T> = this.firstOrNull(predicate).toOption()
 
 fun <T> Iterable<T>.singleOrNone(): Option<T> = this.singleOrNull().toOption()
 
-inline fun <T> Iterable<T>.singleOrNone(predicate: (T) -> Boolean): Option<T> = this.singleOrNull(predicate).toOption()
+fun <T> Iterable<T>.singleOrNone(predicate: (T) -> Boolean): Option<T> = this.singleOrNull(predicate).toOption()
 
 fun <T> Iterable<T>.lastOrNone(): Option<T> = this.lastOrNull().toOption()
 
-inline fun <T> Iterable<T>.lastOrNone(predicate: (T) -> Boolean): Option<T> = this.lastOrNull(predicate).toOption()
+fun <T> Iterable<T>.lastOrNone(predicate: (T) -> Boolean): Option<T> = this.lastOrNull(predicate).toOption()
 
 fun <T> Iterable<T>.elementAtOrNone(index: Int): Option<T> = this.elementAtOrNull(index).toOption()

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -199,3 +199,17 @@ fun <A> Boolean.maybe(f: () -> A): Option<A> =
 fun <A> A.some(): Option<A> = Some(this)
 
 fun <A> none(): Option<A> = None
+
+fun <T> Iterable<T>.singleOrNone(): Option<T> = this.singleOrNull().toOption()
+
+inline fun <T> Iterable<T>.singleOrNone(predicate: (T) -> Boolean): Option<T> = this.singleOrNull(predicate).toOption()
+
+fun <T> Iterable<T>.firstOrNone(): Option<T> = this.firstOrNull().toOption()
+
+inline fun <T> Iterable<T>.firstOrNone(predicate: (T) -> Boolean): Option<T> = this.firstOrNull(predicate).toOption()
+
+fun <T> Iterable<T>.lastOrNone(): Option<T> = this.lastOrNull().toOption()
+
+inline fun <T> Iterable<T>.lastOrNone(predicate: (T) -> Boolean): Option<T> = this.lastOrNull(predicate).toOption()
+
+fun <T> Iterable<T>.elementAtOrNone(index: Int): Option<T> = this.elementAtOrNull(index).toOption()

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -200,13 +200,13 @@ fun <A> A.some(): Option<A> = Some(this)
 
 fun <A> none(): Option<A> = None
 
-fun <T> Iterable<T>.singleOrNone(): Option<T> = this.singleOrNull().toOption()
-
-inline fun <T> Iterable<T>.singleOrNone(predicate: (T) -> Boolean): Option<T> = this.singleOrNull(predicate).toOption()
-
 fun <T> Iterable<T>.firstOrNone(): Option<T> = this.firstOrNull().toOption()
 
 inline fun <T> Iterable<T>.firstOrNone(predicate: (T) -> Boolean): Option<T> = this.firstOrNull(predicate).toOption()
+
+fun <T> Iterable<T>.singleOrNone(): Option<T> = this.singleOrNull().toOption()
+
+inline fun <T> Iterable<T>.singleOrNone(predicate: (T) -> Boolean): Option<T> = this.singleOrNull(predicate).toOption()
 
 fun <T> Iterable<T>.lastOrNone(): Option<T> = this.lastOrNull().toOption()
 

--- a/modules/docs/arrow-docs/docs/docs/datatypes/option/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/option/README.md
@@ -138,6 +138,29 @@ val nullableValue: String? = "Hello"
 nullableValue.toOption()
 ```
 
+Some Iterable extensions were added, so you can maintain a friendly API syntax while avoiding null handling (`firstOrNull()`)
+
+```
+val myList: List<Int> = listOf(1,2,3,4)
+myList.firstOrNone { it == 4 }
+// Some(4)
+myList.firstOrNone { it == 5 }
+// None
+```
+
+Sample usage
+
+```
+fun foo() {
+    val foxMap = mapOf(1 to "The", 2 to "Quick", 3 to "Brown", 4 to "Fox")
+
+    val ugly = foxMap.entries.firstOrNull { it.key == 5 }?.value.let { it?.toCharArray() }.toOption()
+    val pretty = foxMap.entries.firstOrNone { it.key == 5 }.map { it.value.toCharArray() }
+    
+    //Do something with pretty Option
+}
+```
+
 Arrow contains `Option` instances for many useful typeclasses that allows you to use and transform optional values
 
 [`Functor`]({{ '/docs/typeclasses/functor/' | relative_url }})

--- a/modules/docs/arrow-docs/docs/docs/datatypes/option/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/option/README.md
@@ -138,14 +138,18 @@ val nullableValue: String? = "Hello"
 nullableValue.toOption()
 ```
 
-Some Iterable extensions were added, so you can maintain a friendly API syntax while avoiding null handling (`firstOrNull()`)
+Some Iterable extensions are available, so you can maintain a friendly API syntax while avoiding null handling (`firstOrNull()`)
 
-```
+```kotlin:ank:silent
 val myList: List<Int> = listOf(1,2,3,4)
+```
+
+```kotlin:ank
 myList.firstOrNone { it == 4 }
-// Some(4)
+```
+
+```kotlin:ank
 myList.firstOrNone { it == 5 }
-// None
 ```
 
 Sample usage


### PR DESCRIPTION
## What

Adding `firstOrNone`, `singleOrNone`, `lastOrNone`, `elementAtOrNone` as Iterable extensions methods.

## Why

This methods allows us to maintain a friendly API syntax when operating on lists while avoiding null handling.

The motivation behind this appeared when we had to iterate over entries of a Map using `firstOrNull`. We are beginning with FP and trying do build a 100% pure Domain. Our domain is very permissive, and almost all of the inputs are Option, so the `firstOrNull` like methods goes against our principles, and `firstOrNone` like methods appears to be a solution to this problem.

Example:

```
fun main() {
    val foxMap = mapOf(1 to "The", 2 to "Quick", 3 to "Brown", 4 to "Fox")

    val ugly = foxMap.entries.firstOrNull { it.key == 5 }?.value.let { it?.toCharArray() }.toOption()
    val pretty = foxMap.entries.firstOrNone { it.key == 5 }.map { it.value.toCharArray() }
    
    //Do something with pretty Option
}
```

