### PR TITLE
Implement hash typeclass and its interfaces

### DIFF
--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
@@ -8,6 +8,7 @@ import arrow.instances.eq
 import arrow.instances.either.applicative.applicative
 import arrow.instances.either.bifunctor.bifunctor
 import arrow.instances.either.eq.eq
+import arrow.instances.either.hash.hash
 import arrow.instances.either.monadError.monadError
 import arrow.instances.either.monoid.monoid
 import arrow.instances.either.semigroup.semigroup
@@ -17,7 +18,9 @@ import arrow.instances.either.traverse.traverse
 import arrow.test.UnitSpec
 import arrow.test.laws.*
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
 import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
 
@@ -41,7 +44,8 @@ class EitherTest : UnitSpec() {
         ShowLaws.laws(Either.show(), Either.eq(String.eq(), Int.eq())) { Right(it) },
         MonadErrorLaws.laws(Either.monadError(), Eq.any(), Eq.any()),
         TraverseLaws.laws(Either.traverse(), Either.applicative(), { Right(it) }, Eq.any()),
-        SemigroupKLaws.laws(Either.semigroupK(), Either.applicative(), EQ)
+        SemigroupKLaws.laws(Either.semigroupK(), Either.applicative(), EQ),
+        HashLaws.laws(Either.hash(Hash.any(), Int.hash()), EQ2) { Right(it) }
       )
 
     "empty should return a Right of the empty of the inner type" {

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/IdTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/IdTest.kt
@@ -1,9 +1,12 @@
 package arrow.core
 
 import arrow.core.Id
+import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.id.applicative.applicative
 import arrow.instances.id.comonad.comonad
 import arrow.instances.id.eq.eq
+import arrow.instances.id.hash.hash
 import arrow.instances.id.monad.monad
 import arrow.instances.id.show.show
 import arrow.instances.id.traverse.traverse
@@ -21,7 +24,8 @@ class IdTest : UnitSpec() {
       ShowLaws.laws(Id.show(), Eq.any()) { Id(it) },
       MonadLaws.laws(Id.monad(), Eq.any()),
       TraverseLaws.laws(Id.traverse(), Id.applicative(), ::Id, Eq.any()),
-      ComonadLaws.laws(Id.comonad(), ::Id, Eq.any())
+      ComonadLaws.laws(Id.comonad(), ::Id, Eq.any()),
+      HashLaws.laws(Id.hash(Int.hash()), Id.eq(Int.eq())) { Id(it) }
     )
   }
 }

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/OptionTest.kt
@@ -3,9 +3,11 @@ package arrow.core
 import arrow.Kind
 import arrow.core.*
 import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.monoid
 import arrow.instances.option.applicative.applicative
 import arrow.instances.option.eq.eq
+import arrow.instances.option.hash.hash
 import arrow.instances.option.monoid.monoid
 import arrow.instances.option.show.show
 import arrow.mtl.instances.option.monadFilter.monadFilter
@@ -37,7 +39,8 @@ class OptionTest : UnitSpec() {
       //testLaws(MonadErrorLaws.laws(monadError<ForOption, Unit>(), Eq.any(), EQ_EITHER)) TODO reenable once the MonadErrorLaws are parametric to `E`
       FunctorFilterLaws.laws(Option.traverseFilter(), {Option(it)}, Eq.any()),
       TraverseFilterLaws.laws(Option.traverseFilter(), Option.applicative(), ::Some, Eq.any()),
-      MonadFilterLaws.laws(Option.monadFilter(), ::Some, Eq.any())
+      MonadFilterLaws.laws(Option.monadFilter(), ::Some, Eq.any()),
+      HashLaws.laws(Option.hash(Int.hash()), Option.eq(Int.eq())) { Some(it) }
     )
 
     "fromNullable should work for both null and non-null values of nullable types" {

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/TryTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/TryTest.kt
@@ -1,21 +1,20 @@
 package arrow.core
 
-import arrow.core.*
+import arrow.instances.*
 import arrow.instances.`try`.applicative.map
 import arrow.instances.`try`.eq.eq
 import arrow.instances.`try`.functor.functor
+import arrow.instances.`try`.hash.hash
 import arrow.instances.`try`.monadError.monadError
 import arrow.instances.`try`.monoid.monoid
 import arrow.instances.`try`.semigroup.semigroup
 import arrow.instances.`try`.show.show
 import arrow.instances.`try`.traverse.traverse
-import arrow.instances.combine
-import arrow.instances.monoid
-import arrow.instances.semigroup
 import arrow.mtl.instances.`try`.functorFilter.functorFilter
 import arrow.test.UnitSpec
 import arrow.test.laws.*
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.*
 import io.kotlintest.properties.forAll
@@ -38,7 +37,8 @@ class TryTest : UnitSpec() {
       ShowLaws.laws(Try.show(), EQ) { Try.just(it) },
       MonadErrorLaws.laws(Try.monadError(), Eq.any(), Eq.any()),
       TraverseLaws.laws(Try.traverse(), Try.functor(), ::Success, Eq.any()),
-      FunctorFilterLaws.laws(Try.functorFilter(), { Try.just(it) }, Eq.any())
+      FunctorFilterLaws.laws(Try.functorFilter(), { Try.just(it) }, Eq.any()),
+      HashLaws.laws(Try.hash(Int.hash(), Hash.any()), Try.eq(Int.eq(), Eq.any())) { Try.just(it) }
     )
 
     "empty should return a Success of the empty of the inner type" {

--- a/modules/core/arrow-core/src/test/kotlin/arrow/instances/NumberHashTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/instances/NumberHashTest.kt
@@ -1,0 +1,22 @@
+package arrow.instances
+
+import arrow.test.UnitSpec
+import arrow.test.laws.HashLaws
+import io.kotlintest.KTestJUnitRunner
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class NumberHashTest : UnitSpec() {
+  init {
+
+    testLaws(
+      HashLaws.laws(Long.hash(), Long.eq()) { it.toLong() },
+      HashLaws.laws(Int.hash(), Int.eq()) { it },
+      HashLaws.laws(Double.hash(), Double.eq()) { it.toDouble() },
+      HashLaws.laws(Float.hash(), Float.eq()) { it.toFloat() },
+      HashLaws.laws(Byte.hash(), Byte.eq()) { it.toByte() },
+      HashLaws.laws(Short.hash(), Short.eq()) { it.toShort() }
+    )
+
+  }
+}

--- a/modules/core/arrow-core/src/test/kotlin/arrow/instances/StringInstancesTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/instances/StringInstancesTest.kt
@@ -2,6 +2,7 @@ package arrow.instances
 
 import arrow.test.UnitSpec
 import arrow.test.laws.EqLaws
+import arrow.test.laws.HashLaws
 import arrow.test.laws.ShowLaws
 import io.kotlintest.KTestJUnitRunner
 import org.junit.runner.RunWith
@@ -11,7 +12,8 @@ class StringInstancesTest : UnitSpec() {
   init {
     testLaws(
       EqLaws.laws(String.eq()) { it.toString() },
-      ShowLaws.laws(String.show(), String.eq()) { it.toString() }
+      ShowLaws.laws(String.show(), String.eq()) { it.toString() },
+      HashLaws.laws(String.hash(), String.eq()) { it.toString() }
     )
   }
 }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/IorTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/IorTest.kt
@@ -5,16 +5,20 @@ import arrow.core.Either
 import arrow.core.None
 import arrow.core.Some
 import arrow.data.Ior.Right
+import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.semigroup
 import arrow.instances.ior.applicative.applicative
 import arrow.instances.ior.bifunctor.bifunctor
 import arrow.instances.ior.eq.eq
+import arrow.instances.ior.hash.hash
 import arrow.instances.ior.monad.monad
 import arrow.instances.ior.show.show
 import arrow.instances.ior.traverse.traverse
 import arrow.test.UnitSpec
 import arrow.test.laws.*
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
 import arrow.typeclasses.Monad
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldBe
@@ -39,7 +43,8 @@ class IorTest : UnitSpec() {
       EqLaws.laws(EQ) { Right(it) },
       ShowLaws.laws(Ior.show(), EQ) { Right(it) },
       MonadLaws.laws(Ior.monad(Int.semigroup()), Eq.any()),
-      TraverseLaws.laws(Ior.traverse(), Ior.applicative(Int.semigroup()), ::Right, Eq.any())
+      TraverseLaws.laws(Ior.traverse(), Ior.applicative(Int.semigroup()), ::Right, Eq.any()),
+      HashLaws.laws(Ior.hash(Hash.any(), Int.hash()), Ior.eq(Eq.any(), Int.eq())) { Right(it) }
     )
 
     "bimap() should allow modify both value" {

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/ListKTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/ListKTest.kt
@@ -1,7 +1,10 @@
 package arrow.data
 
+import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.listk.applicative.applicative
 import arrow.instances.listk.eq.eq
+import arrow.instances.listk.hash.hash
 import arrow.instances.listk.monoidK.monoidK
 import arrow.instances.listk.semigroupK.semigroupK
 import arrow.instances.listk.show.show
@@ -30,7 +33,8 @@ class ListKTest : UnitSpec() {
       MonadCombineLaws.laws(ListK.monadCombine(),
         { n -> ListK(listOf(n)) },
         { n -> ListK(listOf({ s: Int -> n * s })) },
-        EQ)
+        EQ),
+      HashLaws.laws(ListK.hash(Int.hash()), ListK.eq(Int.eq())) { listOf(it).k() }
     )
 
   }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/MapKTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/MapKTest.kt
@@ -2,9 +2,11 @@ package arrow.data
 
 import arrow.Kind2
 import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.semigroup
 import arrow.instances.mapk.eq.eq
 import arrow.instances.mapk.functor.functor
+import arrow.instances.mapk.hash.hash
 import arrow.instances.mapk.monoid.monoid
 import arrow.instances.mapk.show.show
 import arrow.instances.mapk.traverse.traverse
@@ -34,7 +36,8 @@ class MapKTest : UnitSpec() {
         mapOf("key" to 1).k(),
         mapOf("key" to 2).k(),
         mapOf("key" to 3).k(),
-        EQ)
+        EQ),
+      HashLaws.laws(MapK.hash(String.hash(), Int.hash()), EQ_TC) { mapOf("key" to it).k() }
     )
   }
 }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/NonEmptyListTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/NonEmptyListTest.kt
@@ -1,9 +1,11 @@
 package arrow.data
 
 import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.nonemptylist.applicative.applicative
 import arrow.instances.nonemptylist.comonad.comonad
 import arrow.instances.nonemptylist.eq.eq
+import arrow.instances.nonemptylist.hash.hash
 import arrow.instances.nonemptylist.monad.monad
 import arrow.instances.nonemptylist.semigroup.semigroup
 import arrow.instances.nonemptylist.semigroupK.semigroupK
@@ -31,7 +33,8 @@ class NonEmptyListTest : UnitSpec() {
         Eq.any()),
       ComonadLaws.laws(NonEmptyList.comonad(), { NonEmptyList.of(it) }, Eq.any()),
       TraverseLaws.laws(NonEmptyList.traverse(), NonEmptyList.applicative(), { n: Int -> NonEmptyList.of(n) }, Eq.any()),
-      SemigroupLaws.laws(NonEmptyList.semigroup(), Nel(1, 2, 3), Nel(3, 4, 5), Nel(6, 7, 8), NonEmptyList.eq(Int.eq()))
+      SemigroupLaws.laws(NonEmptyList.semigroup(), Nel(1, 2, 3), Nel(3, 4, 5), Nel(6, 7, 8), NonEmptyList.eq(Int.eq())),
+      HashLaws.laws(NonEmptyList.hash(Int.hash()), EQ) { Nel.of(it) }
     )
   }
 }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/SequenceKTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/SequenceKTest.kt
@@ -2,8 +2,10 @@ package arrow.data
 
 import arrow.Kind
 import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.sequencek.applicative.applicative
 import arrow.instances.sequencek.eq.eq
+import arrow.instances.sequencek.hash.hash
 import arrow.instances.sequencek.monad.monad
 import arrow.instances.sequencek.monoid.monoid
 import arrow.instances.sequencek.monoidK.monoidK
@@ -38,7 +40,8 @@ class SequenceKTest : UnitSpec() {
       MonadLaws.laws(SequenceK.monad(), eq),
       MonoidKLaws.laws(SequenceK.monoidK(), SequenceK.applicative(), eq),
       MonoidLaws.laws(SequenceK.monoid(), Gen.list(Gen.int()).map { it.asSequence() }.generate().k(), eq),
-      TraverseLaws.laws(SequenceK.traverse(), SequenceK.applicative(), { n: Int -> SequenceK(sequenceOf(n)) }, eq)
+      TraverseLaws.laws(SequenceK.traverse(), SequenceK.applicative(), { n: Int -> SequenceK(sequenceOf(n)) }, eq),
+      HashLaws.laws(SequenceK.hash(Int.hash()), SequenceK.eq(Int.eq())) { sequenceOf(it).k() }
     )
   }
 }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/SetKTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/SetKTest.kt
@@ -1,8 +1,10 @@
 package arrow.data
 
 import arrow.instances.eq
+import arrow.instances.hash
 import arrow.instances.setk.eq.eq
 import arrow.instances.setk.foldable.foldable
+import arrow.instances.setk.hash.hash
 import arrow.instances.setk.monoidK.monoidK
 import arrow.instances.setk.semigroupK.semigroupK
 import arrow.instances.setk.show.show
@@ -24,7 +26,8 @@ class SetKTest : UnitSpec() {
       ShowLaws.laws(SetK.show(), EQ) { SetK.just(it) },
       SemigroupKLaws.laws(SetK.semigroupK(), { SetK.just(it) }, Eq.any()),
       MonoidKLaws.laws(SetK.monoidK(), { SetK.just(it) }, Eq.any()),
-      FoldableLaws.laws(SetK.foldable(), { SetK.just(it) }, Eq.any())
+      FoldableLaws.laws(SetK.foldable(), { SetK.just(it) }, Eq.any()),
+      HashLaws.laws(SetK.hash(Int.hash()), SetK.eq(Int.eq())) { SetK.just(it) }
     )
   }
 }

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/boolean.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/boolean.kt
@@ -1,6 +1,7 @@
 package arrow.instances
 
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
 import arrow.typeclasses.Show
 
 interface BooleanShowInstance : Show<Boolean> {
@@ -12,8 +13,15 @@ interface BooleanEqInstance : Eq<Boolean> {
   override fun Boolean.eqv(b: Boolean): Boolean = this == b
 }
 
+interface BooleanHashInstance : Hash<Boolean>, BooleanEqInstance {
+  override fun Boolean.hash(): Int = this.hashCode()
+}
+
 fun Boolean.Companion.show(): Show<Boolean> =
   object : BooleanShowInstance {}
 
 fun Boolean.Companion.eq(): Eq<Boolean> =
   object : BooleanEqInstance {}
+
+fun Boolean.Companion.hash(): Hash<Boolean> =
+  object : BooleanHashInstance {}

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/char.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/char.kt
@@ -1,6 +1,7 @@
 package arrow.instances
 
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
 
@@ -30,6 +31,10 @@ interface CharOrderInstance : Order<Char> {
   override fun Char.neqv(b: Char): Boolean = this != b
 }
 
+interface CharHashInstance : Hash<Char>, CharEqInstance {
+  override fun Char.hash(): Int = this.hashCode()
+}
+
 fun Char.Companion.show(): Show<Char> =
   object : CharShowInstance {}
 
@@ -38,3 +43,6 @@ fun Char.Companion.eq(): Eq<Char> =
 
 fun Char.Companion.order(): Order<Char> =
   object : CharOrderInstance {}
+
+fun Char.Companion.hash(): Hash<Char> =
+  object : CharHashInstance {}

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
@@ -95,6 +95,15 @@ interface ConstShowInstance<A, T> : Show<Const<A, T>> {
     toString()
 }
 
+@extension
+interface ConstHashInstance<A, T> : Hash<Const<A, T>>, ConstEqInstance<A, T> {
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun Const<A, T>.hash(): Int = HA().run { value.hash() }
+}
+
 class ConstContext<A>(val MA: Monoid<A>) : ConstApplicativeInstance<A>, ConstTraverseInstance<A> {
   override fun MA(): Monoid<A> = MA
 

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/either.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/either.kt
@@ -5,6 +5,7 @@ import arrow.Kind2
 import arrow.core.*
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
+import arrow.instances.either.eq.eq
 import arrow.typeclasses.*
 import arrow.core.ap as eitherAp
 import arrow.core.combineK as eitherCombineK
@@ -151,6 +152,23 @@ interface EitherEqInstance<in L, in R> : Eq<Either<L, R>> {
 interface EitherShowInstance<L, R> : Show<Either<L, R>> {
   override fun Either<L, R>.show(): String =
     toString()
+}
+
+@extension
+interface EitherHashInstance<L, R> : Hash<Either<L, R>>, EitherEqInstance<L, R> {
+
+  fun HL(): Hash<L>
+  fun HR(): Hash<R>
+
+  override fun EQL(): Eq<L> = HL()
+
+  override fun EQR(): Eq<R> = HR()
+
+  override fun Either<L, R>.hash(): Int = fold({
+    HL().run { it.hash() }
+  }, {
+    HR().run { it.hash() }
+  })
 }
 
 class EitherContext<L> : EitherMonadErrorInstance<L>, EitherTraverseInstance<L>, EitherSemigroupKInstance<L> {

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.core.*
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
+import arrow.instances.id.eq.eq
 import arrow.typeclasses.*
 import arrow.instances.traverse as idTraverse
 
@@ -123,6 +124,16 @@ interface IdTraverseInstance : Traverse<ForId> {
 
   override fun <A, B> arrow.Kind<arrow.core.ForId, A>.foldRight(lb: arrow.core.Eval<B>, f: (A, arrow.core.Eval<B>) -> arrow.core.Eval<B>): Eval<B> =
     fix().foldRight(lb, f)
+}
+
+@extension
+interface IdHashInstance<A> : Hash<Id<A>>, IdEqInstance<A> {
+
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun Id<A>.hash(): Int = HA().run { value.hash() }
 }
 
 object IdContext : IdBimonadInstance, IdTraverseInstance {

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/number.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/number.kt
@@ -26,6 +26,13 @@ interface ByteShowInstance : Show<Byte> {
   override fun Byte.show(): String = toString()
 }
 
+interface ByteHashInstance : Hash<Byte>, ByteEqInstance {
+  override fun Byte.hash(): Int = hashCode()
+}
+
+fun Byte.Companion.hash(): Hash<Byte> =
+  object : ByteHashInstance {}
+
 fun Byte.Companion.show(): Show<Byte> =
   object : ByteShowInstance {}
 
@@ -72,6 +79,13 @@ interface DoubleEqInstance : Eq<Double> {
 interface DoubleShowInstance : Show<Double> {
   override fun Double.show(): String = toString()
 }
+
+interface DoubleHashInstance : Hash<Double>, DoubleEqInstance {
+  override fun Double.hash(): Int = hashCode()
+}
+
+fun Double.Companion.hash(): Hash<Double> =
+  object : DoubleHashInstance {}
 
 fun Double.Companion.show(): Show<Double> =
   object : DoubleShowInstance {}
@@ -120,6 +134,13 @@ interface IntOrderInstance : Order<Int> {
   override fun Int.compare(b: Int): Int = compareTo(b)
 }
 
+interface IntHashInstance : Hash<Int>, IntEqInstance {
+  override fun Int.hash(): Int = hashCode()
+}
+
+fun Int.Companion.hash(): Hash<Int> =
+  object : IntHashInstance {}
+
 fun Int.Companion.show(): Show<Int> =
   object : IntShowInstance {}
 
@@ -166,6 +187,13 @@ interface LongEqInstance : Eq<Long> {
 interface LongShowInstance : Show<Long> {
   override fun Long.show(): String = toString()
 }
+
+interface LongHashInstance : Hash<Long>, LongEqInstance {
+  override fun Long.hash(): Int = hashCode()
+}
+
+fun Long.Companion.hash(): Hash<Long> =
+  object : LongHashInstance {}
 
 fun Long.Companion.show(): Show<Long> =
   object : LongShowInstance {}
@@ -214,6 +242,13 @@ interface ShortShowInstance : Show<Short> {
   override fun Short.show(): String = toString()
 }
 
+interface ShortHashInstance : Hash<Short>, ShortEqInstance {
+  override fun Short.hash(): Int = hashCode()
+}
+
+fun Short.Companion.hash(): Hash<Short> =
+  object : ShortHashInstance {}
+
 fun Short.Companion.show(): Show<Short> =
   object : ShortShowInstance {}
 
@@ -260,6 +295,13 @@ interface FloatEqInstance : Eq<Float> {
 interface FloatShowInstance : Show<Float> {
   override fun Float.show(): String = toString()
 }
+
+interface FloatHashInstance : Hash<Float>, FloatEqInstance {
+  override fun Float.hash(): Int = hashCode()
+}
+
+fun Float.Companion.hash(): Hash<Float> =
+  object : FloatHashInstance {}
 
 fun Float.Companion.show(): Show<Float> =
   object : FloatShowInstance {}

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/option.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/option.kt
@@ -180,6 +180,20 @@ interface OptionTraverseInstance : Traverse<ForOption> {
     fix().nonEmpty()
 }
 
+@extension
+interface OptionHashInstance<A> : Hash<Option<A>>, OptionEqInstance<A> {
+
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun Option<A>.hash(): Int = fold({
+    None.hashCode()
+  }, {
+    HA().run { it.hash() }
+  })
+}
+
 object OptionContext : OptionMonadErrorInstance, OptionTraverseInstance {
   override fun <A, B> Kind<ForOption, A>.map(f: (A) -> B): Option<B> =
     fix().map(f)

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/string.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/string.kt
@@ -37,6 +37,13 @@ interface StringOrderInstance : Order<String> {
 fun String.Companion.order(): Order<String> =
   object : StringOrderInstance {}
 
+interface StringHashInstance : Hash<String>, StringEqInstance {
+  override fun String.hash(): Int = hashCode()
+}
+
+fun String.Companion.hash(): Hash<String> =
+  object : StringHashInstance {}
+
 object StringContext : StringShowInstance, StringOrderInstance, StringMonoidInstance
 
 object ForString {

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/try.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/try.kt
@@ -156,6 +156,23 @@ interface TryTraverseInstance : Traverse<ForTry> {
     fix().foldRight(lb, f)
 }
 
+@extension
+interface TryHashInstance<A> : Hash<Try<A>>, TryEqInstance<A> {
+
+  fun HA(): Hash<A>
+  fun HT(): Hash<Throwable>
+
+  override fun EQA(): Eq<A> = HA()
+
+  override fun EQT(): Eq<Throwable> = HT()
+
+  override fun Try<A>.hash(): Int = fold({
+    HT().run { it.hash() }
+  }, {
+    HA().run { it.hash() }
+  })
+}
+
 object TryContext : TryMonadErrorInstance, TryTraverseInstance {
   override fun <A, B> Kind<ForTry, A>.map(f: (A) -> B): Try<B> =
     fix().map(f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/ior.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/ior.kt
@@ -102,6 +102,23 @@ interface IorShowInstance<L, R> : Show<Ior<L, R>> {
     toString()
 }
 
+@extension
+interface IorHashInstance<L, R> : Hash<Ior<L, R>>, IorEqInstance<L, R> {
+
+  fun HL(): Hash<L>
+  fun HR(): Hash<R>
+
+  override fun EQL(): Eq<L> = HL()
+
+  override fun EQR(): Eq<R> = HR()
+
+  override fun Ior<L, R>.hash(): Int = when (this) {
+    is Ior.Left -> HL().run { value.hash() }
+    is Ior.Right -> HR().run { value.hash() }
+    is Ior.Both -> 31 * HL().run { leftValue.hash() } + HR().run { rightValue.hash() }
+  }
+}
+
 class IorContext<L>(val SL: Semigroup<L>) : IorMonadInstance<L>, IorTraverseInstance<L> {
 
   override fun SL(): Semigroup<L> = SL

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/listk.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/listk.kt
@@ -5,7 +5,9 @@ import arrow.core.*
 import arrow.data.*
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
+import arrow.instances.listk.foldable.foldLeft
 import arrow.typeclasses.*
+import java.util.*
 import arrow.data.combineK as listCombineK
 import kotlin.collections.plus as listPlus
 
@@ -123,6 +125,18 @@ interface ListKMonoidKInstance : MonoidK<ForListK> {
 
   override fun <A> Kind<ForListK, A>.combineK(y: Kind<ForListK, A>): ListK<A> =
     fix().listCombineK(y)
+}
+
+@extension
+interface ListKHashInstance<A>: Hash<ListKOf<A>>, ListKEqInstance<A> {
+
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun ListKOf<A>.hash(): Int = foldLeft(1) { hash, a ->
+    31 * hash + HA().run { a.hash() }
+  }
 }
 
 object ListKContext : ListKMonadInstance, ListKTraverseInstance, ListKMonoidKInstance {

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/nonemptylist.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/nonemptylist.kt
@@ -139,6 +139,17 @@ interface NonEmptyListSemigroupKInstance : SemigroupK<ForNonEmptyList> {
     fix().nelCombineK(y)
 }
 
+@extension
+interface NonEmptyListHashInstance<A> : Hash<NonEmptyList<A>>, NonEmptyListEqInstance<A> {
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun NonEmptyList<A>.hash(): Int = foldLeft(1) { hash, a ->
+    31 * hash + HA().run { a.hash() }
+  }
+}
+
 fun <F, A> Reducible<F>.toNonEmptyList(fa: Kind<F, A>): NonEmptyList<A> =
   fa.reduceRightTo({ a -> NonEmptyList.of(a) }, { a, lnel ->
     lnel.map { nonEmptyList -> NonEmptyList(a, listOf(nonEmptyList.head) + nonEmptyList.tail) }

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/sequence.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/sequence.kt
@@ -121,6 +121,17 @@ interface SequenceKMonoidKInstance : MonoidK<ForSequenceK> {
     fix().sequenceCombineK(y)
 }
 
+@extension
+interface SequenceKHashInstance<A> : Hash<SequenceK<A>>, SequenceKEqInstance<A> {
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun SequenceK<A>.hash(): Int = foldLeft(1) { hash, a ->
+    31 * hash + HA().run { a.hash() }
+  }
+}
+
 object SequenceKContext : SequenceKMonadInstance, SequenceKTraverseInstance, SequenceKMonoidKInstance {
   override fun <A, B> Kind<ForSequenceK, A>.map(f: (A) -> B): SequenceK<B> =
     fix().map(f)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/setk.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/setk.kt
@@ -68,6 +68,17 @@ interface SetKMonoidKInstance : MonoidK<ForSetK> {
     fix().setCombineK(y)
 }
 
+@extension
+interface SetKHashInstance<A> : Hash<SetK<A>>, SetKEqInstance<A> {
+  fun HA(): Hash<A>
+
+  override fun EQ(): Eq<A> = HA()
+
+  override fun SetK<A>.hash(): Int = foldLeft(1) { hash, a ->
+    31 * hash + HA().run { a.hash() }
+  }
+}
+
 object SetKContext : SetKFoldableInstance, SetKMonoidKInstance
 
 @Deprecated(ExtensionsDSLDeprecated)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/validated.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/validated.kt
@@ -89,6 +89,21 @@ interface ValidatedShowInstance<L, R> : Show<Validated<L, R>> {
     toString()
 }
 
+@extension
+interface ValidatedHashInstance<L, R> : Hash<Validated<L, R>>, ValidatedEqInstance<L, R> {
+  fun HL(): Hash<L>
+  fun HR(): Hash<R>
+
+  override fun EQL(): Eq<L> = HL()
+  override fun EQR(): Eq<R> = HR()
+
+  override fun Validated<L, R>.hash(): Int = fold({
+    HL().run { it.hash() }
+  }, {
+    HR().run { it.hash() }
+  })
+}
+
 class ValidatedContext<L>(val SL: Semigroup<L>) : ValidatedApplicativeErrorInstance<L>, ValidatedTraverseInstance<L>, ValidatedSemigroupKInstance<L> {
   override fun SE(): Semigroup<L> = SL
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/HashLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/HashLaws.kt
@@ -8,7 +8,8 @@ import io.kotlintest.properties.forAll
 object HashLaws {
   fun <F> laws(HF: Hash<F>, EQ: Eq<F>, cf: (Int) -> F): List<Law> =
     listOf(
-      Law("Hash Laws: Equality implies equal hash") { equalHash(HF, EQ, cf) }
+      Law("Hash Laws: Equality implies equal hash") { equalHash(HF, EQ, cf) },
+      Law("Hash Laws: Multiple calls to hash should result in the same hash") { equalHashM(HF, cf) }
     )
 
   fun <F> equalHash(HF: Hash<F>, EQ: Eq<F>, cf: (Int) -> F): Unit {
@@ -16,6 +17,13 @@ object HashLaws {
       val a = cf(f)
       val b = cf(f)
       EQ.run { a.eqv(b) } && HF.run { a.hash() == b.hash() }
+    }
+  }
+  
+  fun <F> equalHashM(HF: Hash<F>, cf: (Int) -> F): Unit {
+    forAll(Gen.int()) { f ->
+      val a = cf(f)
+      HF.run { a.hash() == a.hash() }
     }
   }
 }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/HashLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/HashLaws.kt
@@ -1,0 +1,21 @@
+package arrow.test.laws
+
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+
+object HashLaws {
+  fun <F> laws(HF: Hash<F>, EQ: Eq<F>, cf: (Int) -> F): List<Law> =
+    listOf(
+      Law("Hash Laws: Equality implies equal hash") { equalHash(HF, EQ, cf) }
+    )
+
+  fun <F> equalHash(HF: Hash<F>, EQ: Eq<F>, cf: (Int) -> F): Unit {
+    forAll(Gen.int()) { f ->
+      val a = cf(f)
+      val b = cf(f)
+      EQ.run { a.eqv(b) } && HF.run { a.hash() == b.hash() }
+    }
+  }
+}

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Hash.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Hash.kt
@@ -1,0 +1,24 @@
+package arrow.typeclasses
+
+interface Hash<in F> : Eq<F> {
+
+  fun F.hash(): Int
+
+  companion object {
+
+    inline operator fun <F> invoke(crossinline hashF: (F) -> Int): Hash<F> = object : Hash<F> {
+      override fun F.hash(): Int = hashF(this)
+
+      // either this.hash == hash, or this == b or supply an eq function, dunno what is best
+      override fun F.eqv(b: F): Boolean = hashF(b) == hashF(this)
+    }
+
+    fun any(): Hash<Any> = HashAny
+
+    private object HashAny : Hash<Any> {
+      override fun Any.hash(): Int = hashCode()
+
+      override fun Any.eqv(b: Any): Boolean = Eq.any().run { eqv(b) }
+    }
+  }
+}

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Hash.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Hash.kt
@@ -1,24 +1,45 @@
 package arrow.typeclasses
 
+/**
+ * A type class used to represent hashing for objects of type [F]
+ *
+ * @see // Fancy link to docs
+ */
 interface Hash<in F> : Eq<F> {
 
+  /**
+   * Produces a hash for an object of type [F].
+   *
+   * @receiver The object to hash
+   * @returns an int representing the object hash
+   */
   fun F.hash(): Int
 
   companion object {
 
+    /**
+     * Construct an instance of [Hash] from a function `(F) -> Int`.
+     *
+     * @param hashF function that computes a hash for any object of type [F]
+     * @returns an instance of [Hash] that is defined by the hashF function
+     */
     inline operator fun <F> invoke(crossinline hashF: (F) -> Int): Hash<F> = object : Hash<F> {
       override fun F.hash(): Int = hashF(this)
 
-      // either this.hash == hash, or this == b or supply an eq function, dunno what is best
-      override fun F.eqv(b: F): Boolean = hashF(b) == hashF(this)
+      override fun F.eqv(b: F): Boolean = this == b
     }
 
-    fun any(): Hash<Any> = HashAny
+    /**
+     * Retrieve an instance of [Hash] where the hash function delegates to kotlin's `Any?.hashCode()` function
+     *
+     * @returns an instance of [Hash] that always delegates to kotlin's native hashCode functionality
+     */
+    fun any(): Hash<Any?> = HashAny
 
-    private object HashAny : Hash<Any> {
-      override fun Any.hash(): Int = hashCode()
+    private object HashAny : Hash<Any?> {
+      override fun Any?.hash(): Int = hashCode()
 
-      override fun Any.eqv(b: Any): Boolean = Eq.any().run { eqv(b) }
+      override fun Any?.eqv(b: Any?): Boolean = this == b
     }
   }
 }

--- a/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/number.kt
+++ b/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/number.kt
@@ -1,10 +1,7 @@
 package arrow.dagger.instances
 
 import arrow.instances.*
-import arrow.typeclasses.Eq
-import arrow.typeclasses.Monoid
-import arrow.typeclasses.Order
-import arrow.typeclasses.Semigroup
+import arrow.typeclasses.*
 import dagger.Module
 import dagger.Provides
 
@@ -24,6 +21,9 @@ class NumberInstances {
   fun byteEq(): Eq<Byte> = Byte.eq()
 
   @Provides
+  fun byteHash(): Hash<Byte> = Byte.hash()
+
+  @Provides
   fun doubleSemigroup(): Semigroup<Double> = Double.semigroup()
 
   @Provides
@@ -34,6 +34,9 @@ class NumberInstances {
 
   @Provides
   fun doubleEq(): Eq<@JvmSuppressWildcards Double> = Double.eq()
+
+  @Provides
+  fun doubleHash(): Hash<Double> = Double.hash()
 
   @Provides
   fun intSemigroup(): Semigroup<Int> = Int.semigroup()
@@ -48,6 +51,9 @@ class NumberInstances {
   fun intEq(): Eq<@JvmSuppressWildcards Int> = Int.eq()
 
   @Provides
+  fun intHash(): Hash<Int> = Int.hash()
+
+  @Provides
   fun longSemigroup(): Semigroup<Long> = Long.semigroup()
 
   @Provides
@@ -58,6 +64,9 @@ class NumberInstances {
 
   @Provides
   fun longEq(): Eq<@JvmSuppressWildcards Long> = Long.eq()
+
+  @Provides
+  fun longHash(): Hash<Long> = Long.hash()
 
   @Provides
   fun shortSemigroup(): Semigroup<Short> = Short.semigroup()
@@ -72,6 +81,9 @@ class NumberInstances {
   fun shortEq(): Eq<@JvmSuppressWildcards Short> = Short.eq()
 
   @Provides
+  fun shortHash(): Hash<Short> = Short.hash()
+
+  @Provides
   fun floatSemigroup(): Semigroup<Float> = Float.semigroup()
 
   @Provides
@@ -82,5 +94,8 @@ class NumberInstances {
 
   @Provides
   fun floatEq(): Eq<@JvmSuppressWildcards Float> = Float.eq()
+
+  @Provides
+  fun floatHash(): Hash<Float> = Float.hash()
 
 }

--- a/modules/dagger/arrow-dagger/src/test/kotlin/arrow/dagger/instances/tests/instances.kt
+++ b/modules/dagger/arrow-dagger/src/test/kotlin/arrow/dagger/instances/tests/instances.kt
@@ -28,21 +28,7 @@ import arrow.data.MapKPartialOf
 import arrow.data.OptionTPartialOf
 import arrow.data.SortedMapKPartialOf
 import arrow.data.StateTPartialOf
-import arrow.typeclasses.Applicative
-import arrow.typeclasses.ApplicativeError
-import arrow.typeclasses.Bimonad
-import arrow.typeclasses.Comonad
-import arrow.typeclasses.Eq
-import arrow.typeclasses.Foldable
-import arrow.typeclasses.Functor
-import arrow.typeclasses.Monad
-import arrow.typeclasses.MonadError
-import arrow.typeclasses.Monoid
-import arrow.typeclasses.MonoidK
-import arrow.typeclasses.Order
-import arrow.typeclasses.Semigroup
-import arrow.typeclasses.SemigroupK
-import arrow.typeclasses.Traverse
+import arrow.typeclasses.*
 import dagger.Component
 import dagger.Module
 import javax.inject.Singleton
@@ -163,26 +149,32 @@ interface Runtime {
   fun byteMonoid(): Monoid<Byte>
   fun byteOrder(): Order<Byte>
   fun byteEq(): Eq<@JvmSuppressWildcards Byte>
+  fun byteHash(): Hash<Byte>
   fun doubleSemigroup(): Semigroup<Double>
   fun doubleMonoid(): Monoid<Double>
   fun doubleOrder(): Order<Double>
   fun doubleEq(): Eq<@JvmSuppressWildcards Double>
+  fun doubleHash(): Hash<Double>
   fun intSemigroup(): Semigroup<Int>
   fun intMonoid(): Monoid<Int>
   fun intOrder(): Order<Int>
   fun intEq(): Eq<@JvmSuppressWildcards Int>
+  fun intHash(): Hash<Int>
   fun longSemigroup(): Semigroup<Long>
   fun longMonoid(): Monoid<Long>
   fun longOrder(): Order<Long>
   fun longEq(): Eq<@JvmSuppressWildcards Long>
+  fun longHash(): Hash<Long>
   fun shortSemigroup(): Semigroup<Short>
   fun shortMonoid(): Monoid<Short>
   fun shortOrder(): Order<Short>
   fun shortEq(): Eq<@JvmSuppressWildcards Short>
+  fun shortHash(): Hash<Short>
   fun floatSemigroup(): Semigroup<Float>
   fun floatMonoid(): Monoid<Float>
   fun floatOrder(): Order<Float>
   fun floatEq(): Eq<@JvmSuppressWildcards Float>
+  fun floatHash(): Hash<Float>
   fun optionFunctor(): Functor<ForOption>
   fun optionApplicative(): Applicative<ForOption>
   fun optionMonad(): Monad<ForOption>


### PR DESCRIPTION
WIP because its missing docs and I have some open questions.

- Some datatypes (specifically ListK/SetK etc.) override hashCode to use kotlins Any.hashCode. Should they instead point to their instance of hash() and if so should the parameter if needed be substituted with `Hash.any()`?
- Are there any datatypes I have missed? I skipped some where I was unsure (Coproduct, Sum etc) so please take a look there :)
- As for laws: Hashes only really need to be consistent (`hash(a) == hash(a)`) and hold the law if `a == b` => `hash(a) == hash(b)`. Is that enough?

@pakoito This should be ready some docs I hope :see_no_evil: 

Solves #687 