### PR TITLE
[WIP] Divide typeclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ reports/
 .DS_Store
 
 target/
+_site/

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,3 @@ reports/
 .DS_Store
 
 target/
-_site/

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/ConstTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/ConstTest.kt
@@ -1,0 +1,23 @@
+package arrow.core
+
+import arrow.instances.const.divisible.divisible
+import arrow.instances.monoid
+import arrow.test.UnitSpec
+import arrow.test.laws.DivisibleLaws
+import arrow.typeclasses.Const
+import arrow.typeclasses.Eq
+import arrow.typeclasses.fix
+import io.kotlintest.KTestJUnitRunner
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class ConstTest : UnitSpec() {
+
+  init {
+    testLaws(
+      DivisibleLaws.laws(Const.divisible(Int.monoid()), { i -> Const(i) }, Eq { a, b ->
+        a.fix().value == b.fix().value
+      })
+    )
+  }
+}

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/Function1Test.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/Function1Test.kt
@@ -1,19 +1,13 @@
 package arrow.core
 
 import arrow.Kind
-import arrow.core.ForFunction1
-import arrow.core.Function1
-import arrow.core.Function1Of
-import arrow.core.invoke
 import arrow.instances.function1.category.category
-import arrow.instances.function1.contravariant.contravariant
+import arrow.instances.function1.divisible.divisible
 import arrow.instances.function1.monad.monad
 import arrow.instances.function1.profunctor.profunctor
+import arrow.instances.monoid
 import arrow.test.UnitSpec
-import arrow.test.laws.CategoryLaws
-import arrow.test.laws.ContravariantLaws
-import arrow.test.laws.MonadLaws
-import arrow.test.laws.ProfunctorLaws
+import arrow.test.laws.*
 import arrow.typeclasses.Conested
 import arrow.typeclasses.Eq
 import arrow.typeclasses.conest
@@ -33,7 +27,7 @@ class Function1Test : UnitSpec() {
 
   init {
     testLaws(
-      ContravariantLaws.laws(Function1.contravariant(), { Function1.just<Int, Int>(it).conest() }, ConestedEQ),
+      DivisibleLaws.laws(Function1.divisible(Int.monoid()), { Function1.just<Int, Int>(it).conest() }, ConestedEQ),
       ProfunctorLaws.laws(Function1.profunctor(), { Function1.just(it) }, EQ),
       MonadLaws.laws(Function1.monad(), EQ),
       CategoryLaws.laws(Function1.category(), { Function1.just(it) }, EQ)

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/EitherTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/EitherTTest.kt
@@ -1,32 +1,47 @@
 package arrow.data
 
+import arrow.Kind
 import arrow.core.*
-import arrow.instances.*
+import arrow.instances.applicative
+import arrow.instances.const.divisible.divisible
 import arrow.instances.either.monadError.monadError
+import arrow.instances.eithert.divisible.divisible
+import arrow.instances.function1.divisible.divisible
 import arrow.instances.id.monad.monad
 import arrow.instances.id.traverse.traverse
+import arrow.instances.monoid
 import arrow.instances.option.functor.functor
+import arrow.instances.semigroupK
+import arrow.instances.traverse
 import arrow.test.UnitSpec
+import arrow.test.laws.DivisibleLaws
 import arrow.test.laws.MonadErrorLaws
 import arrow.test.laws.SemigroupKLaws
 import arrow.test.laws.TraverseLaws
-import arrow.typeclasses.Eq
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)
 class EitherTTest : UnitSpec() {
-  init {
 
-      testLaws(
-        MonadErrorLaws.laws(Either.monadError(), Eq.any(), Eq.any()),
-        TraverseLaws.laws(EitherT.traverse<ForId, Int>(Id.traverse()), EitherT.applicative<ForId, Int>(Id.monad()), { EitherT(Id(Right(it))) }, Eq.any()),
-        SemigroupKLaws.laws<EitherTPartialOf<ForId, Int>>(
-          EitherT.semigroupK(Id.monad()),
-          EitherT.applicative(Id.monad()),
-          Eq.any())
-      )
+  init {
+    testLaws(
+      DivisibleLaws.laws(
+        EitherT.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
+        { i -> EitherT(Const(i)) },
+        Eq { a: Kind<EitherTPartialOf<ConstPartialOf<Int>, Int>, Int>, b ->
+          a.fix().value.fix().value == b.fix().value.fix().value
+        }
+      ),
+      MonadErrorLaws.laws(Either.monadError(), Eq.any(), Eq.any()),
+      TraverseLaws.laws(EitherT.traverse<ForId, Int>(Id.traverse()), EitherT.applicative<ForId, Int>(Id.monad()), { EitherT(Id(Right(it))) }, Eq.any()),
+      SemigroupKLaws.laws<EitherTPartialOf<ForId, Int>>(
+        EitherT.semigroupK(Id.monad()),
+        EitherT.applicative(Id.monad()),
+        Eq.any())
+    )
 
     "mapLeft should alter left instance only" {
       forAll { i: Int, j: Int ->
@@ -37,6 +52,5 @@ class EitherTTest : UnitSpec() {
           EitherT(Option.empty<Either<Int, Int>>()).mapLeft(Option.functor()) { it + 1 } == EitherT(Option.empty<Either<Int, Int>>())
       }
     }
-
   }
 }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/KleisliTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/KleisliTest.kt
@@ -8,17 +8,18 @@ import arrow.effects.instances.io.applicativeError.attempt
 import arrow.effects.instances.io.bracket.bracket
 import arrow.effects.instances.kleisli.bracket.bracket
 import arrow.instances.`try`.monadError.monadError
+import arrow.instances.const.divisible.divisible
 import arrow.instances.id.monad.monad
 import arrow.instances.kleisli.contravariant.contravariant
+import arrow.instances.kleisli.divisible.divisible
 import arrow.instances.kleisli.monadError.monadError
+import arrow.instances.monoid
 import arrow.test.UnitSpec
 import arrow.test.laws.BracketLaws
 import arrow.test.laws.ContravariantLaws
+import arrow.test.laws.DivisibleLaws
 import arrow.test.laws.MonadErrorLaws
-import arrow.typeclasses.Conested
-import arrow.typeclasses.Eq
-import arrow.typeclasses.conest
-import arrow.typeclasses.counnest
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldBe
 import org.junit.runner.RunWith
@@ -45,6 +46,13 @@ class KleisliTest : UnitSpec() {
   init {
 
     testLaws(
+      DivisibleLaws.laws(
+        Kleisli.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
+        { i -> Kleisli { Const(i) } },
+        Eq { a: Kind<KleisliPartialOf<ConstPartialOf<Int>, Int>, Int>, b ->
+          a.fix().run(1).fix().value == b.fix().run(1).fix().value
+        }
+      ),
       BracketLaws.laws(
         BF = Kleisli.bracket<ForIO, Int, Throwable>(IO.bracket()),
         EQ = IOEQ(),

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/OptionTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/OptionTTest.kt
@@ -4,10 +4,12 @@ import arrow.Kind
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
+import arrow.instances.const.divisible.divisible
+import arrow.instances.monoid
 import arrow.instances.nonemptylist.monad.monad
 import arrow.instances.option.monad.monad
-import arrow.instances.option.semigroup.semigroup
 import arrow.instances.optiont.applicative.applicative
+import arrow.instances.optiont.divisible.divisible
 import arrow.instances.optiont.monad.monad
 import arrow.instances.optiont.monoidK.monoidK
 import arrow.instances.optiont.semigroupK.semigroupK
@@ -16,8 +18,7 @@ import arrow.mtl.instances.optiont.functorFilter.functorFilter
 import arrow.mtl.instances.optiont.traverseFilter.traverseFilter
 import arrow.test.UnitSpec
 import arrow.test.laws.*
-import arrow.typeclasses.Eq
-import arrow.typeclasses.Monad
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
@@ -38,6 +39,13 @@ class OptionTTest : UnitSpec() {
   init {
 
     testLaws(
+      DivisibleLaws.laws(
+        OptionT.divisible(Const.divisible(Int.monoid())),
+        { i -> OptionT(Const(i)) },
+        Eq { a: Kind<OptionTPartialOf<ConstPartialOf<Int>>, Int>, b ->
+          a.fix().value.fix().value == b.fix().value.fix().value
+        }
+      ),
       MonadLaws.laws(OptionT.monad(Option.monad()), Eq.any()),
       SemigroupKLaws.laws(
         OptionT.semigroupK(Option.monad()),

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/SumTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/SumTest.kt
@@ -4,20 +4,24 @@ import arrow.Kind
 import arrow.core.ForId
 import arrow.core.Id
 import arrow.core.fix
+import arrow.instances.const.divisible.divisible
+import arrow.instances.const.eq.eq
 import arrow.instances.eq
 import arrow.instances.hash
 import arrow.instances.id.comonad.comonad
 import arrow.instances.id.eq.eq
 import arrow.instances.id.functor.functor
 import arrow.instances.id.hash.hash
+import arrow.instances.monoid
 import arrow.instances.sum.comonad.comonad
+import arrow.instances.sum.divisible.divisible
 import arrow.instances.sum.eq.eq
 import arrow.instances.sum.hash.hash
 import arrow.test.UnitSpec
 import arrow.test.laws.ComonadLaws
+import arrow.test.laws.DivisibleLaws
 import arrow.test.laws.HashLaws
-import arrow.typeclasses.Eq
-import arrow.typeclasses.Hash
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldBe
 import org.junit.runner.RunWith
@@ -36,6 +40,14 @@ class SumTest : UnitSpec() {
     val IDH = Hash<Kind<ForId, Int>> { Id.hash(Int.hash()).run { it.fix().hash() } }
 
     testLaws(
+      DivisibleLaws.laws(
+        Sum.divisible(Const.divisible(Int.monoid()), Const.divisible(Int.monoid())),
+        { i -> Sum(Const(i), Const(i)) },
+        Eq { a, b ->
+          a.fix().left.value() == b.fix().left.value() &&
+            a.fix().right.value() == b.fix().right.value()
+        }
+      ),
       ComonadLaws.laws(Sum.comonad(Id.comonad(), Id.comonad()), cf, EQ),
       HashLaws.laws(Sum.hash(IDH, IDH), Sum.eq(IDEQ, IDEQ), cf)
     )

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/WriterTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/WriterTTest.kt
@@ -1,15 +1,14 @@
 package arrow.data
 
 import arrow.Kind
-import arrow.core.ForOption
-import arrow.core.Option
-import arrow.core.Tuple2
-import arrow.core.fix
+import arrow.core.*
+import arrow.instances.const.divisible.divisible
 import arrow.instances.monoid
 import arrow.instances.listk.monad.monad
 import arrow.instances.listk.monoidK.monoidK
 import arrow.instances.option.monad.monad
 import arrow.instances.writert.applicative.applicative
+import arrow.instances.writert.divisible.divisible
 import arrow.instances.writert.monad.monad
 import arrow.instances.writert.monoidK.monoidK
 import arrow.mtl.instances.option.monadFilter.monadFilter
@@ -18,11 +17,8 @@ import arrow.mtl.instances.writert.monadWriter.monadWriter
 import arrow.test.UnitSpec
 import arrow.test.generators.genIntSmall
 import arrow.test.generators.genTuple
-import arrow.test.laws.MonadFilterLaws
-import arrow.test.laws.MonadLaws
-import arrow.test.laws.MonadWriterLaws
-import arrow.test.laws.MonoidKLaws
-import arrow.typeclasses.Eq
+import arrow.test.laws.*
+import arrow.typeclasses.*
 import io.kotlintest.KTestJUnitRunner
 import org.junit.runner.RunWith
 
@@ -31,6 +27,13 @@ class WriterTTest : UnitSpec() {
   init {
 
     testLaws(
+      DivisibleLaws.laws(
+        WriterT.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
+        { i -> WriterT(Const(i)) },
+        Eq { a, b ->
+          a.value().value() == b.value().value()
+        }
+      ),
       MonadLaws.laws(WriterT.monad(Option.monad(), Int.monoid()), Eq.any()),
       MonoidKLaws.laws(
         WriterT.monoidK<ForListK, Int>(ListK.monoidK()),

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
@@ -1,7 +1,6 @@
 package arrow.instances
 
 import arrow.Kind
-import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Tuple2
 import arrow.deprecation.ExtensionsDSLDeprecated

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
@@ -1,7 +1,9 @@
 package arrow.instances
 
 import arrow.Kind
+import arrow.core.Either
 import arrow.core.Eval
+import arrow.core.Tuple2
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
 import arrow.typeclasses.*
@@ -18,6 +20,24 @@ interface ConstInvariant<A> : Invariant<ConstPartialOf<A>> {
 interface ConstContravariant<A> : Contravariant<ConstPartialOf<A>> {
   override fun <T, U> Kind<ConstPartialOf<A>, T>.contramap(f: (U) -> T): Const<A, U> =
     fix().retag()
+}
+
+@extension
+interface ConstDivideInstance<O> : Divide<ConstPartialOf<O>>, ConstContravariant<O> {
+  fun MO(): Monoid<O>
+  override fun <A, B, Z> divide(fa: Kind<ConstPartialOf<O>, A>, fb: Kind<ConstPartialOf<O>, B>, f: (Z) -> Tuple2<A, B>): Kind<ConstPartialOf<O>, Z> =
+    Const(
+      MO().run { fa.fix().value + fb.fix().value }
+    )
+}
+
+@extension
+interface ConstDivisibleInstance<O> : Divisible<ConstPartialOf<O>>, ConstDivideInstance<O> {
+  fun MOO(): Monoid<O>
+  override fun MO(): Monoid<O> = MOO()
+
+  override fun <A> conquer(): Kind<ConstPartialOf<O>, A> =
+    Const(MOO().empty())
 }
 
 @extension

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
@@ -1,10 +1,11 @@
 package arrow.instances
 
 import arrow.Kind
-import arrow.core.Either
-import arrow.core.Tuple2
-import arrow.core.toT
+import arrow.core.*
 import arrow.data.WriterT
+import arrow.data.WriterTOf
+import arrow.data.WriterTPartialOf
+import arrow.data.fix
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
 import arrow.typeclasses.*

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
@@ -1,11 +1,10 @@
 package arrow.instances
 
 import arrow.Kind
-import arrow.core.*
+import arrow.core.Either
+import arrow.core.Tuple2
+import arrow.core.toT
 import arrow.data.WriterT
-import arrow.data.WriterTOf
-import arrow.data.WriterTPartialOf
-import arrow.data.fix
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
 import arrow.typeclasses.*
@@ -53,7 +52,7 @@ interface WriterTDecidableInstance<F, W> : Decidable<WriterTPartialOf<F, W>>, Wr
 
   override fun <A, B, Z> choose(fa: Kind<WriterTPartialOf<F, W>, A>, fb: Kind<WriterTPartialOf<F, W>, B>, f: (Z) -> Either<A, B>): Kind<WriterTPartialOf<F, W>, Z> =
     WriterT(
-      CF().choose(fa.fix().value, fb.fix().value) {  (w, z) ->
+      CF().choose(fa.fix().value, fb.fix().value) { (w, z) ->
         f(z).fold({ a ->
           (w toT a).left()
         }, { b ->

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/DivideLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/DivideLaws.kt
@@ -1,0 +1,41 @@
+package arrow.test.laws
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.core.toT
+import arrow.test.generators.genConstructor
+import arrow.typeclasses.Divide
+import arrow.typeclasses.Eq
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+
+object DivideLaws {
+
+  fun <F> laws(
+    DF: Divide<F>,
+    cf: (Int) ->Kind<F, Int>,
+    EQ: Eq<Kind<F, Int>>
+  ): List<Law> = ContravariantLaws.laws(DF, cf, EQ) + listOf(
+    Law("Divide laws: Associative") { DF.associative(cf, EQ) }
+  )
+
+  fun <A> delta(a: A): Tuple2<A, A> = a toT a
+
+  fun <F> Divide<F>.associative(
+    cf: (Int) -> Kind<F, Int>,
+    EQ: Eq<Kind<F, Int>>
+  ): Unit =
+    forAll(genConstructor(Gen.int(), cf)) { fa: Kind<F, Int> ->
+      EQ.run {
+        divide<Int, Int, Int>(
+          fa,
+          divide(fa, fa) { delta(it) }
+        ) { delta(it) }.eqv(
+          divide<Int, Int, Int>(
+            divide(fa, fa) { delta(it) },
+            fa
+          ) { delta(it) }
+        )
+      }
+    }
+}

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/DivisibleLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/DivisibleLaws.kt
@@ -1,0 +1,40 @@
+package arrow.test.laws
+
+import arrow.Kind
+import arrow.test.generators.genConstructor
+import arrow.typeclasses.Divisible
+import arrow.typeclasses.Eq
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+
+object DivisibleLaws {
+
+  fun <F> laws(
+    DF: Divisible<F>,
+    cf: (Int) -> Kind<F, Int>,
+    EQ: Eq<Kind<F, Int>>
+  ): List<Law> = DivideLaws.laws(DF, cf, EQ) + listOf(
+    Law("Divisible laws: Left identity") { DF.leftIdentity(cf, EQ) },
+    Law("Divisible laws: Right identity") { DF.rightIdentity(cf, EQ) }
+  )
+
+  fun <F> Divisible<F>.leftIdentity(
+    cf: (Int) -> Kind<F, Int>,
+    EQ: Eq<Kind<F, Int>>
+  ): Unit =
+    forAll(genConstructor(Gen.int(), cf)) { fa ->
+      EQ.run {
+        divide<Int, Int, Int>(fa, conquer()) { DivideLaws.delta(it) }.eqv(fa)
+      }
+    }
+
+  fun <F> Divisible<F>.rightIdentity(
+    cf: (Int) -> Kind<F, Int>,
+    EQ: Eq<Kind<F, Int>>
+  ): Unit =
+    forAll(genConstructor(Gen.int(), cf)) { fa ->
+      EQ.run {
+        divide<Int, Int, Int>(conquer(), fa) { DivideLaws.delta(it) }.eqv(fa)
+      }
+    }
+}

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Decidable.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Decidable.kt
@@ -1,0 +1,371 @@
+package arrow.typeclasses
+
+import arrow.Kind
+import arrow.core.*
+
+/**
+ *
+ * [Decidable] is a typeclass modeling contravariant decision. [Decidable] is the contravariant version of [Alternative].
+ *
+ * [Decidable] basically states: Given a Kind<F, A> and a Kind<F, B> and a way to turn C into either A or B it gives you a Kind<F, C>
+ *
+ * For example a serializer for either a string or an int:
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.Kind
+ * import arrow.core.Either
+ * import arrow.core.Tuple2
+ * import arrow.core.identity
+ * import arrow.core.right
+ * import arrow.typeclasses.Decidable
+ *
+ * // Boilerplate that @higherkind usually generates
+ * class ForSerializer
+ *
+ * fun <A> Kind<ForSerializer, A>.fix() = this as Serializer<A>
+ * class Serializer<A>(val func: (A) -> String) : Kind<ForSerializer, A> {
+ *   companion object {
+ *    fun decidable() = object : Decidable<ForSerializer> {
+ *      override fun <A, B> Kind<ForSerializer, A>.contramap(f: (B) -> A): Kind<ForSerializer, B> =
+ *        Serializer { fix().func(f(it)) }
+ *
+ *      override fun <A, B, Z> divide(fa: Kind<ForSerializer, A>, fb: Kind<ForSerializer, B>, f: (Z) -> Tuple2<A, B>) =
+ *        Serializer { z: Z ->
+ *          val (a, b) = f(z)
+ *          "A: ${fa.fix().func(a)}; B: ${fb.fix().func(b)}"
+ *      }
+ *
+ *      override fun <A> conquer(): Kind<ForSerializer, A> =
+ *        Serializer { "EMPTY" }
+ *
+ *      override fun <A, B, Z> choose(fa: Kind<ForSerializer, A>, fb: Kind<ForSerializer, B>, f: (Z) -> Either<A, B>): Kind<ForSerializer, Z> =
+ *        Serializer {
+ *          f(it).fold({
+ *            "LEFT: " + fa.fix().func(it)
+ *          }, {
+ *            "RIGHT: " + fb.fix().func(it)
+ *          })
+ *        }
+ *      }
+ *   }
+ * }
+ *
+ * val stringSerializer = Serializer<String> { "STRING: $it" }
+ * val intSerializer = Serializer<Int> { "INT: $it" }
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val stringOrInt: Serializer<Either<String, Int>> = Serializer.decidable()
+ *      .choose<String, Int, Either<String, Int>>(stringSerializer, intSerializer, ::identity).fix()
+ *
+ *   val stringOrIntEither = 1.right()
+ *   val result = stringOrInt.func(stringOrIntEither)
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ *
+ * ank_macro_hierarchy(arrow.typeclasses.Divisible)
+ */
+interface Decidable<F> : Divisible<F> {
+
+  /**
+   * Choose takes two data-types of type `Kind<F, A>` and `Kind<F, B>` and produces a type of `Kind<F, C>` when given
+   *  a function from `C -> Either<A, B>`
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.Kind
+   * import arrow.core.Either
+   * import arrow.core.Tuple2
+   * import arrow.core.identity
+   * import arrow.core.right
+   * import arrow.typeclasses.Decidable
+   *
+   * // Boilerplate that @higherkind usually generates
+   * class ForSerializer
+   *
+   * fun <A> Kind<ForSerializer, A>.fix() = this as Serializer<A>
+   * class Serializer<A>(val func: (A) -> String) : Kind<ForSerializer, A> {
+   *   companion object {
+   *    fun decidable() = object : Decidable<ForSerializer> {
+   *      override fun <A, B> Kind<ForSerializer, A>.contramap(f: (B) -> A): Kind<ForSerializer, B> =
+   *        Serializer { fix().func(f(it)) }
+   *
+   *      override fun <A, B, Z> divide(fa: Kind<ForSerializer, A>, fb: Kind<ForSerializer, B>, f: (Z) -> Tuple2<A, B>) =
+   *        Serializer { z: Z ->
+   *          val (a, b) = f(z)
+   *          "A: ${fa.fix().func(a)}; B: ${fb.fix().func(b)}"
+   *      }
+   *
+   *      override fun <A> conquer(): Kind<ForSerializer, A> =
+   *        Serializer { "EMPTY" }
+   *
+   *      override fun <A, B, Z> choose(fa: Kind<ForSerializer, A>, fb: Kind<ForSerializer, B>, f: (Z) -> Either<A, B>): Kind<ForSerializer, Z> =
+   *        Serializer {
+   *          f(it).fold({
+   *            "LEFT: " + fa.fix().func(it)
+   *          }, {
+   *            "RIGHT: " + fb.fix().func(it)
+   *          })
+   *        }
+   *      }
+   *   }
+   * }
+   *
+   * val stringSerializer = Serializer<String> { "STRING: $it" }
+   * val intSerializer = Serializer<Int> { "INT: $it" }
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val stringOrInt: Serializer<Either<String, Int>> = Serializer.decidable()
+   *      .choose<String, Int, Either<String, Int>>(stringSerializer, intSerializer, ::identity).fix()
+   *
+   *   val stringOrIntEither = 1.right()
+   *   val result = stringOrInt.func(stringOrIntEither)
+   *   //sampleEnd
+   *   println(result)
+   * }
+   * ```
+   */
+  fun <A, B, Z> choose(fa: Kind<F, A>, fb: Kind<F, B>, f: (Z) -> Either<A, B>): Kind<F, Z>
+
+  fun <A, B, C, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    f: (Z) -> Either<A, Either<B, C>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(fb, fc, ::identity),
+      f
+    )
+
+  fun <A, B, C, D, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    f: (Z) -> Either<A, Either<B, Either<C, D>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, D, Either<C, D>>(fc, fd, ::identity),
+        ::identity
+      ),
+      f
+    )
+
+  fun <A, B, C, D, E, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    f: (Z) -> Either<A, Either<B, Either<C, Either<D, E>>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, Either<D, E>, Either<C, Either<D, E>>>(
+          fc,
+          choose(fd, fe, ::identity),
+          ::identity
+        ),
+        ::identity
+      ),
+      f
+    )
+
+  fun <A, B, C, D, E, FF, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    f: (Z) -> Either<A, Either<B, Either<C, Either<D, Either<E, FF>>>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, Either<D, Either<E, FF>>, Either<C, Either<D, Either<E, FF>>>>(
+          fc,
+          choose<D, Either<E, FF>, Either<D, Either<E, FF>>>(
+            fd,
+            choose(fe, ff, ::identity),
+            ::identity
+          ),
+          ::identity
+        ),
+        ::identity
+      ),
+      f
+    )
+
+  fun <A, B, C, D, E, FF, G, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    f: (Z) -> Either<A, Either<B, Either<C, Either<D, Either<E, Either<FF, G>>>>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, Either<D, Either<E, Either<FF, G>>>, Either<C, Either<D, Either<E, Either<FF, G>>>>>(
+          fc,
+          choose(
+            fd,
+            choose<E, Either<FF, G>, Either<E, Either<FF, G>>>(
+              fe,
+              choose(ff, fg, ::identity),
+              ::identity
+            ),
+            ::identity
+          ),
+          ::identity
+        ),
+        ::identity
+      ),
+      f
+    )
+
+  fun <A, B, C, D, E, FF, G, H, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    fh: Kind<F, H>,
+    f: (Z) -> Either<A, Either<B, Either<C, Either<D, Either<E, Either<FF, Either<G, H>>>>>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, Either<D, Either<E, Either<FF, Either<G, H>>>>, Either<C, Either<D, Either<E, Either<FF, Either<G, H>>>>>>(
+          fc,
+          choose(
+            fd,
+            choose<E, Either<FF, Either<G, H>>, Either<E, Either<FF, Either<G, H>>>>(
+              fe,
+              choose<FF, Either<G, H>, Either<FF, Either<G, H>>>(
+                ff,
+                choose(fg, fh, ::identity),
+                ::identity
+              ),
+              ::identity
+            ),
+            ::identity
+          ),
+          ::identity
+        ),
+        ::identity
+      ),
+      f
+    )
+
+  fun <A, B, C, D, E, FF, G, H, I, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    fh: Kind<F, H>,
+    fi: Kind<F, I>,
+    f: (Z) -> Either<A, Either<B, Either<C, Either<D, Either<E, Either<FF, Either<G, Either<H, I>>>>>>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, Either<D, Either<E, Either<FF, Either<G, Either<H, I>>>>>, Either<C, Either<D, Either<E, Either<FF, Either<G, Either<H, I>>>>>>>(
+          fc,
+          choose(
+            fd,
+            choose<E, Either<FF, Either<G, Either<H, I>>>, Either<E, Either<FF, Either<G, Either<H, I>>>>>(
+              fe,
+              choose(
+                ff,
+                choose<G, Either<H, I>, Either<G, Either<H, I>>>(
+                  fg,
+                  choose(fh, fi, ::identity),
+                  ::identity
+                ),
+                ::identity
+              ),
+              ::identity
+            ),
+            ::identity
+          ),
+          ::identity
+        ),
+        ::identity
+      ),
+      f
+    )
+
+  fun <A, B, C, D, E, FF, G, H, I, J, Z> choose(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    fh: Kind<F, H>,
+    fi: Kind<F, I>,
+    fj: Kind<F, J>,
+    f: (Z) -> Either<A, Either<B, Either<C, Either<D, Either<E, Either<FF, Either<G, Either<H, Either<I, J>>>>>>>>>
+  ): Kind<F, Z> =
+    choose(
+      fa,
+      choose(
+        fb,
+        choose<C, Either<D, Either<E, Either<FF, Either<G, Either<H, Either<I, J>>>>>>, Either<C, Either<D, Either<E, Either<FF, Either<G, Either<H, Either<I, J>>>>>>>>(
+          fc,
+          choose(
+            fd,
+            choose<E, Either<FF, Either<G, Either<H, Either<I, J>>>>, Either<E, Either<FF, Either<G, Either<H, Either<I, J>>>>>>(
+              fe,
+              choose(
+                ff,
+                choose<G, Either<H, Either<I, J>>, Either<G, Either<H, Either<I, J>>>>(
+                  fg,
+                  choose<H, Either<I, J>, Either<H, Either<I, J>>>(
+                    fh,
+                    choose(fi, fj, ::identity),
+                    ::identity
+                  ),
+                  ::identity
+                ),
+                ::identity
+              ),
+              ::identity
+            ),
+            ::identity
+          ),
+          ::identity
+        ),
+        ::identity
+      ),
+      f
+    )
+}

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Divide.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Divide.kt
@@ -1,0 +1,322 @@
+package arrow.typeclasses
+
+import arrow.Kind
+import arrow.core.*
+
+/**
+ * [Divide] is a typeclass that models the divide part of divide and conquer.
+ *
+ * [Divide] basically states: Given a Kind<F, A> and a Kind<F, B> and a way to turn C into an A and B it gives you a Kind<F, C>
+ *
+ * A useful example is a serializer for a datatype that contains several other datatypes.
+ *
+ * {: data-executable='true'}
+ *
+ * ```kotlin:ank
+ * import arrow.typeclasses.divide
+ * import arrow.Kind
+ * import arrow.core.Tuple2
+ * import arrow.core.toT
+ *
+ * data class User(val name: String, val age: Int)
+ *
+ * // Boilerplate that @higherkind usually generates
+ * class ForSerializer
+ * fun <A> Kind<ForSerializer, A>.fix() = this as Serializer<A>
+ *
+ * class Serializer<A>(val func: (A) -> String): Kind<ForSerializer, A> {
+ *    companion object {
+ *      fun divide() = object: Divide<ForSerializer> {
+ *        override fun <A, B> Kind<ForSerializer, A>.contramap(f: (B) -> A): Kind<ForSerializer, B> =
+ *          Serializer { fix().func(f(it)) }
+ *        override fun <A, B, Z> divide(fa: Kind<ForSerializer, A>, fb: Kind<ForSerializer, B>, f: (Z) -> Tuple2<A, B>) =
+ *          Serializer { z: Z ->
+ *            val (a, b) = f(z)
+ *            "A: ${fa.fix().func(a)}; B: ${fb.fix().func(b)}"
+ *          }
+ *      }
+ *    }
+ * }
+ *
+ * val stringSerializer = Serializer<String> { "STRING = $it" }
+ * val intSerializer = Serializer<Int> { "INT = $it" }
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val userSerializer: Serializer<User> = Serializer.divide().divide(
+ *      stringSerializer,
+ *      intSerializer
+ *   ) { user: User ->
+ *      user.name toT user.age
+ *   }.fix()
+ *
+ *   val user = User("John", 31)
+ *
+ *   val result = userSerializer.func(user)
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ *
+ * ank_macro_hierarchy(arrow.typeclasses.Divide)
+ */
+interface Divide<F> : Contravariant<F> {
+
+  /**
+   * Divide takes two data-types of type `Kind<F, A>` and `Kind<F, B>` and produces a type of `Kind<F, C>` when given
+   *  a function from `C -> Tuple2<A, B>`
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.typeclasses.divide
+   * import arrow.Kind
+   * import arrow.core.Tuple2
+   * import arrow.core.toT
+   *
+   * data class User(val name: String, val age: Int)
+   *
+   * // Boilerplate that @higherkind usually generates
+   * class ForSerializer
+   * fun <A> Kind<ForSerializer, A>.fix() = this as Serializer<A>
+   *
+   * class Serializer<A>(val func: (A) -> String): Kind<ForSerializer, A> {
+   *    companion object {
+   *      fun divide() = object: Divide<ForSerializer> {
+   *        override fun <A, B> Kind<ForSerializer, A>.contramap(f: (B) -> A): Kind<ForSerializer, B> =
+   *          Serializer { fix().func(f(it)) }
+   *        override fun <A, B, Z> divide(fa: Kind<ForSerializer, A>, fb: Kind<ForSerializer, B>, f: (Z) -> Tuple2<A, B>) =
+   *          Serializer { z: Z ->
+   *            val (a, b) = f(z)
+   *            "A: ${fa.fix().func(a)}; B: ${fb.fix().func(b)}"
+   *          }
+   *      }
+   *    }
+   * }
+   *
+   * val stringSerializer = Serializer<String> { "STRING = $it" }
+   * val intSerializer = Serializer<Int> { "INT = $it" }
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val userSerializer: Serializer<User> = Serializer.divide().divide(
+   *      stringSerializer,
+   *      intSerializer
+   *   ) { user: User ->
+   *      user.name toT user.age
+   *   }.fix()
+   *
+   *   val user = User("John", 31)
+   *
+   *   val result = userSerializer.func(user)
+   *   //sampleEnd
+   *   println(result)
+   * }
+   * ```
+   */
+  fun <A, B, Z> divide(fa: Kind<F, A>, fb: Kind<F, B>, f: (Z) -> Tuple2<A, B>): Kind<F, Z>
+
+  fun <A, B> Kind<F, A>.product(other: Kind<F, B>): Kind<F, Tuple2<A, B>> =
+    divide(this, other, ::identity)
+
+  fun <A, B, C> Kind<F, Tuple2<A, B>>.product(
+    other: Kind<F, C>,
+    dummy: Unit = Unit
+  ): Kind<F, Tuple3<A, B, C>> =
+    divide(this, other) { Tuple2(it.a toT it.b, it.c) }
+
+  fun <A, B, C, D> Kind<F, Tuple3<A, B, C>>.product(
+    other: Kind<F, D>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit
+  ): Kind<F, Tuple4<A, B, C, D>> =
+    divide(this, other) { Tuple2(Tuple3(it.a, it.b, it.c), it.d) }
+
+  fun <A, B, C, D, E> Kind<F, Tuple4<A, B, C, D>>.product(
+    other: Kind<F, E>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit,
+    dummy3: Unit = Unit
+  ): Kind<F, Tuple5<A, B, C, D, E>> =
+    divide(this, other) { Tuple2(Tuple4(it.a, it.b, it.c, it.d), it.e) }
+
+  fun <A, B, C, D, E, FF> Kind<F, Tuple5<A, B, C, D, E>>.product(
+    other: Kind<F, FF>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit,
+    dummy3: Unit = Unit,
+    dummy4: Unit = Unit
+  ): Kind<F, Tuple6<A, B, C, D, E, FF>> =
+    divide(this, other) { Tuple2(Tuple5(it.a, it.b, it.c, it.d, it.e), it.f) }
+
+  fun <A, B, C, D, E, FF, G> Kind<F, Tuple6<A, B, C, D, E, FF>>.product(
+    other: Kind<F, G>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit,
+    dummy3: Unit = Unit,
+    dummy4: Unit = Unit,
+    dummy5: Unit = Unit
+  ): Kind<F, Tuple7<A, B, C, D, E, FF, G>> =
+    divide(this, other) { Tuple2(Tuple6(it.a, it.b, it.c, it.d, it.e, it.f), it.g) }
+
+  fun <A, B, C, D, E, FF, G, H> Kind<F, Tuple7<A, B, C, D, E, FF, G>>.product(
+    other: Kind<F, H>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit,
+    dummy3: Unit = Unit,
+    dummy4: Unit = Unit,
+    dummy5: Unit = Unit,
+    dummy6: Unit = Unit
+  ): Kind<F, Tuple8<A, B, C, D, E, FF, G, H>> =
+    divide(this, other) { Tuple2(Tuple7(it.a, it.b, it.c, it.d, it.e, it.f, it.g), it.h) }
+
+  fun <A, B, C, D, E, FF, G, H, I> Kind<F, Tuple8<A, B, C, D, E, FF, G, H>>.product(
+    other: Kind<F, I>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit,
+    dummy3: Unit = Unit,
+    dummy4: Unit = Unit,
+    dummy5: Unit = Unit,
+    dummy6: Unit = Unit,
+    dummy7: Unit = Unit
+  ): Kind<F, Tuple9<A, B, C, D, E, FF, G, H, I>> =
+    divide(this, other) { Tuple2(Tuple8(it.a, it.b, it.c, it.d, it.e, it.f, it.g, it.h), it.i) }
+
+  fun <A, B, C, D, E, FF, G, H, I, J> Kind<F, Tuple9<A, B, C, D, E, FF, G, H, I>>.product(
+    other: Kind<F, J>,
+    dummy: Unit = Unit,
+    dummy2: Unit = Unit,
+    dummy3: Unit = Unit,
+    dummy4: Unit = Unit,
+    dummy5: Unit = Unit,
+    dummy6: Unit = Unit,
+    dummy7: Unit = Unit,
+    dummy8: Unit = Unit
+  ): Kind<F, Tuple10<A, B, C, D, E, FF, G, H, I, J>> =
+    divide(this, other) { Tuple2(Tuple9(it.a, it.b, it.c, it.d, it.e, it.f, it.g, it.h, it.i), it.j) }
+
+  fun <A, B, C, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    f: (Z) -> Tuple3<A, B, C>
+  ): Kind<F, Z> = divide(fa, fb.product(fc)) {
+    val (a, b, c) = f(it)
+    a toT (b toT c)
+  }
+
+  fun <A, B, C, D, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    f: (Z) -> Tuple4<A, B, C, D>
+  ): Kind<F, Z> = divide(fa, fb.product(fc).product(fd)) {
+    val (a, b, c, d) = f(it)
+    a toT Tuple3(b, c, d)
+  }
+
+  fun <A, B, C, D, E, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    f: (Z) -> Tuple5<A, B, C, D, E>
+  ): Kind<F, Z> = divide(fa, fb.product(fc).product(fd).product(fe)) {
+    val (a, b, c, d, e) = f(it)
+    a toT Tuple4(b, c, d, e)
+  }
+
+  fun <A, B, C, D, E, FF, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    f: (Z) -> Tuple6<A, B, C, D, E, FF>
+  ): Kind<F, Z> = divide(
+    fa,
+    fb.product(fc).product(fd).product(fe).product(ff)
+  ) {
+    val (a, b, c, d, e, fff) = f(it)
+    a toT Tuple5(b, c, d, e, fff)
+  }
+
+  fun <A, B, C, D, E, FF, G, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    f: (Z) -> Tuple7<A, B, C, D, E, FF, G>
+  ): Kind<F, Z> = divide(
+    fa,
+    fb.product(fc).product(fd).product(fe).product(ff).product(fg)
+  ) {
+    val (a, b, c, d, e, fff, g) = f(it)
+    a toT Tuple6(b, c, d, e, fff, g)
+  }
+
+  fun <A, B, C, D, E, FF, G, H, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    fh: Kind<F, H>,
+    f: (Z) -> Tuple8<A, B, C, D, E, FF, G, H>
+  ): Kind<F, Z> = divide(
+    fa,
+    fb.product(fc).product(fd).product(fe).product(ff).product(fg).product(fh)
+  ) {
+    val (a, b, c, d, e, fff, g, h) = f(it)
+    a toT Tuple7(b, c, d, e, fff, g, h)
+  }
+
+  fun <A, B, C, D, E, FF, G, H, I, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    fh: Kind<F, H>,
+    fi: Kind<F, I>,
+    f: (Z) -> Tuple9<A, B, C, D, E, FF, G, H, I>
+  ): Kind<F, Z> = divide(
+    fa,
+    fb.product(fc).product(fd).product(fe).product(ff).product(fg).product(fh)
+      .product(fi)
+  ) {
+    val (a, b, c, d, e, fff, g, h, i) = f(it)
+    a toT Tuple8(b, c, d, e, fff, g, h, i)
+  }
+
+  fun <A, B, C, D, E, FF, G, H, I, J, Z> divide(
+    fa: Kind<F, A>,
+    fb: Kind<F, B>,
+    fc: Kind<F, C>,
+    fd: Kind<F, D>,
+    fe: Kind<F, E>,
+    ff: Kind<F, FF>,
+    fg: Kind<F, G>,
+    fh: Kind<F, H>,
+    fi: Kind<F, I>,
+    fj: Kind<F, J>,
+    f: (Z) -> Tuple10<A, B, C, D, E, FF, G, H, I, J>
+  ): Kind<F, Z> = divide(
+    fa,
+    fb.product(fc).product(fd).product(fe).product(ff).product(fg).product(fh)
+      .product(fi).product(fj)
+  ) {
+    val (a, b, c, d, e, fff, g, h, i, j) = f(it)
+    a toT Tuple9(b, c, d, e, fff, g, h, i, j)
+  }
+}

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Divisible.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Divisible.kt
@@ -1,0 +1,16 @@
+package arrow.typeclasses
+
+import arrow.Kind
+
+/**
+ * [Divisible] extends [Divide] by providing an empty value
+ *
+ * ank_macro_hierarchy(arrow.typeclasses.Divisible)
+ */
+interface Divisible<F> : Divide<F> {
+
+  /**
+   * Provides an empty value for `Kind<F, A>`
+   */
+  fun <A> conquer(): Kind<F, A>
+}

--- a/modules/docs/arrow-docs/docs/docs/typeclasses/decidable/README.md
+++ b/modules/docs/arrow-docs/docs/docs/typeclasses/decidable/README.md
@@ -1,0 +1,24 @@
+---
+layout: docs
+title: Eq
+permalink: /docs/arrow/typeclasses/decidable/
+redirect_from:
+  - /docs/typeclasses/decidable
+---
+
+## Divide/Divisible/Decidable
+
+{:.beginner}
+
+See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | relative_url }}) to provide your own `Decidable` instances for custom datatypes.
+
+### Data types
+
+```kotlin:ank:replace
+import arrow.reflect.*
+import arrow.typeclasses.Decidable
+
+TypeClass(Decidable::class).dtMarkdownList()
+```
+
+ank_macro_hierarchy(arrow.typeclasses.Decidable)


### PR DESCRIPTION
Finally got around to doing something :)
Partially solves #284 (Only divide not apply, because apply is a lot of refractoring and has some annoyances when it comes to defaults for map etc.)

Docs are mostly wip atm.

Few things:
- There is no test for StateT because it explicitly requires a monad that is divisible and we don't have that afaik)
- There are no laws for decidable atm, there are some [here](http://hackage.haskell.org/package/contravariant-1.5/docs/src/Data.Functor.Contravariant.Divisible.html), but I don't really understand them well enough to attempt to port them :/ Scala cats and/or scalaz don't include them either afaik.
- Docs for Divisible are a bit annoying as tbh I don't quite see a good example usecase for conquer...
- Should the typeclass docs include an entry for each typeclass or would also work in one file as they share a lot of functionality (or better they share usecases)