### PR TITLE
fixing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For this, it includes the most popular data types, type classes and abstractions
 Use the list below to learn more about Λrrow's main features.
 
 - [Documentation](http://arrow-kt.io)
-- [Patterns](http://arrow-kt.io/docs/patterns/glossary/): tutorials and approaches to day-to-day challenges using FP 
+- [Patterns](http://arrow-kt.io/docs/patterns/glossary/): tutorials and approaches to day-to-day challenges using FP
 - [Libraries](http://arrow-kt.io/docs/quickstart/libraries/): all the libraries provided by Λrrow
 - [Type classes](http://arrow-kt.io/docs/typeclasses/intro/): defining behaviors for data
 - [Data types](http://arrow-kt.io/docs/datatypes/intro/): common abstractions
@@ -48,12 +48,12 @@ def arrow_version = "0.8.0"
 dependencies {
     compile "io.arrow-kt:arrow-core:$arrow_version"
     compile "io.arrow-kt:arrow-syntax:$arrow_version"
-    compile "io.arrow-kt:arrow-typeclasses:$arrow_version" 
-    compile "io.arrow-kt:arrow-data:$arrow_version" 
+    compile "io.arrow-kt:arrow-typeclasses:$arrow_version"
+    compile "io.arrow-kt:arrow-data:$arrow_version"
     compile "io.arrow-kt:arrow-instances-core:$arrow_version"
     compile "io.arrow-kt:arrow-instances-data:$arrow_version"
-    kapt    "io.arrow-kt:arrow-annotations-processor:$arrow_version" 
-    
+    kapt    "io.arrow-kt:arrow-annotations-processor:$arrow_version"
+
     compile "io.arrow-kt:arrow-free:$arrow_version" //optional
     compile "io.arrow-kt:arrow-instances-free:$arrow_version" //optional
     compile "io.arrow-kt:arrow-mtl:$arrow_version" //optional
@@ -69,7 +69,7 @@ dependencies {
     compile "io.arrow-kt:arrow-generic:$arrow_version" //optional
     compile "io.arrow-kt:arrow-recursion:$arrow_version" //optional
     compile "io.arrow-kt:arrow-instances-recursion:$arrow_version" //optional
-    compile "io.arrow-kt:arrow-integrations-retrofit-adapter:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-integration-retrofit-adapter:$arrow_version" //optional
 }
 ```
 
@@ -133,4 +133,3 @@ idea {
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -18,7 +18,7 @@ For this, it includes the most popular data types, type classes and abstractions
 
 Use the list below to learn more about Λrrow's main features.
 
-- [Patterns](http://arrow-kt.io/docs/patterns/glossary/): tutorials and approaches to day-to-day challenges using FP 
+- [Patterns](http://arrow-kt.io/docs/patterns/glossary/): tutorials and approaches to day-to-day challenges using FP
 - [Libraries](http://arrow-kt.io/docs/quickstart/libraries/): all the libraries provided by Λrrow
 - [Type classes](http://arrow-kt.io/docs/typeclasses/intro/): defining behaviors for data
 - [Data types](http://arrow-kt.io/docs/datatypes/intro/): common abstractions
@@ -51,12 +51,12 @@ def arrow_version = "0.8.0"
 dependencies {
     compile "io.arrow-kt:arrow-core:$arrow_version"
     compile "io.arrow-kt:arrow-syntax:$arrow_version"
-    compile "io.arrow-kt:arrow-typeclasses:$arrow_version" 
-    compile "io.arrow-kt:arrow-data:$arrow_version" 
+    compile "io.arrow-kt:arrow-typeclasses:$arrow_version"
+    compile "io.arrow-kt:arrow-data:$arrow_version"
     compile "io.arrow-kt:arrow-instances-core:$arrow_version"
     compile "io.arrow-kt:arrow-instances-data:$arrow_version"
-    kapt    "io.arrow-kt:arrow-annotations-processor:$arrow_version" 
-    
+    kapt    "io.arrow-kt:arrow-annotations-processor:$arrow_version"
+
     compile "io.arrow-kt:arrow-free:$arrow_version" //optional
     compile "io.arrow-kt:arrow-instances-free:$arrow_version" //optional
     compile "io.arrow-kt:arrow-mtl:$arrow_version" //optional
@@ -72,7 +72,7 @@ dependencies {
     compile "io.arrow-kt:arrow-generic:$arrow_version" //optional
     compile "io.arrow-kt:arrow-recursion:$arrow_version" //optional
     compile "io.arrow-kt:arrow-instances-recursion:$arrow_version" //optional
-    compile "io.arrow-kt:arrow-integrations-retrofit-adapter:$arrow_version" //optional
+    compile "io.arrow-kt:arrow-integration-retrofit-adapter:$arrow_version" //optional
 }
 ```
 


### PR DESCRIPTION
The POM for retrofit adapter is:
```
 POM_ARTIFACT_ID=arrow-integration-retrofit-adapter
```

So there's a small typo in the docs: 

compile "io.arrow-kt:arrow-integrations-retrofit-adapter:$arrow_version" //optional

That should be correct. Or the POM should be changed to it gets equal to the documentation