### PR TITLE
Fixes StackOverFlow issue in MonoidK typeclass

### DIFF
--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonoidK.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonoidK.kt
@@ -17,7 +17,7 @@ interface MonoidK<F> : SemigroupK<F> {
 
   override fun <A> algebra(): Monoid<Kind<F, A>> = object : Monoid<Kind<F, A>> {
 
-    override fun empty(): Kind<F, A> = empty()
+    override fun empty(): Kind<F, A> = this@MonoidK.empty()
 
     override fun Kind<F, A>.combine(b: Kind<F, A>): Kind<F, A> = this.combineK(b)
   }

--- a/modules/core/arrow-typeclasses/src/test/kotlin/arrow/typeclasses/MonoidKTest.kt
+++ b/modules/core/arrow-typeclasses/src/test/kotlin/arrow/typeclasses/MonoidKTest.kt
@@ -1,0 +1,25 @@
+package arrow.typeclasses
+
+import arrow.Kind
+import arrow.core.ForOption
+import arrow.core.Option
+import arrow.core.fix
+import arrow.instances.list.foldable.fold
+import arrow.instances.option.monoidK.monoidK
+import arrow.test.UnitSpec
+import arrow.test.laws.MonoidKLaws
+import io.kotlintest.KTestJUnitRunner
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class MonoidKTest : UnitSpec() {
+    val EQ: Eq<Kind<ForOption, Int>> = Eq.invoke { a, b ->
+        a.fix().run { listOf(a).fold(Option.monoidK().algebra()) } == b.fix().run { listOf(b).fold(Option.monoidK().algebra()) }
+    }
+
+    init {
+        testLaws(
+            MonoidKLaws.laws(Option.monoidK(), { Option.just(it) }, EQ)
+        )
+    }
+}


### PR DESCRIPTION
This pull request fixes the `StackOverflowError` exception that is thrown when running the following code:
```
listOf(Option(1)).fold(Option.monoidK().algebra())
```

It closes #1126 