### PR TITLE
[WIP] Move to Kotlin 1.3.0 and coroutines 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ buildscript {
         gradleVersionsPluginVersion = '0.20.0'
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = '2.0.7'
-        kotlinVersion = '1.3.0-rc-190'
+        kotlinVersion = '1.3.0'
         daggerVersion = '2.17'
-        kotlinxCoroutinesVersion = '0.30.2-eap13'
+        kotlinxCoroutinesVersion = '1.0.0'
         kotlinxCollectionsImmutableVersion = '0.1'
         kotlinPoetVersion='1.0.0-RC1'
         projectReactorVersion='3.1.8.RELEASE'
@@ -125,7 +125,7 @@ subprojects { project ->
         maxParallelForks = Runtime.runtime.availableProcessors()
     }
 
-    build.dependsOn ':detekt'
+    // build.dependsOn ':detekt'
 
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ VERSION_NAME=0.8.1-SNAPSHOT
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 # Kotlin configuration
-kotlin.coroutines=enable
 kotlin.incremental=true
 # Pomfile definitions
 POM_DESCRIPTION=Functional companion to Kotlin's Standard Library

--- a/modules/core/arrow-annotations-processor/build.gradle
+++ b/modules/core/arrow-annotations-processor/build.gradle
@@ -5,10 +5,12 @@ apply plugin: 'kotlin-kapt'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    compile "com.squareup:kotlinpoet:$kotlinPoetVersion"
+    compile("com.squareup:kotlinpoet:$kotlinPoetVersion") {
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-reflect'
+    }
     compile project(':arrow-annotations')
     compile 'me.eugeniomarletti.kotlin.metadata:kotlin-metadata:1.4.0'
-    compile 'com.squareup:kotlinpoet:1.0.0-RC1'
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     compile 'com.github.aballano:MnemoniK:1.0.0'
     compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
     kapt 'com.google.auto.service:auto-service:1.0-rc4'

--- a/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
+++ b/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
@@ -207,7 +207,7 @@ Note that while most data types include an instance of [`Monad`]({{ '/docs/typec
 ### What about those threads?
 
 Arrow uses the same abstraction as coroutines to group threads and other contexts of execution: `CoroutineContext`.
-There are multiple default values and wrappers for common cases in both the standard library, and the extension library [kotlinx.coroutines](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-coroutine-dispatcher/index.html).
+There are multiple default values and wrappers for common cases in both the standard library, and the extension library [kotlinx.coroutines](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-dispatcher/index.html).
 
 #### Blocking thread jumps
 


### PR DESCRIPTION
Need help with tests here 😞 
Currently, tests fail in DeferredTest.kt, it looks like `.invokeOnCompletion` which throws Exception is now forbidden according to [docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-completion-handler.html) - it gets wrapped with `CompletionHandlerException` and propagated. 

What has been done: 
* Tried to use Dispatchers.IO - throws `AssertionError`, which means re-thrown exceptions are caught in run block. 
* Tried to catch `CompletionHandlerException` - still getting that exception in wrong `catch { .. }` block though. 
