### PR TITLE
Delete api docs on clean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,14 @@ buildscript {
 
 apply from: 'detekt.gradle.kts'
 
+def pathApiDocs = "${rootDir}/modules/docs/arrow-docs/docs/docs/apidocs"
+
 allprojects {
     apply plugin: 'base'
 
     clean.doFirst {
         delete "${rootDir}/infographic/arrow-infographic.txt"
+        delete pathApiDocs
     }
 
     repositories {
@@ -87,8 +90,7 @@ subprojects { project ->
     //dokka log spam `Can't find node by signature` comes from https://github.com/Kotlin/dokka/issues/269
     dokka {
         outputFormat = 'jekyll'
-        outputDirectory = project.rootDir.absolutePath +
-                "/modules/docs/arrow-docs/docs/docs/apidocs"
+        outputDirectory = pathApiDocs
 
         includes = ['README.md']
         reportUndocumented = false


### PR DESCRIPTION
`./gradlew clean build test dokka runAnk` should produce a correct result after branch switch. Currently, when there're API docs for new classes the build will fail because they cannot be compiled with Ank.