### PR TITLE
Add jitpack to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Add it in your root `build.gradle` at the end of repositories.
 allprojects {
     repositories {
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 }
 ```


### PR DESCRIPTION
Adds `jitpack` as a gradle repository in order to fetch MnemoniK