### PR TITLE
Add a section regarding Maven Support on Quick Start

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -30,7 +30,8 @@ Use the list below to learn more about Λrrow's main features.
 - [Projects and Examples](http://arrow-kt.io/docs/quickstart/projects/)
 - [Blogs and Presentations](http://arrow-kt.io/docs/quickstart/blogs/)
 
-# Basic Setup
+# Gradle 
+## Basic Setup
 
 Make sure to have the latest version of JDK 1.8 installed.
 
@@ -76,7 +77,7 @@ dependencies {
 }
 ```
 
-# Additional Setup
+## Additional Setup
 
 For projects that wish to use their own `@higherkind`, `@optics` and other meta programming facilities provided by Λrrow
 the setup below is also required:
@@ -120,3 +121,114 @@ idea {
     }
 }
 ```
+# Maven 
+## Basic Setup
+
+Make sure to have the at least the latest version of JDK 1.8 installed.
+Add to your pom.xml file the following properties:
+```
+    <properties>
+        <kotlin.version>1.3.0</kotlin.version>
+        <arrow.version>0.8.0</arrow.version>
+    </properties>
+```
+
+Add the dependencies that you want to use
+```
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-core</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-syntax</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-typeclasses</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-data</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-instances-core</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-instances-data</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+```
+
+## Enabling kapt
+
+Add to your pom.xml file the following repository:
+``
+  <repositories>
+   <repository>
+      <snapshots>
+         <enabled>false</enabled>
+      </snapshots>
+      <id>jitpack</id>
+      <url>https://jitpack.io</url>
+   </repository>
+ </repositories>
+```
+
+Enable annotaton processing using kotlin plugin 
+```
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>io.arrow-kt</groupId>
+                                    <artifactId>arrow-annotations-processor</artifactId>
+                                    <version>${arrow.version}</version>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+```
+
+
+


### PR DESCRIPTION
Added related section at the bottom of the file.
It includes the basic maven setup, and instructions on how to enable kapt using kotlin plugin.