### PR TITLE
Fiber 

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/effects/fiber/README.MD
+++ b/modules/docs/arrow-docs/docs/docs/effects/fiber/README.MD
@@ -1,0 +1,50 @@
+---
+layout: docs
+title: Fiber
+permalink: /docs/effects/fiber/
+---
+
+## Fiber
+
+{:.advanced}
+advanced
+
+A `Fiber` is a concurrency primitive for describing parallel operations or multi-tasking.
+Concurrently started tasks can either be joined or canceled and this are the only two operators available on `Fiber`.
+
+Using `Fiber` we can verily easily describe parallel operations such as `parallelMap`.
+
+```kotlin:ank
+import arrow.effects.*
+import arrow.effects.deferredk.monad.monad
+import arrow.effects.typeclasses.Fiber
+import arrow.typeclasses.binding
+
+fun <A, B, C> parallelMap(first: DeferredK<A>,
+                     second: DeferredK<B>,
+                     f: (A, B) -> C): DeferredK<C> =
+  DeferredK.monad().binding {
+    val fiberOne: Fiber<ForDeferredK, A> = first.startF().bind()
+    val fiberTwo: Fiber<ForDeferredK, B> = second.startF().bind()
+    f(fiberOne.join.bind(), fiberTwo.join.bind())
+  }.fix()
+
+val first = DeferredK.sleep(5000).map {
+  println("Hi, I am first")
+  1
+}
+
+val second = DeferredK.sleep(3000).map {
+  println("Hi, I am second")
+  2
+}
+```
+
+```kotlin
+parMap(first, second, Int::plus).await()
+
+//Hi, I am second
+//Hi, I am first
+//3
+```
+

--- a/modules/docs/arrow-docs/docs/docs/effects/fiber/README.MD
+++ b/modules/docs/arrow-docs/docs/docs/effects/fiber/README.MD
@@ -18,7 +18,6 @@ Using `Fiber` we can verily easily describe parallel operations such as `paralle
 import arrow.effects.*
 import arrow.effects.deferredk.monad.monad
 import arrow.effects.typeclasses.Fiber
-import arrow.typeclasses.binding
 
 fun <A, B, C> parallelMap(first: DeferredK<A>,
                      second: DeferredK<B>,

--- a/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
+++ b/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
@@ -9,15 +9,13 @@ import kotlinx.coroutines.Dispatchers.Unconfined
 
 val UI = Unconfined
 
-fun <A> DeferredKOf<A>.startF(ctx: CoroutineContext = Dispatchers.Default): DeferredK<Fiber<ForDeferredK, A>> {
-  return this.fix().scope.run {
+fun <A> DeferredKOf<A>.startF(ctx: CoroutineContext = Dispatchers.Default): DeferredK<Fiber<ForDeferredK, A>> = this.fix().scope.run {
     val start = asyncK(ctx = ctx, start = CoroutineStart.DEFAULT) {
       this@startF.await()
     }
 
     DeferredK.just(Fiber(start, asyncK { start.cancel() }))
   }
-}
 
 fun DeferredK.Companion.sleep(milis: Long, scope: CoroutineScope = GlobalScope): DeferredK<Unit> =
   scope.asyncK {

--- a/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
+++ b/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
@@ -1,5 +1,48 @@
 package arrow.effects
 
+import arrow.effects.deferredk.monad.monad
+import arrow.effects.typeclasses.Fiber
+import arrow.typeclasses.binding
+import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers.IO
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers.Unconfined
 
 val UI = Unconfined
+
+fun <A> DeferredKOf<A>.startF(ctx: CoroutineContext = Dispatchers.Default): DeferredK<Fiber<ForDeferredK, A>> {
+  return this.fix().scope.run {
+    val start = asyncK(ctx = ctx, start = CoroutineStart.DEFAULT) {
+      this@startF.await()
+    }
+
+    DeferredK.just(Fiber(start, asyncK { start.cancel() }))
+  }
+}
+
+fun DeferredK.Companion.sleep(milis: Long, scope: CoroutineScope = GlobalScope): DeferredK<Unit> =
+  scope.asyncK {
+    delay(milis)
+  }
+
+fun <A, B, C> parMap(first: DeferredK<A>,
+                     second: DeferredK<B>,
+                     f: (A, B) -> C): DeferredK<C> =
+  DeferredK.monad().binding {
+    val fiberOne: Fiber<ForDeferredK, A> = first.startF(IO).bind()
+    val fiberTwo: Fiber<ForDeferredK, B> = second.startF(IO).bind()
+
+    val one: A = fiberOne.join.bind()
+    val two: B = fiberTwo.join.bind()
+    f(one, two)
+  }.fix()
+
+val first = DeferredK.sleep(5000).map {
+  println("Hi I am first")
+  1
+}
+
+val second = DeferredK.sleep(3000).map {
+  println("Hi I am second")
+  2
+}

--- a/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
+++ b/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
@@ -2,7 +2,6 @@ package arrow.effects
 
 import arrow.effects.deferredk.monad.monad
 import arrow.effects.typeclasses.Fiber
-import arrow.typeclasses.binding
 import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlin.coroutines.CoroutineContext

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Fiber.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Fiber.kt
@@ -1,6 +1,7 @@
 package arrow.effects.typeclasses
 
 import arrow.Kind
+import arrow.effects.internal.CancelToken
 
 /**
  * [Fiber] represents the pure result of an [Async] data type
@@ -23,10 +24,10 @@ interface Fiber<F, A> {
    *
    * @returns a task that trigger the cancellation upon evaluation.
    */
-  val cancel: Kind<F, Unit>
+  val cancel: CancelToken<F>
 
   operator fun component1(): Kind<F, A> = join
-  operator fun component2(): Kind<F, Unit> = cancel
+  operator fun component2(): CancelToken<F> = cancel
 
   companion object {
 
@@ -36,9 +37,9 @@ interface Fiber<F, A> {
      * @param join task that will trigger the cancellation.
      * @param cancel task that will await for the completion of the underlying fiber.
      */
-    operator fun <F, A> invoke(join: Kind<F, A>, cancel: Kind<F, Unit>): Fiber<F, A> = object : Fiber<F, A> {
-      override val cancel: Kind<F, Unit> = cancel
+    operator fun <F, A> invoke(join: Kind<F, A>, cancel: CancelToken<F>): Fiber<F, A> = object : Fiber<F, A> {
       override val join: Kind<F, A> = join
+      override val cancel: CancelToken<F> = cancel
       override fun toString(): String = "Fiber(join= $join, cancel= $cancel)"
     }
   }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Fiber.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Fiber.kt
@@ -1,0 +1,47 @@
+package arrow.effects.typeclasses
+
+import arrow.Kind
+import arrow.effects.IO
+
+/**
+ * [Fiber] represents the pure result of an [Async] data type
+ * being started concurrently and that can be either joined or canceled.
+ *
+ * You can think of fibers as being lightweight threads, a fiber being a
+ * concurrency primitive for doing cooperative multi-tasking.
+ */
+interface Fiber<F, A> {
+
+  /**
+   * Returns a new task that will await for the completion of the
+   * underlying fiber, (asynchronously) blocking the current run-loop
+   * until that result is available.
+   */
+  val join: Kind<F, A>
+
+  /**
+   * Triggers the cancellation of the fiber.
+   *
+   * @returns a task that trigger the cancellation upon evaluation.
+   */
+  val cancel: Kind<F, Unit>
+
+  operator fun component1(): Kind<F, A> = join
+  operator fun component2(): Kind<F, Unit> = cancel
+
+  companion object {
+
+    /**
+     * [Fiber] constructor.
+     *
+     * @param join task that will trigger the cancellation.
+     * @param cancel task that will await for the completion of the underlying fiber.
+     */
+    operator fun <F, A> invoke(join: Kind<F, A>, cancel: Kind<F, Unit>): Fiber<F, A> = object : Fiber<F, A> {
+      override val cancel: Kind<F, Unit> = cancel
+      override val join: Kind<F, A> = join
+      override fun toString(): String = "Fiber(join= $join, cancel= $cancel)"
+    }
+  }
+
+}

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Fiber.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Fiber.kt
@@ -1,7 +1,6 @@
 package arrow.effects.typeclasses
 
 import arrow.Kind
-import arrow.effects.IO
 
 /**
  * [Fiber] represents the pure result of an [Async] data type


### PR DESCRIPTION
I left the docs unpublished because this doesn't make a lot of sense without `Concurrent`.

For that reason, I have also not published the code for `Deferred` and left it in docs. This should be enabled with the `Concurrent` type class.

Closes #1089 