### PR TITLE
avoiding the creation of intermediate collection

### DIFF
--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/SetK.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/SetK.kt
@@ -11,7 +11,7 @@ data class SetK<out A>(val set: Set<A>) : SetKOf<A>, Set<A> by set {
   fun <B> foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> {
     fun loop(fa_p: SetK<A>): Eval<B> = when {
       fa_p.set.isEmpty() -> lb
-      else -> f(fa_p.set.first(), Eval.defer { loop(fa_p.set.drop(1).toSet().k()) })
+      else -> f(fa_p.set.first(), Eval.defer { loop(fa_p.set.asSequence().drop(1).toSet().k()) })
     }
     return Eval.defer { loop(this) }
   }


### PR DESCRIPTION
This is just a simple performance fix that I caught while taking a look at the code for another PR. 

It avoids the creation of a intermediate collection after the `drop(1)` method. So it goes easier with the Garbage Collector. 