### PR TITLE
Attempt to make DeferredK rerunnable

### DIFF
--- a/modules/ank/arrow-ank/build.gradle
+++ b/modules/ank/arrow-ank/build.gradle
@@ -1,9 +1,10 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compile project(":arrow-instances-free")
     compile project(":arrow-instances-core")
     compile project(":arrow-instances-data")
+    compile project(":arrow-effects-instances")
+
     compile "org.jetbrains:markdown:0.1.25"
     compile "com.github.born2snipe:cli-progress:0.4"
     compile "org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/algebra.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/algebra.kt
@@ -1,33 +1,34 @@
 package arrow.ank
 
+import arrow.Kind
+import arrow.core.Option
+import arrow.core.Try
 import arrow.core.Tuple2
+import arrow.data.Nel
+import arrow.typeclasses.MonadThrow
 import org.intellij.markdown.ast.ASTNode
-import java.io.File
+import java.nio.file.Path
 
-fun createTarget(source: File, target: File): File =
-  createTargetImpl(source, target)
+interface AnkOps<F> {
+  fun MF(): MonadThrow<F>
 
-fun getFileCandidates(target: File): List<File> =
-  getFileCandidatesImpl(target)
+  fun createTargetDirectory(source: Path, target: Path): Kind<F, Try<Path>>
 
-fun readFile(source: File): String =
-  readFileImpl(source)
+  fun getCandidatePaths(root: Path): Kind<F, Option<Nel<Path>>>
 
-fun preProcessMacros(source: Tuple2<File, String>): String =
-  preProcessMacrosImpl(source)
+  fun readFile(path: Path): Kind<F, Try<String>>
 
-fun parseMarkdown(markdown: String): ASTNode =
-  parseMarkDownImpl(markdown)
+  fun preProcessMacros(pathAndContent: Tuple2<Path, String>): String
 
-fun extractCode(source: String, tree: ASTNode): List<Snippet> =
-  extractCodeImpl(source, tree)
+  fun parseMarkdown(markdown: String): Kind<F, Try<ASTNode>>
 
-fun compileCode(snippets: Map<File, List<Snippet>>, compilerArgs: List<String>): List<CompiledMarkdown> =
-  compileCodeImpl(snippets, compilerArgs)
+  fun extractCode(content: String, ast: ASTNode): Kind<F, Option<Nel<Snippet>>>
 
-fun replaceAnkToLang(compilationResults: CompiledMarkdown): String =
-  replaceAnkToLangImpl(compilationResults)
+  fun compileCode(snippets: Tuple2<Path, Nel<Snippet>>, compilerArgs: List<String>): Kind<F, Try<Nel<Snippet>>>
 
-fun generateFile(candidate: File, newContents: String): File =
-  generateFileImpl(candidate, newContents)
+  fun replaceAnkToLang(content: String, compiledSnippets: Nel<Snippet>): String
 
+  fun generateFile(path: Path, newContent: String): Kind<F, Try<Unit>>
+
+  fun printConsole(msg: String): Kind<F, Unit>
+}

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/algebra.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/algebra.kt
@@ -2,7 +2,6 @@ package arrow.ank
 
 import arrow.Kind
 import arrow.core.Option
-import arrow.core.Try
 import arrow.core.Tuple2
 import arrow.data.Nel
 import arrow.typeclasses.MonadThrow
@@ -12,23 +11,23 @@ import java.nio.file.Path
 interface AnkOps<F> {
   fun MF(): MonadThrow<F>
 
-  fun createTargetDirectory(source: Path, target: Path): Kind<F, Try<Path>>
+  fun createTargetDirectory(source: Path, target: Path): Kind<F, Path>
 
   fun getCandidatePaths(root: Path): Kind<F, Option<Nel<Path>>>
 
-  fun readFile(path: Path): Kind<F, Try<String>>
+  fun readFile(path: Path): Kind<F, String>
 
   fun preProcessMacros(pathAndContent: Tuple2<Path, String>): String
 
-  fun parseMarkdown(markdown: String): Kind<F, Try<ASTNode>>
+  fun parseMarkdown(markdown: String): Kind<F, ASTNode>
 
   fun extractCode(content: String, ast: ASTNode): Kind<F, Option<Nel<Snippet>>>
 
-  fun compileCode(snippets: Tuple2<Path, Nel<Snippet>>, compilerArgs: List<String>): Kind<F, Try<Nel<Snippet>>>
+  fun compileCode(snippets: Tuple2<Path, Nel<Snippet>>, compilerArgs: List<String>): Kind<F, Nel<Snippet>>
 
   fun replaceAnkToLang(content: String, compiledSnippets: Nel<Snippet>): String
 
-  fun generateFile(path: Path, newContent: String): Kind<F, Try<Unit>>
+  fun generateFile(path: Path, newContent: String): Kind<F, Unit>
 
   fun printConsole(msg: String): Kind<F, Unit>
 }

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -20,7 +20,8 @@ fun <F> ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkO
       acc.flatMap { generated ->
         MF().binding {
           // ignore first one, then output on every 100 or every fifth when below 1000
-          if (curr != 0 && (curr % 100 == 0 || (candidates.size < 1000 && curr % 5 == 0))) {
+          val printAnkProgress = (curr % 100 == 0 || (candidates.size < 1000 && curr % 5 == 0))
+          if (curr != 0 && printAnkProgress) {
             val message = "Ank: Processed ~> [$curr of ${candidates.size}]"
             printConsole(colored(ANSI_GREEN, message)).bind()
           }

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -1,45 +1,57 @@
 package arrow.ank
 
+import arrow.Kind
 import arrow.core.toT
+import arrow.data.Nel
 import org.intellij.markdown.ast.ASTNode
-import java.io.File
+import java.nio.file.Path
 
-const val AnkBlock = ":ank"
-const val AnkSilentBlock = ":ank:silent"
-const val AnkReplaceBlock = ":ank:replace"
-const val AnkOutFileBlock = ":ank:outFile"
+fun <F> ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkOps<F>): Kind<F, Int> = with(ankOps) {
+  MF().binding {
+    printConsole(colored(ANSI_PURPLE, AnkHeader)).bind()
 
-fun ank(source: File, target: File, compilerArgs: List<String>): List<File> {
-    val heapSize = Runtime.getRuntime().totalMemory()
-    val heapMaxSize = Runtime.getRuntime().maxMemory()
-    println("Current heap used: ${(heapSize - Runtime.getRuntime().freeMemory()).humanBytes()}")
-    println("Starting ank with Heap Size: ${heapSize.humanBytes()}, Max Heap Size: ${heapMaxSize.humanBytes()}")
-    println(colored(ANSI_PURPLE, AnkHeader))
-    val targetDirectory: File = createTarget(source, target)
-    val files: List<File> = getFileCandidates(targetDirectory)
-    return files.mapIndexed { n, file -> n toT file }.flatMap { (n, file) ->
-        if (files.size < 1000 || n % 100 == 0 || n < 100) {
-            //report first 100 hundred then every 100 files, or report them all if under 1000
-            val message = "Ank: Processed ~> [${n + 1} of ${files.size}] ~ Heap in use ${(Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()).humanBytes()}"
-            println(colored(ANSI_GREEN, message))
+    val path = createTargetDirectory(source, target).bind()
+      .fold({ MF().raiseError<Path>(it).bind() }, { it })
+
+    val candidates = getCandidatePaths(path).bind()
+      .fold({ MF().raiseError<Nel<Path>>(Exception("No matching files found")).bind() }, { it })
+
+    val generated = candidates.all.foldIndexed(MF().just(0)) { curr, acc, p ->
+      acc.flatMap { generated ->
+        MF().binding {
+          // ignore first one, then output on every 100 or every fifth when below 1000
+          if (curr != 0 && (curr % 100 == 0 || (candidates.size < 1000 && curr % 5 == 0))) {
+            val message = "Ank: Processed ~> [$curr of ${candidates.size}]"
+            printConsole(colored(ANSI_GREEN, message)).bind()
+          }
+
+          val content = readFile(p).bind()
+            .fold({ MF().raiseError<String>(Exception("Failed to load file $p")).bind() }, { it })
+
+          val preProcessed = preProcessMacros(p toT content)
+
+          val parsedMarkdown = parseMarkdown(preProcessed).bind()
+            .fold({ MF().raiseError<ASTNode>(Exception("Failed to parse markdown in file $p")).bind() }, { it })
+
+          val snippets = extractCode(preProcessed, parsedMarkdown).bind()
+            .fold({ return@binding generated }, { it })
+
+          val compiledResult = compileCode(p toT snippets, compilerArgs).bind()
+            .fold({ MF().raiseError<Nel<Snippet>>(it).bind() }, { it })
+
+          val result = replaceAnkToLang(preProcessed, compiledResult)
+
+          generateFile(p, result).bind()
+            .fold({ MF().raiseError<Unit>(it).bind() }, { })
+
+          generated + snippets.foldLeft(1) { a, s -> if (s.isOutFile) a + 1 else a }
         }
-        val content: String = readFile(file)
-        val preProcessedMacros: String = preProcessMacros(file toT content)
-        val parsedMarkDown: ASTNode = parseMarkdown(preProcessedMacros)
-        val snippets = extractCode(preProcessedMacros, parsedMarkDown)
-        val compilationResult = compileCode(mapOf(file to snippets), compilerArgs)
-        val replacedResult = compilationResult.map(::replaceAnkToLang)
-        replacedResult.map { newContent -> generateFile(file, newContent) }
-    }
-  }
+      }
+    }.bind()
 
-/**
- * From https://stackoverflow.com/questions/3758606/how-to-convert-byte-size-into-human-readable-format-in-java
- */
-fun Long.humanBytes(): String {
-    val unit = 1024
-    if (this < unit) return toString() + " B"
-    val exp = (Math.log(toDouble()) / Math.log(unit.toDouble())).toInt()
-    val pre = ("KMGTPE")[exp - 1] + "i"
-    return String.format("%.1f %sB", this / Math.pow(unit.toDouble(), exp.toDouble()), pre)
+    val message = "Ank: Processed ~> [${candidates.size} of ${candidates.size}]"
+    printConsole(colored(ANSI_GREEN, message)).bind()
+
+    generated
+  }
 }

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -3,7 +3,6 @@ package arrow.ank
 import arrow.Kind
 import arrow.core.toT
 import arrow.data.Nel
-import org.intellij.markdown.ast.ASTNode
 import java.nio.file.Path
 
 fun <F> ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkOps<F>): Kind<F, Int> = with(ankOps) {

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
@@ -143,7 +143,7 @@ fun <F> monadDeferInterpreter(MF: MonadDefer<F>): AnkOps<F> = object : AnkOps<F>
           }.fold({
             // raise error and print to console
             defer {
-              println(colored(ANSI_RED, "[$1%] ✗ ${snippets.a} [${i + 1} of ${snippets.b.size}]"))
+              println(colored(ANSI_RED, "[${(i + 1) * 100 / snippets.b.size}%] ✗ ${snippets.a} [${i + 1} of ${snippets.b.size}]"))
               raiseError<Snippet>(
                 CompilationException(snippets.a, snip, it, msg = "\n" + """
                     |

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
@@ -1,19 +1,26 @@
 package arrow.ank
 
+import arrow.Kind
 import arrow.core.*
-import arrow.data.ListK
-import arrow.data.k
-import arrow.instances.option.monad.forEffect
-import org.intellij.markdown.MarkdownElementTypes.CODE_FENCE
+import arrow.data.Nel
+import arrow.data.fix
+import arrow.effects.typeclasses.MonadDefer
+import arrow.instances.`try`.applicative.applicative
+import arrow.instances.list.traverse.sequence
+import arrow.instances.listk.traverse.sequence
+import arrow.instances.sequence.foldable.isEmpty
+import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.accept
 import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.ast.visitors.RecursiveVisitor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.parser.MarkdownParser
-import java.io.File
 import java.net.URL
 import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
 import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
 
@@ -35,36 +42,15 @@ val SupportedMarkdownExtensions: Set<String> = setOf(
   "Rmd"
 )
 
-fun createTargetImpl(source: File, target: File): File {
-  source.copyRecursively(target, overwrite = true)
-  return target
-}
-
-fun getFileCandidatesImpl(target: File): ListK<File> =
-  ListK(target.walkTopDown().filter {
-    SupportedMarkdownExtensions.contains(it.extension.toLowerCase())
-  }.toList())
-
-fun readFileImpl(source: File): String =
-  source.readText()
-
-fun parseMarkDownImpl(markdown: String): ASTNode =
-  MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
-
-abstract class NoStackTrace(msg: String) : Throwable(msg, null, false, false)
-
 data class CompilationException(
-  val file: File,
+  val path: Path,
   val snippet: Snippet,
   val underlying: Throwable,
   val msg: String) : NoStackTrace(msg) {
   override fun toString(): String = msg
 }
 
-data class CompiledMarkdown(val origin: File, val snippets: ListK<Snippet>)
-
-private fun String.removeSpaces(): String =
-  replace(" ", "")
+abstract class NoStackTrace(msg: String) : Throwable(msg, null, false, false)
 
 data class Snippet(
   val fence: String,
@@ -75,164 +61,188 @@ data class Snippet(
   val result: Option<String> = None,
   val isSilent: Boolean = fence.contains(AnkSilentBlock),
   val isReplace: Boolean = fence.contains(AnkReplaceBlock),
-  val isOutFile: Boolean = fence.contains(AnkOutFileBlock))
+  val isOutFile: Boolean = fence.contains(AnkOutFileBlock)
+)
 
-fun extractCodeImpl(source: String, tree: ASTNode): ListK<Snippet> {
-  val sb = mutableListOf<Snippet>()
-  tree.accept(object : RecursiveVisitor() {
-    override fun visitNode(node: ASTNode) {
-      if (node.type == CODE_FENCE) {
-        val fence = node.getTextInNode(source)
-        val lang = fence.takeWhile { it != ':' }.toString().replace("```", "")
-        if (fence.startsWith("```$lang$AnkBlock")) {
-          val code = fence.split("\n").drop(1).dropLast(1).joinToString("\n")
-          sb.add(Snippet(fence.toString(), lang, node.startOffset, node.endOffset, code))
-        }
-      }
-      super.visitNode(node)
-    }
-  })
-  return sb.k()
-}
+const val AnkBlock = ":ank"
+const val AnkSilentBlock = ":ank:silent"
+const val AnkReplaceBlock = ":ank:replace"
+const val AnkOutFileBlock = ":ank:outFile"
 
 val ankMacroRegex: Regex = "ank_macro_hierarchy\\((.*?)\\)".toRegex()
 
-fun preProcessMacrosImpl(source: Tuple2<File, String>): String {
-  val matches: List<MatchResult> = ankMacroRegex.findAll(source.b).toList()
-  val result: String = when {
-    matches.isEmpty() -> source.b
-    else -> {
-      val classes: List<String> = matches.map { it.groupValues[1] }
-      val cleanedSource = ankMacroRegex.replace(source.b) { "" }
-      cleanedSource +
-        "\n\n\n## Type Class Hierarchy\n\n" +
-        generateMixedHierarchyDiagramCode(classes).joinToString("\n")
+fun <F> monadDeferInterpreter(MF: MonadDefer<F>): AnkOps<F> = object : AnkOps<F> {
+  override fun MF(): MonadDefer<F> = MF
+
+  override fun printConsole(msg: String): Kind<F, Unit> = MF.delay { println(msg) }
+
+  override fun createTargetDirectory(source: Path, target: Path): Kind<F, Try<Path>> = MF.delay {
+    Try { source.toFile().copyRecursively(target.toFile(), overwrite = true); target }
+  }
+
+  override fun getCandidatePaths(root: Path): Kind<F, Option<Nel<Path>>> = MF.delay {
+    Nel.fromList<Path>(
+      Files.walk(root).filter { Files.isDirectory(it).not() }.filter { path ->
+        SupportedMarkdownExtensions.fold(false) { c, ext ->
+          c || path.toString().endsWith(ext)
+        }
+      }.collect(Collectors.toList())
+    )
+  }
+
+  override fun readFile(path: Path): Kind<F, Try<String>> = MF.delay {
+    Try { String(Files.readAllBytes(path)) }
+  }
+
+  override fun preProcessMacros(pathAndContent: Tuple2<Path, String>): String {
+    val matches = ankMacroRegex.findAll(pathAndContent.b)
+    return if (matches.isEmpty()) pathAndContent.b else {
+      val classes = matches.map { it.groupValues[1] }
+      val cleanedSource = ankMacroRegex.replace(pathAndContent.b) { "" }
+      cleanedSource + "\n\n\n## Type Class Hierarchy\n\n" +
+        generateMixedHierarchyDiagramCode(classes.toList()).joinToString("\n")
+    }
+  }
+
+  override fun parseMarkdown(markdown: String): Kind<F, Try<ASTNode>> = MF.delay {
+    Try { MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(markdown) }
+  }
+
+  override fun extractCode(content: String, ast: ASTNode): Kind<F, Option<Nel<Snippet>>> = MF.delay {
+    val snippets = mutableListOf<Snippet>()
+    ast.accept(object : RecursiveVisitor() {
+      override fun visitNode(node: ASTNode) {
+        if (node.type == MarkdownElementTypes.CODE_FENCE) {
+          val fence = node.getTextInNode(content)
+          val lang = fence.takeWhile { it != ':' }.toString().replace("```", "")
+          if (fence.startsWith("```$lang$AnkBlock")) {
+            val code = fence.split("\n").drop(1).dropLast(1).joinToString("\n")
+            snippets.add(Snippet(fence.toString(), lang, node.startOffset, node.endOffset, code))
+          }
+        }
+        super.visitNode(node)
+      }
+    })
+
+    Nel.fromList(snippets)
+  }
+
+  override fun compileCode(snippets: Tuple2<Path, Nel<Snippet>>, compilerArgs: List<String>): Kind<F, Try<Nel<Snippet>>> = MF.run {
+    MF.binding {
+      createEngineCache(snippets.b, compilerArgs).bind()
+        .flatMap { engineCache ->
+          // run each snipped and handle its result
+          snippets.b.all.mapIndexed { i, snip ->
+            binding {
+              Try {
+                engineCache.getOrElse(snip.lang) {
+                  throw CompilationException(
+                    path = snippets.a,
+                    snippet = snip,
+                    underlying = IllegalStateException("No engine configured for `${snip.lang}`"),
+                    msg = colored(ANSI_RED, "ΛNK compilation failed [ ${snippets.a} ]")
+                  )
+                }.eval(snip.code)
+              }.fold({
+                // raise error and print to console
+                defer {
+                  println(colored(ANSI_RED, "[$1%] ✗ ${snippets.a} [${i + 1} of ${snippets.b.size}]"))
+                  raiseError<Try<Snippet>>(
+                    CompilationException(snippets.a, snip, it, msg = "\n" + """
+                    |
+                    |```
+                    |${snip.code}
+                    |```
+                    |${colored(ANSI_RED, it.localizedMessage)}
+                    """.trimMargin())
+                  )
+                }.bind()
+              }, { result ->
+                // handle results, ignore silent snippets
+                if (snip.isSilent) snip.success()
+                else {
+                  val resultString: Option<String> = Option.fromNullable(result).fold({ None }, {
+                    when {
+                      // replace entire snippet with result
+                      snip.isReplace -> Some("$it")
+                      // write result to a new file
+                      snip.isOutFile -> delay {
+                        val fileName = snip.fence.lines()[0].substringAfter("(").substringBefore(")")
+                        val dir = snippets.a.parent
+                        Files.write(dir.resolve(fileName), result.toString().toByteArray())
+                        Some("")
+                      }.bind()
+                      // simply append result
+                      else -> Some("// $it")
+                    }
+                  })
+                  snip.copy(result = resultString).success()
+                }
+              })
+            }
+          }.sequence(MF).bind()
+            .sequence(Try.applicative()).fix().map {
+              Nel.fromListUnsafe(it.fix())
+            }
+        }
+    }
+  }
+
+  override fun replaceAnkToLang(content: String, compiledSnippets: Nel<Snippet>): String =
+    compiledSnippets.foldLeft(content) { content, snippet ->
+      snippet.result.fold(
+        { content.replace(snippet.fence, "```${snippet.lang}\n" + snippet.code + "\n```") },
+        {
+          when {
+            snippet.isReplace -> content.replace(snippet.fence, it)
+            snippet.isOutFile -> content.replace(snippet.fence, "")
+            else -> content.replace(snippet.fence, "```${snippet.lang}\n" + snippet.code + "\n" + it + "\n```")
+          }
+        }
+      )
     }
 
+  override fun generateFile(path: Path, newContent: String): Kind<F, Try<Unit>> = MF.delay {
+    Try {
+      Files.write(path, newContent.toByteArray())
+    }.map { Unit }
   }
-  val originalFile = source.a
-  originalFile.writeText(result)
-  return result
-}
 
-//TODO Try by overriding dokka settings for packages so it does not create it's markdown package file, then for regular type classes pages we only check the first result with the comment but remove them all regardless
-private fun generateMixedHierarchyDiagramCode(classes: List<String>): List<String> {
-  val packageName = classes.firstOrNull()?.substringBeforeLast(".")
-  //careful meta-meta-programming ahead
-  val hierarchyGraphsJoined =
-    "listOf(" + classes
-      .map { "TypeClass($it::class)" }
-      .joinToString(", ") + ").mixedHierarchyGraph()"
+  private fun createEngineCache(snippets: Nel<Snippet>, compilerArgs: List<String>): Kind<F, Try<Map<String, ScriptEngine>>> = MF.run {
+    bindingCatch {
+      val classLoader = delay { URLClassLoader(compilerArgs.map { URL(it) }.toTypedArray()) }.bind()
+      val seManager = delay { ScriptEngineManager(classLoader) }.bind()
+      delay {
+        snippets.all.asSequence().distinctBy { it.lang }.map {
+          it.lang to seManager.getEngineByExtension(extensionMappings.getOrDefault(it.lang, "kts"))
+        }.toMap()
+      }.bind()
+    }
+      .map { it.success() }
+      .handleError { it.failure<Map<String, ScriptEngine>>() }
+  }
 
-  return listOf(
-    """
+  //TODO Try by overriding dokka settings for packages so it does not create it's markdown package file, then for regular type classes pages we only check the first result with the comment but remove them all regardless
+  private fun generateMixedHierarchyDiagramCode(classes: List<String>): List<String> {
+    val packageName = classes.firstOrNull()?.substringBeforeLast(".")
+    //careful meta-meta-programming ahead
+    val hierarchyGraphsJoined =
+      "listOf(" + classes
+        .map { "TypeClass($it::class)" }
+        .joinToString(", ") + ").mixedHierarchyGraph()"
+
+    return listOf(
+      """
       |<canvas id="$packageName-hierarchy-diagram"></canvas>
       |<script>
       |  drawNomNomlDiagram('$packageName-hierarchy-diagram', '$packageName-diagram.nomnol')
       |</script>
     """.trimMargin(),
-    """
+      """
       |```kotlin:ank:outFile($packageName-diagram.nomnol)
       |import arrow.reflect.*
       |$hierarchyGraphsJoined
       |```
       |""".trimMargin())
-}
-
-private fun generateHierarchyDiagramCode(fqClassName: String): List<String> =
-  listOf(
-    """
-      |<canvas id="hierarchy-diagram"></canvas>
-      |<script>
-      |  drawNomNomlDiagram('hierarchy-diagram', 'diagram.nomnol')
-      |</script>
-    """.trimMargin(),
-    """
-      |```kotlin:ank:outFile(diagram.nomnol)
-      |import arrow.reflect.*
-      |TypeClass($fqClassName::class).hierarchyGraph()
-      |```
-      |""".trimMargin())
-
-fun compileCodeImpl(snippets: Map<File, List<Snippet>>, classpath: List<String>): ListK<CompiledMarkdown> {
-  val sortedSnippets = snippets.toList()
-  val result = sortedSnippets.mapIndexed { n, (file, codeBlocks) ->
-    val progress: Int = if (snippets.isNotEmpty()) ((n + 1) * 100 / snippets.size) else 100
-    val classLoader = URLClassLoader(classpath.map { URL(it) }.toTypedArray())
-    val seManager = ScriptEngineManager(classLoader)
-    val engineCache: Map<String, ScriptEngine> =
-      codeBlocks
-        .asSequence()
-        .distinctBy { it.lang }
-        .map {
-          it.lang to seManager.getEngineByExtension(extensionMappings.getOrDefault(it.lang, "kts"))
-        }
-        .toList()
-        .toMap()
-    val evaledSnippets: ListK<Snippet> = codeBlocks.mapIndexed { _, snippet ->
-      val result: Any? = Try {
-        val engine: ScriptEngine = engineCache.k().getOrElse(
-          snippet.lang
-        ) {
-          throw CompilationException(
-            file = file,
-            snippet = snippet,
-            underlying = IllegalStateException("No engine configured for `${snippet.lang}`"),
-            msg = colored(ANSI_RED, "ΛNK compilation failed [ ${file.parentFile.name}/${file.name} ]"))
-        }
-        val result = engine.eval(snippet.code)
-        result
-      }.fold({
-        println(colored(ANSI_RED, "[$progress%] ✗ ${file.parentFile.name}/${file.name} [${n + 1} of ${snippets.size}]"))
-        throw CompilationException(file, snippet, it, msg = "\n" + """
-                    |
-                    |```
-                    |${snippet.code}
-                    |```
-                    |${colored(ANSI_RED, it.localizedMessage)}
-                    """.trimMargin())
-      }, { it })
-      if (snippet.isSilent) {
-        snippet
-      } else {
-        val resultString: Option<String> = Option.fromNullable(result).fold({ None }, {
-          when {
-            snippet.isReplace -> Some("$it")
-            snippet.isOutFile -> Some("").forEffect(Some(snippet.writeToOutFile(file.parentFile, result.toString())))
-            else -> Some("// $it")
-          }
-        })
-        snippet.copy(result = resultString)
-      }
-    }.k()
-    CompiledMarkdown(file, evaledSnippets)
-  }.k()
-  return result
-}
-
-private fun Snippet.writeToOutFile(parent: File, result: String): Unit {
-  val fileName = fence.lines()[0].substringAfter("(").substringBefore(")")
-  val file = File(parent, fileName)
-  file.writeText(result)
-}
-
-fun replaceAnkToLangImpl(compiledMarkdown: CompiledMarkdown): String =
-  compiledMarkdown.snippets.fold(compiledMarkdown.origin.readText()) { content, snippet ->
-    snippet.result.fold(
-      { content.replace(snippet.fence, "```${snippet.lang}\n" + snippet.code + "\n```") },
-      {
-        when {
-          snippet.isReplace -> content.replace(snippet.fence, it)
-          snippet.isOutFile -> content.replace(snippet.fence, "")
-          else -> content.replace(snippet.fence, "```${snippet.lang}\n" + snippet.code + "\n" + it + "\n```")
-        }
-      }
-    )
   }
-
-fun generateFileImpl(file: File, contents: String): File {
-  file.printWriter().use {
-    it.print(contents)
-  }
-  return file
 }

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/main.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/main.kt
@@ -3,16 +3,19 @@
 package arrow.ank
 
 import arrow.core.Try
-import java.io.File
+import arrow.effects.IO
+import arrow.effects.fix
+import arrow.effects.instances.io.monadDefer.monadDefer
+import java.nio.file.Paths
 
 fun main(vararg args: String) {
   when {
     args.size > 1 -> {
-      Try { ank(File(args[0]), File(args[1]), args.drop(2)) }
+      Try { ank(Paths.get(args[0]), Paths.get(args[1]), args.drop(2), monadDeferInterpreter(IO.monadDefer())).fix().unsafeRunSync() }
         .fold({ ex ->
           throw ex
         }, { files ->
-          println("ΛNK Generated ${files.size} files")
+          println("ΛNK Generated $files files")
         })
     }
     else -> throw IllegalArgumentException("Required first 2 args as directory paths in this order: <required: source> <required: destination> <optional: classpath entries, one per arg..>")

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
@@ -47,11 +47,8 @@ object MonadDeferLaws {
       Law("Sync laws: defer suspens evaluation") { SC.deferSuspendsEvaluation(EQ) },
       Law("Sync laws: delay suspends evaluation") { SC.delaySuspendsEvaluation(EQ) },
       Law("Sync laws: flatMap suspends evaluation") { SC.flatMapSuspendsEvaluation(EQ) },
-      Law("Sync laws: map suspends evaluation") { SC.mapSuspendsEvaluation(EQ) }
-      /*
-      FIXME: https://github.com/arrow-kt/arrow/issues/1156 - DeferredK fails this because coroutines only run once and then memoize results
+      Law("Sync laws: map suspends evaluation") { SC.mapSuspendsEvaluation(EQ) },
       Law("Sync laws: Repeated evaluation not memoized") { SC.repeatedSyncEvaluationNotMemoized(EQ) }
-      */
     ) + if (testStackSafety) {
       listOf(
         Law("Sync laws: stack safety over repeated left binds") { SC.stackSafetyOverRepeatedLeftBinds(5000, EQ) },
@@ -146,25 +143,25 @@ object MonadDeferLaws {
     df.flatMap { df }.flatMap { df }.equalUnderTheLaw(just(3), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOverRepeatedLeftBinds(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOverRepeatedLeftBinds(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().k().foldLeft(just(0)) { def, x ->
       def.flatMap { just(x) }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOverRepeatedRightBinds(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOverRepeatedRightBinds(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().foldRight(just(iterations)) { x, def ->
       lazy().flatMap { def }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOverRepeatedAttempts(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOverRepeatedAttempts(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().foldLeft(just(0)) { def, x ->
       def.attempt().map { x }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOnRepeatedMaps(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOnRepeatedMaps(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().foldLeft(just(0)) { def, x ->
       def.map { x }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
@@ -143,25 +143,25 @@ object MonadDeferLaws {
     df.flatMap { df }.flatMap { df }.equalUnderTheLaw(just(3), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOverRepeatedLeftBinds(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOverRepeatedLeftBinds(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().k().foldLeft(just(0)) { def, x ->
       def.flatMap { just(x) }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOverRepeatedRightBinds(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOverRepeatedRightBinds(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().foldRight(just(iterations)) { x, def ->
       lazy().flatMap { def }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOverRepeatedAttempts(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOverRepeatedAttempts(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().foldLeft(just(0)) { def, x ->
       def.attempt().map { x }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true
   }
 
-  fun <F> MonadDefer<F>.stackSafetyOnRepeatedMaps(iterations: Int = 50000, EQ: Eq<Kind<F, Int>>): Unit {
+  fun <F> MonadDefer<F>.stackSafetyOnRepeatedMaps(iterations: Int = 5000, EQ: Eq<Kind<F, Int>>): Unit {
     (0..iterations).toList().foldLeft(just(0)) { def, x ->
       def.map { x }
     }.equalUnderTheLaw(just(iterations), EQ) shouldBe true

--- a/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
+++ b/modules/docs/arrow-docs/src/main/kotlin/EffectsHelper.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.Dispatchers.Unconfined
 
 val UI = Unconfined
 
-fun <A> DeferredKOf<A>.startF(ctx: CoroutineContext = Dispatchers.Default): DeferredK<Fiber<ForDeferredK, A>> = this.fix().scope.run {
+fun <A> DeferredKOf<A>.startF(ctx: CoroutineContext = Dispatchers.Default): DeferredK<Fiber<ForDeferredK, A>> = this.fix().scope().run {
     val start = asyncK(ctx = ctx, start = CoroutineStart.DEFAULT) {
       this@startF.await()
     }

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -93,7 +93,7 @@ interface DeferredKAsyncInstance : Async<ForDeferredK>, DeferredKMonadDeferInsta
     fix().continueOn(ctx = ctx)
 
   override fun <A> invoke(ctx: CoroutineContext, f: () -> A): Kind<ForDeferredK, A> =
-    DeferredK.invoke(ctx = ctx, f = f)
+    DeferredK.invoke(ctx = ctx, f = { f() })
 }
 
 @extension

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -165,13 +165,13 @@ fun <A> DeferredKOf<A>.unsafeRunSync(): A =
   runBlocking { await() }
 
 fun <A> DeferredKOf<A>.runAsync(cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
-  DeferredK.invoke(fix().scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  DeferredK.invoke(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     fix().forceExceptionPropagation()
     unsafeRunAsync(cb.andThen { it.unsafeRunAsync { } })
   }
 
 fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent, cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Disposable> =
-  DeferredK.invoke(fix().scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  DeferredK.invoke(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     fix().forceExceptionPropagation()
     val call = CompletableDeferred<Unit>(parent = runAsync(cb))
     val disposable: Disposable = {
@@ -184,7 +184,7 @@ fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent,
   }
 
 fun <A> DeferredKOf<A>.unsafeRunAsync(cb: (Either<Throwable, A>) -> Unit): Unit =
-  fix().scope().async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  scope().async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     Try { await() }.fold({ cb(Left(it)) }, { cb(Right(it)) })
   }.forceExceptionPropagation()
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -78,7 +78,7 @@ sealed class DeferredK<A>(
         use(a).also { release(a, ExitCase.Completed) }
       } catch (e: Exception) {
         release(a, ExitCase.Error(e))
-        DeferredK.failed<B>(e)
+        DeferredK.raiseError<B>(e)
       }
     }
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -8,14 +8,75 @@ import arrow.higherkind
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Wraps a [Deferred] with [DeferredK]
+ *
+ * Note: Using this extension means that the resulting [DeferredK] will use a memoized version of [Deferred].
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.k
+ * import arrow.effects.unsafeRunSync
+ * import kotlinx.coroutines.GlobalScope
+ * import kotlinx.coroutines.async
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: DeferredK<String> = GlobalScope.async {
+ *     // some computation ...
+ *     "Done"
+ *   }.k()
+ *   //sampleEnd
+ *   println(result.unsafeRunSync())
+ * }
+ *  ```
+ */
 fun <A> Deferred<A>.k(): DeferredK<A> =
   DeferredK.Wrapped(memoized = this)
 
+/**
+ * Wrap a suspend function in a [DeferredK] given a context and a start method
+ *
+ * Note: Using this extension means that the resulting [DeferredK] will rerun f on every await, hence
+ *  awaiting a new coroutine every time. This means it won't be memoized and as such can be used for repeated/retried actions and
+ *  it will properly re-execute side-effects.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.asyncK
+ * import arrow.effects.unsafeRunSync
+ * import kotlinx.coroutines.GlobalScope
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: DeferredK<String> = GlobalScope.asyncK {
+ *     // some computation ...
+ *     "Done"
+ *   }
+ *   //sampleEnd
+ *   println(result.unsafeRunSync())
+ * }
+ * ```
+ */
 fun <A> CoroutineScope.asyncK(ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend CoroutineScope.() -> A): DeferredK<A> =
   DeferredK.Generated(ctx, start, this) { f() }
 
+/**
+ * Return the wrapped [Deferred] from a [DeferredK]
+ *
+ * Note: `aDeferredK.value().await()` does not necessarily equal `aDeferredK.await()`. That is because [DeferredK] will attempt to rerun
+ *  all computation and if the code executed is not pure it may change on every await. This is important because otherwise impure code would not
+ *  rerun, and its side effects never happen. This only applies to [DeferredK]'s created without `Deferred.k()`
+ */
 fun <A> DeferredKOf<A>.value(): Deferred<A> = this.fix().memoized
 
+/**
+ * Returns the [CoroutineScope] the [DeferredK] operates on
+ */
 fun <A> DeferredKOf<A>.scope(): CoroutineScope = this.fix().scope
 
 @higherkind
@@ -26,25 +87,28 @@ sealed class DeferredK<A>(
 ) : DeferredKOf<A>, Deferred<A> by memoized {
 
   /**
-   * Pure wrapper for already constructed deferred instances, does nothing special really
+   * Pure wrapper for already constructed [Deferred] instances. Created solely by `Deferred.k()` extension method
    */
-  class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
+  internal class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
 
   /**
-   * Represents a DeferredK that can generate an instance of deferred on every await
+   * Represents a [DeferredK] that can generate an instance of [Deferred] on every await
    *
-   * It does not memoize results and thus can be rerun just as expected from a MonadDefer
+   * It does not memoize results and thus can be rerun just as expected from a [MonadDefer]
    * However one can still break this system by ie returning or using a deferred in one of the functions
    *  only when creating all deferred instances inside DeferredK or using DeferredK's methods
    *  one can guarantee not having memoization
    */
-  class Generated<A>(
+  internal class Generated<A>(
     val ctx: CoroutineContext = Dispatchers.Default,
     val coroutineStart: CoroutineStart = CoroutineStart.LAZY,
     scope: CoroutineScope = GlobalScope,
     val generator: suspend () -> A
   ) : DeferredK<A>(scope, scope.async(ctx, coroutineStart) { generator() }) {
 
+    /**
+     * Returns either the memoized [Deferred] if it has not been run yet. Or creates a new one.
+     */
     override suspend fun await(): A =
       if (memoized.isCompleted || memoized.isActive || memoized.isCancelled) {
         scope.async(ctx, coroutineStart) { generator() }.await()
@@ -101,13 +165,92 @@ sealed class DeferredK<A>(
   override fun hashCode(): Int = memoized.hashCode()
 
   companion object {
+
+    /**
+     * [DeferredK] that just contains [Unit]
+     *
+     * Useful for comprehensions to avoid executing code at the beginning of a binding.
+     *
+     * This below executes `println("Stuff")` despite the resulting [DeferredK] never being executed itself.
+     * To avoid that call [bind] on a [DeferredK] before that. The second binding won't print a thing before run.
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.effects.DeferredK
+     * import arrow.effects.deferredk.monad.monad
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   DeferredK.monad().binding {
+     *     println("Stuff")
+     *     DeferredK { 10 }.bind()
+     *   }
+     *
+     *   DeferredK.monad().binding {
+     *     DeferredK.unit().bind()
+     *     println("Other Stuff")
+     *     DeferredK { 10 }.bind()
+     *   }
+     *   //sampleEnd
+     * }
+     * ```
+     */
     fun unit(): DeferredK<Unit> = just(Unit)
 
     fun <A> just(a: A): DeferredK<A> = CompletableDeferred(a).k()
 
-    fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: () -> DeferredKOf<A>): DeferredK<A> =
+    /**
+     * Wraps a function that returns a [DeferredK] in a [DeferredK] together with a specific [CoroutineScope], a [CoroutineContext] and a
+     *  [CoroutineStart]. All those parameters (except f) have defaults.
+     *
+     * Note: Using this method means the resulting [DeferredK] will rerun fa on await, not memoizing its result.
+     *  As long as the result of fa is also re-runnable, this [DeferredK] this [DeferredK] will correctly re-run.
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.effects.DeferredK
+     * import arrow.effects.unsafeRunSync
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = DeferredK.defer {
+     *     println("Calculating solution:")
+     *     DeferredK.just(42)
+     *   }
+     *   //sampleEnd
+     *   println(result.unsafeRunSync())
+     * }
+     * ```
+     */
+    fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Unconfined, start: CoroutineStart = CoroutineStart.LAZY, fa: () -> DeferredKOf<A>): DeferredK<A> =
       Generated(ctx, start, scope) { fa().await() }
 
+    /**
+     * Wraps a suspend function in a [DeferredK] together with a specific [CoroutineScope], a [CoroutineContext] and a
+     *  [CoroutineStart]. All those parameters (except f) have defaults.
+     *
+     * Note: Using this method means the resulting [DeferredK] will rerun f on await. Making this [DeferredK] re-runnable as long as f itself does not use a non re-runnable
+     *  [Deferred] or [DeferredK].
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.effects.DeferredK
+     * import arrow.effects.unsafeRunSync
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = DeferredK {
+     *     println("Calculating solution:")
+     *     42
+     *   }
+     *   //sampleEnd
+     *   println(result.unsafeRunSync())
+     * }
+     * ```
+     */
     operator fun <A> invoke(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
       Generated(ctx, start, scope, f)
 
@@ -119,7 +262,7 @@ sealed class DeferredK<A>(
      *
      * Matching the behavior of [async],
      * its [CoroutineContext] is set to [DefaultDispatcher]
-     * and its [CoroutineStart] is [CoroutineStart.DEFAULT].
+     * and its [CoroutineStart] is [CoroutineStart.LAZY].
      */
     fun <A> async(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: Proc<A>): DeferredK<A> =
       Generated(ctx, start, scope) {

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -9,18 +9,49 @@ import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
 fun <A> Deferred<A>.k(): DeferredK<A> =
-  DeferredK(this)
+  DeferredK.Wrapped(memoized = this)
 
 fun <A> CoroutineScope.asyncK(ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend CoroutineScope.() -> A): DeferredK<A> =
-  this.async(ctx, start, f).k()
+  DeferredK.Generated(ctx, start, this) { f() }
 
-fun <A> DeferredKOf<A>.value(): Deferred<A> = this.fix()
+fun <A> DeferredKOf<A>.value(): Deferred<A> = this.fix().memoized
 
 fun <A> DeferredKOf<A>.scope(): CoroutineScope = this.fix().scope
 
 @higherkind
 @ExperimentalCoroutinesApi
-data class DeferredK<out A>(private val deferred: Deferred<A>, val scope: CoroutineScope = GlobalScope) : DeferredKOf<A>, Deferred<A> by deferred {
+sealed class DeferredK<A>(
+  val scope: CoroutineScope = GlobalScope,
+  val memoized: Deferred<A>
+) : DeferredKOf<A>, Deferred<A> by memoized {
+
+  /**
+   * Pure wrapper for already constructed deferred instances, does nothing special really
+   */
+  class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
+
+  /**
+   * Represents a DeferredK that can generate an instance of deferred on every await
+   *
+   * It does not memoize results and thus can be rerun just as expected from a MonadDefer
+   * However one can still break this system by ie returning or using a deferred in one of the functions
+   *  only when creating all deferred instances inside DeferredK or using DeferredK's methods
+   *  one can guarantee not having memoization
+   */
+  class Generated<A>(
+    val ctx: CoroutineContext = Dispatchers.Default,
+    val coroutineStart: CoroutineStart = CoroutineStart.LAZY,
+    scope: CoroutineScope = GlobalScope,
+    val generator: suspend () -> A
+  ) : DeferredK<A>(scope, scope.async(ctx, coroutineStart) { generator() }) {
+
+    override suspend fun await(): A =
+      if (memoized.isCompleted || memoized.isActive || memoized.isCancelled) {
+        scope.async(ctx, coroutineStart) { generator() }.await()
+      } else {
+        memoized.await()
+      }
+  }
 
   fun <B> map(f: (A) -> B): DeferredK<B> =
     flatMap { a: A -> just(f(a)) }
@@ -28,10 +59,18 @@ data class DeferredK<out A>(private val deferred: Deferred<A>, val scope: Corout
   fun <B> ap(fa: DeferredKOf<(A) -> B>): DeferredK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
-  fun <B> flatMap(f: (A) -> DeferredKOf<B>): DeferredK<B> =
-    scope.asyncK(Dispatchers.Unconfined, CoroutineStart.LAZY) {
-      f(await()).await()
+  fun <B> flatMap(f: (A) -> DeferredKOf<B>): DeferredK<B> = when (this) {
+    is Generated -> Generated(ctx, coroutineStart, scope) {
+      f(
+        scope.async(ctx, coroutineStart) { generator() }.await()
+      ).await()
     }
+    is Wrapped -> Generated(Dispatchers.Unconfined, CoroutineStart.LAZY, scope) {
+      f(
+        memoized.await()
+      ).await()
+    }
+  }
 
   fun <B> bracketCase(use: (A) -> DeferredK<B>, release: (A, ExitCase<Throwable>) -> DeferredK<Unit>): DeferredK<B> =
     flatMap { a ->
@@ -43,41 +82,43 @@ data class DeferredK<out A>(private val deferred: Deferred<A>, val scope: Corout
       }
     }
 
-  fun continueOn(ctx: CoroutineContext): DeferredK<A> =
-    scope.asyncK(ctx, CoroutineStart.LAZY) {
-      deferred.await()
+  fun continueOn(ctx: CoroutineContext): DeferredK<A> = when (this) {
+    is Generated -> Generated(ctx, coroutineStart, scope) {
+      scope.async(this@DeferredK.ctx, coroutineStart) {
+        generator()
+      }.await()
     }
+    is Wrapped -> scope.asyncK(ctx, CoroutineStart.LAZY) { memoized.await() }
+  }
 
   override fun equals(other: Any?): Boolean =
     when (other) {
-      is DeferredK<*> -> this.deferred == other.deferred
-      is Deferred<*> -> this.deferred == other
+      is DeferredK<*> -> this.memoized == other.memoized
+      is Deferred<*> -> this.memoized == other
       else -> false
     }
 
-  override fun hashCode(): Int = deferred.hashCode()
+  override fun hashCode(): Int = memoized.hashCode()
 
   companion object {
-    fun unit(): DeferredK<Unit> =
-      CompletableDeferred(Unit).k()
+    fun unit(): DeferredK<Unit> = just(Unit)
 
-    fun <A> just(a: A): DeferredK<A> =
-      CompletableDeferred(a).k()
+    fun <A> just(a: A): DeferredK<A> = CompletableDeferred(a).k()
 
     fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
-      scope.asyncK(ctx, start) { f() }
+      Generated(ctx, start, scope, f)
 
     fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: () -> DeferredKOf<A>): DeferredK<A> =
-      scope.asyncK(ctx, start) { fa().await() }
+      Generated(ctx, start, scope) { fa().await() }
 
-    operator fun <A> invoke(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: () -> A): DeferredK<A> =
-      scope.asyncK(ctx, start) { f() }
-
-    fun <A> failed(t: Throwable): DeferredK<A> =
-      CompletableDeferred<A>().apply { completeExceptionally(t) }.k()
+    operator fun <A> invoke(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
+      Generated(ctx, start, scope, f)
 
     fun <A> raiseError(t: Throwable): DeferredK<A> =
       failed(t)
+
+    fun <A> failed(t: Throwable): DeferredK<A> =
+      CompletableDeferred<A>().apply { completeExceptionally(t) }.k()
 
     /**
      * Starts a coroutine that'll run [Proc].
@@ -87,7 +128,7 @@ data class DeferredK<out A>(private val deferred: Deferred<A>, val scope: Corout
      * and its [CoroutineStart] is [CoroutineStart.DEFAULT].
      */
     fun <A> async(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: Proc<A>): DeferredK<A> =
-      scope.asyncK(ctx, start) {
+      Generated(ctx, start, scope) {
         CompletableDeferred<A>().apply {
           fa {
             it.fold(this::completeExceptionally, this::complete)
@@ -98,7 +139,7 @@ data class DeferredK<out A>(private val deferred: Deferred<A>, val scope: Corout
     fun <A, B> tailRecM(a: A, f: (A) -> DeferredKOf<Either<A, B>>): DeferredK<B> =
       f(a).value().let { initial: Deferred<Either<A, B>> ->
         var current: Deferred<Either<A, B>> = initial
-        GlobalScope.async(Dispatchers.Unconfined, CoroutineStart.LAZY) {
+        Generated(Dispatchers.Unconfined, CoroutineStart.LAZY, GlobalScope) {
           val result: B
           while (true) {
             val actual: Either<A, B> = current.await()
@@ -110,13 +151,13 @@ data class DeferredK<out A>(private val deferred: Deferred<A>, val scope: Corout
             }
           }
           result
-        }.k()
+        }
       }
   }
 }
 
 fun <A> DeferredKOf<A>.handleErrorWith(f: (Throwable) -> DeferredK<A>): DeferredK<A> =
-  scope().asyncK(Dispatchers.Unconfined, CoroutineStart.LAZY) {
+  DeferredK.Generated(Dispatchers.Unconfined, CoroutineStart.LAZY) {
     Try { await() }.fold({ f(it).await() }, ::identity)
   }
 
@@ -127,13 +168,13 @@ fun <A> DeferredKOf<A>.unsafeRunSync(): A =
   runBlocking { await() }
 
 fun <A> DeferredKOf<A>.runAsync(cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
-  DeferredK.invoke(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  DeferredK.invoke(fix().scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     fix().forceExceptionPropagation()
     unsafeRunAsync(cb.andThen { it.unsafeRunAsync { } })
   }
 
 fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent, cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Disposable> =
-  DeferredK.invoke(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  DeferredK.invoke(fix().scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     fix().forceExceptionPropagation()
     val call = CompletableDeferred<Unit>(parent = runAsync(cb))
     val disposable: Disposable = {
@@ -146,7 +187,7 @@ fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent,
   }
 
 fun <A> DeferredKOf<A>.unsafeRunAsync(cb: (Either<Throwable, A>) -> Unit): Unit =
-  scope().async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  fix().scope().async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     Try { await() }.fold({ cb(Left(it)) }, { cb(Right(it)) })
   }.forceExceptionPropagation()
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -12,6 +12,7 @@ import kotlin.coroutines.CoroutineContext
  * Wraps a [Deferred] with [DeferredK]
  *
  * Note: Using this extension means that the resulting [DeferredK] will use a memoized version of [Deferred].
+ *  For more Information visit the general [DeferredK] documentation.
  *
  * {: data-executable='true'}
  *
@@ -42,6 +43,7 @@ fun <A> Deferred<A>.k(): DeferredK<A> =
  * Note: Using this extension means that the resulting [DeferredK] will rerun f on every await, hence
  *  awaiting a new coroutine every time. This means it won't be memoized and as such can be used for repeated/retried actions and
  *  it will properly re-execute side-effects.
+ *  For more Information visit the general [DeferredK] documentation.
  *
  * {: data-executable='true'}
  *
@@ -71,25 +73,66 @@ fun <A> CoroutineScope.asyncK(ctx: CoroutineContext = Dispatchers.Default, start
  * Note: `aDeferredK.value().await()` does not necessarily equal `aDeferredK.await()`. That is because [DeferredK] will attempt to rerun
  *  all computation and if the code executed is not pure it may change on every await. This is important because otherwise impure code would not
  *  rerun, and its side effects never happen. This only applies to [DeferredK]'s created without `Deferred.k()`
+ *  To be extra safe, one should always use the wrapper directly.
+ *  For more Information visit the general [DeferredK] documentation.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.value
+ * import kotlinx.coroutines.Deferred
+ * import kotlinx.coroutines.runBlocking
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: Deferred<String> = DeferredK {
+ *     // some computation ...
+ *     "Done"
+ *   }.value()
+ *   //sampleEnd
+ *   runBlocking {
+ *     println(result.await())
+ *   }
+ * }
+ * ```
  */
 fun <A> DeferredKOf<A>.value(): Deferred<A> = this.fix().memoized
 
 /**
  * Returns the [CoroutineScope] the [DeferredK] operates on
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.scope
+ * import kotlinx.coroutines.CoroutineScope
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val scope: CoroutineScope = DeferredK.just(1).scope()
+ *   println(scope)
+ *   //sampleEnd
+ * }
+ * ```
  */
-fun <A> DeferredKOf<A>.scope(): CoroutineScope = this.fix().scope
+fun <A> DeferredKOf<A>.scope(): CoroutineScope = this.fix()._scope
 
+/**
+ * A wrapper class for [Deferred] that either memoizes its result or re-runs the computation each time, based on how it is constructed.
+ */
 @higherkind
 @ExperimentalCoroutinesApi
 sealed class DeferredK<A>(
-  val scope: CoroutineScope = GlobalScope,
-  val memoized: Deferred<A>
+  internal val _scope: CoroutineScope = GlobalScope,
+  internal val memoized: Deferred<A>
 ) : DeferredKOf<A>, Deferred<A> by memoized {
 
   /**
    * Pure wrapper for already constructed [Deferred] instances. Created solely by `Deferred.k()` extension method
    */
-  internal class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
+  internal class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(_scope = scope, memoized = memoized)
 
   /**
    * Represents a [DeferredK] that can generate an instance of [Deferred] on every await
@@ -111,31 +154,145 @@ sealed class DeferredK<A>(
      */
     override suspend fun await(): A =
       if (memoized.isCompleted || memoized.isActive || memoized.isCancelled) {
-        scope.async(ctx, coroutineStart) { generator() }.await()
+        _scope.async(ctx, coroutineStart) { generator() }.await()
       } else {
         memoized.await()
       }
   }
 
+  /**
+   * Map over the result of the [DeferredK]
+   *
+   * Note: This function will always rerun when await is called. For more Information visit the general [DeferredK] documentation.
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.effects.DeferredK
+   * import arrow.effects.unsafeRunSync
+   *
+   * fun main(args: Array<String>) {
+   *    //sampleStart
+   *   val result: DeferredK<String> = DeferredK.just(1).map {
+   *     it.toString()
+   *   }
+   *   //sampleEnd
+   *   println(result.unsafeRunSync())
+   * }
+   * ```
+   */
   fun <B> map(f: (A) -> B): DeferredK<B> =
     flatMap { a: A -> just(f(a)) }
 
+  /**
+   * Apply a function inside a [DeferredK] to the result of this [DeferredK]
+   *
+   * Note: This function inside will always be rerun when await is called, but the [DeferredK] the function comes from
+   *  might not be depending on how it was created.
+   *  For more Information visit the general [DeferredK] documentation.
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.effects.DeferredK
+   * import arrow.effects.unsafeRunSync
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val other: DeferredK<(Int) -> String> = DeferredK {
+   *     { i: Int -> "The number is $i" }
+   *   }
+   *
+   *   val result: DeferredK<String> = DeferredK.just(1).ap(other)
+   *   //sampleEnd
+   *   println(result.unsafeRunSync())
+   * }
+   * ```
+   */
   fun <B> ap(fa: DeferredKOf<(A) -> B>): DeferredK<B> =
     flatMap { a -> fa.fix().map { ff -> ff(a) } }
 
+  /**
+   * Maps over the value of the [DeferredK] and flattens the returned [DeferredK]
+   *
+   * Note: This function will always rerun when await is called. However the [DeferredK] returned from it might not, depending on how it was created.
+   *  For more Information visit the general [DeferredK] documentation.
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.effects.DeferredK
+   * import arrow.effects.unsafeRunSync
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val result: DeferredK<Int> = DeferredK.just(1).flatMap {
+   *     DeferredK {
+   *       // some time consuming task
+   *       it * 31
+   *     }
+   *   }
+   *   //sampleEnd
+   *   println(result.unsafeRunSync())
+   * }
+   * ```
+   */
   fun <B> flatMap(f: (A) -> DeferredKOf<B>): DeferredK<B> = when (this) {
-    is Generated -> Generated(ctx, coroutineStart, scope) {
+    is Generated -> Generated(ctx, coroutineStart, _scope) {
       f(
-        scope.async(ctx, coroutineStart) { generator() }.await()
+        _scope.async(ctx, coroutineStart) { generator() }.await()
       ).await()
     }
-    is Wrapped -> Generated(Dispatchers.Unconfined, CoroutineStart.LAZY, scope) {
+    is Wrapped -> Generated(Dispatchers.Unconfined, CoroutineStart.LAZY, _scope) {
       f(
         memoized.await()
       ).await()
     }
   }
 
+  /**
+   * Try-catch-finally in a function way
+   *
+   * Note: This function will always re-run when await is called. But the [DeferredK] returned by use or release may not be depending on how they were created.
+   *  For more Information visit the general [DeferredK] documentation.
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.effects.DeferredK
+   * import arrow.effects.deferredk.bracket.bracket
+   * import arrow.Kind
+   * import arrow.effects.typeclasses.Bracket
+   * import arrow.effects.unsafeRunSync
+   *
+   * class File(url: String) {
+   *   fun open(): File = this
+   *   fun close(): Unit {}
+   *   override fun toString(): String = "This file contains some interesting content!"
+   * }
+   *
+   * class Program<F>(BF: Bracket<F, Throwable>) : Bracket<F, Throwable> by BF {
+   *
+   *   fun openFile(uri: String): Kind<F, File> = just(File(uri).open())
+   *
+   *   fun closeFile(file: File): Kind<F, Unit> = just(file.close())
+   *
+   *   fun fileToString(file: File): Kind<F, String> = just(file.toString())
+   * }
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val deferredProgram = Program(DeferredK.bracket())
+   *
+   *   val safeComputation = with (deferredProgram) {
+   *   openFile("data.json").bracket(
+   *     release = { file -> closeFile(file) },
+   *     use = { file -> fileToString(file) })
+   *   }
+   *   //sampleEnd
+   *   println(safeComputation.unsafeRunSync())
+   * }
+   */
   fun <B> bracketCase(use: (A) -> DeferredK<B>, release: (A, ExitCase<Throwable>) -> DeferredK<Unit>): DeferredK<B> =
     flatMap { a ->
       try {
@@ -146,13 +303,33 @@ sealed class DeferredK<A>(
       }
     }
 
+  /**
+   * Continue the next computation on a different [CoroutineContext].
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.effects.DeferredK
+   * import arrow.effects.unsafeRunSync
+   * import kotlinx.coroutines.Dispatchers
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val result = DeferredK.just(1)
+   *     .continueOn(Dispatchers.IO)
+   *     .map { println("This is now on IO") }
+   *   //sampleEnd
+   *   println(result.unsafeRunSync())
+   * }
+   * ```
+   */
   fun continueOn(ctx: CoroutineContext): DeferredK<A> = when (this) {
-    is Generated -> Generated(ctx, coroutineStart, scope) {
-      scope.async(this@DeferredK.ctx, coroutineStart) {
+    is Generated -> Generated(ctx, coroutineStart, _scope) {
+      _scope.async(this@DeferredK.ctx, coroutineStart) {
         generator()
       }.await()
     }
-    is Wrapped -> scope.asyncK(ctx, CoroutineStart.LAZY) { memoized.await() }
+    is Wrapped -> _scope.asyncK(ctx, CoroutineStart.LAZY) { memoized.await() }
   }
 
   override fun equals(other: Any?): Boolean =
@@ -167,7 +344,7 @@ sealed class DeferredK<A>(
   companion object {
 
     /**
-     * [DeferredK] that just contains [Unit]
+     * Creates a [DeferredK] that just contains [Unit]
      *
      * Useful for comprehensions to avoid executing code at the beginning of a binding.
      *
@@ -198,14 +375,31 @@ sealed class DeferredK<A>(
      */
     fun unit(): DeferredK<Unit> = just(Unit)
 
+    /**
+     * Lifts a value a into a [DeferredK] of A
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.effects.DeferredK
+     * import arrow.effects.unsafeRunSync
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = DeferredK.just(1)
+     *   //sampleEnd
+     *   println(result.unsafeRunSync())
+     * }
+     * ```
+     */
     fun <A> just(a: A): DeferredK<A> = CompletableDeferred(a).k()
 
     /**
-     * Wraps a function that returns a [DeferredK] in a [DeferredK] together with a specific [CoroutineScope], a [CoroutineContext] and a
-     *  [CoroutineStart]. All those parameters (except f) have defaults.
+     * Wraps a function that returns a [DeferredK] in a [DeferredK].
      *
      * Note: Using this method means the resulting [DeferredK] will rerun fa on await, not memoizing its result.
      *  As long as the result of fa is also re-runnable, this [DeferredK] this [DeferredK] will correctly re-run.
+     *  For more Information visit the general [DeferredK] documentation.
      *
      * {: data-executable='true'}
      *
@@ -228,11 +422,11 @@ sealed class DeferredK<A>(
       Generated(ctx, start, scope) { fa().await() }
 
     /**
-     * Wraps a suspend function in a [DeferredK] together with a specific [CoroutineScope], a [CoroutineContext] and a
-     *  [CoroutineStart]. All those parameters (except f) have defaults.
+     * Wraps a suspend function in a [DeferredK]
      *
      * Note: Using this method means the resulting [DeferredK] will rerun f on await. Making this [DeferredK] re-runnable as long as f itself does not use a non re-runnable
      *  [Deferred] or [DeferredK].
+     *  For more Information visit the general [DeferredK] documentation.
      *
      * {: data-executable='true'}
      *
@@ -254,6 +448,50 @@ sealed class DeferredK<A>(
     operator fun <A> invoke(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
       Generated(ctx, start, scope, f)
 
+    /**
+     * Wraps an existing [Deferred] in [DeferredK]
+     *
+     * Note: Using this method the resulting [DeferredK] will always return a memoized version on await. Side-effects will not be re-run.
+     *  For more Information visit the general [DeferredK] documentation.
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.effects.DeferredK
+     * import arrow.effects.unsafeRunSync
+     * import kotlinx.coroutines.GlobalScope
+     * import kotlinx.coroutines.async
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = DeferredK(
+     *     GlobalScope.async { 42 }
+     *   )
+     *   //sampleEnd
+     *   println(result.unsafeRunSync())
+     * }
+     * ```
+     */
+    operator fun <A> invoke(fa: Deferred<A>, scope: CoroutineScope = GlobalScope): DeferredK<A> =
+      Wrapped(scope, fa)
+
+    /**
+     * Creates a failed [DeferredK] with the throwable
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.effects.DeferredK
+     * import arrow.effects.unsafeAttemptSync
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result: DeferredK<String> = DeferredK.raiseError<String>(Exception("BOOM"))
+     *   //sampleEnd
+     *   println(result.unsafeAttemptSync())
+     * }
+     * ```
+     */
     fun <A> raiseError(t: Throwable): DeferredK<A> =
       CompletableDeferred<A>().apply { completeExceptionally(t) }.k()
 
@@ -263,6 +501,26 @@ sealed class DeferredK<A>(
      * Matching the behavior of [async],
      * its [CoroutineContext] is set to [DefaultDispatcher]
      * and its [CoroutineStart] is [CoroutineStart.LAZY].
+     *
+     * {: data-executable='true'}
+     *
+     * ```kotlin:ank
+     * import arrow.core.Either
+     * import arrow.core.left
+     * import arrow.effects.DeferredK
+     * import arrow.effects.unsafeAttemptSync
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = DeferredK.async { cb: (Either<Throwable, Int>) -> Unit ->
+     *     cb(
+     *       Exception("BOOM").left()
+     *     )
+     *   }
+     *   //sampleEnd
+     *   println(result.unsafeAttemptSync())
+     * }
+     * ```
      */
     fun <A> async(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: Proc<A>): DeferredK<A> =
       Generated(ctx, start, scope) {
@@ -293,25 +551,138 @@ sealed class DeferredK<A>(
   }
 }
 
+/**
+ * Handle errors from [MonadThrow]
+ *
+ * Note: This function will be rerun when awaited multiple times, but the [DeferredK] returned by f might not be depending on how it was created.
+ *  For more Information visit the general [DeferredK] documentation.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.unsafeAttemptSync
+ * import arrow.effects.handleErrorWith
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: DeferredK<String> = DeferredK.raiseError<String>(Exception("BOOM"))
+ *     .handleErrorWith { t: Throwable ->
+ *       DeferredK.just(t.toString())
+ *     }
+ *   //sampleEnd
+ *   println(result.unsafeAttemptSync())
+ * }
+ * ```
+ */
 fun <A> DeferredKOf<A>.handleErrorWith(f: (Throwable) -> DeferredK<A>): DeferredK<A> =
   DeferredK.Generated(Dispatchers.Unconfined, CoroutineStart.LAZY) {
     Try { await() }.fold({ f(it).await() }, ::identity)
   }
 
+/**
+ * Wrap [unsafeRunSync] in [Try] to catch any thrown errors
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.unsafeAttemptSync
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: DeferredK<String> = DeferredK.raiseError<String>(Exception("BOOM"))
+ *   //sampleEnd
+ *   println(result.unsafeAttemptSync())
+ * }
+ * ```
+ */
 fun <A> DeferredKOf<A>.unsafeAttemptSync(): Try<A> =
   Try { unsafeRunSync() }
 
+/**
+ * Runs this [DeferredK] with [runBlocking]. Does not handle errors at all, rethrowing them if they happen.
+ * Use [unsafeAttemptSync] if they should be caught automatically.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.effects.DeferredK
+ * import arrow.effects.unsafeRunSync
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: DeferredK<String> = DeferredK.raiseError<String>(Exception("BOOM"))
+ *   //sampleEnd
+ *   println(result.unsafeRunSync())
+ * }
+ * ```
+ */
 fun <A> DeferredKOf<A>.unsafeRunSync(): A =
   runBlocking { await() }
 
+/**
+ * Runs the [DeferredK] asynchronously and continues with the [DeferredK] returned by cb.
+ *
+ * Note: This and/or the [DeferredK] will only rerun properly on multiple await calls if both are created properly.
+ *  For more Information visit the general [DeferredK] documentation.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.core.Either
+ * import arrow.effects.DeferredK
+ * import arrow.effects.unsafeRunSync
+ * import arrow.effects.runAsync
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   DeferredK.just(1).runAsync { either: Either<Throwable, Int> ->
+ *     either.fold({ t: Throwable ->
+ *       DeferredK.raiseError<Unit>(t)
+ *     }, { i: Int ->
+ *       DeferredK { println("DONE WITH $i") }
+ *     })
+ *   }
+ *   //sampleEnd
+ * }
+ * ```
+ */
 fun <A> DeferredKOf<A>.runAsync(cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Unit> =
-  DeferredK.invoke(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  DeferredK(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     fix().forceExceptionPropagation()
     unsafeRunAsync(cb.andThen { it.unsafeRunAsync { } })
   }
 
+/**
+ * Runs the [DeferredK] asynchronously and continues with the [DeferredK] returned by cb.
+ * Also provides means to cancel the execution.
+ *
+ * Note: This and/or the [DeferredK] will only rerun properly on multiple await calls if both are created properly.
+ *  For more Information visit the general [DeferredK] documentation.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.core.Either
+ * import arrow.effects.DeferredK
+ * import arrow.effects.unsafeAttemptSync
+ * import arrow.effects.typeclasses.Disposable
+ * import arrow.effects.runAsyncCancellable
+ * import kotlinx.coroutines.delay
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result = DeferredK.just(1).runAsyncCancellable { either: Either<Throwable, Int> ->
+ *     DeferredK { delay(100) }.map { println("DONE") }
+ *   }.map { dispose: Disposable -> dispose() }
+ *   //sampleEnd
+ *   println(result.unsafeAttemptSync())
+ * }
+ * ```
+ */
 fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent, cb: (Either<Throwable, A>) -> DeferredKOf<Unit>): DeferredK<Disposable> =
-  DeferredK.invoke(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
+  DeferredK(scope(), Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     fix().forceExceptionPropagation()
     val call = CompletableDeferred<Unit>(parent = runAsync(cb))
     val disposable: Disposable = {
@@ -323,6 +694,34 @@ fun <A> DeferredKOf<A>.runAsyncCancellable(onCancel: OnCancel = OnCancel.Silent,
     disposable
   }
 
+/**
+ * Runs the [DeferredK] asynchronously and then runs the cb.
+ * Catches all errors that may be thrown in await. Errors from cb will still throw as expected.
+ *
+ * Note: This [DeferredK] will only rerun properly on multiple await calls if created supporting that.
+ *  For more Information visit the general [DeferredK] documentation.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.core.Either
+ * import arrow.effects.DeferredK
+ * import arrow.effects.unsafeRunAsync
+ * import kotlinx.coroutines.delay
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   DeferredK.just(1).unsafeRunAsync { either: Either<Throwable, Int> ->
+ *     either.fold({ t: Throwable ->
+ *       println(t)
+ *     }, { i: Int ->
+ *       println("DONE WITH $i")
+ *     })
+ *   }
+ *   //sampleEnd
+ * }
+ * ```
+ */
 fun <A> DeferredKOf<A>.unsafeRunAsync(cb: (Either<Throwable, A>) -> Unit): Unit =
   scope().async(Dispatchers.Unconfined, CoroutineStart.DEFAULT) {
     Try { await() }.fold({ cb(Left(it)) }, { cb(Right(it)) })

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -105,9 +105,6 @@ sealed class DeferredK<A>(
 
     fun <A> just(a: A): DeferredK<A> = CompletableDeferred(a).k()
 
-    fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, f: suspend () -> A): DeferredK<A> =
-      Generated(ctx, start, scope, f)
-
     fun <A> defer(scope: CoroutineScope = GlobalScope, ctx: CoroutineContext = Dispatchers.Default, start: CoroutineStart = CoroutineStart.LAZY, fa: () -> DeferredKOf<A>): DeferredK<A> =
       Generated(ctx, start, scope) { fa().await() }
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -82,14 +82,14 @@ fun <A> DeferredKOf<A>.scope(): CoroutineScope = this.fix().scope
 @higherkind
 @ExperimentalCoroutinesApi
 sealed class DeferredK<A>(
-  val scope: CoroutineScope = GlobalScope,
-  val memoized: Deferred<A>
+  open val scope: CoroutineScope = GlobalScope,
+  open val memoized: Deferred<A>
 ) : DeferredKOf<A>, Deferred<A> by memoized {
 
   /**
    * Pure wrapper for already constructed [Deferred] instances. Created solely by `Deferred.k()` extension method
    */
-  internal class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
+  internal data class Wrapped<A>(override val scope: CoroutineScope = GlobalScope, override val memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
 
   /**
    * Represents a [DeferredK] that can generate an instance of [Deferred] on every await
@@ -99,10 +99,10 @@ sealed class DeferredK<A>(
    *  only when creating all deferred instances inside DeferredK or using DeferredK's methods
    *  one can guarantee not having memoization
    */
-  internal class Generated<A>(
+  internal data class Generated<A>(
     val ctx: CoroutineContext = Dispatchers.Default,
     val coroutineStart: CoroutineStart = CoroutineStart.LAZY,
-    scope: CoroutineScope = GlobalScope,
+    override val scope: CoroutineScope = GlobalScope,
     val generator: suspend () -> A
   ) : DeferredK<A>(scope, scope.async(ctx, coroutineStart) { generator() }) {
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -82,14 +82,14 @@ fun <A> DeferredKOf<A>.scope(): CoroutineScope = this.fix().scope
 @higherkind
 @ExperimentalCoroutinesApi
 sealed class DeferredK<A>(
-  open val scope: CoroutineScope = GlobalScope,
-  open val memoized: Deferred<A>
+  val scope: CoroutineScope = GlobalScope,
+  val memoized: Deferred<A>
 ) : DeferredKOf<A>, Deferred<A> by memoized {
 
   /**
    * Pure wrapper for already constructed [Deferred] instances. Created solely by `Deferred.k()` extension method
    */
-  internal data class Wrapped<A>(override val scope: CoroutineScope = GlobalScope, override val memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
+  internal class Wrapped<A>(scope: CoroutineScope = GlobalScope, memoized: Deferred<A>) : DeferredK<A>(scope = scope, memoized = memoized)
 
   /**
    * Represents a [DeferredK] that can generate an instance of [Deferred] on every await
@@ -99,10 +99,10 @@ sealed class DeferredK<A>(
    *  only when creating all deferred instances inside DeferredK or using DeferredK's methods
    *  one can guarantee not having memoization
    */
-  internal data class Generated<A>(
+  internal class Generated<A>(
     val ctx: CoroutineContext = Dispatchers.Default,
     val coroutineStart: CoroutineStart = CoroutineStart.LAZY,
-    override val scope: CoroutineScope = GlobalScope,
+    scope: CoroutineScope = GlobalScope,
     val generator: suspend () -> A
   ) : DeferredK<A>(scope, scope.async(ctx, coroutineStart) { generator() }) {
 

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -112,9 +112,6 @@ sealed class DeferredK<A>(
       Generated(ctx, start, scope, f)
 
     fun <A> raiseError(t: Throwable): DeferredK<A> =
-      failed(t)
-
-    fun <A> failed(t: Throwable): DeferredK<A> =
       CompletableDeferred<A>().apply { completeExceptionally(t) }.k()
 
     /**


### PR DESCRIPTION
Solves #1156 and maybe #1131 
Re-enable no-memoization law and fix deferredK to follow it (if used correctly)
Changes practically nothing from the public api.

I'll add some info to the docs later because if used wrong it might produce unexpected results.
Should the methods in DeferredK (well the public ones) have api docs (runnable ones) as well?

@pakoito I have skipped the invoke constructor for Wrapped because its syntax conflicts with the other one too much (the compiler was only able to infer which one to choose after passing more and more arguments which defeats the point of default argumens there), one should just use the other one or `.k()` instead. (And going from `() -> Deferred<A>` to `suspend () -> A` is trivial)