### PR TITLE
Update kotlinx.coroutines to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ buildscript {
         gradleVersionsPluginVersion = '0.20.0'
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = '2.0.7'
-        kotlinVersion = '1.3.0-rc-190'
+        kotlinVersion = '1.3.0'
         daggerVersion = '2.17'
-        kotlinxCoroutinesVersion = '0.30.2-eap13'
+        kotlinxCoroutinesVersion = '1.0.0'
         kotlinxCollectionsImmutableVersion = '0.1'
         kotlinPoetVersion='1.0.0-RC1'
         projectReactorVersion='3.1.8.RELEASE'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ VERSION_NAME=0.8.1-SNAPSHOT
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 # Kotlin configuration
-kotlin.coroutines=enable
 kotlin.incremental=true
 # Pomfile definitions
 POM_DESCRIPTION=Functional companion to Kotlin's Standard Library

--- a/modules/core/arrow-annotations-processor/build.gradle
+++ b/modules/core/arrow-annotations-processor/build.gradle
@@ -5,10 +5,12 @@ apply plugin: 'kotlin-kapt'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    compile "com.squareup:kotlinpoet:$kotlinPoetVersion"
     compile project(':arrow-annotations')
     compile 'me.eugeniomarletti.kotlin.metadata:kotlin-metadata:1.4.0'
-    compile 'com.squareup:kotlinpoet:1.0.0-RC1'
+    compile("com.squareup:kotlinpoet:$kotlinPoetVersion") {
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-reflect'
+    }
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     compile 'com.github.aballano:MnemoniK:1.0.0'
     compileOnly 'com.google.auto.service:auto-service:1.0-rc4'
     kapt 'com.google.auto.service:auto-service:1.0-rc4'

--- a/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
+++ b/modules/docs/arrow-docs/docs/docs/patterns/monadcomprehensions/README.md
@@ -207,7 +207,7 @@ Note that while most data types include an instance of [`Monad`]({{ '/docs/typec
 ### What about those threads?
 
 Arrow uses the same abstraction as coroutines to group threads and other contexts of execution: `CoroutineContext`.
-There are multiple default values and wrappers for common cases in both the standard library, and the extension library [kotlinx.coroutines](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-coroutine-dispatcher/index.html).
+There are multiple default values and wrappers for common cases in both the standard library, and the extension library [kotlinx.coroutines](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-dispatcher/index.html).
 
 #### Blocking thread jumps
 

--- a/modules/effects/arrow-effects-instances/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects-instances/src/test/kotlin/arrow/effects/IOTest.kt
@@ -7,7 +7,6 @@ import arrow.effects.instances.io.async.async
 import arrow.effects.instances.io.monad.monad
 import arrow.effects.typeclasses.milliseconds
 import arrow.effects.typeclasses.seconds
-import arrow.instances.either.applicativeError.applicativeError
 import arrow.instances.option.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.concurrency.SideEffect
@@ -156,6 +155,7 @@ class IOTest : UnitSpec() {
         ioa.unsafeRunAsync { either ->
           either.fold({ throw exception }, { fail("") })
         }
+        fail("Should rethrow the exception")
       } catch (myException: MyException) {
         // Success
       } catch (throwable: Throwable) {

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -7,7 +7,6 @@ import arrow.effects.deferredk.applicative.applicative
 import arrow.effects.typeclasses.*
 import arrow.extension
 import arrow.typeclasses.*
-import kotlinx.coroutines.GlobalScope
 import kotlin.coroutines.CoroutineContext
 import arrow.effects.handleErrorWith as deferredHandleErrorWith
 import arrow.effects.runAsync as deferredRunAsync
@@ -37,7 +36,7 @@ suspend fun <F, A> Kind<F, DeferredKOf<A>>.awaitAll(T: Traverse<F>): Kind<F, A> 
 @extension
 interface DeferredKMonadInstance : Monad<ForDeferredK> {
   override fun <A, B> Kind<ForDeferredK, A>.flatMap(f: (A) -> Kind<ForDeferredK, B>): DeferredK<B> =
-    fix().flatMap(f)
+    fix().flatMap(f = f)
 
   override fun <A, B> Kind<ForDeferredK, A>.map(f: (A) -> B): DeferredK<B> =
     fix().map(f)
@@ -82,7 +81,7 @@ interface DeferredKAsyncInstance : Async<ForDeferredK>, DeferredKMonadDeferInsta
     DeferredK.async(fa = fa)
 
   override fun <A> DeferredKOf<A>.continueOn(ctx: CoroutineContext): DeferredK<A> =
-    fix().continueOn(ctx)
+    fix().continueOn(ctx = ctx)
 
   override fun <A> invoke(f: () -> A): DeferredK<A> =
     DeferredK.invoke(f = f)
@@ -94,13 +93,13 @@ interface DeferredKAsyncInstance : Async<ForDeferredK>, DeferredKMonadDeferInsta
 @extension
 interface DeferredKEffectInstance : Effect<ForDeferredK>, DeferredKAsyncInstance {
   override fun <A> Kind<ForDeferredK, A>.runAsync(cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
-    fix().deferredRunAsync(GlobalScope, cb)
+    fix().deferredRunAsync(cb = cb)
 }
 
 @extension
 interface DeferredKConcurrentEffectInstance : ConcurrentEffect<ForDeferredK>, DeferredKEffectInstance {
   override fun <A> Kind<ForDeferredK, A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> Kind<ForDeferredK, Unit>): Kind<ForDeferredK, Disposable> =
-    fix().runAsyncCancellable(GlobalScope, OnCancel.ThrowCancellationException, cb)
+    fix().runAsyncCancellable(onCancel = OnCancel.ThrowCancellationException, cb = cb)
 }
 
 object DeferredKContext : DeferredKConcurrentEffectInstance

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -7,6 +7,7 @@ import arrow.effects.deferredk.applicative.applicative
 import arrow.effects.typeclasses.*
 import arrow.extension
 import arrow.typeclasses.*
+import kotlinx.coroutines.GlobalScope
 import kotlin.coroutines.CoroutineContext
 import arrow.effects.handleErrorWith as deferredHandleErrorWith
 import arrow.effects.runAsync as deferredRunAsync
@@ -93,13 +94,13 @@ interface DeferredKAsyncInstance : Async<ForDeferredK>, DeferredKMonadDeferInsta
 @extension
 interface DeferredKEffectInstance : Effect<ForDeferredK>, DeferredKAsyncInstance {
   override fun <A> Kind<ForDeferredK, A>.runAsync(cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
-    fix().deferredRunAsync(cb)
+    fix().deferredRunAsync(GlobalScope, cb)
 }
 
 @extension
 interface DeferredKConcurrentEffectInstance : ConcurrentEffect<ForDeferredK>, DeferredKEffectInstance {
   override fun <A> Kind<ForDeferredK, A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> Kind<ForDeferredK, Unit>): Kind<ForDeferredK, Disposable> =
-    fix().runAsyncCancellable(OnCancel.ThrowCancellationException, cb)
+    fix().runAsyncCancellable(GlobalScope, OnCancel.ThrowCancellationException, cb)
 }
 
 object DeferredKContext : DeferredKConcurrentEffectInstance

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/test/kotlin/arrow/effects/DeferredTest.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/test/kotlin/arrow/effects/DeferredTest.kt
@@ -1,8 +1,11 @@
 package arrow.effects
 
 import arrow.Kind
-import arrow.core.*
-import arrow.data.*
+import arrow.core.Option
+import arrow.core.Try
+import arrow.data.ListK
+import arrow.data.NonEmptyList
+import arrow.data.k
 import arrow.effects.deferredk.async.async
 import arrow.instances.`try`.functor.functor
 import arrow.instances.`try`.traverse.traverse
@@ -24,7 +27,7 @@ import io.kotlintest.matchers.shouldBe
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Unconfined
+import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -21,13 +21,13 @@ data class DeferredK<out A>(val deferred: Deferred<A>) : DeferredKOf<A>, Deferre
   fun <B> ap(fa: DeferredKOf<(A) -> B>): DeferredK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
-  fun <B> flatMap(f: (A) -> DeferredKOf<B>): DeferredK<B> =
-    GlobalScope.async(Dispatchers.Unconfined, CoroutineStart.LAZY) {
+  fun <B> flatMap(scope: CoroutineScope = GlobalScope, f: (A) -> DeferredKOf<B>): DeferredK<B> =
+    scope.async(Dispatchers.Unconfined, CoroutineStart.LAZY) {
       f(await()).await()
     }.k()
 
-  fun continueOn(ctx: CoroutineContext): DeferredK<A> =
-    GlobalScope.async(ctx, CoroutineStart.LAZY) {
+  fun continueOn(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext): DeferredK<A> =
+    scope.async(ctx, CoroutineStart.LAZY) {
       deferred.await()
     }.k()
 
@@ -38,17 +38,17 @@ data class DeferredK<out A>(val deferred: Deferred<A>) : DeferredKOf<A>, Deferre
     fun <A> just(a: A): DeferredK<A> =
       CompletableDeferred(a).k()
 
-    fun <A> defer(ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
-      GlobalScope.async(ctx, start) { f() }.k()
+    fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
+      scope.async(ctx, start) { f() }.k()
 
-    fun <A> defer(ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: () -> DeferredKOf<A>): DeferredK<A> =
-      GlobalScope.async(ctx, start) { fa().await() }.k()
+    fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: () -> DeferredKOf<A>): DeferredK<A> =
+      scope.async(ctx, start) { fa().await() }.k()
 
-    operator fun <A> invoke(ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.DEFAULT, f: () -> A): DeferredK<A> =
-      GlobalScope.async(ctx, start) { f() }.k()
+    operator fun <A> invoke(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.DEFAULT, f: () -> A): DeferredK<A> =
+      scope.async(ctx, start) { f() }.k()
 
     fun <A> failed(t: Throwable): DeferredK<A> =
-      CompletableDeferred<A>().apply { cancel(t) }.k()
+      CompletableDeferred<A>().apply { completeExceptionally(t) }.k()
 
     fun <A> raiseError(t: Throwable): DeferredK<A> =
       failed(t)
@@ -60,11 +60,11 @@ data class DeferredK<out A>(val deferred: Deferred<A>) : DeferredKOf<A>, Deferre
      * its [CoroutineContext] is set to [DefaultDispatcher]
      * and its [CoroutineStart] is [CoroutineStart.DEFAULT].
      */
-    fun <A> async(ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.DEFAULT, fa: Proc<A>): DeferredK<A> =
-      GlobalScope.async(ctx, start) {
+    fun <A> async(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.DEFAULT, fa: Proc<A>): DeferredK<A> =
+      scope.async(ctx, start) {
         CompletableDeferred<A>().apply {
           fa {
-            it.fold(this::cancel, this::complete)
+            it.fold(this::completeExceptionally, this::complete)
           }
         }.await()
       }.k()
@@ -89,8 +89,8 @@ data class DeferredK<out A>(val deferred: Deferred<A>) : DeferredKOf<A>, Deferre
   }
 }
 
-fun <A> DeferredKOf<A>.handleErrorWith(f: (Throwable) -> DeferredK<A>): DeferredK<A> =
-  GlobalScope.async(Dispatchers.Unconfined, CoroutineStart.LAZY) {
+fun <A> DeferredKOf<A>.handleErrorWith(scope: CoroutineScope = GlobalScope, f: (Throwable) -> DeferredK<A>): DeferredK<A> =
+  scope.async(Dispatchers.Unconfined, CoroutineStart.LAZY) {
     Try { await() }.fold({ f(it).await() }, ::identity)
   }.k()
 
@@ -100,31 +100,36 @@ fun <A> DeferredKOf<A>.unsafeAttemptSync(): Try<A> =
 fun <A> DeferredKOf<A>.unsafeRunSync(): A =
   runBlocking { await() }
 
-fun <A> DeferredKOf<A>.runAsync(cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
-  DeferredK(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
-    unsafeRunAsync(cb.andThen { })
-  }
+fun <A> DeferredKOf<A>.runAsync(scope: CoroutineScope = GlobalScope, cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
+  scope.async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+    forceExceptionPropagation()
+    unsafeRunAsync(this, cb.andThen { it.unsafeRunAsync(this) { } })
+  }.k()
 
-fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent, cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Disposable> =
-  GlobalScope.async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
-    val call = runAsync(cb)
+fun <A> DeferredKOf<A>.runAsyncCancellable(scope: CoroutineScope = GlobalScope, onCancel: OnCancel = OnCancel.Silent, cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Disposable> =
+  scope.async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+    val call = CompletableDeferred<Unit>(parent = runAsync(scope, cb))
     val disposable: Disposable = {
       when (onCancel) {
-        OnCancel.ThrowCancellationException -> call.cancel(OnCancel.CancellationException)
+        OnCancel.ThrowCancellationException -> call.completeExceptionally(OnCancel.CancellationException)
         OnCancel.Silent -> call.cancel()
       }
     }
     disposable
   }.k()
 
-fun <A> DeferredKOf<A>.unsafeRunAsync(cb: (Either<Throwable, A>) -> Unit): Unit =
-  GlobalScope.async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+fun <A> DeferredKOf<A>.unsafeRunAsync(scope: CoroutineScope = GlobalScope, cb: (Either<Throwable, A>) -> Unit): Unit =
+  scope.async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     Try { await() }.fold({ cb(Left(it)) }, { cb(Right(it)) })
-  }.let {
-    // Deferred swallows all exceptions. How about no.
-    it.invokeOnCompletion { a: Throwable? ->
-      if (a != null) throw a
-    }
-  }
+  }.forceExceptionPropagation()
+
+private fun DeferredKOf<*>.forceExceptionPropagation(): Unit =
+  fix().deferred.forceExceptionPropagation()
+
+private fun Deferred<*>.forceExceptionPropagation(): Unit =
+// Deferred swallows all exceptions. How about no.
+  invokeOnCompletion { a: Throwable? ->
+    if (a != null) throw a
+  }.let { }
 
 suspend fun <A> DeferredKOf<A>.await(): A = this.fix().await()


### PR DESCRIPTION
This PR includes the changes required to support `CoroutineScope` in a reasonable way, plus a fix for the new exception wrapping behavior.