### PR TITLE
Deprecate `invoke`, add a `delay` function that does the same thing

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
@@ -75,7 +75,7 @@ object MonadDeferLaws {
   fun <F> MonadDefer<F>.asyncParallelBind(EQ: Eq<Kind<F, Int>>): Unit =
     forAll(genIntSmall(), genIntSmall(), genIntSmall()) { x: Int, y: Int, z: Int ->
       val (bound, _) = bindingCancellable {
-        val value = bind { tupled(invoke { x }, invoke { y }, invoke { z }) }
+        val value = bind { tupled(delay { x }, delay { y }, delay { z }) }
         value.a + value.b + value.c
       }
       bound.equalUnderTheLaw(just(x + y + z), EQ)

--- a/modules/docs/arrow-examples/src/test/kotlin/arrow/FpToTheMax.kt
+++ b/modules/docs/arrow-examples/src/test/kotlin/arrow/FpToTheMax.kt
@@ -22,8 +22,8 @@ interface Console<F> {
 }
 
 class ConsoleInstance<F>(val delay: MonadDefer<F>) : Console<F> {
-    override fun putStrLn(s: String): Kind<F, Unit> = delay { println(s) }
-    override fun getStrLn(): Kind<F, String> = delay { readLine().orEmpty() }
+    override fun putStrLn(s: String): Kind<F, Unit> = delay.delay { println(s) }
+    override fun getStrLn(): Kind<F, String> = delay.delay { readLine().orEmpty() }
 }
 
 interface FRandom<F> {
@@ -31,7 +31,7 @@ interface FRandom<F> {
 }
 
 class FRandomInstance<F>(val delay: MonadDefer<F>) : FRandom<F> {
-    override fun nextInt(upper: Int): Kind<F, Int> = delay { ORandom.nextInt(upper) }
+    override fun nextInt(upper: Int): Kind<F, Int> = delay.delay { ORandom.nextInt(upper) }
 }
 
 class MonadAndConsoleRandom<F>(M: Monad<F>, C: Console<F>, R: FRandom<F>) : Monad<F> by M, Console<F> by C, FRandom<F> by R

--- a/modules/effects/arrow-effects-instances/src/main/kotlin/arrow/effects/instances/io.kt
+++ b/modules/effects/arrow-effects-instances/src/main/kotlin/arrow/effects/instances/io.kt
@@ -102,7 +102,7 @@ interface IOAsyncInstance : Async<ForIO>, IOMonadDeferInstance {
   override fun <A> IOOf<A>.continueOn(ctx: CoroutineContext): IO<A> =
     fix().continueOn(ctx)
 
-  override fun <A> invoke(f: () -> A): IO<A> =
+  override fun <A> delay(f: () -> A): IO<A> =
     IO.invoke(f)
 }
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -92,7 +92,7 @@ interface DeferredKAsyncInstance : Async<ForDeferredK>, DeferredKMonadDeferInsta
   override fun <A> DeferredKOf<A>.continueOn(ctx: CoroutineContext): DeferredK<A> =
     fix().continueOn(ctx = ctx)
 
-  override fun <A> invoke(f: () -> A): DeferredK<A> =
+  override fun <A> delay(f: () -> A): DeferredK<A> =
     DeferredK.invoke(f = f)
 
   override fun <A> invoke(ctx: CoroutineContext, f: () -> A): Kind<ForDeferredK, A> =

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/Ref.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/Ref.kt
@@ -103,7 +103,7 @@ interface Ref<F, A> {
     /**
      * Creates an asynchronous, concurrent mutable reference initialized to the supplied value.
      */
-    fun <F, A> of(a: A, MD: MonadDefer<F>): Kind<F, Ref<F, A>> = MD {
+    fun <F, A> of(a: A, MD: MonadDefer<F>): Kind<F, Ref<F, A>> = MD.delay {
       unsafe(a, MD)
     }
 
@@ -120,15 +120,15 @@ interface Ref<F, A> {
      */
     private class MonadDeferRef<F, A>(private val ar: AtomicReference<A>, private val MD: MonadDefer<F>) : Ref<F, A> {
 
-      override fun get(): Kind<F, A> = MD {
+      override fun get(): Kind<F, A> = MD.delay {
         ar.get()
       }
 
-      override fun set(a: A): Kind<F, Unit> = MD {
+      override fun set(a: A): Kind<F, Unit> = MD.delay {
         ar.set(a)
       }
 
-      override fun getAndSet(a: A): Kind<F, A> = MD {
+      override fun getAndSet(a: A): Kind<F, A> = MD.delay {
         ar.getAndSet(a)
       }
 
@@ -136,19 +136,19 @@ interface Ref<F, A> {
         set(a).flatMap { get() }
       }
 
-      override fun getAndUpdate(f: (A) -> A): Kind<F, A> = MD {
+      override fun getAndUpdate(f: (A) -> A): Kind<F, A> = MD.delay {
         ar.getAndUpdate(f)
       }
 
-      override fun updateAndGet(f: (A) -> A): Kind<F, A> = MD {
+      override fun updateAndGet(f: (A) -> A): Kind<F, A> = MD.delay {
         ar.updateAndGet(f)
       }
 
-      override fun access(): Kind<F, Tuple2<A, (A) -> Kind<F, Boolean>>> = MD {
+      override fun access(): Kind<F, Tuple2<A, (A) -> Kind<F, Boolean>>> = MD.delay {
         val snapshot = ar.get()
         val hasBeenCalled = AtomicBoolean(false)
         val setter = { a: A ->
-          MD { hasBeenCalled.compareAndSet(false, true) && ar.compareAndSet(snapshot, a) }
+          MD.delay { hasBeenCalled.compareAndSet(false, true) && ar.compareAndSet(snapshot, a) }
         }
         Tuple2(snapshot, setter)
       }
@@ -157,7 +157,7 @@ interface Ref<F, A> {
         tryModify { a -> Tuple2(f(a), Unit) }.map(Option<Unit>::isDefined)
       }
 
-      override fun <B> tryModify(f: (A) -> Tuple2<A, B>): Kind<F, Option<B>> = MD {
+      override fun <B> tryModify(f: (A) -> Tuple2<A, B>): Kind<F, Option<B>> = MD.delay {
         val a = ar.get()
         val (u, b) = f(a)
         if (ar.compareAndSet(a, u)) Some(b)
@@ -174,7 +174,7 @@ interface Ref<F, A> {
           return if (!ar.compareAndSet(a, u)) go() else b
         }
 
-        return MD(::go)
+        return MD.delay(::go)
       }
 
     }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/internal/ParallelUtils.kt
@@ -17,14 +17,14 @@ internal fun <F, A, B, C> Effect<F>.parMap2(ctx: CoroutineContext, ioA: Kind<F, 
   val a: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioA.map { it.left() }.runAsync {
-        it.fold({ invoke { ca.resumeWith(Result.failure(it)) } }, { invoke { ca.resumeWith(Result.success(it)) } })
+        it.fold({ delay { ca.resumeWith(Result.failure(it)) } }, { delay { ca.resumeWith(Result.success(it)) } })
       })
     }
   }
   val b: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioB.map { it.right() }.runAsync {
-        it.fold({ invoke { ca.resumeWith(Result.failure(it)) } }, { invoke { ca.resumeWith(Result.success(it)) } })
+        it.fold({ delay { ca.resumeWith(Result.failure(it)) } }, { delay { ca.resumeWith(Result.success(it)) } })
       })
     }
   }
@@ -43,21 +43,21 @@ internal fun <F, A, B, C, D> Effect<F>.parMap3(ctx: CoroutineContext, ioA: Kind<
   val a: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioA.map { Treither.Left<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWith(Result.failure(it)) } }, { invoke { ca.resumeWith(Result.success(it)) } })
+        it.fold({ delay { ca.resumeWith(Result.failure(it)) } }, { delay { ca.resumeWith(Result.success(it)) } })
       })
     }
   }
   val b: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioB.map { Treither.Middle<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWith(Result.failure(it)) } }, { invoke { ca.resumeWith(Result.success(it)) } })
+        it.fold({ delay { ca.resumeWith(Result.failure(it)) } }, { delay { ca.resumeWith(Result.success(it)) } })
       })
     }
   }
   val c: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioC.map { Treither.Right<A, B, C>(it) }.runAsync {
-        it.fold({ invoke { ca.resumeWith(Result.failure(it)) } }, { invoke { ca.resumeWith(Result.success(it)) } })
+        it.fold({ delay { ca.resumeWith(Result.failure(it)) } }, { delay { ca.resumeWith(Result.success(it)) } })
       })
     }
   }
@@ -75,14 +75,14 @@ fun <F, A, B, C> ConcurrentEffect<F>.parMapCancellable2(
   val a: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioA.map { it.left() }.runAsyncCancellable {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ delay { ca.resumeWithException(it) } }, { delay { ca.resume(it) } })
       })
     }
   }
   val b: suspend () -> Either<A, B> = {
     suspendCoroutine { ca: Continuation<Either<A, B>> ->
       start(ioB.map { it.right() }.runAsyncCancellable {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ delay { ca.resumeWithException(it) } }, { delay { ca.resume(it) } })
       })
     }
   }
@@ -98,21 +98,21 @@ fun <F, A, B, C, D> ConcurrentEffect<F>.parMapCancellable3(ctx: CoroutineContext
   val a: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioA.map { Treither.Left<A, B, C>(it) }.runAsyncCancellable {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ delay { ca.resumeWithException(it) } }, { delay { ca.resume(it) } })
       })
     }
   }
   val b: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioB.map { Treither.Middle<A, B, C>(it) }.runAsyncCancellable {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ delay { ca.resumeWithException(it) } }, { delay { ca.resume(it) } })
       })
     }
   }
   val c: suspend () -> Treither<A, B, C> = {
     suspendCoroutine { ca: Continuation<Treither<A, B, C>> ->
       start(ioC.map { Treither.Right<A, B, C>(it) }.runAsyncCancellable {
-        it.fold({ invoke { ca.resumeWithException(it) } }, { invoke { ca.resume(it) } })
+        it.fold({ delay { ca.resumeWithException(it) } }, { delay { ca.resume(it) } })
       })
     }
   }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Async.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/Async.kt
@@ -15,7 +15,7 @@ interface Async<F> : MonadDefer<F> {
   fun <A> Kind<F, A>.continueOn(ctx: CoroutineContext): Kind<F, A>
 
   operator fun <A> invoke(ctx: CoroutineContext, f: () -> A): Kind<F, A> =
-    lazy().continueOn(ctx).flatMap { invoke(f) }
+    lazy().continueOn(ctx).flatMap { delay(f) }
 
   fun <A> defer(ctx: CoroutineContext, f: () -> Kind<F, A>): Kind<F, A> =
     lazy().continueOn(ctx).flatMap { defer(f) }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
@@ -15,6 +15,17 @@ interface MonadDefer<F> : MonadThrow<F>, Bracket<F, Throwable> {
 
   fun <A> defer(fa: () -> Kind<F, A>): Kind<F, A>
 
+  fun <A> delay(f: () -> A): Kind<F, A> =
+    defer {
+      try {
+        just(f())
+      } catch (t: Throwable) {
+        raiseError<A>(t)
+      }
+    }
+
+  @Deprecated("Use delay instead",
+          ReplaceWith("delay(f)", "arrow.effects.typeclasses.MonadDefer"))
   operator fun <A> invoke(f: () -> A): Kind<F, A> =
     defer {
       try {
@@ -24,7 +35,7 @@ interface MonadDefer<F> : MonadThrow<F>, Bracket<F, Throwable> {
       }
     }
 
-  fun lazy(): Kind<F, Unit> = invoke { }
+  fun lazy(): Kind<F, Unit> = delay { }
 
   fun <A> deferUnsafe(f: () -> Either<Throwable, A>): Kind<F, A> =
     defer { f().fold({ raiseError<A>(it) }, { just(it) }) }

--- a/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
+++ b/modules/effects/arrow-effects/src/main/kotlin/arrow/effects/typeclasses/MonadSuspendCancellableContinuations.kt
@@ -27,7 +27,7 @@ open class MonadDeferCancellableContinuation<F, A>(SC: MonadDefer<F>, override v
   override fun returnedMonad(): Kind<F, A> = returnedMonad
 
   suspend fun <B> bindDefer(f: () -> B): B =
-    invoke(f).bind()
+    delay(f).bind()
 
   suspend fun <B> bindDeferIn(context: CoroutineContext, f: () -> B): B =
     defer { bindingCatch { bindIn(context, f) } }.bind()

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow/integrations/retrofit/adapter/syntax.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/main/kotlin/arrow/integrations/retrofit/adapter/syntax.kt
@@ -26,7 +26,7 @@ fun <F, A> Call<A>.runAsync(AC: Async<F>): Kind<F, Response<A>> =
     enqueue(ResponseCallback(callback))
   }
 
-fun <F, A> Call<A>.runSyncDeferred(defer: MonadDefer<F>): Kind<F, Response<A>> = defer { execute() }
+fun <F, A> Call<A>.runSyncDeferred(defer: MonadDefer<F>): Kind<F, Response<A>> = defer.delay { execute() }
 
 fun <F, A> Call<A>.runSyncCatch(monadError: MonadError<F, Throwable>): Kind<F, Response<A>> =
   monadError.run {


### PR DESCRIPTION
Fixes #1135

the `delay` has the same implementation as the `invoke` operator.
I added `@Deprecated` with `@ReplaceWith` to the `invoke` operator. 
I replaced all usages of `invoke` with `delay` (that I could find).

Is that all? Or am I missing something?

Note:
When I run the tests with `./gradlew test` (both before and after this change) a test inside `IOTests` fails. If I run trough IntelliJ only for that class, everything works fine. Is this a know issue? Should I report a bug?