### PR TITLE
configure codecov via yaml file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+coverage:
+  status:
+    project: off
+    patch: off
+comment:
+  require_changes: yes


### PR DESCRIPTION
### :tophat: What is the goal?

Some problems raised with PRs that update docs and pass the CI but fails on coverage report without any code change. This PR create a configuration file for codecov following it [docs](https://docs.codecov.io/docs/codecov-yaml) 

### :memo: Notes
As the current project is in heavy development and an early stage (current version < 1.0.0)in order to not block changes and be more agile, the initial configuration will post coverage reports as comments only on coverage change and remove the status check to pass the PR.