### PR TITLE
Missing instances monad transformers

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Eval.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Eval.kt
@@ -2,6 +2,8 @@ package arrow.core
 
 import arrow.higherkind
 
+fun <A> EvalOf<A>.value(): A = this.fix().value()
+
 /**
  * Eval is a monad which controls evaluation of a value or a computation that produces a value.
  *

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Id.kt
@@ -2,29 +2,31 @@ package arrow.core
 
 import arrow.higherkind
 
-fun <A> IdOf<A>.value(): A = this.fix().value
+fun <A> IdOf<A>.value(): A = this.fix().value()
 
 @higherkind
-data class Id<out A>(val value: A) : IdOf<A> {
+data class Id<out A>(private val value: A) : IdOf<A> {
 
-  inline fun <B> map(f: (A) -> B): Id<B> = Id(f(value))
+  inline fun <B> map(f: (A) -> B): Id<B> = Id(f(value()))
 
-  inline fun <B> flatMap(f: (A) -> IdOf<B>): Id<B> = f(value).fix()
+  inline fun <B> flatMap(f: (A) -> IdOf<B>): Id<B> = f(value()).fix()
 
-  fun <B> foldLeft(initial: B, operation: (B, A) -> B): B = operation(initial, this.fix().value)
+  fun <B> foldLeft(initial: B, operation: (B, A) -> B): B = operation(initial, value)
 
-  fun <B> foldRight(initial: Eval<B>, operation: (A, Eval<B>) -> Eval<B>): Eval<B> = operation(this.fix().value, initial)
+  fun <B> foldRight(initial: Eval<B>, operation: (A, Eval<B>) -> Eval<B>): Eval<B> = operation(value, initial)
 
   fun <B> coflatMap(f: (IdOf<A>) -> B): Id<B> = this.fix().map { f(this) }
 
-  fun extract(): A = this.fix().value
+  fun extract(): A = value
+
+  fun value(): A = value
 
   fun <B> ap(ff: IdOf<(A) -> B>): Id<B> = ff.fix().flatMap { f -> map(f) }.fix()
 
   companion object {
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> IdOf<Either<A, B>>): Id<B> {
-      val x: Either<A, B> = f(a).fix().value
+      val x: Either<A, B> = f(a).value()
       return when (x) {
         is Either.Left -> tailRecM(x.a, f)
         is Either.Right -> Id(x.b)
@@ -39,4 +41,7 @@ data class Id<out A>(val value: A) : IdOf<A> {
       is Id<*> -> other.value == value
       else -> other == value
     }
+
+  override fun hashCode(): Int = value.hashCode()
+
 }

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/EvalTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/EvalTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 @RunWith(KTestJUnitRunner::class)
 class EvalTest : UnitSpec() {
   val EQ: Eq<Kind<ForEval, Int>> = Eq { a, b ->
-    a.fix().value() == b.fix().value()
+    a.value() == b.value()
   }
 
   init {

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/Coreader.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/Coreader.kt
@@ -1,9 +1,6 @@
 package arrow.data
 
-import arrow.core.ForId
-import arrow.core.Id
-import arrow.core.IdOf
-import arrow.core.fix
+import arrow.core.*
 import arrow.typeclasses.Comonad
 import arrow.typeclasses.internal.IdBimonad
 
@@ -12,7 +9,7 @@ fun <A, B> ((A) -> B).coreader(): CoreaderT<ForId, A, B> = Coreader(this)
 fun <A, B> CoreaderT<ForId, A, B>.runId(d: A): B = this.run(Id(d))
 
 object Coreader {
-  operator fun <A, B> invoke(run: (A) -> B): CoreaderT<ForId, A, B> = Cokleisli(IdBimonad) { a: IdOf<A> -> run(a.fix().value) }
+  operator fun <A, B> invoke(run: (A) -> B): CoreaderT<ForId, A, B> = Cokleisli(IdBimonad) { a: IdOf<A> -> run(a.value()) }
 
   fun <A, B> just(MF: Comonad<ForId>, x: B): CoreaderT<ForId, A, B> = Cokleisli.just(MF, x)
 

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/EitherT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/EitherT.kt
@@ -10,7 +10,12 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 
-fun <F, A, B> EitherTOf<F, A, B>.value() = fix().value
+@Deprecated(message = "The value property is now directly accessible on the kinded version",
+  replaceWith = ReplaceWith(expression = "value"))
+fun <F, A, B> EitherTOf<F, A, B>.value() = value
+
+val <F, A, B> EitherTOf<F, A, B>.value
+  get() = fix().value
 
 /**
  * [EitherT]`<F, A, B>` is a light wrapper on an `F<`[Either]`<A, B>>` with some
@@ -23,13 +28,15 @@ data class EitherT<F, A, B>(val value: Kind<F, Either<A, B>>) : EitherTOf<F, A, 
 
   companion object {
 
-    operator fun <F, A, B> invoke(value: Kind<F, Either<A, B>>): EitherT<F, A, B> = EitherT(value)
+    operator fun <F, A, B> invoke(value: Kind<F, Either<A, B>>): EitherT<F, A, B> =
+      EitherT(value)
 
-    fun <F, A, B> just(MF: Applicative<F>, b: B): EitherT<F, A, B> = right(MF, b)
+    fun <F, A, B> just(MF: Applicative<F>, b: B): EitherT<F, A, B> =
+      right(MF, b)
 
     fun <F, L, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> EitherTOf<F, L, Either<A, B>>): EitherT<F, L, B> =
       EitherT(MF.tailRecM(a) {
-        val value = f(it).fix().value
+        val value = f(it).value
         MF.run {
           value.map { recursionControl ->
             when (recursionControl) {
@@ -46,32 +53,41 @@ data class EitherT<F, A, B>(val value: Kind<F, Either<A, B>>) : EitherTOf<F, A, 
         }
       })
 
-    fun <F, A, B> right(MF: Applicative<F>, b: B): EitherT<F, A, B> = EitherT(MF.just(Right(b)))
+    fun <F, A, B> right(MF: Applicative<F>, b: B): EitherT<F, A, B> =
+      EitherT(MF.just(Right(b)))
 
-    fun <F, A, B> left(MF: Applicative<F>, a: A): EitherT<F, A, B> = EitherT(MF.just(Left(a)))
+    fun <F, A, B> left(MF: Applicative<F>, a: A): EitherT<F, A, B> =
+      EitherT(MF.just(Left(a)))
 
     fun <F, A, B> fromEither(AP: Applicative<F>, value: Either<A, B>): EitherT<F, A, B> =
       EitherT(AP.just(value))
+
+    fun <F, A, B> liftF(FF: Functor<F>, fa: Kind<F, B>): EitherT<F, A, B> = FF.run {
+      EitherT(fa.map(::Right))
+    }
+
   }
 
   inline fun <C> fold(FF: Functor<F>, crossinline l: (A) -> C, crossinline r: (B) -> C): Kind<F, C> = FF.run {
     value.map { either -> either.fold(l, r) }
   }
 
-  fun <C> flatMap(MF: Monad<F>, f: (B) -> EitherT<F, A, C>): EitherT<F, A, C> =
+  fun <C> flatMap(MF: Monad<F>, f: (B) -> EitherTOf<F, A, C>): EitherT<F, A, C> =
     flatMapF(MF) { it -> f(it).value }
 
   fun <C> flatMapF(MF: Monad<F>, f: (B) -> Kind<F, Either<A, C>>): EitherT<F, A, C> = MF.run {
     EitherT(value.flatMap { either -> either.fold({ MF.just(Left(it)) }, { f(it) }) })
   }
 
-  fun <C> cata(FF: Functor<F>, l: (A) -> C, r: (B) -> C): Kind<F, C> = fold(FF, l, r)
+  fun <C> cata(FF: Functor<F>, l: (A) -> C, r: (B) -> C): Kind<F, C> =
+    fold(FF, l, r)
 
   fun <C> liftF(FF: Functor<F>, fa: Kind<F, C>): EitherT<F, A, C> = FF.run {
     EitherT(fa.map { Right(it) })
   }
 
-  fun <C> semiflatMap(MF: Monad<F>, f: (B) -> Kind<F, C>): EitherT<F, A, C> = flatMap(MF) { liftF(MF, f(it)) }
+  fun <C> semiflatMap(MF: Monad<F>, f: (B) -> Kind<F, C>): EitherT<F, A, C> =
+    flatMap(MF) { liftF(MF, f(it)) }
 
   fun <C> map(FF: Functor<F>, f: (B) -> C): EitherT<F, A, C> = FF.run {
     EitherT(value.map { it.map(f) })
@@ -89,20 +105,27 @@ data class EitherT<F, A, B>(val value: Kind<F, Either<A, B>>) : EitherTOf<F, A, 
     EitherT(value.map { f(it) })
   }
 
-  fun <C> subflatMap(FF: Functor<F>, f: (B) -> Either<A, C>): EitherT<F, A, C> = transform(FF) { it.flatMap(f = f) }
+  fun <C> subflatMap(FF: Functor<F>, f: (B) -> Either<A, C>): EitherT<F, A, C> =
+    transform(FF) { it.flatMap(f = f) }
 
   fun toOptionT(FF: Functor<F>): OptionT<F, B> = FF.run {
     OptionT(value.map { it.toOption() })
   }
 
   fun combineK(MF: Monad<F>, y: EitherTOf<F, A, B>): EitherT<F, A, B> = MF.run {
-    EitherT(fix().value.flatMap {
+    EitherT(value.flatMap {
       when (it) {
-        is Either.Left -> y.fix().value
+        is Either.Left -> y.value
         is Either.Right -> just(it)
       }
     })
   }
 
-  fun <C> ap(MF: Monad<F>, ff: EitherTOf<F, A, (B) -> C>): EitherT<F, A, C> = ff.fix().flatMap(MF) { f -> map(MF, f) }
+  fun <C> ap(AF: Applicative<F>, ff: EitherTOf<F, A, (B) -> C>): EitherT<F, A, C> =
+    EitherT(AF.map(ff.value, value) { (a, b) ->
+      b.flatMap { bb ->
+        a.map { f -> f(bb) }
+      }
+    })
+
 }

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/OptionT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/OptionT.kt
@@ -7,6 +7,10 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 
+@Deprecated(message = "The value property is now directly accessible on the kinded version",
+  replaceWith = ReplaceWith(expression = "value"))
+fun <F, A> OptionTOf<F, A>.value() = value
+
 val <F, A> OptionTOf<F, A>.value: Kind<F, Option<A>> get() = this.fix().value
 
 /**

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/OptionT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/OptionT.kt
@@ -7,6 +7,8 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 
+val <F, A> OptionTOf<F, A>.value: Kind<F, Option<A>> get() = this.fix().value
+
 /**
  * [OptionT]`<F, A>` is a light wrapper on an `F<`[Option]`<A>>` with some
  * convenient methods for working with this nested structure.
@@ -28,18 +30,21 @@ data class OptionT<F, A>(val value: Kind<F, Option<A>>) : OptionTOf<F, A>, Optio
       OptionT(AF.just(value))
 
     fun <F, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> OptionTOf<F, Either<A, B>>): OptionT<F, B> =
-      OptionT(MF.tailRecM(a) {
-        val value = f(it).fix().value
+      OptionT(MF.tailRecM(a) { aa ->
         MF.run {
-          value.map {
+          f(aa).value.map {
             it.fold({
               Right<Option<B>>(None)
-            }, {
-              it.map { Some(it) }
+            }, { ab ->
+              ab.map(::Some)
             })
           }
         }
       })
+
+    fun <F, A> liftF(FF: Functor<F>, fa: Kind<F, A>): OptionT<F, A> = FF.run {
+      OptionT(fa.map { Some(it) })
+    }
 
   }
 
@@ -49,9 +54,14 @@ data class OptionT<F, A>(val value: Kind<F, Option<A>>) : OptionTOf<F, A>, Optio
 
   fun <B> cata(FF: Functor<F>, default: () -> B, f: (A) -> B): Kind<F, B> = fold(FF, default, f)
 
-  fun <B> ap(MF: Monad<F>, ff: OptionTOf<F, (A) -> B>): OptionT<F, B> = ff.fix().flatMap(MF) { f -> map(MF, f) }
+  fun <B> ap(AF: Applicative<F>, ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
+    OptionT(AF.map(ff.value, value) { (a, b) ->
+      b.flatMap { bb ->
+        a.map { f -> f(bb) }
+      }
+    })
 
-  fun <B> flatMap(MF: Monad<F>, f: (A) -> OptionT<F, B>): OptionT<F, B> = flatMapF(MF) { it -> f(it).value }
+  fun <B> flatMap(MF: Monad<F>, f: (A) -> OptionTOf<F, B>): OptionT<F, B> = flatMapF(MF) { it -> f(it).value }
 
   fun <B> flatMapF(MF: Monad<F>, f: (A) -> Kind<F, Option<B>>): OptionT<F, B> = MF.run {
     OptionT(value.flatMap { option -> option.fold({ just(None) }, f) })
@@ -70,7 +80,7 @@ data class OptionT<F, A>(val value: Kind<F, Option<A>>) : OptionTOf<F, A>, Optio
   fun getOrElse(FF: Functor<F>, default: () -> A): Kind<F, A> = FF.run { value.map { it.getOrElse(default) } }
 
   fun getOrElseF(MF: Monad<F>, default: () -> Kind<F, A>): Kind<F, A> = MF.run {
-    value.flatMap { it.fold(default) { just(it) } }
+    value.flatMap { it.fold(default, ::just) }
   }
 
   fun filter(FF: Functor<F>, p: (A) -> Boolean): OptionT<F, A> = FF.run {
@@ -82,11 +92,11 @@ data class OptionT<F, A>(val value: Kind<F, Option<A>>) : OptionTOf<F, A>, Optio
   }
 
   fun isDefined(FF: Functor<F>): Kind<F, Boolean> = FF.run {
-    value.map { it.isDefined() }
+    value.map(Option<A>::isDefined)
   }
 
   fun isEmpty(FF: Functor<F>): Kind<F, Boolean> = FF.run {
-    value.map { it.isEmpty() }
+    value.map(Option<A>::isEmpty)
   }
 
   fun orElse(MF: Monad<F>, default: () -> OptionT<F, A>): OptionT<F, A> = orElseF(MF) { default().value }
@@ -101,10 +111,10 @@ data class OptionT<F, A>(val value: Kind<F, Option<A>>) : OptionTOf<F, A>, Optio
   }
 
   fun <B> transform(FF: Functor<F>, f: (Option<A>) -> Option<B>): OptionT<F, B> = FF.run {
-    OptionT(value.map { f(it) })
+    OptionT(value.map(f))
   }
 
-  fun <B> subflatMap(FF: Functor<F>, f: (A) -> Option<B>): OptionT<F, B> = transform(FF) { it.flatMap(f) }
+  fun <B> subflatMap(FF: Functor<F>, f: (A) -> OptionOf<B>): OptionT<F, B> = transform(FF) { it.flatMap(f) }
 
   fun <R> toLeft(FF: Functor<F>, default: () -> R): EitherT<F, A, R> =
     EitherT(cata(FF, { Right(default()) }, { Left(it) }))
@@ -113,8 +123,6 @@ data class OptionT<F, A>(val value: Kind<F, Option<A>>) : OptionTOf<F, A>, Optio
     EitherT(cata(FF, { Left(default()) }, { Right(it) }))
 }
 
-fun <F, A, B> OptionTOf<F, A>.mapFilter(FF: Functor<F>, f: (A) -> Option<B>): OptionT<F, B> = FF.run {
-  OptionT(fix().value.map { it.flatMap(f) })
+fun <F, A, B> OptionTOf<F, A>.mapFilter(FF: Functor<F>, f: (A) -> OptionOf<B>): OptionT<F, B> = FF.run {
+  OptionT(value.map { it.flatMap(f) })
 }
-
-fun <F, A> OptionTOf<F, A>.value(): Kind<F, Option<A>> = this.fix().value

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/StateT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/StateT.kt
@@ -42,16 +42,16 @@ class StateT<F, S, A>(
 
   companion object {
 
-    fun <F, S, T> just(MF: Monad<F>, t: T): StateT<F, S, T> =
-      StateT(MF) { s -> MF.just(s toT t) }
+    fun <F, S, T> just(AF: Applicative<F>, t: T): StateT<F, S, T> =
+      StateT(AF) { s -> AF.just(s toT t) }
 
     /**
      * Constructor to create `StateT<F, S, A>` given a [StateTFun].
      *
-     * @param MF [Monad] for the context [F].
+     * @param AF [Applicative] for the context [F].
      * @param run the stateful function to wrap with [StateT].
      */
-    operator fun <F, S, A> invoke(MF: Monad<F>, run: StateTFun<F, S, A>): StateT<F, S, A> = MF.run {
+    operator fun <F, S, A> invoke(AF: Applicative<F>, run: StateTFun<F, S, A>): StateT<F, S, A> = AF.run {
       StateT(just(run))
     }
 
@@ -60,15 +60,16 @@ class StateT<F, S, A>(
      *
      * @param runF the function to wrap within [StateT].
      */
-    fun <F, S, A> invokeF(runF: StateTFunOf<F, S, A>): StateT<F, S, A> = StateT(runF)
+    fun <F, S, A> invokeF(runF: StateTFunOf<F, S, A>): StateT<F, S, A> =
+      StateT(runF)
 
     /**
-     * Lift a value of type `A` into `StateT<F, S, A>`.
+     * Lift a value of type `Kind<F, A>` into `StateT<F, S, A>`.
      *
-     * @param MF [Monad] for the context [F].
-     * @param fa the value to lift.
+     * @param AF [Applicative] for the context [F].
+     * @param fa the value to liftF.
      */
-    fun <F, S, A> lift(MF: Monad<F>, fa: Kind<F, A>): StateT<F, S, A> = MF.run {
+    fun <F, S, A> liftF(AF: Applicative<F>, fa: Kind<F, A>): StateT<F, S, A> = AF.run {
       StateT(just({ s -> fa.map { a -> Tuple2(s, a) } }))
     }
 
@@ -97,13 +98,11 @@ class StateT<F, S, A>(
      * @param AF [Applicative] for the context [F].
      * @param f the modify function to apply.
      */
-    fun <F, S> modify(AF: Applicative<F>, f: (S) -> S): StateT<F, S, Unit> =
-      StateT(AF.just({ s ->
-        val just = AF.just(f(s))
-        AF.run {
-          just.map { Tuple2(it, Unit) }
-        }
+    fun <F, S> modify(AF: Applicative<F>, f: (S) -> S): StateT<F, S, Unit> = AF.run {
+      StateT<F, S, Unit>(just({ s ->
+        just(f(s)).map { Tuple2(it, Unit) }
       }))
+    }
 
     /**
      * Modify the state with an [Applicative] function [f] `(S) -> Kind<F, S>` and return [Unit].
@@ -135,40 +134,41 @@ class StateT<F, S, A>(
     /**
      * Tail recursive function that keeps calling [f]  until [arrow.Either.Right] is returned.
      *
+     * @param MF [Monad] for the context [F].
      * @param a initial value to start running recursive call to [f]
      * @param f function that is called recusively until [arrow.Either.Right] is returned.
-     * @param MF [Monad] for the context [F].
      */
-    fun <F, S, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> Kind<StateTPartialOf<F, S>, Either<A, B>>): StateT<F, S, B> =
-      StateT(MF.just({ s: S ->
-        MF.tailRecM(Tuple2(s, a)) { (s, a0) ->
-          MF.run {
-            f(a0).runM(this, s).map { (s, ab) ->
-              ab.bimap({ a1 -> Tuple2(s, a1) }, { b -> Tuple2(s, b) })
-            }
+    fun <F, S, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> StateTOf<F, S, Either<A, B>>): StateT<F, S, B> = MF.run {
+      StateT(just({ s: S ->
+        tailRecM(Tuple2(s, a)) { (s, a0) ->
+          f(a0).runM(this, s).map { (s, ab) ->
+            ab.bimap({ a1 -> Tuple2(s, a1) }, { b -> Tuple2(s, b) })
           }
         }
-      }))
+      })
+      )
+    }
+
   }
 
   /**
    * Map current value [A] given a function [f].
    *
-   * @param f the function to apply.
    * @param FF [Functor] for the context [F].
+   * @param f the function to apply.
    */
   fun <B> map(FF: Functor<F>, f: (A) -> B): StateT<F, S, B> = transform(FF) { (s, a) -> Tuple2(s, f(a)) }
 
   /**
    * Combine with another [StateT] of same context [F] and state [S].
    *
-   * @param sb other state with value of type `B`.
-   * @param f the function to apply.
    * @param MF [Monad] for the context [F].
+   * @param sb other state with value of type `B`.
+   * @param fn the function to apply.
    */
-  fun <B, Z> map2(MF: Monad<F>, sb: StateT<F, S, B>, fn: (A, B) -> Z): StateT<F, S, Z> =
+  fun <B, Z> map2(MF: Monad<F>, sb: StateTOf<F, S, B>, fn: (A, B) -> Z): StateT<F, S, Z> =
     MF.run {
-      invokeF(runF.map2(sb.runF) { (ssa, ssb) ->
+      invokeF(runF.map2(sb.fix().runF) { (ssa, ssb) ->
         ssa.andThen { fsa ->
           fsa.flatMap { (s, a) ->
             ssb(s).map { (s, b) -> Tuple2(s, fn(a, b)) }
@@ -180,12 +180,12 @@ class StateT<F, S, A>(
   /**
    * Controlled combination of [StateT] that is of same context [F] and state [S] using [Eval].
    *
-   * @param sb other state with value of type `B`.
-   * @param f the function to apply.
    * @param MF [Monad] for the context [F].
+   * @param sb other state with value of type `B`.
+   * @param fn the function to apply.
    */
-  fun <B, Z> map2Eval(MF: Monad<F>, sb: Eval<StateT<F, S, B>>, fn: (A, B) -> Z): Eval<StateT<F, S, Z>> = MF.run {
-    runF.map2Eval(sb.map { it.runF }) { (ssa, ssb) ->
+  fun <B, Z> map2Eval(MF: Monad<F>, sb: EvalOf<StateT<F, S, B>>, fn: (A, B) -> Z): Eval<StateT<F, S, Z>> = MF.run {
+    runF.map2Eval(sb.fix().map { it.runF }) { (ssa, ssb) ->
       ssa.andThen { fsa ->
         fsa.flatMap { (s, a) ->
           ssb((s)).map { (s, b) -> Tuple2(s, fn(a, b)) }
@@ -197,8 +197,8 @@ class StateT<F, S, A>(
   /**
    * Apply a function `(S) -> B` that operates within the [StateT] context.
    *
-   * @param ff function with the [StateT] context.
    * @param MF [Monad] for the context [F].
+   * @param ff function with the [StateT] context.
    */
   fun <B> ap(MF: Monad<F>, ff: StateTOf<F, S, (A) -> B>): StateT<F, S, B> =
     ff.fix().map2(MF, this) { f, a -> f(a) }
@@ -206,16 +206,17 @@ class StateT<F, S, A>(
   /**
    * Create a product of the value types of [StateT].
    *
-   * @param sb other stateful computation.
    * @param MF [Monad] for the context [F].
+   * @param sb other stateful computation.
    */
-  fun <B> product(MF: Monad<F>, sb: StateT<F, S, B>): StateT<F, S, Tuple2<A, B>> = map2(MF, sb) { a, b -> Tuple2(a, b) }
+  fun <B> product(MF: Monad<F>, sb: StateTOf<F, S, B>): StateT<F, S, Tuple2<A, B>> =
+    map2(MF, sb) { a, b -> Tuple2(a, b) }
 
   /**
    * Map the value [A] to another [StateT] object for the same state [S] and context [F] and flatten the structure.
    *
-   * @param fas the function to apply.
    * @param MF [Monad] for the context [F].
+   * @param fas the function to apply.
    */
   fun <B> flatMap(MF: Monad<F>, fas: (A) -> StateTOf<F, S, B>): StateT<F, S, B> = MF.run {
     invokeF(
@@ -231,8 +232,8 @@ class StateT<F, S, A>(
   /**
    * Map the value [A] to a arbitrary type [B] that is within the context of [F].
    *
-   * @param faf the function to apply.
    * @param MF [Monad] for the context [F].
+   * @param faf the function to apply.
    */
   fun <B> flatMapF(MF: Monad<F>, faf: (A) -> Kind<F, B>): StateT<F, S, B> = MF.run {
     invokeF(
@@ -248,8 +249,8 @@ class StateT<F, S, A>(
   /**
    * Transform the product of state [S] and value [A] to an another product of state [S] and an arbitrary type [B].
    *
-   * @param f the function to apply.
    * @param FF [Functor] for the context [F].
+   * @param f the function to apply.
    */
   fun <B> transform(FF: Functor<F>, f: (Tuple2<S, A>) -> Tuple2<S, B>): StateT<F, S, B> = FF.run {
     invokeF(
@@ -263,9 +264,9 @@ class StateT<F, S, A>(
   /**
    * Combine two [StateT] objects using an instance of [SemigroupK] for [F].
    *
-   * @param y other [StateT] object to combine.
    * @param MF [Monad] for the context [F].
    * @param SF [SemigroupK] for [F].
+   * @param y other [StateT] object to combine.
    */
   fun combineK(MF: Monad<F>, SF: SemigroupK<F>, y: StateTOf<F, S, A>): StateT<F, S, A> = SF.run {
     StateT(MF.just({ s -> run(MF, s).combineK(y.fix().run(MF, s)) }))
@@ -274,7 +275,7 @@ class StateT<F, S, A>(
   /**
    * Run the stateful computation within the context `F`.
    *
-   * @param s initial state to run stateful computation.
+   * @param initial state to run stateful computation.
    * @param MF [Monad] for the context [F].
    */
   fun run(MF: Monad<F>, initial: S): Kind<F, Tuple2<S, A>> = MF.run {

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/WriterT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/WriterT.kt
@@ -7,8 +7,8 @@ import arrow.core.toT
 import arrow.higherkind
 import arrow.typeclasses.*
 
-@Suppress("UNCHECKED_CAST")
-fun <F, W, A> WriterTOf<F, W, A>.value(): Kind<F, Tuple2<W, A>> = this.fix().value
+val <F, W, A> WriterTOf<F, W, A>.value: Kind<F, Tuple2<W, A>>
+  get() = this.fix().value
 
 @higherkind
 data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, A>, WriterTKindedJ<F, W, A> {
@@ -18,11 +18,14 @@ data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, 
     fun <F, W, A> just(AF: Applicative<F>, MM: Monoid<W>, a: A) =
       WriterT(AF.just(Tuple2(MM.empty(), a)))
 
-    fun <F, W, A> both(MF: Monad<F>, w: W, a: A) = WriterT(MF.just(Tuple2(w, a)))
+    fun <F, W, A> both(AF: Applicative<F>, w: W, a: A) =
+      WriterT(AF.just(Tuple2(w, a)))
 
-    fun <F, W, A> fromTuple(MF: Monad<F>, z: Tuple2<W, A>) = WriterT(MF.just(z))
+    fun <F, W, A> fromTuple(AF: Applicative<F>, z: Tuple2<W, A>) =
+      WriterT(AF.just(z))
 
-    operator fun <F, W, A> invoke(value: Kind<F, Tuple2<W, A>>): WriterT<F, W, A> = WriterT(value)
+    operator fun <F, W, A> invoke(value: Kind<F, Tuple2<W, A>>): WriterT<F, W, A> =
+      WriterT(value)
 
     fun <F, W, A> putT(FF: Functor<F>, vf: Kind<F, A>, w: W): WriterT<F, W, A> = FF.run {
       WriterT(vf.map { v -> Tuple2(w, v) })
@@ -38,40 +41,48 @@ data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, 
     fun <F, W, A> put2(AF: Applicative<F>, a: A, w: W): WriterT<F, W, A> =
       putT2(AF, AF.just(a), w)
 
-    fun <F, W> tell(AF: Applicative<F>, l: W): WriterT<F, W, Unit> = put(AF, Unit, l)
+    fun <F, W> tell(AF: Applicative<F>, l: W): WriterT<F, W, Unit> =
+      put(AF, Unit, l)
 
-    fun <F, W> tell2(AF: Applicative<F>, l: W): WriterT<F, W, Unit> = put2(AF, Unit, l)
+    fun <F, W> tell2(AF: Applicative<F>, l: W): WriterT<F, W, Unit> =
+      put2(AF, Unit, l)
 
-    fun <F, W, A> value(AF: Applicative<F>, monoidW: Monoid<W>, v: A):
-      WriterT<F, W, A> = put(AF, v, monoidW.empty())
+    fun <F, W, A> value(AF: Applicative<F>, monoidW: Monoid<W>, v: A): WriterT<F, W, A> =
+      put(AF, v, monoidW.empty())
 
     fun <F, W, A> valueT(AF: Applicative<F>, monoidW: Monoid<W>, vf: Kind<F, A>): WriterT<F, W, A> =
       putT(AF, vf, monoidW.empty())
 
-    fun <F, W, A> empty(MMF: MonoidK<F>): WriterTOf<F, W, A> = WriterT(MMF.empty())
+    fun <F, W, A> empty(MMF: MonoidK<F>): WriterTOf<F, W, A> =
+      WriterT(MMF.empty())
 
-    fun <F, W, A> pass(MF: Monad<F>, fa: Kind<WriterTPartialOf<F, W>, Tuple2<(W) -> W, A>>): WriterT<F, W, A> = MF.run {
+    fun <F, W, A> pass(MF: Monad<F>, fa: WriterTOf<F, W, Tuple2<(W) -> W, A>>): WriterT<F, W, A> = MF.run {
       WriterT(fa.fix().content(this).flatMap { tuple2FA -> fa.fix().write(this).map { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) } })
     }
 
-    fun <F, W, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> Kind<WriterTPartialOf<F, W>, Either<A, B>>): WriterT<F, W, B> =
+    fun <F, W, A, B> tailRecM(MF: Monad<F>, a: A, f: (A) -> WriterTOf<F, W, Either<A, B>>): WriterT<F, W, B> =
       WriterT(MF.tailRecM(a) {
         val value = f(it).fix().value
         MF.run {
-          value.map {
-            val right = it.b
+          value.map { (a, right) ->
             when (right) {
               is Either.Left -> Either.Left(right.a)
-              is Either.Right -> Either.Right(it.a toT right.b)
+              is Either.Right -> Either.Right(a toT right.b)
             }
           }
         }
       })
+
+    fun <F, W, A> liftF(fa: Kind<F, A>, MM: Monoid<W>, AF: Applicative<F>): WriterT<F, W, A> = AF.run {
+      WriterT(fa.map { a -> Tuple2(MM.empty(), a) })
+    }
+
   }
 
-  fun tell(MF: Monad<F>, SG: Semigroup<W>, w: W): WriterT<F, W, A> = mapAcc(MF) { SG.run { it.combine(w) } }
+  fun tell(MF: Monad<F>, SG: Semigroup<W>, w: W): WriterT<F, W, A> =
+    mapAcc(MF) { SG.run { it.combine(w) } }
 
-  fun listen(MF: Monad<F>): Kind<WriterTPartialOf<F, W>, Tuple2<W, A>> = MF.run {
+  fun listen(MF: Monad<F>): WriterTOf<F, W, Tuple2<W, A>> = MF.run {
     WriterT(content(this).flatMap { a -> write(this).map { l -> Tuple2(l, Tuple2(l, a)) } })
   }
 
@@ -83,22 +94,28 @@ data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, 
     value.map { it.a }
   }
 
-  fun reset(MF: Monad<F>, MM: Monoid<W>): WriterT<F, W, A> = mapAcc(MF) { MM.empty() }
+  fun reset(MF: Monad<F>, MM: Monoid<W>): WriterT<F, W, A> =
+    mapAcc(MF) { MM.empty() }
 
   fun <B> map(FF: Functor<F>, f: (A) -> B): WriterT<F, W, B> = FF.run {
     WriterT(value.map { it.a toT f(it.b) })
   }
 
-  fun <U> mapAcc(MF: Monad<F>, f: (W) -> U): WriterT<F, U, A> = transform(MF) { f(it.a) toT it.b }
+  fun <U> mapAcc(MF: Monad<F>, f: (W) -> U): WriterT<F, U, A> =
+    transform(MF) { f(it.a) toT it.b }
 
-  fun <C, U> bimap(MF: Monad<F>, g: (W) -> U, f: (A) -> C): WriterT<F, U, C> = transform(MF) { g(it.a) toT f(it.b) }
+  fun <C, U> bimap(MF: Monad<F>, g: (W) -> U, f: (A) -> C): WriterT<F, U, C> =
+    transform(MF) { g(it.a) toT f(it.b) }
 
-  fun swap(MF: Monad<F>): WriterT<F, A, W> = transform(MF) { it.b toT it.a }
+  fun swap(MF: Monad<F>): WriterT<F, A, W> =
+    transform(MF) { it.b toT it.a }
 
-  fun <B> ap(MF: Monad<F>, SG: Semigroup<W>, ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
-    ff.fix().flatMap(MF, SG) { map(MF, it) }
+  fun <B> ap(AF: Applicative<F>, SG: Semigroup<W>, ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
+    WriterT(AF.map(ff.fix().value, value) { (a, b) ->
+      Tuple2(SG.run { a.a.combine(b.a) }, a.b(b.b))
+    })
 
-  fun <B> flatMap(MF: Monad<F>, SG: Semigroup<W>, f: (A) -> WriterT<F, W, B>): WriterT<F, W, B> = MF.run {
+  fun <B> flatMap(MF: Monad<F>, SG: Semigroup<W>, f: (A) -> WriterTOf<F, W, B>): WriterT<F, W, B> = MF.run {
     WriterT(value.flatMap { value -> f(value.b).value.map { SG.run { it.a.combine(value.a) } toT it.b } })
   }
 
@@ -112,9 +129,11 @@ data class WriterT<F, W, A>(val value: Kind<F, Tuple2<W, A>>) : WriterTOf<F, W, 
   fun <C> semiflatMap(MF: Monad<F>, SG: Semigroup<W>, f: (A) -> Kind<F, C>): WriterT<F, W, C> =
     flatMap(MF, SG) { liftF(MF, f(it)) }
 
-  fun <B> subflatMap(MF: Monad<F>, f: (A) -> Tuple2<W, B>): WriterT<F, W, B> = transform(MF) { f(it.b) }
+  fun <B> subflatMap(MF: Monad<F>, f: (A) -> Tuple2<W, B>): WriterT<F, W, B> =
+    transform(MF) { f(it.b) }
 
   fun combineK(SF: SemigroupK<F>, y: WriterTOf<F, W, A>): WriterT<F, W, A> = SF.run {
     WriterT(value.combineK(y.fix().value))
   }
+
 }

--- a/modules/core/arrow-data/src/main/kotlin/arrow/data/WriterT.kt
+++ b/modules/core/arrow-data/src/main/kotlin/arrow/data/WriterT.kt
@@ -7,6 +7,10 @@ import arrow.core.toT
 import arrow.higherkind
 import arrow.typeclasses.*
 
+@Deprecated(message = "The value property is now directly accessible on the kinded version",
+  replaceWith = ReplaceWith(expression = "value"))
+fun <F, W, A> WriterTOf<F, W, A>.value() = value
+
 val <F, W, A> WriterTOf<F, W, A>.value: Kind<F, Tuple2<W, A>>
   get() = this.fix().value
 

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/EitherTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/EitherTTest.kt
@@ -4,11 +4,10 @@ import arrow.Kind
 import arrow.core.*
 import arrow.effects.ForIO
 import arrow.effects.IO
+import arrow.effects.instances.eithert.async.async
 import arrow.effects.instances.io.applicativeError.attempt
 import arrow.effects.instances.io.async.async
-import arrow.instances.either.monadError.monadError
 import arrow.instances.eithert.applicative.applicative
-import arrow.instances.eithert.async.async
 import arrow.instances.eithert.semigroupK.semigroupK
 import arrow.instances.eithert.traverse.traverse
 import arrow.instances.id.monad.monad
@@ -16,7 +15,6 @@ import arrow.instances.id.traverse.traverse
 import arrow.instances.option.functor.functor
 import arrow.test.UnitSpec
 import arrow.test.laws.AsyncLaws
-import arrow.test.laws.MonadErrorLaws
 import arrow.test.laws.SemigroupKLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -28,11 +26,11 @@ import org.junit.runner.RunWith
 class EitherTTest : UnitSpec() {
 
   private fun IOEQ(): Eq<Kind<EitherTPartialOf<ForIO, Throwable>, Int>> = Eq { a, b ->
-    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+    a.value().attempt().unsafeRunSync() == b.value().attempt().unsafeRunSync()
   }
 
   private fun IOEitherEQ(): Eq<Kind<EitherTPartialOf<ForIO, Throwable>, Either<Throwable, Int>>> = Eq { a, b ->
-    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+    a.value().attempt().unsafeRunSync() == b.value().attempt().unsafeRunSync()
   }
 
   init {

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/EitherTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/EitherTTest.kt
@@ -1,12 +1,21 @@
 package arrow.data
 
+import arrow.Kind
 import arrow.core.*
-import arrow.instances.*
+import arrow.effects.ForIO
+import arrow.effects.IO
+import arrow.effects.instances.io.applicativeError.attempt
+import arrow.effects.instances.io.async.async
 import arrow.instances.either.monadError.monadError
+import arrow.instances.eithert.applicative.applicative
+import arrow.instances.eithert.async.async
+import arrow.instances.eithert.semigroupK.semigroupK
+import arrow.instances.eithert.traverse.traverse
 import arrow.instances.id.monad.monad
 import arrow.instances.id.traverse.traverse
 import arrow.instances.option.functor.functor
 import arrow.test.UnitSpec
+import arrow.test.laws.AsyncLaws
 import arrow.test.laws.MonadErrorLaws
 import arrow.test.laws.SemigroupKLaws
 import arrow.test.laws.TraverseLaws
@@ -17,10 +26,19 @@ import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)
 class EitherTTest : UnitSpec() {
+
+  private fun IOEQ(): Eq<Kind<EitherTPartialOf<ForIO, Throwable>, Int>> = Eq { a, b ->
+    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+  }
+
+  private fun IOEitherEQ(): Eq<Kind<EitherTPartialOf<ForIO, Throwable>, Either<Throwable, Int>>> = Eq { a, b ->
+    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+  }
+
   init {
 
       testLaws(
-        MonadErrorLaws.laws(Either.monadError(), Eq.any(), Eq.any()),
+        AsyncLaws.laws(EitherT.async(IO.async()), IOEQ(), IOEitherEQ()),
         TraverseLaws.laws(EitherT.traverse<ForId, Int>(Id.traverse()), EitherT.applicative<ForId, Int>(Id.monad()), { EitherT(Id(Right(it))) }, Eq.any()),
         SemigroupKLaws.laws<EitherTPartialOf<ForId, Int>>(
           EitherT.semigroupK(Id.monad()),

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/KleisliTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/KleisliTest.kt
@@ -5,14 +5,14 @@ import arrow.core.*
 import arrow.effects.ForIO
 import arrow.effects.IO
 import arrow.effects.instances.io.applicativeError.attempt
-import arrow.effects.instances.io.bracket.bracket
-import arrow.effects.instances.kleisli.bracket.bracket
+import arrow.effects.instances.io.async.async
+import arrow.effects.instances.kleisli.async.async
 import arrow.instances.`try`.monadError.monadError
 import arrow.instances.id.monad.monad
 import arrow.instances.kleisli.contravariant.contravariant
 import arrow.instances.kleisli.monadError.monadError
 import arrow.test.UnitSpec
-import arrow.test.laws.BracketLaws
+import arrow.test.laws.AsyncLaws
 import arrow.test.laws.ContravariantLaws
 import arrow.test.laws.MonadErrorLaws
 import arrow.typeclasses.Conested
@@ -27,29 +27,28 @@ import org.junit.runner.RunWith
 @RunWith(KTestJUnitRunner::class)
 class KleisliTest : UnitSpec() {
   private fun <A> TryEQ(): Eq<KleisliOf<ForTry, Int, A>> = Eq { a, b ->
-    a.fix().run(1) == b.fix().run(1)
+    a.run(1) == b.run(1)
   }
 
   private fun <A> ConestTryEQ(): Eq<Kind<Conested<Kind<ForKleisli, ForTry>, A>, Int>> = Eq { a, b ->
-    a.counnest().fix().run(1) == b.counnest().fix().run(1)
+    a.counnest().run(1) == b.counnest().run(1)
   }
 
   private fun IOEQ(): Eq<Kind<KleisliPartialOf<ForIO, Int>, Int>> = Eq { a, b ->
-    a.fix().run(1).attempt().unsafeRunSync() == b.fix().run(1).attempt().unsafeRunSync()
+    a.run(1).attempt().unsafeRunSync() == b.run(1).attempt().unsafeRunSync()
   }
 
   private fun IOEitherEQ(): Eq<Kind<KleisliPartialOf<ForIO, Int>, Either<Throwable, Int>>> = Eq { a, b ->
-    a.fix().run(1).attempt().unsafeRunSync() == b.fix().run(1).attempt().unsafeRunSync()
+    a.run(1).attempt().unsafeRunSync() == b.run(1).attempt().unsafeRunSync()
   }
 
   init {
 
     testLaws(
-      BracketLaws.laws(
-        BF = Kleisli.bracket<ForIO, Int, Throwable>(IO.bracket()),
+      AsyncLaws.laws(
+        Kleisli.async<ForIO, Int>(IO.async()),
         EQ = IOEQ(),
-        EQ_EITHER = IOEitherEQ(),
-        EQERR = IOEQ()
+        EQ_EITHER = IOEitherEQ()
       ),
       ContravariantLaws.laws(Kleisli.contravariant(), { Kleisli { x: Int -> Try.just(x) }.conest() }, ConestTryEQ()),
       MonadErrorLaws.laws(Kleisli.monadError<ForTry, Int, Throwable>(Try.monadError()), TryEQ(), TryEQ())
@@ -58,9 +57,9 @@ class KleisliTest : UnitSpec() {
     "andThen should continue sequence" {
       val kleisli: Kleisli<ForId, Int, Int> = Kleisli { a: Int -> Id(a) }
 
-      kleisli.andThen(Id.monad(), Id(3)).run(0).fix().value shouldBe 3
+      kleisli.andThen(Id.monad(), Id(3)).run(0).value() shouldBe 3
 
-      kleisli.andThen(Id.monad()) { b -> Id(b + 1) }.run(0).fix().value shouldBe 1
+      kleisli.andThen(Id.monad()) { b -> Id(b + 1) }.run(0).value() shouldBe 1
     }
   }
 }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/KleisliTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/KleisliTest.kt
@@ -5,14 +5,14 @@ import arrow.core.*
 import arrow.effects.ForIO
 import arrow.effects.IO
 import arrow.effects.instances.io.applicativeError.attempt
-import arrow.effects.instances.io.async.async
-import arrow.effects.instances.kleisli.async.async
+import arrow.effects.instances.io.bracket.bracket
+import arrow.effects.instances.kleisli.bracket.bracket
 import arrow.instances.`try`.monadError.monadError
 import arrow.instances.id.monad.monad
 import arrow.instances.kleisli.contravariant.contravariant
 import arrow.instances.kleisli.monadError.monadError
 import arrow.test.UnitSpec
-import arrow.test.laws.AsyncLaws
+import arrow.test.laws.BracketLaws
 import arrow.test.laws.ContravariantLaws
 import arrow.test.laws.MonadErrorLaws
 import arrow.typeclasses.Conested
@@ -45,10 +45,11 @@ class KleisliTest : UnitSpec() {
   init {
 
     testLaws(
-      AsyncLaws.laws(
-        Kleisli.async<ForIO, Int>(IO.async()),
+      BracketLaws.laws(
+        BF = Kleisli.bracket<ForIO, Int, Throwable>(IO.bracket()),
         EQ = IOEQ(),
-        EQ_EITHER = IOEitherEQ()
+        EQ_EITHER = IOEitherEQ(),
+        EQERR = IOEQ()
       ),
       ContravariantLaws.laws(Kleisli.contravariant(), { Kleisli { x: Int -> Try.just(x) }.conest() }, ConestTryEQ()),
       MonadErrorLaws.laws(Kleisli.monadError<ForTry, Int, Throwable>(Try.monadError()), TryEQ(), TryEQ())

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/OptionTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/OptionTTest.kt
@@ -9,12 +9,10 @@ import arrow.effects.ForIO
 import arrow.effects.IO
 import arrow.effects.instances.io.applicativeError.attempt
 import arrow.effects.instances.io.async.async
+import arrow.effects.instances.optiont.async.async
 import arrow.instances.nonemptylist.monad.monad
 import arrow.instances.option.monad.monad
-import arrow.instances.option.semigroup.semigroup
 import arrow.instances.optiont.applicative.applicative
-import arrow.instances.optiont.async.async
-import arrow.instances.optiont.monad.monad
 import arrow.instances.optiont.monoidK.monoidK
 import arrow.instances.optiont.semigroupK.semigroupK
 import arrow.mtl.instances.option.traverseFilter.traverseFilter
@@ -32,19 +30,19 @@ import org.junit.runner.RunWith
 class OptionTTest : UnitSpec() {
 
   fun <A> EQ(): Eq<Kind<OptionTPartialOf<A>, Int>> = Eq { a, b ->
-    a.value == b.value
+    a.value() == b.value()
   }
 
   fun <A> EQ_NESTED(): Eq<Kind<OptionTPartialOf<A>, Kind<OptionTPartialOf<A>, Int>>> = Eq { a, b ->
-    a.value == b.value
+    a.value() == b.value()
   }
 
   private fun IOEQ(): Eq<Kind<OptionTPartialOf<ForIO>, Int>> = Eq { a, b ->
-    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+    a.value().attempt().unsafeRunSync() == b.value().attempt().unsafeRunSync()
   }
 
   private fun IOEitherEQ(): Eq<Kind<OptionTPartialOf<ForIO>, Either<Throwable, Int>>> = Eq { a, b ->
-    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+    a.value().attempt().unsafeRunSync() == b.value().attempt().unsafeRunSync()
   }
 
   val NELM: Monad<ForNonEmptyList> = NonEmptyList.monad()

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/StateTTests.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/StateTTests.kt
@@ -1,8 +1,15 @@
 package arrow.data
 
 import arrow.Kind
+import arrow.core.Either
 import arrow.core.ForTry
 import arrow.core.Try
+import arrow.effects.ForIO
+import arrow.effects.IO
+import arrow.effects.instances.io.applicativeError.attempt
+import arrow.effects.instances.io.async.async
+import arrow.effects.instances.io.monad.monad
+import arrow.effects.instances.statet.async.async
 import arrow.instances.`try`.monad.monad
 import arrow.instances.listk.monad.monad
 import arrow.instances.listk.semigroupK.semigroupK
@@ -13,6 +20,7 @@ import arrow.mtl.instances.listk.monadCombine.monadCombine
 import arrow.mtl.instances.statet.monadCombine.monadCombine
 import arrow.mtl.instances.statet.monadState.monadState
 import arrow.test.UnitSpec
+import arrow.test.laws.AsyncLaws
 import arrow.test.laws.MonadCombineLaws
 import arrow.test.laws.MonadStateLaws
 import arrow.test.laws.SemigroupKLaws
@@ -37,17 +45,26 @@ class StateTTests : UnitSpec() {
     a.runM(ListK.monad(), 1) == b.runM(ListK.monad(), 1)
   }
 
+  private fun IOEQ(): Eq<StateTOf<ForIO, Int, Int>> = Eq { a, b ->
+    a.runM(IO.monad(), 1).attempt().unsafeRunSync() == b.runM(IO.monad(), 1).attempt().unsafeRunSync()
+  }
+
+  private fun IOEitherEQ(): Eq<StateTOf<ForIO, Int, Either<Throwable, Int>>> = Eq { a, b ->
+    a.runM(IO.monad(), 1).attempt().unsafeRunSync() == b.runM(IO.monad(), 1).attempt().unsafeRunSync()
+  }
+
   init {
 
     testLaws(
       MonadStateLaws.laws(M, EQ, EQ_UNIT),
+      AsyncLaws.laws<StateTPartialOf<ForIO, Int>>(StateT.async(IO.async()), IOEQ(), IOEitherEQ()),
       SemigroupKLaws.laws(
         StateT.semigroupK<ForListK, Int>(ListK.monad(), ListK.semigroupK()),
         StateT.applicative<ForListK, Int>(ListK.monad()),
         EQ_LIST),
       MonadCombineLaws.laws(StateT.monadCombine<ForListK, Int>(ListK.monadCombine()),
-        { StateT.lift(ListK.monad(), ListK.just(it)) },
-        { StateT.lift(ListK.monad(), ListK.just({ s: Int -> s * 2 })) },
+        { StateT.liftF(ListK.monad(), ListK.just(it)) },
+        { StateT.liftF(ListK.monad(), ListK.just({ s: Int -> s * 2 })) },
         EQ_LIST)
     )
   }

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/WriterTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/WriterTTest.kt
@@ -6,12 +6,12 @@ import arrow.effects.ForIO
 import arrow.effects.IO
 import arrow.effects.instances.io.applicativeError.attempt
 import arrow.effects.instances.io.async.async
+import arrow.effects.instances.writert.async.async
 import arrow.instances.*
 import arrow.instances.listk.monad.monad
 import arrow.instances.listk.monoidK.monoidK
 import arrow.instances.option.monad.monad
 import arrow.instances.writert.applicative.applicative
-import arrow.instances.writert.async.async
 import arrow.instances.writert.monad.monad
 import arrow.instances.writert.monoidK.monoidK
 import arrow.mtl.instances.option.monadFilter.monadFilter
@@ -29,11 +29,11 @@ import org.junit.runner.RunWith
 class WriterTTest : UnitSpec() {
 
   private fun IOEQ(): Eq<Kind<WriterTPartialOf<ForIO, Int>, Int>> = Eq { a, b ->
-    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+    a.value().attempt().unsafeRunSync() == b.value().attempt().unsafeRunSync()
   }
 
   private fun IOEitherEQ(): Eq<Kind<WriterTPartialOf<ForIO, Int>, Either<Throwable, Int>>> = Eq { a, b ->
-    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+    a.value().attempt().unsafeRunSync() == b.value().attempt().unsafeRunSync()
   }
 
   init {
@@ -45,7 +45,7 @@ class WriterTTest : UnitSpec() {
         WriterT.  monoidK<ForListK, Int>(ListK.monoidK()),
         WriterT.applicative(ListK.monad(), Int.monoid()),
         Eq { a, b ->
-          a.value == b.value
+          a.value() == b.value()
         }),
 
       MonadWriterLaws.laws(WriterT.monad(Option.monad(), Int.monoid()),
@@ -54,14 +54,14 @@ class WriterTTest : UnitSpec() {
         genIntSmall(),
         genTuple(genIntSmall(), genIntSmall()),
         Eq { a, b ->
-          a.value.fix().let { optionA: Option<Tuple2<Int, Int>> ->
-            val optionB = b.value.fix()
+          a.value().fix().let { optionA: Option<Tuple2<Int, Int>> ->
+            val optionB = b.value().fix()
             optionA.fold({ optionB.fold({ true }, { false }) }, { value: Tuple2<Int, Int> -> optionB.fold({ false }, { value == it }) })
           }
         },
         Eq { a, b ->
-          a.value.fix().let { optionA: Option<Tuple2<Int, Tuple2<Int, Int>>> ->
-            val optionB = b.value.fix()
+          a.value().fix().let { optionA: Option<Tuple2<Int, Tuple2<Int, Int>>> ->
+            val optionB = b.value().fix()
             optionA.fold({ optionB.fold({ true }, { false }) }, { value: Tuple2<Int, Tuple2<Int, Int>> -> optionB.fold({ false }, { value == it }) })
           }
         }
@@ -71,8 +71,8 @@ class WriterTTest : UnitSpec() {
         { WriterT(Option(Tuple2(it, it))) },
         object : Eq<Kind<WriterTPartialOf<ForOption, Int>, Int>> {
           override fun Kind<WriterTPartialOf<ForOption, Int>, Int>.eqv(b: Kind<WriterTPartialOf<ForOption, Int>, Int>): Boolean =
-            value.fix().let { optionA: Option<Tuple2<Int, Int>> ->
-              val optionB = b.value.fix()
+            value().fix().let { optionA: Option<Tuple2<Int, Int>> ->
+              val optionB = b.value().fix()
               optionA.fold({ optionB.fold({ true }, { false }) }, { value: Tuple2<Int, Int> -> optionB.fold({ false }, { value == it }) })
             }
         })

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/WriterTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/WriterTTest.kt
@@ -1,15 +1,17 @@
 package arrow.data
 
 import arrow.Kind
-import arrow.core.ForOption
-import arrow.core.Option
-import arrow.core.Tuple2
-import arrow.core.fix
-import arrow.instances.monoid
+import arrow.core.*
+import arrow.effects.ForIO
+import arrow.effects.IO
+import arrow.effects.instances.io.applicativeError.attempt
+import arrow.effects.instances.io.async.async
+import arrow.instances.*
 import arrow.instances.listk.monad.monad
 import arrow.instances.listk.monoidK.monoidK
 import arrow.instances.option.monad.monad
 import arrow.instances.writert.applicative.applicative
+import arrow.instances.writert.async.async
 import arrow.instances.writert.monad.monad
 import arrow.instances.writert.monoidK.monoidK
 import arrow.mtl.instances.option.monadFilter.monadFilter
@@ -18,25 +20,32 @@ import arrow.mtl.instances.writert.monadWriter.monadWriter
 import arrow.test.UnitSpec
 import arrow.test.generators.genIntSmall
 import arrow.test.generators.genTuple
-import arrow.test.laws.MonadFilterLaws
-import arrow.test.laws.MonadLaws
-import arrow.test.laws.MonadWriterLaws
-import arrow.test.laws.MonoidKLaws
+import arrow.test.laws.*
 import arrow.typeclasses.Eq
 import io.kotlintest.KTestJUnitRunner
 import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)
 class WriterTTest : UnitSpec() {
+
+  private fun IOEQ(): Eq<Kind<WriterTPartialOf<ForIO, Int>, Int>> = Eq { a, b ->
+    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+  }
+
+  private fun IOEitherEQ(): Eq<Kind<WriterTPartialOf<ForIO, Int>, Either<Throwable, Int>>> = Eq { a, b ->
+    a.value.attempt().unsafeRunSync() == b.value.attempt().unsafeRunSync()
+  }
+
   init {
 
     testLaws(
-      MonadLaws.laws(WriterT.monad(Option.monad(), Int.monoid()), Eq.any()),
+      AsyncLaws.laws(WriterT.async(IO.async(), Int.monoid()), IOEQ(), IOEitherEQ()),
+
       MonoidKLaws.laws(
-        WriterT.monoidK<ForListK, Int>(ListK.monoidK()),
+        WriterT.  monoidK<ForListK, Int>(ListK.monoidK()),
         WriterT.applicative(ListK.monad(), Int.monoid()),
         Eq { a, b ->
-          a.fix().value == b.fix().value
+          a.value == b.value
         }),
 
       MonadWriterLaws.laws(WriterT.monad(Option.monad(), Int.monoid()),
@@ -45,14 +54,14 @@ class WriterTTest : UnitSpec() {
         genIntSmall(),
         genTuple(genIntSmall(), genIntSmall()),
         Eq { a, b ->
-          a.fix().value.fix().let { optionA: Option<Tuple2<Int, Int>> ->
-            val optionB = b.fix().value.fix()
+          a.value.fix().let { optionA: Option<Tuple2<Int, Int>> ->
+            val optionB = b.value.fix()
             optionA.fold({ optionB.fold({ true }, { false }) }, { value: Tuple2<Int, Int> -> optionB.fold({ false }, { value == it }) })
           }
         },
         Eq { a, b ->
-          a.fix().value.fix().let { optionA: Option<Tuple2<Int, Tuple2<Int, Int>>> ->
-            val optionB = b.fix().value.fix()
+          a.value.fix().let { optionA: Option<Tuple2<Int, Tuple2<Int, Int>>> ->
+            val optionB = b.value.fix()
             optionA.fold({ optionB.fold({ true }, { false }) }, { value: Tuple2<Int, Tuple2<Int, Int>> -> optionB.fold({ false }, { value == it }) })
           }
         }
@@ -62,8 +71,8 @@ class WriterTTest : UnitSpec() {
         { WriterT(Option(Tuple2(it, it))) },
         object : Eq<Kind<WriterTPartialOf<ForOption, Int>, Int>> {
           override fun Kind<WriterTPartialOf<ForOption, Int>, Int>.eqv(b: Kind<WriterTPartialOf<ForOption, Int>, Int>): Boolean =
-            fix().value.fix().let { optionA: Option<Tuple2<Int, Int>> ->
-              val optionB = b.fix().value.fix()
+            value.fix().let { optionA: Option<Tuple2<Int, Int>> ->
+              val optionB = b.value.fix()
               optionA.fold({ optionB.fold({ true }, { false }) }, { value: Tuple2<Int, Int> -> optionB.fold({ false }, { value == it }) })
             }
         })

--- a/modules/core/arrow-data/src/test/kotlin/arrow/instances/ComposedInstancesTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/instances/ComposedInstancesTest.kt
@@ -42,12 +42,12 @@ class ComposedInstancesTest : UnitSpec() {
 
     val EQ_OPTIONT_ID_NEL: Eq<NestedType<OptionTPartialOf<ForId>, OptionTPartialOf<ForNonEmptyList>, Int>> =
       Eq { a, b ->
-        a.unnest().value.value().fold(
-          { b.unnest().value.value().isEmpty() },
+        a.unnest().value().value().fold(
+          { b.unnest().value().value().isEmpty() },
           { optionA: OptionTNel ->
-            b.unnest().value.value().fix().fold(
+            b.unnest().value().value().fix().fold(
               { false },
-              { it.value == optionA.value })
+              { it.value() == optionA.value() })
           })
       }
 

--- a/modules/core/arrow-data/src/test/kotlin/arrow/instances/ComposedInstancesTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/instances/ComposedInstancesTest.kt
@@ -42,12 +42,12 @@ class ComposedInstancesTest : UnitSpec() {
 
     val EQ_OPTIONT_ID_NEL: Eq<NestedType<OptionTPartialOf<ForId>, OptionTPartialOf<ForNonEmptyList>, Int>> =
       Eq { a, b ->
-        a.unnest().value().value().fold(
-          { b.unnest().value().value().isEmpty() },
+        a.unnest().value.value().fold(
+          { b.unnest().value.value().isEmpty() },
           { optionA: OptionTNel ->
-            b.unnest().value().value().fix().fold(
+            b.unnest().value.value().fix().fold(
               { false },
-              { it.value() == optionA.value() })
+              { it.value == optionA.value })
           })
       }
 

--- a/modules/core/arrow-free/src/test/kotlin/arrow/free/CofreeTest.kt
+++ b/modules/core/arrow-free/src/test/kotlin/arrow/free/CofreeTest.kt
@@ -145,9 +145,9 @@ class CofreeTest : UnitSpec() {
           override fun <A> invoke(fa: Kind<ForEval, A>): Kind<EvalOptionF, A> =
             OptionT(fa.fix().map { Some(it) })
         }
-        val cataHundred = cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).value.fix().value()
+        val cataHundred = cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).value().value()
         val newCof = Cofree(Option.functor(), 2001, Eval.now(Some(startTwoThousand)))
-        val cataHundredOne = newCof.cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).value.fix().value()
+        val cataHundredOne = newCof.cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).value().value()
 
         cataHundred shouldBe Some(NonEmptyList.fromListUnsafe((0..2000).toList()))
         cataHundredOne shouldBe None

--- a/modules/core/arrow-free/src/test/kotlin/arrow/free/CofreeTest.kt
+++ b/modules/core/arrow-free/src/test/kotlin/arrow/free/CofreeTest.kt
@@ -145,9 +145,9 @@ class CofreeTest : UnitSpec() {
           override fun <A> invoke(fa: Kind<ForEval, A>): Kind<EvalOptionF, A> =
             OptionT(fa.fix().map { Some(it) })
         }
-        val cataHundred = cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).fix().value.fix().value()
+        val cataHundred = cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).value.fix().value()
         val newCof = Cofree(Option.functor(), 2001, Eval.now(Some(startTwoThousand)))
-        val cataHundredOne = newCof.cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).fix().value.fix().value()
+        val cataHundredOne = newCof.cataM(OptionT.monad(Eval.monad()), Option.traverse(), inclusion, folder).value.fix().value()
 
         cataHundred shouldBe Some(NonEmptyList.fromListUnsafe((0..2000).toList()))
         cataHundredOne shouldBe None

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/const.kt
@@ -10,19 +10,19 @@ import arrow.typeclasses.combine as combineAp
 
 @extension
 interface ConstInvariant<A> : Invariant<ConstPartialOf<A>> {
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.imap(f: (T) -> U, g: (U) -> T): Const<A, U> =
+  override fun <T, U> ConstOf<A, T>.imap(f: (T) -> U, g: (U) -> T): Const<A, U> =
     fix().retag()
 }
 
 @extension
 interface ConstContravariant<A> : Contravariant<ConstPartialOf<A>> {
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.contramap(f: (U) -> T): Const<A, U> =
+  override fun <T, U> ConstOf<A, T>.contramap(f: (U) -> T): Const<A, U> =
     fix().retag()
 }
 
 @extension
 interface ConstFunctorInstance<A> : Functor<ConstPartialOf<A>> {
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.map(f: (T) -> U): Const<A, U> =
+  override fun <T, U> ConstOf<A, T>.map(f: (T) -> U): Const<A, U> =
     fix().retag()
 }
 
@@ -31,23 +31,23 @@ interface ConstApplicativeInstance<A> : Applicative<ConstPartialOf<A>> {
 
   fun MA(): Monoid<A>
 
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.map(f: (T) -> U): Const<A, U> = fix().retag()
+  override fun <T, U> ConstOf<A, T>.map(f: (T) -> U): Const<A, U> = fix().retag()
 
   override fun <T> just(a: T): Const<A, T> = object : ConstMonoidInstance<A, T> {
     override fun SA(): Semigroup<A> = MA()
     override fun MA(): Monoid<A> = this@ConstApplicativeInstance.MA()
   }.empty().fix()
 
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.ap(ff: Kind<ConstPartialOf<A>, (T) -> U>): Const<A, U> =
+  override fun <T, U> ConstOf<A, T>.ap(ff: ConstOf<A, (T) -> U>): Const<A, U> =
     constAp(MA(), ff)
 }
 
 @extension
 interface ConstFoldableInstance<A> : Foldable<ConstPartialOf<A>> {
 
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.foldLeft(b: U, f: (U, T) -> U): U = b
+  override fun <T, U> ConstOf<A, T>.foldLeft(b: U, f: (U, T) -> U): U = b
 
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
+  override fun <T, U> ConstOf<A, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
 
 }
 
@@ -86,7 +86,7 @@ interface ConstEqInstance<A, T> : Eq<Const<A, T>> {
   fun EQ(): Eq<A>
 
   override fun Const<A, T>.eqv(b: Const<A, T>): Boolean =
-    EQ().run { value.eqv(b.value) }
+    EQ().run { value().eqv(b.value()) }
 }
 
 @extension
@@ -101,13 +101,13 @@ interface ConstHashInstance<A, T> : Hash<Const<A, T>>, ConstEqInstance<A, T> {
 
   override fun EQ(): Eq<A> = HA()
 
-  override fun Const<A, T>.hash(): Int = HA().run { value.hash() }
+  override fun Const<A, T>.hash(): Int = HA().run { value().hash() }
 }
 
 class ConstContext<A>(val MA: Monoid<A>) : ConstApplicativeInstance<A>, ConstTraverseInstance<A> {
   override fun MA(): Monoid<A> = MA
 
-  override fun <T, U> Kind<ConstPartialOf<A>, T>.map(f: (T) -> U): Const<A, U> =
+  override fun <T, U> ConstOf<A, T>.map(f: (T) -> U): Const<A, U> =
     fix().map(f)
 }
 

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
@@ -13,7 +13,7 @@ interface IdEqInstance<A> : Eq<Id<A>> {
   fun EQ(): Eq<A>
 
   override fun Id<A>.eqv(b: Id<A>): Boolean =
-    EQ().run { value.eqv(b.value) }
+    EQ().run { value().eqv(b.value()) }
 }
 
 @extension
@@ -132,7 +132,7 @@ interface IdHashInstance<A> : Hash<Id<A>>, IdEqInstance<A> {
 
   override fun EQ(): Eq<A> = HA()
 
-  override fun Id<A>.hash(): Int = HA().run { value.hash() }
+  override fun Id<A>.hash(): Int = HA().run { value().hash() }
 }
 
 object IdContext : IdBimonadInstance, IdTraverseInstance {

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/eithert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/eithert.kt
@@ -2,170 +2,160 @@ package arrow.instances
 
 import arrow.Kind
 import arrow.core.*
-import arrow.data.EitherT
-import arrow.data.EitherTOf
-import arrow.data.EitherTPartialOf
-import arrow.data.fix
+import arrow.data.*
 import arrow.deprecation.ExtensionsDSLDeprecated
+import arrow.extension
 import arrow.instances.either.foldable.foldable
 import arrow.instances.either.monad.monad
 import arrow.instances.either.traverse.traverse
+import arrow.instances.validated.applicativeError.raiseError
 import arrow.typeclasses.*
 
+@extension
 interface EitherTFunctorInstance<F, L> : Functor<EitherTPartialOf<F, L>> {
 
   fun FF(): Functor<F>
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.map(f: (A) -> B): EitherT<F, L, B> = fix().map(FF()) { f(it) }
+  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+    fix().map(FF(), f)
 }
 
+@extension
 interface EitherTApplicativeInstance<F, L> : Applicative<EitherTPartialOf<F, L>>, EitherTFunctorInstance<F, L> {
+
+  fun AF(): Applicative<F>
+
+  override fun FF(): Functor<F> = AF()
+
+  override fun <A> just(a: A): EitherT<F, L, A> =
+    EitherT.just(AF(), a)
+
+  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+    fix().map(AF(), f)
+
+  override fun <A, B> EitherTOf<F, L, A>.ap(ff: EitherTOf<F, L, (A) -> B>): EitherT<F, L, B> =
+    fix().ap(AF(), ff)
+}
+
+@extension
+interface EitherTMonadInstance<F, L> : Monad<EitherTPartialOf<F, L>>, EitherTApplicativeInstance<F, L> {
 
   fun MF(): Monad<F>
 
-  override fun <A> just(a: A): EitherT<F, L, A> = EitherT.just(MF(), a)
+  override fun AF(): Applicative<F> = MF()
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.map(f: (A) -> B): EitherT<F, L, B> = fix().map(MF()) { f(it) }
+  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+    fix().map(MF(), f)
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.ap(ff: Kind<EitherTPartialOf<F, L>, (A) -> B>): EitherT<F, L, B> =
-    fix().ap(MF(), ff)
-}
-
-interface EitherTMonadInstance<F, L> : Monad<EitherTPartialOf<F, L>>, EitherTApplicativeInstance<F, L> {
-
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.map(f: (A) -> B): EitherT<F, L, B> = fix().map(MF()) { f(it) }
-
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.ap(ff: Kind<EitherTPartialOf<F, L>, (A) -> B>): EitherT<F, L, B> =
+  override fun <A, B> EitherTOf<F, L, A>.ap(ff: EitherTOf<F, L, (A) -> B>): EitherT<F, L, B> =
     fix().ap(MF(), ff)
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.flatMap(f: (A) -> Kind<EitherTPartialOf<F, L>, B>): EitherT<F, L, B> = fix().flatMap(MF()) { f(it).fix() }
+  override fun <A, B> EitherTOf<F, L, A>.flatMap(f: (A) -> EitherTOf<F, L, B>): EitherT<F, L, B> =
+    fix().flatMap(MF(), f)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> EitherTOf<F, L, Either<A, B>>): EitherT<F, L, B> =
     EitherT.tailRecM(MF(), a, f)
 }
 
+@extension
 interface EitherTApplicativeErrorInstance<F, L> : ApplicativeError<EitherTPartialOf<F, L>, L>, EitherTApplicativeInstance<F, L> {
 
-  override fun <A> Kind<EitherTPartialOf<F, L>, A>.handleErrorWith(f: (L) -> Kind<EitherTPartialOf<F, L>, A>): EitherT<F, L, A> = MF().run {
-    EitherT(fix().value.flatMap {
-      when (it) {
-        is Either.Left -> f(it.a).fix().value
-        is Either.Right -> just(it)
-      }
-    })
+  fun AE(): ApplicativeError<F, L>
+
+  override fun AF(): Applicative<F> = AE()
+
+  override fun <A> EitherTOf<F, L, A>.handleErrorWith(f: (L) -> EitherTOf<F, L, A>): EitherT<F, L, A> = AE().run {
+    EitherT(value.handleErrorWith { l -> f(l).value })
   }
 
-  override fun <A> raiseError(e: L): EitherT<F, L, A> = EitherT(MF().just(Left(e)))
+  override fun <A> raiseError(e: L): EitherT<F, L, A> = AE().run {
+    EitherT.liftF(this, raiseError(e))
+  }
+
 }
 
-interface EitherTMonadErrorInstance<F, L> : MonadError<EitherTPartialOf<F, L>, L>, EitherTApplicativeErrorInstance<F, L>, EitherTMonadInstance<F, L>
+@extension
+interface EitherTMonadErrorInstance<F, L> : MonadError<EitherTPartialOf<F, L>, L>, EitherTApplicativeErrorInstance<F, L>, EitherTMonadInstance<F, L> {
+  override fun MF(): Monad<F>
+  override fun AE(): ApplicativeError<F, L>
+  override fun AF(): Applicative<F> = MF()
+}
 
+fun <F, L> EitherT.Companion.monadError(ME: MonadError<F, L>): MonadError<EitherTPartialOf<F, L>, L> =
+  object : EitherTMonadErrorInstance<F, L> {
+    override fun MF(): Monad<F> = ME
+    override fun AE(): ApplicativeError<F, L> = ME
+  }
+
+@extension
+interface EitherTMonadThrowInstance<F> : MonadThrow<EitherTPartialOf<F, Throwable>>, EitherTMonadErrorInstance<F, Throwable> {
+  override fun MF(): Monad<F>
+  override fun AE(): ApplicativeError<F, Throwable>
+}
+
+@extension
 interface EitherTFoldableInstance<F, L> : Foldable<EitherTPartialOf<F, L>> {
 
   fun FFF(): Foldable<F>
 
-  override fun <B, C> Kind<EitherTPartialOf<F, L>, B>.foldLeft(b: C, f: (C, B) -> C): C = fix().foldLeft(FFF(), b, f)
+  override fun <B, C> EitherTOf<F, L, B>.foldLeft(b: C, f: (C, B) -> C): C =
+    fix().foldLeft(FFF(), b, f)
 
-  override fun <B, C> Kind<EitherTPartialOf<F, L>, B>.foldRight(lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
+  override fun <B, C> EitherTOf<F, L, B>.foldRight(lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fix().foldRight(FFF(), lb, f)
 }
 
+@extension
 interface EitherTTraverseInstance<F, L> : Traverse<EitherTPartialOf<F, L>>, EitherTFunctorInstance<F, L>, EitherTFoldableInstance<F, L> {
 
   fun TF(): Traverse<F>
 
-  override fun <A, B> Kind<EitherTPartialOf<F, L>, A>.map(f: (A) -> B): EitherT<F, L, B> = fix().map(TF()) { f(it) }
+  override fun FF(): Functor<F> = TF()
 
-  override fun <G, B, C> Kind<EitherTPartialOf<F, L>, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<F, L, C>> =
+  override fun FFF(): Foldable<F> = TF()
+
+  override fun <A, B> EitherTOf<F, L, A>.map(f: (A) -> B): EitherT<F, L, B> =
+    fix().map(TF(), f)
+
+  override fun <G, B, C> EitherTOf<F, L, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<F, L, C>> =
     fix().traverse(TF(), AP, f)
 }
 
+@extension
 interface EitherTSemigroupKInstance<F, L> : SemigroupK<EitherTPartialOf<F, L>> {
   fun MF(): Monad<F>
 
-  override fun <A> Kind<EitherTPartialOf<F, L>, A>.combineK(y: Kind<EitherTPartialOf<F, L>, A>): EitherT<F, L, A> =
+  override fun <A> EitherTOf<F, L, A>.combineK(y: EitherTOf<F, L, A>): EitherT<F, L, A> =
     fix().combineK(MF(), y)
 }
 
 fun <F, A, B, C> EitherTOf<F, A, B>.foldLeft(FF: Foldable<F>, b: C, f: (C, B) -> C): C =
-  FF.compose(Either.foldable<A>()).foldLC(fix().value, b, f)
+  FF.compose(Either.foldable<A>()).foldLC(value, b, f)
 
 fun <F, A, B, C> EitherTOf<F, A, B>.foldRight(FF: Foldable<F>, lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = FF.compose(Either.foldable<A>()).run {
-  fix().value.foldRC(lb, f)
+  value.foldRC(lb, f)
 }
 
 fun <F, A, B, G, C> EitherTOf<F, A, B>.traverse(FF: Traverse<F>, GA: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<F, A, C>> {
-  val fa: Kind<G, Kind<Nested<F, EitherPartialOf<A>>, C>> = ComposedTraverse(FF, Either.traverse(), Either.monad<A>()).run { fix().value.traverseC(f, GA) }
-  val mapper: (Kind<Nested<F, EitherPartialOf<A>>, C>) -> EitherT<F, A, C> = { EitherT(FF.run { it.unnest().map { it.fix() } }) }
+  val fa: Kind<G, Kind<Nested<F, EitherPartialOf<A>>, C>> = ComposedTraverse(FF, Either.traverse(), Either.monad<A>()).run { value.traverseC(f, GA) }
+  val mapper: (Kind<Nested<F, EitherPartialOf<A>>, C>) -> EitherT<F, A, C> = { nested -> EitherT(FF.run { nested.unnest().map { it.fix() } }) }
   return GA.run { fa.map(mapper) }
 }
 
 fun <F, G, A, B> EitherTOf<F, A, Kind<G, B>>.sequence(FF: Traverse<F>, GA: Applicative<G>): Kind<G, EitherT<F, A, B>> =
   traverse(FF, GA, ::identity)
 
-fun <F, L> EitherT.Companion.functor(FF: Functor<F>): Functor<EitherTPartialOf<F, L>> =
-  object : EitherTFunctorInstance<F, L> {
-    override fun FF(): Functor<F> = FF
-
-  }
-
-fun <F, L> EitherT.Companion.applicative(MF: Monad<F>): Applicative<EitherTPartialOf<F, L>> =
-  object : EitherTApplicativeInstance<F, L> {
-    override fun FF(): Functor<F> = MF
-
-    override fun MF(): Monad<F> = MF
-  }
-
-fun <F, L> EitherT.Companion.monad(MF: Monad<F>): Monad<EitherTPartialOf<F, L>> =
-  object : EitherTMonadInstance<F, L> {
-    override fun FF(): Functor<F> = MF
-
-    override fun MF(): Monad<F> = MF
-  }
-
-fun <F, L> EitherT.Companion.applicativeError(MF: Monad<F>): ApplicativeError<EitherTPartialOf<F, L>, L> =
-  object : EitherTApplicativeErrorInstance<F, L> {
-    override fun FF(): Functor<F> = MF
-
-    override fun MF(): Monad<F> = MF
-  }
-
-fun <F, L> EitherT.Companion.monadError(MF: Monad<F>): MonadError<EitherTPartialOf<F, L>, L> =
-  object : EitherTMonadErrorInstance<F, L> {
-    override fun FF(): Functor<F> = MF
-
-    override fun MF(): Monad<F> = MF
-  }
-
-fun <F, A> EitherT.Companion.traverse(FF: Traverse<F>): Traverse<EitherTPartialOf<F, A>> =
-  object : EitherTTraverseInstance<F, A> {
-    override fun FF(): Functor<F> = FF
-
-    override fun FFF(): Foldable<F> = FF
-
-    override fun TF(): Traverse<F> = FF
-  }
-
-fun <F, A> EitherT.Companion.foldable(FF: Traverse<F>): Foldable<EitherTPartialOf<F, A>> =
-  object : EitherTFoldableInstance<F, A> {
-    override fun FFF(): Foldable<F> = FF
-  }
-
-fun <F, L> EitherT.Companion.semigroupK(MF: Monad<F>): SemigroupK<EitherTPartialOf<F, L>> =
-  object : EitherTSemigroupKInstance<F, L> {
-    override fun MF(): Monad<F> = MF
-  }
-
-class EitherTContext<F, E>(val MF: Monad<F>) : EitherTMonadErrorInstance<F, E>, EitherTSemigroupKInstance<F, E> {
+class EitherTContext<F, E>(val MF: MonadError<F, E>) : EitherTMonadErrorInstance<F, E>, EitherTSemigroupKInstance<F, E> {
   override fun FF(): Functor<F> = MF
   override fun MF(): Monad<F> = MF
+  override fun AE(): ApplicativeError<F, E> = MF
 }
 
-class EitherTContextPartiallyApplied<F, E>(val MF: Monad<F>) {
+class EitherTContextPartiallyApplied<F, E>(val MF: MonadError<F, E>) {
   @Deprecated(ExtensionsDSLDeprecated)
   infix fun <A> extensions(f: EitherTContext<F, E>.() -> A): A =
     f(EitherTContext(MF))
 }
 
-fun <F, E> ForEitherT(MF: Monad<F>): EitherTContextPartiallyApplied<F, E> =
+fun <F, E> ForEitherT(MF: MonadError<F, E>): EitherTContextPartiallyApplied<F, E> =
   EitherTContextPartiallyApplied(MF)

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/eithert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/eithert.kt
@@ -65,7 +65,7 @@ interface EitherTApplicativeErrorInstance<F, L> : ApplicativeError<EitherTPartia
   override fun AF(): Applicative<F> = AE()
 
   override fun <A> EitherTOf<F, L, A>.handleErrorWith(f: (L) -> EitherTOf<F, L, A>): EitherT<F, L, A> = AE().run {
-    EitherT(value.handleErrorWith { l -> f(l).value })
+    EitherT(value().handleErrorWith { l -> f(l).value() })
   }
 
   override fun <A> raiseError(e: L): EitherT<F, L, A> = AE().run {
@@ -130,14 +130,14 @@ interface EitherTSemigroupKInstance<F, L> : SemigroupK<EitherTPartialOf<F, L>> {
 }
 
 fun <F, A, B, C> EitherTOf<F, A, B>.foldLeft(FF: Foldable<F>, b: C, f: (C, B) -> C): C =
-  FF.compose(Either.foldable<A>()).foldLC(value, b, f)
+  FF.compose(Either.foldable<A>()).foldLC(value(), b, f)
 
 fun <F, A, B, C> EitherTOf<F, A, B>.foldRight(FF: Foldable<F>, lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = FF.compose(Either.foldable<A>()).run {
-  value.foldRC(lb, f)
+  value().foldRC(lb, f)
 }
 
 fun <F, A, B, G, C> EitherTOf<F, A, B>.traverse(FF: Traverse<F>, GA: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, EitherT<F, A, C>> {
-  val fa: Kind<G, Kind<Nested<F, EitherPartialOf<A>>, C>> = ComposedTraverse(FF, Either.traverse(), Either.monad<A>()).run { value.traverseC(f, GA) }
+  val fa: Kind<G, Kind<Nested<F, EitherPartialOf<A>>, C>> = ComposedTraverse(FF, Either.traverse(), Either.monad<A>()).run { value().traverseC(f, GA) }
   val mapper: (Kind<Nested<F, EitherPartialOf<A>>, C>) -> EitherT<F, A, C> = { nested -> EitherT(FF.run { nested.unnest().map { it.fix() } }) }
   return GA.run { fa.map(mapper) }
 }

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/kleisli.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/kleisli.kt
@@ -18,7 +18,8 @@ interface KleisliFunctorInstance<F, D> : Functor<KleisliPartialOf<F, D>> {
 
   fun FF(): Functor<F>
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.map(f: (A) -> B): Kleisli<F, D, B> = fix().map(FF(), f)
+  override fun <A, B> KleisliOf<F, D, A>.map(f: (A) -> B): Kleisli<F, D, B> =
+    fix().map(FF(), f)
 }
 
 @extension
@@ -37,16 +38,17 @@ interface KleisliApplicativeInstance<F, D> : Applicative<KleisliPartialOf<F, D>>
 
   override fun FF(): Functor<F> = AF()
 
-  override fun <A> just(a: A): Kleisli<F, D, A> = Kleisli { AF().just(a) }
+  override fun <A> just(a: A): Kleisli<F, D, A> =
+    Kleisli { AF().just(a) }
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.map(f: (A) -> B): Kleisli<F, D, B> =
+  override fun <A, B> KleisliOf<F, D, A>.map(f: (A) -> B): Kleisli<F, D, B> =
     fix().map(AF(), f)
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.ap(ff: Kind<KleisliPartialOf<F, D>, (A) -> B>): Kleisli<F, D, B> =
+  override fun <A, B> KleisliOf<F, D, A>.ap(ff: KleisliOf<F, D, (A) -> B>): Kleisli<F, D, B> =
     fix().ap(AF(), ff)
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.product(fb: Kind<KleisliPartialOf<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
-    Kleisli { AF().run { fix().run(it).product(fb.fix().run(it)) } }
+  override fun <A, B> KleisliOf<F, D, A>.product(fb: KleisliOf<F, D, B>): Kleisli<F, D, Tuple2<A, B>> =
+    Kleisli { AF().run { run(it).product(fb.run(it)) } }
 }
 
 @extension
@@ -56,13 +58,13 @@ interface KleisliMonadInstance<F, D> : Monad<KleisliPartialOf<F, D>>, KleisliApp
 
   override fun AF(): Applicative<F> = MF()
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.map(f: (A) -> B): Kleisli<F, D, B> =
+  override fun <A, B> KleisliOf<F, D, A>.map(f: (A) -> B): Kleisli<F, D, B> =
     fix().map(MF(), f)
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.flatMap(f: (A) -> Kind<KleisliPartialOf<F, D>, B>): Kleisli<F, D, B> =
-    fix().flatMap(MF(), f.andThen { it.fix() })
+  override fun <A, B> KleisliOf<F, D, A>.flatMap(f: (A) -> KleisliOf<F, D, B>): Kleisli<F, D, B> =
+    fix().flatMap(MF(), f)
 
-  override fun <A, B> Kind<KleisliPartialOf<F, D>, A>.ap(ff: Kind<KleisliPartialOf<F, D>, (A) -> B>): Kleisli<F, D, B> =
+  override fun <A, B> KleisliOf<F, D, A>.ap(ff: KleisliOf<F, D, (A) -> B>): Kleisli<F, D, B> =
     fix().ap(MF(), ff)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> KleisliOf<F, D, Either<A, B>>): Kleisli<F, D, B> =
@@ -76,7 +78,7 @@ interface KleisliApplicativeErrorInstance<F, D, E> : ApplicativeError<KleisliPar
 
   override fun AF(): Applicative<F> = AE()
 
-  override fun <A> Kind<KleisliPartialOf<F, D>, A>.handleErrorWith(f: (E) -> Kind<KleisliPartialOf<F, D>, A>): Kleisli<F, D, A> =
+  override fun <A> KleisliOf<F, D, A>.handleErrorWith(f: (E) -> KleisliOf<F, D, A>): Kleisli<F, D, A> =
     fix().handleErrorWith(AE(), f)
 
   override fun <A> raiseError(e: E): Kleisli<F, D, A> =

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/optiont.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/optiont.kt
@@ -2,15 +2,14 @@ package arrow.instances
 
 import arrow.Kind
 import arrow.core.*
-import arrow.data.OptionT
-import arrow.data.OptionTOf
-import arrow.data.OptionTPartialOf
-import arrow.data.fix
+import arrow.data.*
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
 import arrow.instances.option.applicative.applicative
 import arrow.instances.option.foldable.foldable
 import arrow.instances.option.traverse.traverse
+import arrow.instances.optiont.applicative.ap
+import arrow.instances.optiont.monad.ap
 import arrow.typeclasses.*
 
 @extension
@@ -18,35 +17,37 @@ interface OptionTFunctorInstance<F> : Functor<OptionTPartialOf<F>> {
 
   fun FF(): Functor<F>
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(FF(), f)
+  override fun <A, B> OptionTOf<F, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(FF(), f)
 
 }
 
 @extension
 interface OptionTApplicativeInstance<F> : Applicative<OptionTPartialOf<F>>, OptionTFunctorInstance<F> {
 
-  fun MF(): Monad<F>
+  fun AF(): Applicative<F>
 
-  override fun FF(): Functor<F> = MF()
+  override fun FF(): Functor<F> = AF()
 
-  override fun <A> just(a: A): OptionT<F, A> = OptionT(MF().just(Option(a)))
+  override fun <A> just(a: A): OptionT<F, A> = OptionT(AF().just(Option(a)))
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(FF(), f)
+  override fun <A, B> OptionTOf<F, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(AF(), f)
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.ap(ff: Kind<OptionTPartialOf<F>, (A) -> B>): OptionT<F, B> =
-    fix().ap(MF(), ff)
+  override fun <A, B> OptionTOf<F, A>.ap(ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
+    fix().ap(AF(), ff)
 }
 
 @extension
 interface OptionTMonadInstance<F> : Monad<OptionTPartialOf<F>>, OptionTApplicativeInstance<F> {
 
-  override fun MF(): Monad<F>
+  fun MF(): Monad<F>
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(FF(), f)
+  override fun AF(): Applicative<F> = MF()
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.flatMap(f: (A) -> Kind<OptionTPartialOf<F>, B>): OptionT<F, B> = fix().flatMap(MF(), { f(it).fix() })
+  override fun <A, B> OptionTOf<F, A>.map(f: (A) -> B): OptionT<F, B> = fix().map(FF(), f)
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.ap(ff: Kind<OptionTPartialOf<F>, (A) -> B>): OptionT<F, B> =
+  override fun <A, B> OptionTOf<F, A>.flatMap(f: (A) -> OptionTOf<F, B>): OptionT<F, B> = fix().flatMap(MF()) { f(it).fix() }
+
+  override fun <A, B> OptionTOf<F, A>.ap(ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
     fix().ap(MF(), ff)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> OptionTOf<F, Either<A, B>>): OptionT<F, B> =
@@ -54,14 +55,47 @@ interface OptionTMonadInstance<F> : Monad<OptionTPartialOf<F>>, OptionTApplicati
 
 }
 
+@extension
+interface OptionTApplicativeErrorInstance<F, E> : ApplicativeError<OptionTPartialOf<F>, E>, OptionTApplicativeInstance<F> {
+
+  fun AE(): ApplicativeError<F, E>
+
+  override fun AF(): Applicative<F> = AE()
+
+  override fun <A> raiseError(e: E): OptionT<F, A> =
+    OptionT(AE().raiseError(e))
+
+  override fun <A> OptionTOf<F, A>.handleErrorWith(f: (E) -> OptionTOf<F, A>): OptionT<F, A> = AE().run {
+    OptionT(value.handleErrorWith { f(it).value })
+  }
+
+}
+
+@extension
+interface OptionTMonadError<F, E> : MonadError<OptionTPartialOf<F>, E>, OptionTMonadInstance<F>, OptionTApplicativeErrorInstance<F, E> {
+
+  fun ME(): MonadError<F, E>
+
+  override fun AF(): Applicative<F> = ME()
+
+  override fun AE(): ApplicativeError<F, E> = ME()
+
+  override fun MF(): Monad<F> = ME()
+}
+
+@extension
+interface OptionTMonadThrow<F> : MonadThrow<OptionTPartialOf<F>>, OptionTMonadError<F, Throwable> {
+  override fun ME(): MonadError<F, Throwable>
+}
+
 fun <F, A, B> OptionTOf<F, A>.foldLeft(FF: Foldable<F>, b: B, f: (B, A) -> B): B = FF.compose(Option.foldable()).foldLC(fix().value, b, f)
 
 fun <F, A, B> OptionTOf<F, A>.foldRight(FF: Foldable<F>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = FF.compose(Option.foldable()).run {
-  fix().value.foldRC(lb, f)
+  value.foldRC(lb, f)
 }
 
 fun <F, G, A, B> OptionTOf<F, A>.traverse(FF: Traverse<F>, GA: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, OptionT<F, B>> {
-  val fa = ComposedTraverse(FF, Option.traverse(), Option.applicative()).run { fix().value.traverseC(f, GA) }
+  val fa = ComposedTraverse(FF, Option.traverse(), Option.applicative()).run { value.traverseC(f, GA) }
   val mapper: (Kind<Nested<F, ForOption>, B>) -> OptionT<F, B> = { OptionT(FF.run { it.unnest().map { it.fix() } }) }
   return GA.run { fa.map(mapper) }
 }
@@ -74,10 +108,10 @@ interface OptionTFoldableInstance<F> : Foldable<OptionTPartialOf<F>> {
 
   fun FFF(): Foldable<F>
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.foldLeft(b: B, f: (B, A) -> B): B =
+  override fun <A, B> OptionTOf<F, A>.foldLeft(b: B, f: (B, A) -> B): B =
     fix().foldLeft(FFF(), b, f)
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
+  override fun <A, B> OptionTOf<F, A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
     fix().foldRight(FFF(), lb, f)
 
 }
@@ -89,7 +123,7 @@ interface OptionTTraverseInstance<F> : Traverse<OptionTPartialOf<F>>, OptionTFol
 
   override fun FFF(): Foldable<F> = FFT()
 
-  override fun <G, A, B> Kind<OptionTPartialOf<F>, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, OptionT<F, B>> =
+  override fun <G, A, B> OptionTOf<F, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, OptionT<F, B>> =
     fix().traverse(FFT(), AP, f)
 
 }
@@ -99,7 +133,7 @@ interface OptionTSemigroupKInstance<F> : SemigroupK<OptionTPartialOf<F>> {
 
   fun MF(): Monad<F>
 
-  override fun <A> Kind<OptionTPartialOf<F>, A>.combineK(y: Kind<OptionTPartialOf<F>, A>): OptionT<F, A> = fix().orElse(MF(), { y.fix() })
+  override fun <A> OptionTOf<F, A>.combineK(y: OptionTOf<F, A>): OptionT<F, A> = fix().orElse(MF(), { y.fix() })
 }
 
 @extension
@@ -114,7 +148,7 @@ class OptionTContext<F>(val MF: Monad<F>) : OptionTMonadInstance<F>, OptionTMono
 
   override fun MF(): Monad<F> = MF
 
-  override fun <A, B> Kind<OptionTPartialOf<F>, A>.map(f: (A) -> B): OptionT<F, B> =
+  override fun <A, B> OptionTOf<F, A>.map(f: (A) -> B): OptionT<F, B> =
     fix().map(f)
 }
 

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/optiont.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/optiont.kt
@@ -66,7 +66,7 @@ interface OptionTApplicativeErrorInstance<F, E> : ApplicativeError<OptionTPartia
     OptionT(AE().raiseError(e))
 
   override fun <A> OptionTOf<F, A>.handleErrorWith(f: (E) -> OptionTOf<F, A>): OptionT<F, A> = AE().run {
-    OptionT(value.handleErrorWith { f(it).value })
+    OptionT(value().handleErrorWith { f(it).value() })
   }
 
 }
@@ -88,14 +88,14 @@ interface OptionTMonadThrow<F> : MonadThrow<OptionTPartialOf<F>>, OptionTMonadEr
   override fun ME(): MonadError<F, Throwable>
 }
 
-fun <F, A, B> OptionTOf<F, A>.foldLeft(FF: Foldable<F>, b: B, f: (B, A) -> B): B = FF.compose(Option.foldable()).foldLC(fix().value, b, f)
+fun <F, A, B> OptionTOf<F, A>.foldLeft(FF: Foldable<F>, b: B, f: (B, A) -> B): B = FF.compose(Option.foldable()).foldLC(value(), b, f)
 
 fun <F, A, B> OptionTOf<F, A>.foldRight(FF: Foldable<F>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = FF.compose(Option.foldable()).run {
-  value.foldRC(lb, f)
+  value().foldRC(lb, f)
 }
 
 fun <F, G, A, B> OptionTOf<F, A>.traverse(FF: Traverse<F>, GA: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, OptionT<F, B>> {
-  val fa = ComposedTraverse(FF, Option.traverse(), Option.applicative()).run { value.traverseC(f, GA) }
+  val fa = ComposedTraverse(FF, Option.traverse(), Option.applicative()).run { value().traverseC(f, GA) }
   val mapper: (Kind<Nested<F, ForOption>, B>) -> OptionT<F, B> = { OptionT(FF.run { it.unnest().map { it.fix() } }) }
   return GA.run { fa.map(mapper) }
 }

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
@@ -3,10 +3,7 @@ package arrow.instances
 import arrow.Kind
 import arrow.core.Either
 import arrow.core.toT
-import arrow.data.WriterT
-import arrow.data.WriterTOf
-import arrow.data.WriterTPartialOf
-import arrow.data.fix
+import arrow.data.*
 import arrow.deprecation.ExtensionsDSLDeprecated
 import arrow.extension
 import arrow.typeclasses.*
@@ -15,47 +12,117 @@ import arrow.typeclasses.*
 interface WriterTFunctorInstance<F, W> : Functor<WriterTPartialOf<F, W>> {
   fun FF(): Functor<F>
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.map(f: (A) -> B): WriterT<F, W, B> = fix().map(FF()) { f(it) }
+  override fun <A, B> WriterTOf<F, W, A>.map(f: (A) -> B): WriterT<F, W, B> = fix().map(FF()) { f(it) }
 }
+
+//fun <F, W> WriterT.Companion.functor(FF: Functor<F>): Functor<WriterTPartialOf<F, W>> = object : WriterTFunctorInstance<F, W> {
+//  override fun FF(): Functor<F> = FF
+//}
 
 @extension
 interface WriterTApplicativeInstance<F, W> : Applicative<WriterTPartialOf<F, W>>, WriterTFunctorInstance<F, W> {
 
-  fun MF(): Monad<F>
+  fun AF(): Applicative<F>
 
-  override fun FF(): Functor<F> = MF()
+  override fun FF(): Functor<F> = AF()
 
   fun MM(): Monoid<W>
 
   override fun <A> just(a: A): WriterTOf<F, W, A> =
-    WriterT(MF().just(MM().empty() toT a))
+    WriterT(AF().just(MM().empty() toT a))
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.ap(ff: Kind<WriterTPartialOf<F, W>, (A) -> B>): WriterT<F, W, B> =
-    fix().ap(MF(), MM(), ff)
+  override fun <A, B> WriterTOf<F, W, A>.ap(ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
+    fix().ap(AF(), MM(), ff)
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.map(f: (A) -> B): WriterT<F, W, B> =
-    fix().map(FF()) { f(it) }
+  override fun <A, B> WriterTOf<F, W, A>.map(f: (A) -> B): WriterT<F, W, B> =
+    fix().map(AF()) { f(it) }
 }
+
+//fun <F, W> WriterT.Companion.applicative(AF: Applicative<F>, MM: Monoid<W>): Applicative<WriterTPartialOf<F, W>> = object : WriterTApplicativeInstance<F, W> {
+//  override fun AF(): Applicative<F> = AF
+//  override fun MM(): Monoid<W> = MM
+//}
 
 @extension
 interface WriterTMonadInstance<F, W> : Monad<WriterTPartialOf<F, W>>, WriterTApplicativeInstance<F, W> {
 
-  override fun MF(): Monad<F>
+  fun MF(): Monad<F>
+
+  override fun AF(): Applicative<F> = MF()
 
   override fun MM(): Monoid<W>
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.map(f: (A) -> B): WriterT<F, W, B> =
+  override fun <A, B> WriterTOf<F, W, A>.map(f: (A) -> B): WriterT<F, W, B> =
     fix().map(FF()) { f(it) }
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.flatMap(f: (A) -> Kind<WriterTPartialOf<F, W>, B>): WriterT<F, W, B> =
-    fix().flatMap(MF(), MM(), { f(it).fix() })
+  override fun <A, B> WriterTOf<F, W, A>.flatMap(f: (A) -> WriterTOf<F, W, B>): WriterT<F, W, B> =
+    fix().flatMap(MF(), MM()) { f(it) }
 
-  override fun <A, B> tailRecM(a: A, f: (A) -> Kind<WriterTPartialOf<F, W>, Either<A, B>>): WriterT<F, W, B> =
+  override fun <A, B> tailRecM(a: A, f: (A) -> WriterTOf<F, W, Either<A, B>>): WriterT<F, W, B> =
     WriterT.tailRecM(MF(), a, f)
 
-  override fun <A, B> Kind<WriterTPartialOf<F, W>, A>.ap(ff: Kind<WriterTPartialOf<F, W>, (A) -> B>): WriterT<F, W, B> =
+  override fun <A, B> WriterTOf<F, W, A>.ap(ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
     fix().ap(MF(), MM(), ff)
 }
+
+//fun <F, W> WriterT.Companion.monad(MF: Monad<F>, MM: Monoid<W>): Monad<WriterTPartialOf<F, W>> = object : WriterTMonadInstance<F, W> {
+//  override fun MF(): Monad<F> = MF
+//  override fun MM(): Monoid<W> = MM
+//}
+
+@extension
+interface WriterTApplicativeError<F, W, E> : ApplicativeError<WriterTPartialOf<F, W>, E>, WriterTApplicativeInstance<F, W> {
+
+  fun AE(): ApplicativeError<F, E>
+
+  override fun MM(): Monoid<W>
+
+  override fun AF(): Applicative<F> = AE()
+
+  override fun <A> raiseError(e: E): WriterT<F, W, A> =
+    WriterT(AE().raiseError(e))
+
+  override fun <A> WriterTOf<F, W, A>.handleErrorWith(f: (E) -> WriterTOf<F, W, A>): WriterT<F, W, A> = AE().run {
+    WriterT(value.handleErrorWith { e -> f(e).value })
+  }
+
+}
+
+//fun <F, W, E> WriterT.Companion.applicativeError(AE: ApplicativeError<F, E>, MM: Monoid<W>): ApplicativeError<WriterTPartialOf<F, W>, E> = object : WriterTApplicativeError<F, W, E> {
+//  override fun AE(): ApplicativeError<F, E> = AE
+//  override fun MM(): Monoid<W> = MM
+//}
+
+@extension
+interface WriterTMonadError<F, W, E> : MonadError<WriterTPartialOf<F, W>, E>, WriterTApplicativeError<F, W, E>, WriterTMonadInstance<F, W> {
+
+  fun ME(): MonadError<F, E>
+
+  override fun MM(): Monoid<W>
+
+  override fun MF(): Monad<F> = ME()
+
+  override fun AF(): Applicative<F> = ME()
+
+  override fun AE(): ApplicativeError<F, E> = ME()
+
+}
+
+//fun <F, W, E> WriterT.Companion.monadError(ME: MonadError<F, E>, MM: Monoid<W>): MonadError<WriterTPartialOf<F, W>, E> = object : WriterTMonadError<F, W, E> {
+//  override fun ME(): MonadError<F, E> = ME
+//  override fun MM(): Monoid<W> = MM
+//}
+
+@extension
+interface WriterTMonadThrow<F, W> : MonadThrow<WriterTPartialOf<F, W>>, WriterTMonadError<F, W, Throwable> {
+  override fun ME(): MonadError<F, Throwable>
+  override fun MM(): Monoid<W>
+}
+
+//fun <F, W> WriterT.Companion.monadThrow(ME: MonadError<F, Throwable>, MM: Monoid<W>): MonadThrow<WriterTPartialOf<F, W>> = object : WriterTMonadThrow<F, W> {
+//  override fun ME(): MonadError<F, Throwable> = ME
+//  override fun MM(): Monoid<W> = MM
+//}
 
 @extension
 interface WriterTSemigroupKInstance<F, W> : SemigroupK<WriterTPartialOf<F, W>> {
@@ -66,6 +133,10 @@ interface WriterTSemigroupKInstance<F, W> : SemigroupK<WriterTPartialOf<F, W>> {
     fix().combineK(SS(), y)
 }
 
+//fun <F, W> WriterT.Companion.sempigroupK(SS: SemigroupK<F>): SemigroupK<WriterTPartialOf<F, W>> = object : WriterTSemigroupKInstance<F, W> {
+//  override fun SS(): SemigroupK<F> = SS
+//}
+
 @extension
 interface WriterTMonoidKInstance<F, W> : MonoidK<WriterTPartialOf<F, W>>, WriterTSemigroupKInstance<F, W> {
 
@@ -75,6 +146,10 @@ interface WriterTMonoidKInstance<F, W> : MonoidK<WriterTPartialOf<F, W>>, Writer
 
   override fun <A> empty(): WriterT<F, W, A> = WriterT(MF().empty())
 }
+
+//fun <F, W> WriterT.Companion.monoidK(MF: MonoidK<F>): MonoidK<WriterTPartialOf<F, W>> = object : WriterTMonoidKInstance<F, W> {
+//  override fun MF(): MonoidK<F> = MF
+//}
 
 class WriterTContext<F, W>(val MF: Monad<F>, val MW: Monoid<W>) : WriterTMonadInstance<F, W> {
   override fun FF(): Functor<F> = MF

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
@@ -15,10 +15,6 @@ interface WriterTFunctorInstance<F, W> : Functor<WriterTPartialOf<F, W>> {
   override fun <A, B> WriterTOf<F, W, A>.map(f: (A) -> B): WriterT<F, W, B> = fix().map(FF()) { f(it) }
 }
 
-//fun <F, W> WriterT.Companion.functor(FF: Functor<F>): Functor<WriterTPartialOf<F, W>> = object : WriterTFunctorInstance<F, W> {
-//  override fun FF(): Functor<F> = FF
-//}
-
 @extension
 interface WriterTApplicativeInstance<F, W> : Applicative<WriterTPartialOf<F, W>>, WriterTFunctorInstance<F, W> {
 
@@ -37,11 +33,6 @@ interface WriterTApplicativeInstance<F, W> : Applicative<WriterTPartialOf<F, W>>
   override fun <A, B> WriterTOf<F, W, A>.map(f: (A) -> B): WriterT<F, W, B> =
     fix().map(AF()) { f(it) }
 }
-
-//fun <F, W> WriterT.Companion.applicative(AF: Applicative<F>, MM: Monoid<W>): Applicative<WriterTPartialOf<F, W>> = object : WriterTApplicativeInstance<F, W> {
-//  override fun AF(): Applicative<F> = AF
-//  override fun MM(): Monoid<W> = MM
-//}
 
 @extension
 interface WriterTMonadInstance<F, W> : Monad<WriterTPartialOf<F, W>>, WriterTApplicativeInstance<F, W> {
@@ -65,11 +56,6 @@ interface WriterTMonadInstance<F, W> : Monad<WriterTPartialOf<F, W>>, WriterTApp
     fix().ap(MF(), MM(), ff)
 }
 
-//fun <F, W> WriterT.Companion.monad(MF: Monad<F>, MM: Monoid<W>): Monad<WriterTPartialOf<F, W>> = object : WriterTMonadInstance<F, W> {
-//  override fun MF(): Monad<F> = MF
-//  override fun MM(): Monoid<W> = MM
-//}
-
 @extension
 interface WriterTApplicativeError<F, W, E> : ApplicativeError<WriterTPartialOf<F, W>, E>, WriterTApplicativeInstance<F, W> {
 
@@ -88,11 +74,6 @@ interface WriterTApplicativeError<F, W, E> : ApplicativeError<WriterTPartialOf<F
 
 }
 
-//fun <F, W, E> WriterT.Companion.applicativeError(AE: ApplicativeError<F, E>, MM: Monoid<W>): ApplicativeError<WriterTPartialOf<F, W>, E> = object : WriterTApplicativeError<F, W, E> {
-//  override fun AE(): ApplicativeError<F, E> = AE
-//  override fun MM(): Monoid<W> = MM
-//}
-
 @extension
 interface WriterTMonadError<F, W, E> : MonadError<WriterTPartialOf<F, W>, E>, WriterTApplicativeError<F, W, E>, WriterTMonadInstance<F, W> {
 
@@ -108,21 +89,11 @@ interface WriterTMonadError<F, W, E> : MonadError<WriterTPartialOf<F, W>, E>, Wr
 
 }
 
-//fun <F, W, E> WriterT.Companion.monadError(ME: MonadError<F, E>, MM: Monoid<W>): MonadError<WriterTPartialOf<F, W>, E> = object : WriterTMonadError<F, W, E> {
-//  override fun ME(): MonadError<F, E> = ME
-//  override fun MM(): Monoid<W> = MM
-//}
-
 @extension
 interface WriterTMonadThrow<F, W> : MonadThrow<WriterTPartialOf<F, W>>, WriterTMonadError<F, W, Throwable> {
   override fun ME(): MonadError<F, Throwable>
   override fun MM(): Monoid<W>
 }
-
-//fun <F, W> WriterT.Companion.monadThrow(ME: MonadError<F, Throwable>, MM: Monoid<W>): MonadThrow<WriterTPartialOf<F, W>> = object : WriterTMonadThrow<F, W> {
-//  override fun ME(): MonadError<F, Throwable> = ME
-//  override fun MM(): Monoid<W> = MM
-//}
 
 @extension
 interface WriterTSemigroupKInstance<F, W> : SemigroupK<WriterTPartialOf<F, W>> {
@@ -133,10 +104,6 @@ interface WriterTSemigroupKInstance<F, W> : SemigroupK<WriterTPartialOf<F, W>> {
     fix().combineK(SS(), y)
 }
 
-//fun <F, W> WriterT.Companion.sempigroupK(SS: SemigroupK<F>): SemigroupK<WriterTPartialOf<F, W>> = object : WriterTSemigroupKInstance<F, W> {
-//  override fun SS(): SemigroupK<F> = SS
-//}
-
 @extension
 interface WriterTMonoidKInstance<F, W> : MonoidK<WriterTPartialOf<F, W>>, WriterTSemigroupKInstance<F, W> {
 
@@ -146,10 +113,6 @@ interface WriterTMonoidKInstance<F, W> : MonoidK<WriterTPartialOf<F, W>>, Writer
 
   override fun <A> empty(): WriterT<F, W, A> = WriterT(MF().empty())
 }
-
-//fun <F, W> WriterT.Companion.monoidK(MF: MonoidK<F>): MonoidK<WriterTPartialOf<F, W>> = object : WriterTMonoidKInstance<F, W> {
-//  override fun MF(): MonoidK<F> = MF
-//}
 
 class WriterTContext<F, W>(val MF: Monad<F>, val MW: Monoid<W>) : WriterTMonadInstance<F, W> {
   override fun FF(): Functor<F> = MF

--- a/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/core/arrow-instances-data/src/main/kotlin/arrow/instances/writert.kt
@@ -69,7 +69,7 @@ interface WriterTApplicativeError<F, W, E> : ApplicativeError<WriterTPartialOf<F
     WriterT(AE().raiseError(e))
 
   override fun <A> WriterTOf<F, W, A>.handleErrorWith(f: (E) -> WriterTOf<F, W, A>): WriterT<F, W, A> = AE().run {
-    WriterT(value.handleErrorWith { e -> f(e).value })
+    WriterT(value().handleErrorWith { e -> f(e).value() })
   }
 
 }

--- a/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/instances/optiont.kt
+++ b/modules/core/arrow-mtl/src/main/kotlin/arrow/mtl/instances/optiont.kt
@@ -41,8 +41,8 @@ interface OptionTTraverseFilterInstance<F> :
 }
 
 fun <F, G, A, B> OptionT<F, A>.traverseFilter(f: (A) -> Kind<G, Option<B>>, GA: Applicative<G>, FF: Traverse<F>): Kind<G, OptionT<F, B>> {
-  val fa = ComposedTraverseFilter(FF, Option.traverseFilter(), Option.applicative()).traverseFilterC(value, f, GA)
-  val mapper: (Kind<Nested<F, ForOption>, B>) -> OptionT<F, B> = { OptionT(FF.run { it.unnest().map { it.fix() } }) }
+  val fa = ComposedTraverseFilter(FF, Option.traverseFilter(), Option.applicative()).traverseFilterC(value(), f, GA)
+  val mapper: (Kind<Nested<F, ForOption>, B>) -> OptionT<F, B> = { nested -> OptionT(FF.run { nested.unnest().map { it.fix() } }) }
   return GA.run { fa.map(mapper) }
 }
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadDeferLaws.kt
@@ -27,34 +27,34 @@ object MonadDeferLaws {
     testStackSafety: Boolean = true
   ): List<Law> =
     BracketLaws.laws(SC, EQ, EQ_EITHER, EQERR) + listOf(
-      Law("Sync bind: binding blocks") { SC.asyncBind(EQ) },
-      Law("Sync bind: binding failure") { SC.asyncBindError(EQERR) },
-      Law("Sync bind: unsafe binding") { SC.asyncBindUnsafe(EQ) },
-      Law("Sync bind: unsafe binding failure") { SC.asyncBindUnsafeError(EQERR) },
-      Law("Sync bind: binding in parallel") { SC.asyncParallelBind(EQ) },
-      Law("Sync bind: binding cancellation before flatMap") { SC.asyncCancellationBefore(EQ) },
-      Law("Sync bind: binding cancellation after flatMap") { SC.asyncCancellationAfter(EQ) },
-      Law("Sync bind: bindingInContext cancellation before flatMap") { SC.inContextCancellationBefore(EQ) },
-      Law("Sync bind: bindingInContext cancellation after flatMap") { SC.inContextCancellationAfter(EQ) },
-      Law("Sync bind: bindingInContext throw equivalent to raiseError") { SC.inContextErrorThrow(EQERR) },
-      Law("Sync bind: monad comprehensions binding in other threads equivalence") { SC.monadComprehensionsBindInContextEquivalent(EQ) },
-      Law("Sync laws: delay constant equals pure") { SC.delayConstantEqualsPure(EQ) },
-      Law("Sync laws: delay throw equals raiseError") { SC.delayThrowEqualsRaiseError(EQERR) },
-      Law("Sync laws: defer constant equals pure") { SC.deferConstantEqualsPure(EQ) },
-      Law("Sync laws: deferUnsafe constant right equals pure") { SC.deferUnsafeConstantRightEqualsPure(EQ) },
-      Law("Sync laws: deferUnsafe constant left equals raiseError") { SC.deferUnsafeConstantLeftEqualsRaiseError(EQERR) },
-      Law("Sync laws: propagate error through bind") { SC.propagateErrorsThroughBind(EQERR) },
-      Law("Sync laws: defer suspens evaluation") { SC.deferSuspendsEvaluation(EQ) },
-      Law("Sync laws: delay suspends evaluation") { SC.delaySuspendsEvaluation(EQ) },
-      Law("Sync laws: flatMap suspends evaluation") { SC.flatMapSuspendsEvaluation(EQ) },
-      Law("Sync laws: map suspends evaluation") { SC.mapSuspendsEvaluation(EQ) },
-      Law("Sync laws: Repeated evaluation not memoized") { SC.repeatedSyncEvaluationNotMemoized(EQ) }
+      Law("MonadDefer bind: binding blocks") { SC.asyncBind(EQ) },
+      Law("MonadDefer bind: binding failure") { SC.asyncBindError(EQERR) },
+      Law("MonadDefer bind: unsafe binding") { SC.asyncBindUnsafe(EQ) },
+      Law("MonadDefer bind: unsafe binding failure") { SC.asyncBindUnsafeError(EQERR) },
+      Law("MonadDefer bind: binding in parallel") { SC.asyncParallelBind(EQ) },
+      Law("MonadDefer bind: binding cancellation before flatMap") { SC.asyncCancellationBefore(EQ) },
+      Law("MonadDefer bind: binding cancellation after flatMap") { SC.asyncCancellationAfter(EQ) },
+      Law("MonadDefer bind: bindingInContext cancellation before flatMap") { SC.inContextCancellationBefore(EQ) },
+      Law("MonadDefer bind: bindingInContext cancellation after flatMap") { SC.inContextCancellationAfter(EQ) },
+      Law("MonadDefer bind: bindingInContext throw equivalent to raiseError") { SC.inContextErrorThrow(EQERR) },
+      Law("MonadDefer bind: monad comprehensions binding in other threads equivalence") { SC.monadComprehensionsBindInContextEquivalent(EQ) },
+      Law("MonadDefer laws: delay constant equals pure") { SC.delayConstantEqualsPure(EQ) },
+      Law("MonadDefer laws: delay throw equals raiseError") { SC.delayThrowEqualsRaiseError(EQERR) },
+      Law("MonadDefer laws: defer constant equals pure") { SC.deferConstantEqualsPure(EQ) },
+      Law("MonadDefer laws: deferUnsafe constant right equals pure") { SC.deferUnsafeConstantRightEqualsPure(EQ) },
+      Law("MonadDefer laws: deferUnsafe constant left equals raiseError") { SC.deferUnsafeConstantLeftEqualsRaiseError(EQERR) },
+      Law("MonadDefer laws: propagate error through bind") { SC.propagateErrorsThroughBind(EQERR) },
+      Law("MonadDefer laws: defer suspens evaluation") { SC.deferSuspendsEvaluation(EQ) },
+      Law("MonadDefer laws: delay suspends evaluation") { SC.delaySuspendsEvaluation(EQ) },
+      Law("MonadDefer laws: flatMap suspends evaluation") { SC.flatMapSuspendsEvaluation(EQ) },
+      Law("MonadDefer laws: map suspends evaluation") { SC.mapSuspendsEvaluation(EQ) },
+      Law("MonadDefer laws: Repeated evaluation not memoized") { SC.repeatedSyncEvaluationNotMemoized(EQ) }
     ) + if (testStackSafety) {
       listOf(
-        Law("Sync laws: stack safety over repeated left binds") { SC.stackSafetyOverRepeatedLeftBinds(5000, EQ) },
-        Law("Sync laws: stack safety over repeated right binds") { SC.stackSafetyOverRepeatedRightBinds(5000, EQ) },
-        Law("Sync laws: stack safety over repeated attempts") { SC.stackSafetyOverRepeatedAttempts(5000, EQ) },
-        Law("Sync laws: stack safety over repeated maps") { SC.stackSafetyOnRepeatedMaps(5000, EQ) }
+        Law("MonadDefer laws: stack safety over repeated left binds") { SC.stackSafetyOverRepeatedLeftBinds(5000, EQ) },
+        Law("MonadDefer laws: stack safety over repeated right binds") { SC.stackSafetyOverRepeatedRightBinds(5000, EQ) },
+        Law("MonadDefer laws: stack safety over repeated attempts") { SC.stackSafetyOverRepeatedAttempts(5000, EQ) },
+        Law("MonadDefer laws: stack safety over repeated maps") { SC.stackSafetyOnRepeatedMaps(5000, EQ) }
       )
     } else {
       emptyList()

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/TraverseLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/TraverseLaws.kt
@@ -55,7 +55,7 @@ object TraverseLaws {
     forAll(genFunctionAToB<Int, Kind<ForId, Int>>(genConstructor(genIntSmall(), ::Id)), genFunctionAToB<Int, Kind<ForId, Int>>(genConstructor(genIntSmall(), ::Id)), genConstructor(genIntSmall(), cf)) { f: (Int) -> Kind<ForId, Int>, g: (Int) -> Kind<ForId, Int>, fha: Kind<F, Int> ->
 
       val fa = fha.traverse(this, f).fix()
-      val composed = fa.map { it.traverse(this, g) }.value.value()
+      val composed = fa.map { it.traverse(this, g) }.value().value()
       val expected = fha.traverse(ComposedApplicative(this, this)) { a: Int -> f(a).map(g).nest() }.unnest().value().value()
       composed.equalUnderTheLaw(expected, EQ)
     }

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Const.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Const.kt
@@ -5,10 +5,10 @@ import arrow.core.Option
 import arrow.core.identity
 import arrow.higherkind
 
-fun <A, T> ConstOf<A, T>.value(): A = this.fix().value
+fun <A, T> ConstOf<A, T>.value(): A = this.fix().value()
 
 @higherkind
-data class Const<A, out T>(val value: A) : ConstOf<A, T> {
+data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
 
   @Suppress("UNCHECKED_CAST")
   fun <U> retag(): Const<A, U> = this as Const<A, U>
@@ -22,6 +22,9 @@ data class Const<A, out T>(val value: A) : ConstOf<A, T> {
   companion object {
     fun <A, T> just(a: A): Const<A, T> = Const(a)
   }
+
+  fun value(): A = value
+
 }
 
 fun <A, T> ConstOf<A, T>.combine(SG: Semigroup<A>, that: ConstOf<A, T>): Const<A, T> = Const(SG.run { value().combine(that.value()) })

--- a/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/eithert.kt
+++ b/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/eithert.kt
@@ -40,9 +40,9 @@ class DaggerEitherTFunctorInstance<F, L> @Inject constructor(val FF: Functor<F>)
   override fun FF(): Functor<F> = FF
 }
 
-class DaggerEitherTApplicativeInstance<F, L> @Inject constructor(val MF: Monad<F>) : EitherTApplicativeInstance<F, L> {
-  override fun MF(): Monad<F> = MF
-  override fun FF(): Functor<F> = MF
+class DaggerEitherTApplicativeInstance<F, L> @Inject constructor(val AF: Applicative<F>) : EitherTApplicativeInstance<F, L> {
+  override fun AF(): Applicative<F> = AF
+  override fun FF(): Functor<F> = AF
 }
 
 class DaggerEitherTMonadInstance<F, L> @Inject constructor(val MF: Monad<F>) : EitherTMonadInstance<F, L> {
@@ -50,9 +50,10 @@ class DaggerEitherTMonadInstance<F, L> @Inject constructor(val MF: Monad<F>) : E
   override fun MF(): Monad<F> = MF
 }
 
-class DaggerEitherTMonadErrorInstance<F, L> @Inject constructor(val MF: MonadError<F, L>) : EitherTMonadErrorInstance<F, L> {
-  override fun FF(): Functor<F> = MF
-  override fun MF(): Monad<F> = MF
+class DaggerEitherTMonadErrorInstance<F, L> @Inject constructor(val ME: MonadError<F, L>) : EitherTMonadErrorInstance<F, L> {
+  override fun FF(): Functor<F> = ME
+  override fun MF(): Monad<F> = ME
+  override fun AE(): ApplicativeError<F, L> = ME
 }
 
 class DaggerEitherTFoldableInstance<F, L> @Inject constructor(val FFF: Foldable<F>) : EitherTFoldableInstance<F, L> {

--- a/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/optiont.kt
+++ b/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/optiont.kt
@@ -37,9 +37,9 @@ class DaggerOptionTFunctorInstance<F> @Inject constructor(val FF: Functor<F>) : 
   override fun FF(): Functor<F> = FF
 }
 
-class DaggerOptionTApplicativeInstance<F> @Inject constructor(val FF: Monad<F>) : OptionTApplicativeInstance<F> {
-  override fun FF(): Monad<F> = FF
-  override fun MF(): Monad<F> = FF
+class DaggerOptionTApplicativeInstance<F> @Inject constructor(val AF: Applicative<F>) : OptionTApplicativeInstance<F> {
+  override fun FF(): Functor<F> = AF
+  override fun AF(): Applicative<F> = AF
 }
 
 class DaggerOptionTMonadInstance<F> @Inject constructor(val FF: Monad<F>) : OptionTMonadInstance<F> {

--- a/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/writert.kt
+++ b/modules/dagger/arrow-dagger/src/main/kotlin/arrow/dagger/instances/writert.kt
@@ -31,10 +31,10 @@ class DaggerWriterTFunctorInstance<F, W> @Inject constructor(val FF: Functor<F>)
   override fun FF(): Functor<F> = FF
 }
 
-class DaggerWriterTApplicativeInstance<F, L> @Inject constructor(val MF: Monad<F>, val ML: Monoid<L>) : WriterTApplicativeInstance<F, L> {
-  override fun FF(): Monad<F> = MF
+class DaggerWriterTApplicativeInstance<F, L> @Inject constructor(val AF: Applicative<F>, val ML: Monoid<L>) : WriterTApplicativeInstance<F, L> {
+  override fun FF(): Functor<F> = AF
   override fun MM(): Monoid<L> = ML
-  override fun MF(): Monad<F> = MF
+  override fun AF(): Applicative<F> = AF
 }
 
 class DaggerWriterTMonadInstance<F, L> @Inject constructor(val MF: Monad<F>, val ML: Monoid<L>) : WriterTMonadInstance<F, L> {

--- a/modules/docs/arrow-docs/build.gradle
+++ b/modules/docs/arrow-docs/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile project(':arrow-core')
     compile project(':arrow-instances-data')
     compile project(':arrow-effects-instances')
+    compile project(':arrow-data-instances-effects')
     compile project(':arrow-effects-rx2-instances')
     compile project(':arrow-effects-reactor-instances')
     compile project(':arrow-effects-kotlinx-coroutines-instances')

--- a/modules/docs/arrow-docs/docs/docs/datatypes/eithert/README.md
+++ b/modules/docs/arrow-docs/docs/docs/datatypes/eithert/README.md
@@ -210,7 +210,7 @@ eitherTVal
 And back to the `ObservableK<Either<BizError, A>>` running the transformer
 
 ```kotlin:ank
-eitherTVal.fix().value
+eitherTVal.value()
 ```
 
 So how would our function look if we implemented it with the EitherT monad transformer?
@@ -226,7 +226,7 @@ fun getCountryCode(personId: Int): ObservableK<Either<BizError, String>> =
     )).bind()
     val country = EitherT(findCountry(address.id)).bind()
     country.code
-  }.value()
+  }.value().fix()
 ```
 
 Here we no longer have to deal with the `Left` cases, and the binding to the values on the left side are already the underlying values we want to focus on instead of the potential biz error values. We have automatically `flatMapped` through the `ObservableK` and `Either` in a single expression reducing the boilerplate and encoding the effects concerns in the type signatures.

--- a/modules/docs/arrow-docs/src/main/kotlin/ExtensionsHelper.kt
+++ b/modules/docs/arrow-docs/src/main/kotlin/ExtensionsHelper.kt
@@ -31,7 +31,7 @@ fun TypeClass.dtMarkdownList(): String =
     supportedDataTypes()
       .asSequence()
       .filterNot { it.kclass == Box::class }
-      .groupBy { it.kclass.java.canonicalName.substringBeforeLast(".") }
+      .groupBy { it.kclass.java.`package`.name }
       .toSortedMap()
       .map { entry ->
         "|__${entry.key}__|" +

--- a/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/eithert.kt
+++ b/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/eithert.kt
@@ -1,0 +1,124 @@
+package arrow.instances
+
+import arrow.core.*
+import arrow.data.*
+import arrow.effects.Ref
+import arrow.effects.typeclasses.*
+import arrow.extension
+import arrow.instances.either.monad.flatten
+import arrow.typeclasses.ApplicativeError
+import arrow.typeclasses.Monad
+import kotlin.coroutines.CoroutineContext
+
+@extension
+interface EitherTBracketInstance<F> : Bracket<EitherTPartialOf<F, Throwable>, Throwable>, EitherTMonadThrowInstance<F> {
+
+  fun MDF(): MonadDefer<F>
+
+  override fun MF(): Monad<F> = MDF()
+
+  override fun AE(): ApplicativeError<F, Throwable> = MDF()
+
+  override fun <A, B> EitherTOf<F, Throwable, A>.bracketCase(
+    release: (A, ExitCase<Throwable>) -> EitherTOf<F, Throwable, Unit>,
+    use: (A) -> EitherTOf<F, Throwable, B>): EitherT<F, Throwable, B> =
+
+    EitherT.liftF<F, Throwable, Ref<F, Option<Throwable>>>(MDF(), Ref.of(None, MDF())).flatMap(MDF()) { ref ->
+      EitherT(
+        MDF().run {
+          value.bracketCase(use = { eith ->
+            when (eith) {
+              is Either.Right -> use(eith.b).value
+              is Either.Left -> just(eith)
+            }
+          }, release = { eith, exitCase ->
+            when (eith) {
+              is Either.Right -> when (exitCase) {
+                is ExitCase.Completed -> {
+                  release(eith.b, ExitCase.Completed).value.flatMap {
+                    it.fold(
+                      { l -> ref.set(Some(l)) },
+                      { just(Unit) }
+                    )
+                  }
+                }
+                else -> release(eith.b, exitCase).value.void()
+              }
+              is Either.Left -> just(Unit)
+            }
+          }).flatMap { eith ->
+            when (eith) {
+              is Either.Right -> ref.get.map {
+                it.fold(
+                  { eith },
+                  { throwable -> throwable.left() })
+              }
+              is Either.Left -> just(eith)
+            }
+          }
+        }
+      )
+    }
+
+}
+
+@extension
+interface EitherTMonadDeferInstance<F> : MonadDefer<EitherTPartialOf<F, Throwable>>, EitherTBracketInstance<F> {
+
+  override fun MDF(): MonadDefer<F>
+
+  override fun <A> defer(fa: () -> EitherTOf<F, Throwable, A>): EitherT<F, Throwable, A> =
+    EitherT(MDF().defer { fa().value })
+
+}
+
+@extension
+interface EitherTAsyncInstance<F> : Async<EitherTPartialOf<F, Throwable>>, EitherTMonadDeferInstance<F> {
+
+  fun ASF(): Async<F>
+
+  override fun MDF(): MonadDefer<F> = ASF()
+
+  override fun <A> async(fa: Proc<A>): EitherT<F, Throwable, A> = ASF().run {
+    EitherT.liftF(this, async(fa))
+  }
+
+  override fun <A> EitherTOf<F, Throwable, A>.continueOn(ctx: CoroutineContext): EitherT<F, Throwable, A> = ASF().run {
+    EitherT(value.continueOn(ctx))
+  }
+
+}
+
+@extension
+interface EitherTEffectInstance<F> : Effect<EitherTPartialOf<F, Throwable>>, EitherTAsyncInstance<F> {
+
+  fun EFF(): Effect<F>
+
+  override fun ASF(): Async<F> = EFF()
+
+  override fun <A> EitherTOf<F, Throwable, A>.runAsync(cb: (Either<Throwable, A>) -> EitherTOf<F, Throwable, Unit>): EitherT<F, Throwable, Unit> = EFF().run {
+    EitherT(value.runAsync { a ->
+      cb(a.flatten())
+        .value
+        .void()
+    }.attempt())
+  }
+
+}
+
+@extension
+interface EitherTConcurrentEffectInstance<F> : ConcurrentEffect<EitherTPartialOf<F, Throwable>>, EitherTEffectInstance<F> {
+
+  fun CEFF(): ConcurrentEffect<F>
+
+  override fun EFF(): Effect<F> = CEFF()
+
+  override fun <A> EitherTOf<F, Throwable, A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> EitherTOf<F, Throwable, Unit>): EitherT<F, Throwable, Disposable> = CEFF().run {
+    EitherT(value.runAsyncCancellable { a ->
+      cb(a.flatten())
+        .value
+        .void()
+    }.attempt())
+  }
+
+}

--- a/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/kleisli.kt
+++ b/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/kleisli.kt
@@ -1,14 +1,12 @@
 package arrow.effects.instances
 
 import arrow.Kind
-import arrow.data.Kleisli
-import arrow.data.KleisliPartialOf
-import arrow.data.fix
-import arrow.effects.typeclasses.Bracket
-import arrow.effects.typeclasses.ExitCase
+import arrow.data.*
+import arrow.effects.typeclasses.*
 import arrow.extension
 import arrow.instances.KleisliMonadErrorInstance
 import arrow.typeclasses.MonadError
+import kotlin.coroutines.CoroutineContext
 
 @extension
 interface KleisliBracketInstance<F, R, E> : Bracket<KleisliPartialOf<F, R>, E>, KleisliMonadErrorInstance<F, R, E> {
@@ -23,14 +21,42 @@ interface KleisliBracketInstance<F, R, E> : Bracket<KleisliPartialOf<F, R>, E>, 
   ): Kleisli<F, R, B> =
     BF().run {
       Kleisli { r ->
-        this@bracketCase.fix().run(r).bracketCase({ a, br ->
-          release(a, br).fix().run(r)
+        this@bracketCase.run(r).bracketCase({ a, br ->
+          release(a, br).run(r)
         }) { a ->
-          use(a).fix().run(r)
+          use(a).run(r)
         }
       }
     }
 
   override fun <A> Kind<KleisliPartialOf<F, R>, A>.uncancelable(): Kleisli<F, R, A> =
-    Kleisli { r -> BF().run { this@uncancelable.fix().run(r).uncancelable() } }
+    Kleisli { r -> BF().run { this@uncancelable.run(r).uncancelable() } }
+}
+
+//TODO fix stack safety issue. AsyncLaws#stack safety over repeated attempts fails.
+internal interface KleisliMonadDeferInstance<F, R> : MonadDefer<KleisliPartialOf<F, R>>, KleisliBracketInstance<F, R, Throwable> {
+
+  fun MDF(): MonadDefer<F>
+
+  override fun BF(): Bracket<F, Throwable> = MDF()
+
+  override fun <A> defer(fa: () -> KleisliOf<F, R, A>): Kleisli<F, R, A> = MDF().run {
+    Kleisli { r -> defer { fa().run(r) } }
+  }
+
+}
+
+internal interface KleisliAsyncInstance<F, R> : Async<KleisliPartialOf<F, R>>, KleisliMonadDeferInstance<F, R> {
+
+  fun ASF(): Async<F>
+
+  override fun MDF(): MonadDefer<F> = ASF()
+
+  override fun <A> async(fa: Proc<A>): Kleisli<F, R, A> =
+    Kleisli.liftF(ASF().async(fa))
+
+  override fun <A> KleisliOf<F, R, A>.continueOn(ctx: CoroutineContext): Kleisli<F, R, A> = ASF().run {
+    Kleisli { r -> run(r).continueOn(ctx) }
+  }
+
 }

--- a/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/optiont.kt
+++ b/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/optiont.kt
@@ -1,0 +1,73 @@
+package arrow.instances
+
+import arrow.core.None
+import arrow.data.*
+import arrow.effects.Ref
+import arrow.effects.typeclasses.*
+import arrow.extension
+import arrow.typeclasses.MonadError
+import kotlin.coroutines.CoroutineContext
+
+@extension
+interface OptionTBracketInstance<F> : Bracket<OptionTPartialOf<F>, Throwable>, OptionTMonadError<F, Throwable> {
+
+  fun MD(): MonadDefer<F>
+
+  override fun ME(): MonadError<F, Throwable> = MD()
+
+  override fun <A, B> OptionTOf<F, A>.bracketCase(release: (A, ExitCase<Throwable>) -> OptionTOf<F, Unit>, use: (A) -> OptionTOf<F, B>): OptionT<F, B> = MD().run {
+    OptionT(Ref.of(false, this).flatMap { ref ->
+      value.bracketCase(use = {
+        it.fold(
+          { just(None) },
+          { a -> use(a).value }
+        )
+      }, release = { option, exitCase ->
+        option.fold(
+          { just(Unit) },
+          { a ->
+            when (exitCase) {
+              is ExitCase.Completed -> release(a, exitCase).value.flatMap {
+                it.fold({ ref.set(true) }, { just(Unit) })
+              }
+              else -> release(a, exitCase).value.void()
+            }
+          }
+        )
+      }).flatMap { option ->
+        option.fold(
+          { just(None) },
+          { ref.get.map { b -> if (b) None else option } }
+        )
+      }
+    })
+  }
+
+}
+
+@extension
+interface OptionTMonadDeferInstance<F> : MonadDefer<OptionTPartialOf<F>>, OptionTBracketInstance<F> {
+
+  override fun MD(): MonadDefer<F>
+
+  override fun <A> defer(fa: () -> OptionTOf<F, A>): OptionT<F, A> =
+    OptionT(MD().defer { fa().value })
+
+}
+
+@extension
+interface OptionTAsyncInstance<F> : Async<OptionTPartialOf<F>>, OptionTMonadDeferInstance<F> {
+
+  fun AS(): Async<F>
+
+  override fun MD(): MonadDefer<F> = AS()
+
+  override fun <A> async(fa: Proc<A>): OptionT<F, A> = AS().run {
+    OptionT.liftF(this, async(fa))
+  }
+
+  override fun <A> OptionTOf<F, A>.continueOn(ctx: CoroutineContext): OptionT<F, A> = AS().run {
+    OptionT(value.continueOn(ctx))
+  }
+
+}

--- a/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/statet.kt
+++ b/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/statet.kt
@@ -1,0 +1,75 @@
+package arrow.effects.instances
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.getOrElse
+import arrow.data.*
+import arrow.effects.Ref
+import arrow.effects.typeclasses.*
+import arrow.extension
+import arrow.instances.StateTMonadThrowInstance
+import arrow.typeclasses.MonadError
+import kotlin.coroutines.CoroutineContext
+
+@extension
+interface StateTBracketInstance<F, S> : Bracket<StateTPartialOf<F, S>, Throwable>, StateTMonadThrowInstance<F, S> {
+
+  fun MD(): MonadDefer<F>
+
+  override fun ME(): MonadError<F, Throwable> = MD()
+
+  override fun <A, B> StateTOf<F, S, A>.bracketCase(
+    release: (A, ExitCase<Throwable>) -> StateTOf<F, S, Unit>,
+    use: (A) -> StateTOf<F, S, B>): StateT<F, S, B> = MD().run {
+
+    StateT.liftF<F, S, Ref<F, Option<S>>>(this, Ref.of(None, this)).flatMap { ref ->
+      StateT<F, S, B>(this) { startS ->
+        runM(this, startS).bracketCase(use = { (s, a) ->
+          use(a).runM(this, s).flatMap { sa ->
+            ref.set(Some(sa.a)).map { sa }
+          }
+        }, release = { (s0, a), exitCase ->
+          when (exitCase) {
+            is ExitCase.Completed ->
+              ref.get.map { it.getOrElse { s0 } }.flatMap { s1 ->
+                release(a, ExitCase.Completed).fix().runS(this, s1).flatMap { s2 ->
+                  ref.set(Some(s2))
+                }
+              }
+            else -> release(a, exitCase).runM(this, s0).void()
+          }
+        }).flatMap { (s, b) -> ref.get.map { it.getOrElse { s } }.tupleRight(b) }
+      }
+    }
+  }
+
+}
+
+@extension
+interface StateTMonadDeferInstance<F, S> : MonadDefer<StateTPartialOf<F, S>>, StateTBracketInstance<F, S> {
+
+  override fun MD(): MonadDefer<F>
+
+  override fun <A> defer(fa: () -> StateTOf<F, S, A>): StateT<F, S, A> = MD().run {
+    StateT(this) { s -> defer { fa().runM(this, s) } }
+  }
+
+}
+
+@extension
+interface StateTAsyncInstane<F, S> : Async<StateTPartialOf<F, S>>, StateTMonadDeferInstance<F, S> {
+
+  fun AS(): Async<F>
+
+  override fun MD(): MonadDefer<F> = AS()
+
+  override fun <A> async(fa: Proc<A>): StateT<F, S, A> = AS().run {
+    StateT.liftF(this, async(fa))
+  }
+
+  override fun <A> StateTOf<F, S, A>.continueOn(ctx: CoroutineContext): StateT<F, S, A> = AS().run {
+    StateT(this) { s -> runM(this, s).continueOn(ctx) }
+  }
+
+}

--- a/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/writert.kt
+++ b/modules/effects/arrow-data-instances-effects/src/main/kotlin/arrow/instances/writert.kt
@@ -1,0 +1,109 @@
+package arrow.instances
+
+import arrow.Kind
+import arrow.core.*
+import arrow.data.*
+import arrow.effects.Ref
+import arrow.effects.typeclasses.*
+import arrow.extension
+import arrow.typeclasses.MonadError
+import arrow.typeclasses.Monoid
+import kotlin.coroutines.CoroutineContext
+
+@extension
+interface WriterTBrackInstance<F, W> : Bracket<WriterTPartialOf<F, W>, Throwable>, WriterTMonadThrow<F, W> {
+
+  fun MD(): MonadDefer<F>
+
+  override fun MM(): Monoid<W>
+
+  override fun ME(): MonadError<F, Throwable> = MD()
+
+  override fun <A, B> WriterTOf<F, W, A>.bracketCase(
+    release: (A, ExitCase<Throwable>) -> WriterTOf<F, W, Unit>,
+    use: (A) -> WriterTOf<F, W, B>): WriterT<F, W, B> = MM().run {
+    MD().run {
+      WriterT(Ref.of(empty(), this).flatMap { ref ->
+        value.bracketCase(use = { wa ->
+          WriterT(wa.just()).flatMap(use).value
+        }, release = { wa, exitCase ->
+          val r = release(wa.b, exitCase).value
+          when (exitCase) {
+            is ExitCase.Completed -> r.flatMap { (l, _) -> ref.set(l) }
+            else -> r.void()
+          }
+        }).flatMap { (w, b) ->
+          ref.get.map { ww -> Tuple2(w.combine(ww), b) }
+        }
+      })
+    }
+  }
+
+}
+
+@extension
+interface WriterTMonadDeferInstance<F, W> : MonadDefer<WriterTPartialOf<F, W>>, WriterTBrackInstance<F, W> {
+
+  override fun MD(): MonadDefer<F>
+
+  override fun MM(): Monoid<W>
+
+  override fun <A> defer(fa: () -> Kind<WriterTPartialOf<F, W>, A>): Kind<WriterTPartialOf<F, W>, A> =
+    WriterT(MD().defer { fa().value })
+
+}
+
+@extension
+interface WriterTAsyncInstance<F, W> : Async<WriterTPartialOf<F, W>>, WriterTMonadDeferInstance<F, W> {
+
+  fun AS(): Async<F>
+
+  override fun MM(): Monoid<W>
+
+  override fun MD(): MonadDefer<F> = AS()
+
+  override fun <A> async(fa: Proc<A>): WriterT<F, W, A> = AS().run {
+    WriterT.liftF(async(fa), MM(), this)
+  }
+
+  override fun <A> WriterTOf<F, W, A>.continueOn(ctx: CoroutineContext): WriterT<F, W, A> = AS().run {
+    WriterT(value.continueOn(ctx))
+  }
+
+}
+
+@extension
+interface WriterTEffectInstance<F, W> : Effect<WriterTPartialOf<F, W>>, WriterTAsyncInstance<F, W> {
+
+  fun EFF(): Effect<F>
+
+  override fun MM(): Monoid<W>
+
+  override fun AS(): Async<F> = EFF()
+
+  override fun <A> WriterTOf<F, W, A>.runAsync(cb: (Either<Throwable, A>) -> WriterTOf<F, W, Unit>): WriterT<F, W, Unit> = EFF().run {
+    WriterT.liftF(value.runAsync { r ->
+      val f = cb.compose { a: Either<Throwable, Tuple2<W, A>> -> a.map(Tuple2<W, A>::b) }
+      f(r).value.void()
+    }, MM(), this)
+  }
+
+}
+
+@extension
+interface WriterTConcurrentEffectInstance<F, W> : ConcurrentEffect<WriterTPartialOf<F, W>>, WriterTEffectInstance<F, W> {
+
+  fun CEFF(): ConcurrentEffect<F>
+
+  override fun MM(): Monoid<W>
+
+  override fun EFF(): Effect<F> = CEFF()
+
+  override fun <A> WriterTOf<F, W, A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> WriterTOf<F, W, Unit>): WriterT<F, W, Disposable> = CEFF().run {
+    WriterT.liftF(value.runAsyncCancellable { r: Either<Throwable, Tuple2<W, A>> ->
+      val f = cb.compose { rr: Either<Throwable, Tuple2<W, A>> -> rr.map(Tuple2<W, A>::b) }
+      f(r).value.void()
+    }, MM(), this)
+  }
+
+}

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxK.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/FluxK.kt
@@ -111,7 +111,7 @@ data class FluxK<A>(val flux: Flux<A>) : FluxKOf<A>, FluxKKindedJ<A> {
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> FluxKOf<Either<A, B>>): FluxK<B> {
-      val either = f(a).fix().value().blockFirst()
+      val either = f(a).value().blockFirst()
       return when (either) {
         is Either.Left -> tailRecM(either.a, f)
         is Either.Right -> Flux.just(either.b).k()

--- a/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoK.kt
+++ b/modules/effects/arrow-effects-reactor/src/main/kotlin/arrow/effects/MonoK.kt
@@ -87,7 +87,7 @@ data class MonoK<A>(val mono: Mono<A>) : MonoKOf<A>, MonoKKindedJ<A> {
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> MonoKOf<Either<A, B>>): MonoK<B> {
-      val either = f(a).fix().value().block()
+      val either = f(a).value().block()
       return when (either) {
         is Either.Left -> tailRecM(either.a, f)
         is Either.Right -> Mono.just(either.b).k()

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/FlowableK.kt
@@ -116,7 +116,7 @@ data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKi
       }, mode).k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> FlowableKOf<Either<A, B>>): FlowableK<B> {
-      val either = f(a).fix().value().blockingFirst()
+      val either = f(a).value().blockingFirst()
       return when (either) {
         is Either.Left -> tailRecM(either.a, f)
         is Either.Right -> Flowable.just(either.b).k()

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/MaybeK.kt
@@ -95,7 +95,7 @@ data class MaybeK<A>(val maybe: Maybe<A>) : MaybeKOf<A>, MaybeKKindedJ<A> {
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> MaybeKOf<Either<A, B>>): MaybeK<B> {
-      val either = f(a).fix().value().blockingGet()
+      val either = f(a).value().blockingGet()
       return when (either) {
         is Either.Left -> tailRecM(either.a, f)
         is Either.Right -> Maybe.just(either.b).k()

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/ObservableK.kt
@@ -110,7 +110,7 @@ data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, Obs
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> ObservableKOf<Either<A, B>>): ObservableK<B> {
-      val either = f(a).fix().value().blockingFirst()
+      val either = f(a).value().blockingFirst()
       return when (either) {
         is Either.Left -> tailRecM(either.a, f)
         is Either.Right -> Observable.just(either.b).k()

--- a/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleK.kt
+++ b/modules/effects/arrow-effects-rx2/src/main/kotlin/arrow/effects/SingleK.kt
@@ -87,7 +87,7 @@ data class SingleK<A>(val single: Single<A>) : SingleKOf<A>, SingleKKindedJ<A> {
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> SingleKOf<Either<A, B>>): SingleK<B> {
-      val either = f(a).fix().value().blockingGet()
+      val either = f(a).value().blockingGet()
       return when (either) {
         is Either.Left -> tailRecM(either.a, f)
         is Either.Right -> Single.just(either.b).k()

--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/Fold.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/Fold.kt
@@ -81,12 +81,12 @@ interface Fold<S, A> : FoldOf<S, A> {
   /**
    * Get the first target
    */
-  fun headOption(s: S): Option<A> = foldMap(firstOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value
+  fun headOption(s: S): Option<A> = foldMap(firstOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value()
 
   /**
    * Get the last target
    */
-  fun lastOption(s: S): Option<A> = foldMap(lastOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value
+  fun lastOption(s: S): Option<A> = foldMap(lastOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value()
 
   /**
    * Fold using the given [Monoid] instance.
@@ -186,7 +186,7 @@ interface Fold<S, A> : FoldOf<S, A> {
    * Find the first element matching the predicate, if one exists.
    */
   fun find(s: S, p: (A) -> Boolean): Option<A> =
-    foldMap(firstOptionMonoid<A>(), s) { b -> (if (p(b)) Const(Some(b)) else Const(None)) }.value
+    foldMap(firstOptionMonoid<A>(), s) { b -> (if (p(b)) Const(Some(b)) else Const(None)) }.value()
 
   /**
    * Check whether at least one element satisfies the predicate.

--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
@@ -231,12 +231,12 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
   /**
    * Find the first target or [Option.None] if no targets
    */
-  fun headOption(s: S): Option<A> = foldMap(firstOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value
+  fun headOption(s: S): Option<A> = foldMap(firstOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value()
 
   /**
    * Find the first target or [Option.None] if no targets
    */
-  fun lastOption(s: S): Option<A> = foldMap(lastOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value
+  fun lastOption(s: S): Option<A> = foldMap(lastOptionMonoid<A>(), s) { b -> Const(Some(b)) }.value()
 
   fun <U, V> choice(other: PTraversal<U, V, A, B>): PTraversal<Either<S, U>, Either<T, V>, A, B> = object : PTraversal<Either<S, U>, Either<T, V>, A, B> {
     override fun <F> modifyF(FA: Applicative<F>, s: Either<S, U>, f: (A) -> Kind<F, B>): Kind<F, Either<T, V>> = FA.run {
@@ -315,7 +315,7 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
   fun find(s: S, p: (A) -> Boolean): Option<A> = foldMap(firstOptionMonoid<A>(), s) { a ->
     if (p(a)) Const(Some(a))
     else Const(None)
-  }.value
+  }.value()
 
   /**
    * Map each target to a Monoid and combine the results

--- a/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/predef.kt
+++ b/modules/optics/arrow-optics/src/main/kotlin/arrow/optics/predef.kt
@@ -20,7 +20,7 @@ internal fun <A> firstOptionMonoid(): Monoid<Const<Option<A>, First>> = object :
   override fun empty(): Const<Option<A>, First> = Const(None)
 
   override fun Const<Option<A>, First>.combine(b: Const<Option<A>, First>): Const<Option<A>, First> =
-    if (value.fold({ false }, { true })) this else b
+    if (value().fold({ false }, { true })) this else b
 
 }
 
@@ -29,6 +29,6 @@ internal fun <A> lastOptionMonoid(): Monoid<Const<Option<A>, Last>> = object : M
   override fun empty(): Const<Option<A>, Last> = Const(None)
 
   override fun Const<Option<A>, Last>.combine(b: Const<Option<A>, Last>): Const<Option<A>, Last> =
-    if (b.value.fold({ false }, { true })) b else this
+    if (b.value().fold({ false }, { true })) b else this
 
 }

--- a/modules/reflect/arrow-reflect/src/main/kotlin/arrow/reflect/TypeClassExtension.kt
+++ b/modules/reflect/arrow-reflect/src/main/kotlin/arrow/reflect/TypeClassExtension.kt
@@ -54,10 +54,12 @@ internal val classPathExtensions: List<TypeClassExtension> =
  * The nasty bits. Down-kind a deeply nested kind to introspect the data type that is targeting
  */
 private fun TypeArgument.unKind(): DataType =
-  Class.forName(toString()
-    .replace("arrow.Kind<? extends", "")
-    .replace(", \\? extends \\w.*?".toRegex(), "")
-    .replace("<.*".toRegex(), "")
-    .replace(">", "")
-    .replace(".For", ".")
-    .trim()).kotlin.let(::DataType)
+    Class.forName(toString()
+      .replace("arrow.Kind<? extends", "")
+      //order is important for next 2 since `*?` removes pattern for `*\w`
+      .replace(", \\? extends \\w.*\\w".toRegex(), "") //? extends java.lang.Throwable
+      .replace(", \\? extends \\w.*?".toRegex(), "") //? extends F
+      .replace("<.*".toRegex(), "")
+      .replace(">", "")
+      .replace(".For", ".")
+      .trim()).kotlin.let(::DataType)

--- a/modules/streams/arrow-streams/src/main/kotlin/arrow/streams/internal/instances.kt
+++ b/modules/streams/arrow-streams/src/main/kotlin/arrow/streams/internal/instances.kt
@@ -10,81 +10,81 @@ import arrow.streams.internal.bracketCase as bracketC
 
 @extension
 interface FreeCFunctor<F> : Functor<FreeCPartialOf<F>> {
-  override fun <A, B> Kind<FreeCPartialOf<F>, A>.map(f: (A) -> B): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> FreeCOf<F, A>.map(f: (A) -> B): FreeCOf<F, B> =
     this.fix().map(f)
 }
 
 @extension
 interface FreeCApplicative<F> : Applicative<FreeCPartialOf<F>> {
-  override fun <A> just(a: A): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> just(a: A): FreeCOf<F, A> =
     FreeC.just(a)
 
-  override fun <A, B> Kind<FreeCPartialOf<F>, A>.ap(ff: Kind<FreeCPartialOf<F>, (A) -> B>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> FreeCOf<F, A>.ap(ff: FreeCOf<F, (A) -> B>): FreeCOf<F, B> =
     apply(ff)
 
 }
 
 @extension
 interface FreeCMonad<F> : Monad<FreeCPartialOf<F>> {
-  override fun <A, B> Kind<FreeCPartialOf<F>, A>.flatMap(f: (A) -> Kind<FreeCPartialOf<F>, B>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> FreeCOf<F, A>.flatMap(f: (A) -> FreeCOf<F, B>): FreeCOf<F, B> =
     this.fix().flatMap(f)
 
-  override fun <A, B> tailRecM(a: A, f: (A) -> Kind<FreeCPartialOf<F>, Either<A, B>>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> tailRecM(a: A, f: (A) -> FreeCOf<F, Either<A, B>>): FreeCOf<F, B> =
     FreeC.tailRecM(a) { f(it).fix() }
 
-  override fun <A> just(a: A): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> just(a: A): FreeCOf<F, A> =
     FreeC.just(a)
 }
 
 @extension
 interface FreeCApplicativeError<F> : ApplicativeError<FreeCPartialOf<F>, Throwable> {
-  override fun <A> raiseError(e: Throwable): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> raiseError(e: Throwable): FreeCOf<F, A> =
     FreeC.raiseError(e)
 
-  override fun <A> Kind<FreeCPartialOf<F>, A>.handleErrorWith(f: (Throwable) -> Kind<FreeCPartialOf<F>, A>): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> FreeCOf<F, A>.handleErrorWith(f: (Throwable) -> FreeCOf<F, A>): FreeCOf<F, A> =
     handleErrorW(f)
 
-  override fun <A> just(a: A): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> just(a: A): FreeCOf<F, A> =
     FreeC.just(a)
 
-  override fun <A, B> Kind<FreeCPartialOf<F>, A>.ap(ff: Kind<FreeCPartialOf<F>, (A) -> B>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> FreeCOf<F, A>.ap(ff: FreeCOf<F, (A) -> B>): FreeCOf<F, B> =
     apply(ff)
 
 }
 
 @extension
 interface FreeCMonadError<F> : MonadError<FreeCPartialOf<F>, Throwable> {
-  override fun <A> raiseError(e: Throwable): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> raiseError(e: Throwable): FreeCOf<F, A> =
     FreeC.raiseError(e)
 
-  override fun <A> Kind<FreeCPartialOf<F>, A>.handleErrorWith(f: (Throwable) -> Kind<FreeCPartialOf<F>, A>): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> FreeCOf<F, A>.handleErrorWith(f: (Throwable) -> FreeCOf<F, A>): FreeCOf<F, A> =
     handleErrorW(f)
 
-  override fun <A> just(a: A): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> just(a: A): FreeCOf<F, A> =
     FreeC.just(a)
 
-  override fun <A, B> Kind<FreeCPartialOf<F>, A>.flatMap(f: (A) -> Kind<FreeCPartialOf<F>, B>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> FreeCOf<F, A>.flatMap(f: (A) -> FreeCOf<F, B>): FreeCOf<F, B> =
     this.fix().flatMap(f)
 
-  override fun <A, B> tailRecM(a: A, f: (A) -> Kind<FreeCPartialOf<F>, Either<A, B>>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> tailRecM(a: A, f: (A) -> FreeCOf<F, Either<A, B>>): FreeCOf<F, B> =
     FreeC.tailRecM(a) { f(it).fix() }
 
 }
 
 @extension
 interface FreeCBracket<F> : Bracket<FreeCPartialOf<F>, Throwable>, FreeCMonadError<F> {
-  override fun <A, B> Kind<FreeCPartialOf<F>, A>.bracketCase(release: (A, ExitCase<Throwable>) -> Kind<FreeCPartialOf<F>, Unit>, use: (A) -> Kind<FreeCPartialOf<F>, B>): Kind<FreeCPartialOf<F>, B> =
+  override fun <A, B> FreeCOf<F, A>.bracketCase(release: (A, ExitCase<Throwable>) -> FreeCOf<F, Unit>, use: (A) -> FreeCOf<F, B>): FreeCOf<F, B> =
     bracketC(use, release)
 }
 
 @extension
 interface FreeCMonadDefer<F> : MonadDefer<FreeCPartialOf<F>>, FreeCBracket<F> {
-  override fun <A> defer(fa: () -> Kind<FreeCPartialOf<F>, A>): Kind<FreeCPartialOf<F>, A> =
+  override fun <A> defer(fa: () -> FreeCOf<F, A>): FreeCOf<F, A> =
     FreeC.defer(fa)
 }
 
 @extension
-interface FreeCEq<F, G, A> : Eq<Kind<FreeCPartialOf<F>, A>> {
+interface FreeCEq<F, G, A> : Eq<FreeCOf<F, A>> {
 
   fun ME(): MonadError<G, Throwable>
 
@@ -92,7 +92,7 @@ interface FreeCEq<F, G, A> : Eq<Kind<FreeCPartialOf<F>, A>> {
 
   fun EQFA(): Eq<Kind<G, Option<A>>>
 
-  override fun Kind<FreeCPartialOf<F>, A>.eqv(b: Kind<FreeCPartialOf<F>, A>): Boolean = EQFA().run {
+  override fun FreeCOf<F, A>.eqv(b: FreeCOf<F, A>): Boolean = EQFA().run {
     fix().foldMap(FK(), ME()).eqv(b.fix().foldMap(FK(), ME()))
   }
 }


### PR DESCRIPTION
Small change to some data types. I exposed `value()` on both the actual type and it's kinded version, and I made the `value` property private. This removed the need for `fix()` in a lot of cases.

1 law failing for `Kleisli` which I was unable to fix for now. So I made them internal for now. I'll make separate tickets for these if that's okay.