### PR TITLE
Release 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ allprojects {
 Add the dependencies into the project's `build.gradle`
 
 ```groovy
-def arrow_version = "0.7.3"
+def arrow_version = "0.8.0"
 dependencies {
     compile "io.arrow-kt:arrow-core:$arrow_version"
     compile "io.arrow-kt:arrow-syntax:$arrow_version"
@@ -54,14 +54,21 @@ dependencies {
     kapt    "io.arrow-kt:arrow-annotations-processor:$arrow_version" 
     
     compile "io.arrow-kt:arrow-free:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-instances-free:$arrow_version" //optional
     compile "io.arrow-kt:arrow-mtl:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects-rx2:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-rx2-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects-reactor:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-reactor-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects-kotlinx-coroutines:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-kotlinx-coroutines-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-optics:$arrow_version" //optional
     compile "io.arrow-kt:arrow-generic:$arrow_version" //optional
     compile "io.arrow-kt:arrow-recursion:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-instances-recursion:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-integrations-retrofit-adapter:$arrow_version" //optional
 }
 ```
 
@@ -76,7 +83,7 @@ Add the dependencies into the project's `build.gradle`
 apply plugin: 'kotlin-kapt' //optional
 apply from: rootProject.file('gradle/generated-kotlin-sources.gradle') //only for Android projects
 
-def arrow_version = "0.7.3"
+def arrow_version = "0.8.0"
 dependencies {
     ...
     kapt    'io.arrow-kt:arrow-annotations-processor:$arrow_version' //optional

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=io.arrow-kt
-VERSION_NAME=0.8.0-SNAPSHOT
+VERSION_NAME=0.8.0
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 # Kotlin configuration

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -47,7 +47,7 @@ allprojects {
 Add the dependencies into the project's `build.gradle`
 
 ```groovy
-def arrow_version = "0.7.3"
+def arrow_version = "0.8.0"
 dependencies {
     compile "io.arrow-kt:arrow-core:$arrow_version"
     compile "io.arrow-kt:arrow-syntax:$arrow_version"
@@ -56,16 +56,23 @@ dependencies {
     compile "io.arrow-kt:arrow-instances-core:$arrow_version"
     compile "io.arrow-kt:arrow-instances-data:$arrow_version"
     kapt    "io.arrow-kt:arrow-annotations-processor:$arrow_version" 
-
+    
     compile "io.arrow-kt:arrow-free:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-instances-free:$arrow_version" //optional
     compile "io.arrow-kt:arrow-mtl:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects-rx2:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-rx2-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects-reactor:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-reactor-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-effects-kotlinx-coroutines:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-effects-kotlinx-coroutines-instances:$arrow_version" //optional
     compile "io.arrow-kt:arrow-optics:$arrow_version" //optional
     compile "io.arrow-kt:arrow-generic:$arrow_version" //optional
     compile "io.arrow-kt:arrow-recursion:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-instances-recursion:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-integrations-retrofit-adapter:$arrow_version" //optional
 }
 ```
 
@@ -80,7 +87,7 @@ Add the dependencies into the project's `build.gradle`
 apply plugin: 'kotlin-kapt' //optional
 apply from: rootProject.file('gradle/generated-kotlin-sources.gradle') //only for Android projects
 
-def arrow_version = "0.7.3"
+def arrow_version = "0.8.0"
 dependencies {
     ...
     kapt    'io.arrow-kt:arrow-annotations-processor:$arrow_version' //optional


### PR DESCRIPTION
## [0.8.0](https://github.com/arrow-kt/arrow/tree/0.8.0) (2018-10-30)
[Full Changelog](https://github.com/arrow-kt/arrow/compare/0.7.3...0.8.0)

**Noteworthy in 0.8.0:**

- `@extension` Toward KEEP-87 [\#1040](https://github.com/arrow-kt/arrow/pull/1040) ([raulraja](https://github.com/raulraja))
- Add ApplicativeError constructors from the Core types [\#988](https://github.com/arrow-kt/arrow/pull/988) ([pakoito](https://github.com/pakoito))
- Add CancellableEffect typeclass. Use it to give races to IO [\#984](https://github.com/arrow-kt/arrow/pull/984) ([pakoito](https://github.com/pakoito))
- Optics state API [\#1047](https://github.com/arrow-kt/arrow/pull/1047) ([nomisRev](https://github.com/nomisRev))
- Optics reader syntax [\#1041](https://github.com/arrow-kt/arrow/pull/1041) ([nomisRev](https://github.com/nomisRev))
- Arrow playground [\#1050](https://github.com/arrow-kt/arrow/pull/1050) ([calvellido](https://github.com/calvellido))
- Adding integration for Retrofit [\#1037](https://github.com/arrow-kt/arrow/pull/1037) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- Comonadic UIs datatypes [\#1020](https://github.com/arrow-kt/arrow/pull/1020) ([Cotel](https://github.com/Cotel))
- `arrow.generic.Coproduct` arities [\#954](https://github.com/arrow-kt/arrow/pull/954) ([abergfeld](https://github.com/abergfeld))

**Merged pull requests:**

- Remove empty file [\#1076](https://github.com/arrow-kt/arrow/pull/1076) ([pakoito](https://github.com/pakoito))
- Make some style changes to the Retrofit integration [\#1075](https://github.com/arrow-kt/arrow/pull/1075) ([pakoito](https://github.com/pakoito))
- avoiding the creation of intermediate collection [\#1074](https://github.com/arrow-kt/arrow/pull/1074) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- fixing some minor problems [\#1072](https://github.com/arrow-kt/arrow/pull/1072) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- Add Polyjokes example [\#1071](https://github.com/arrow-kt/arrow/pull/1071) ([dcampogiani](https://github.com/dcampogiani))
- Add links to other glossaries [\#1070](https://github.com/arrow-kt/arrow/pull/1070) ([pakoito](https://github.com/pakoito))
- Adding integration for retrofit integration [\#1069](https://github.com/arrow-kt/arrow/pull/1069) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- removing unnecessary `fix\(\)`call [\#1068](https://github.com/arrow-kt/arrow/pull/1068) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- Add Droidcon example [\#1066](https://github.com/arrow-kt/arrow/pull/1066) ([pakoito](https://github.com/pakoito))
- Add contributing guidelines with how to build docs [\#1065](https://github.com/arrow-kt/arrow/pull/1065) ([iboss-ptk](https://github.com/iboss-ptk))
- Adding Iterable Extensions that returns Option [\#1064](https://github.com/arrow-kt/arrow/pull/1064) ([guilherme-pohlmann](https://github.com/guilherme-pohlmann))
- Make ApplicativeError\#catch have bias to the right [\#1063](https://github.com/arrow-kt/arrow/pull/1063) ([pakoito](https://github.com/pakoito))
- Fix several potential crashes on Android [\#1058](https://github.com/arrow-kt/arrow/pull/1058) ([pakoito](https://github.com/pakoito))
- Bump Kotlin version to 1.3-RC and updated Coroutines [\#1057](https://github.com/arrow-kt/arrow/pull/1057) ([raulraja](https://github.com/raulraja))
- Remove @Deprecated functions + General warning cleanup [\#1056](https://github.com/arrow-kt/arrow/pull/1056) ([raulraja](https://github.com/raulraja))
- Replace BooleanInstances with Boolean companion object [\#1055](https://github.com/arrow-kt/arrow/pull/1055) ([starkej2](https://github.com/starkej2))
- Fix Foldable foldMapM restrictions [\#1054](https://github.com/arrow-kt/arrow/pull/1054) ([AdrianRaFo](https://github.com/AdrianRaFo))
- Add async `defer` in `Async` [\#1053](https://github.com/arrow-kt/arrow/pull/1053) ([pakoito](https://github.com/pakoito))
- Specify z-index for code snippets to avoid them clashing with sidebar [\#1051](https://github.com/arrow-kt/arrow/pull/1051) ([calvellido](https://github.com/calvellido))
- Arrow playground [\#1050](https://github.com/arrow-kt/arrow/pull/1050) ([calvellido](https://github.com/calvellido))
- Ref [\#1049](https://github.com/arrow-kt/arrow/pull/1049) ([nomisRev](https://github.com/nomisRev))
- Optics state API [\#1047](https://github.com/arrow-kt/arrow/pull/1047) ([nomisRev](https://github.com/nomisRev))
- adding Tuple2 extension functions [\#1046](https://github.com/arrow-kt/arrow/pull/1046) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- Fixing urls and adding co-datatypes to the intro page [\#1045](https://github.com/arrow-kt/arrow/pull/1045) ([Cotel](https://github.com/Cotel))
- Revert "Interactive code snippets" [\#1042](https://github.com/arrow-kt/arrow/pull/1042) ([calvellido](https://github.com/calvellido))
- Optics reader syntax [\#1041](https://github.com/arrow-kt/arrow/pull/1041) ([nomisRev](https://github.com/nomisRev))
- @extension Toward KEEP-87 [\#1040](https://github.com/arrow-kt/arrow/pull/1040) ([raulraja](https://github.com/raulraja))
- Interactive code snippets [\#1039](https://github.com/arrow-kt/arrow/pull/1039) ([calvellido](https://github.com/calvellido))
- Adding integration for Retrofit [\#1037](https://github.com/arrow-kt/arrow/pull/1037) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- Add `compareTo` overload for `Order` [\#1035](https://github.com/arrow-kt/arrow/pull/1035) ([Mishkun](https://github.com/Mishkun))
- Update projects section for Android and Backend [\#1032](https://github.com/arrow-kt/arrow/pull/1032) ([pedrovgs](https://github.com/pedrovgs))
- Publish a shadowed uber jar of Arrow [\#1031](https://github.com/arrow-kt/arrow/pull/1031) ([raulraja](https://github.com/raulraja))
- Add documentation for Option.fromNullable [\#1030](https://github.com/arrow-kt/arrow/pull/1030) ([veiset](https://github.com/veiset))
- \[partials\] avoid initializing partial object multiple times [\#1025](https://github.com/arrow-kt/arrow/pull/1025) ([Laimiux](https://github.com/Laimiux))
- \[pipe\] remove inline modifier [\#1024](https://github.com/arrow-kt/arrow/pull/1024) ([Laimiux](https://github.com/Laimiux))
- Slim down effects [\#1022](https://github.com/arrow-kt/arrow/pull/1022) ([pakoito](https://github.com/pakoito))
- Comonadic UIs datatypes [\#1020](https://github.com/arrow-kt/arrow/pull/1020) ([Cotel](https://github.com/Cotel))
- Rename MonadSuspendLaws to MonadDeferLaws [\#1019](https://github.com/arrow-kt/arrow/pull/1019) ([alissonfpmorais](https://github.com/alissonfpmorais))
- Fix links to impl and laws [\#1016](https://github.com/arrow-kt/arrow/pull/1016) ([pakoito](https://github.com/pakoito))
- Publish arrow-validation to Maven [\#1014](https://github.com/arrow-kt/arrow/pull/1014) ([tdelev](https://github.com/tdelev))
- Try's success/failure extfuns  [\#1011](https://github.com/arrow-kt/arrow/pull/1011) ([alissonfpmorais](https://github.com/alissonfpmorais))
- Updated main dependencies and Gradle [\#1008](https://github.com/arrow-kt/arrow/pull/1008) ([jrgonzalezg](https://github.com/jrgonzalezg))
- Add small snippet about datatype representation on the glossary [\#1004](https://github.com/arrow-kt/arrow/pull/1004) ([pakoito](https://github.com/pakoito))
- Add effectM to Monad, to ignore the result of a second monadic operation [\#1003](https://github.com/arrow-kt/arrow/pull/1003) ([pakoito](https://github.com/pakoito))
- updating blogs and presentation docs [\#1001](https://github.com/arrow-kt/arrow/pull/1001) ([leandroBorgesFerreira](https://github.com/leandroBorgesFerreira))
- Add a Category typeclass, CategoryLaws and make Function1 a Category instance  [\#999](https://github.com/arrow-kt/arrow/pull/999) ([paulcadman](https://github.com/paulcadman))
- Add `arrow.generic.Coproduct` docs [\#998](https://github.com/arrow-kt/arrow/pull/998) ([abergfeld](https://github.com/abergfeld))
- Improving the FpToTheMax example [\#997](https://github.com/arrow-kt/arrow/pull/997) ([enhan](https://github.com/enhan))
- Fix links in Libraries doc [\#995](https://github.com/arrow-kt/arrow/pull/995) ([pakoito](https://github.com/pakoito))
- Added Try.toEither with onLeft mapper [\#994](https://github.com/arrow-kt/arrow/pull/994) ([atomcat1978](https://github.com/atomcat1978))
- Specify that MonadDefer focuses on synchronous effects [\#992](https://github.com/arrow-kt/arrow/pull/992) ([pakoito](https://github.com/pakoito))
- EqLaws: Add law tests for an equivalence relation [\#991](https://github.com/arrow-kt/arrow/pull/991) ([paulcadman](https://github.com/paulcadman))
- Next Development Iteration 0.7.4-SNAPSHOT [\#990](https://github.com/arrow-kt/arrow/pull/990) ([raulraja](https://github.com/raulraja))
- Add ApplicativeError constructors from the Core types [\#988](https://github.com/arrow-kt/arrow/pull/988) ([pakoito](https://github.com/pakoito))
- Add CancellableEffect typeclass. Use it to give races to IO [\#984](https://github.com/arrow-kt/arrow/pull/984) ([pakoito](https://github.com/pakoito))
- Contravariant & Invariant [\#975](https://github.com/arrow-kt/arrow/pull/975) ([Cotel](https://github.com/Cotel))
- `arrow.generic.Coproduct` arities [\#954](https://github.com/arrow-kt/arrow/pull/954) ([abergfeld](https://github.com/abergfeld))
