### PR TITLE
Fix Travis timeouts because no output was received

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
  global:
  # include $HOME/.local/bin for `aws`
  - PATH=$HOME/.local/bin:$PATH
+ - JAVA_OPTS="-Xms512m -Xmx1024m"
 
 before_install:
 - pip install --user awscli

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,6 @@ jobs:
    script:
    - aws s3 sync s3://$S3_BUCKET/site ~/site > aws_sync_jekyll.log
    - rvm use 2.5.3 --install --fuzzy
-   - bundle install --gemfile modules/docs/arrow-docs/Gemfile --path vendor/bundle   
-   - bundle exec jekyll build -s ~/site -d ~/_site
+   - bundle install --gemfile modules/docs/arrow-docs/Gemfile --path vendor/bundle
+   - travis_wait BUNDLE_GEMFILE=modules/docs/arrow-docs/Gemfile bundle exec jekyll build -s ~/site -d ~/_site
    - aws s3 sync ~/_site s3://$S3_BUCKET > aws_sync_site.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ jobs:
    script:
    # redirecting outputs to files to avoid exceeding travis' logs limit
    - ./gradlew clean build > build.log
-   - ./gradlew dokka :arrow-docs:runAnk > run_ank.log
+   - travis_wait 30 ./gradlew dokka :arrow-docs:runAnk > run_ank.log
  - stage: build-and-dokka-transfer
    script:
    - ./gradlew clean build > build.log
-   - ./gradlew dokka :arrow-docs:runAnk > run_ank.log
+   - travis_wait 30 ./gradlew dokka :arrow-docs:runAnk > run_ank.log
    - aws s3 sync modules/docs/arrow-docs/build/site s3://$S3_BUCKET/site > aws_sync_dokka.log
  - stage: coverage-report
    script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ jobs:
    script:
    # redirecting outputs to files to avoid exceeding travis' logs limit
    - ./gradlew clean build > build.log
-   - travis_wait 30 ./gradlew dokka :arrow-docs:runAnk > run_ank.log
+   - ./gradlew dokka :arrow-docs:runAnk > run_ank.log
  - stage: build-and-dokka-transfer
    script:
    - ./gradlew clean build > build.log
-   - travis_wait 30 ./gradlew dokka :arrow-docs:runAnk > run_ank.log
+   - ./gradlew dokka :arrow-docs:runAnk > run_ank.log
    - aws s3 sync modules/docs/arrow-docs/build/site s3://$S3_BUCKET/site > aws_sync_dokka.log
  - stage: coverage-report
    script:
@@ -50,5 +50,5 @@ jobs:
    - aws s3 sync s3://$S3_BUCKET/site ~/site > aws_sync_jekyll.log
    - rvm use 2.5.3 --install --fuzzy
    - bundle install --gemfile modules/docs/arrow-docs/Gemfile --path vendor/bundle
-   - travis_wait BUNDLE_GEMFILE=modules/docs/arrow-docs/Gemfile bundle exec jekyll build -s ~/site -d ~/_site
+   - travis_wait 10 BUNDLE_GEMFILE=modules/docs/arrow-docs/Gemfile bundle exec jekyll build -s ~/site -d ~/_site
    - aws s3 sync ~/_site s3://$S3_BUCKET > aws_sync_site.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ jobs:
  - stage: build-and-dokka
    script:
    # redirecting outputs to files to avoid exceeding travis' logs limit
-   - ./gradlew clean build > build.log
-   - ./gradlew dokka :arrow-docs:runAnk > run_ank.log
+   - ./gradlew clean build
+   - ./gradlew dokka :arrow-docs:runAnk
  - stage: build-and-dokka-transfer
    script:
-   - ./gradlew clean build > build.log
-   - ./gradlew dokka :arrow-docs:runAnk > run_ank.log
+   - ./gradlew clean build
+   - ./gradlew dokka :arrow-docs:runAnk
    - aws s3 sync modules/docs/arrow-docs/build/site s3://$S3_BUCKET/site > aws_sync_dokka.log
  - stage: coverage-report
    script:

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/Kleisli.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/Kleisli.kt
@@ -8,12 +8,12 @@ import arrow.higherkind
 import arrow.typeclasses.*
 
 /**
- * Alias that represents an arrow from [D] to a monadic value `Kind<F, A>`
+ * Alias that represents a function from [D] to a monadic value `Kind<F, A>`
  */
 typealias KleisliFun<F, D, A> = (D) -> Kind<F, A>
 
 /**
- * [Kleisli] represents an arrow from [D] to a monadic value `Kind<F, A>`.
+ * [Kleisli] represents a function parameter from [D] to a value `Kind<F, A>`.
  *
  * @param F the context of the result.
  * @param D the dependency or environment we depend on.


### PR DESCRIPTION
* Fix a problem that may occur when building and deploying docs where the Travis job would fail when no output is received after 10 minutes. `jekyll build` is north of 9 minutes on my machine so there's a potential risk of the Travis job eventually failing due to this.