### PR TITLE
(#1179) Add function to Either similar to filterOrElse but that provi…

### DIFF
--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -267,6 +267,36 @@ inline fun <A, B> EitherOf<A, B>.filterOrElse(predicate: (B) -> Boolean, default
   flatMap { if (predicate(it)) Right(it) else Left(default()) }
 
 /**
+ * * Returns [Either.Right] with the existing value of [Either.Right] if this is a [Either.Right] and the given
+ * predicate holds for the right value.
+ * * Returns `Left(default({right}))` if this is a [Either.Right] and the given predicate does not
+ * hold for the right value. Useful for error handling where 'default' returns a message with context on why the value
+ * did not pass the filter
+ * * Returns [Either.Left] with the existing value of [Either.Left] if this is a [Either.Left].
+ *
+ * Example:
+ *
+ * {: data-executable='true'}
+ * ```kotlin:ank
+ * import arrow.core.*
+ *
+ * Right(12).filterOrOther({ it > 10 }, { -1 })
+ * ```
+ *
+ * {: data-executable='true'}
+ * ```kotlin:ank
+ * Right(7).filterOrOther({ it > 10 }, { "Value '$it' not greater than 10" })
+ * ```
+ *
+ * {: data-executable='true'}
+ * ```kotlin:ank
+ * val left: Either<Int, Int> = Left(12)
+ * left.filterOrOther({ it > 10 }, { -1 })
+ * ```
+ */inline fun <A, B> EitherOf<A, B>.filterOrOther(predicate: (B) -> Boolean, default: (B) -> A): Either<A, B> =
+  flatMap { if (predicate(it)) arrow.core.Either.Right(it) else arrow.core.Either.Left(default(it)) }
+
+/**
  * * Returns [Either.Right] with the existing value of [Either.Right] if this is an [Either.Right] with a non-null value.
  * The returned Either.Right type is not nullable.
  * * Returns `Left(default())` if this is an [Either.Right] and the existing value is null

--- a/modules/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/modules/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
@@ -3,8 +3,7 @@ package arrow.core
 import arrow.Kind
 import arrow.Kind2
 import arrow.core.*
-import arrow.instances.*
-import arrow.instances.eq
+import arrow.instances.combine
 import arrow.instances.either.applicative.applicative
 import arrow.instances.either.bifunctor.bifunctor
 import arrow.instances.either.eq.eq
@@ -15,12 +14,22 @@ import arrow.instances.either.semigroup.semigroup
 import arrow.instances.either.semigroupK.semigroupK
 import arrow.instances.either.show.show
 import arrow.instances.either.traverse.traverse
+import arrow.instances.eq
+import arrow.instances.hash
+import arrow.instances.monoid
+import arrow.instances.semigroup
 import arrow.test.UnitSpec
-import arrow.test.laws.*
+import arrow.test.laws.BifunctorLaws
+import arrow.test.laws.HashLaws
+import arrow.test.laws.MonadErrorLaws
+import arrow.test.laws.MonoidLaws
+import arrow.test.laws.SemigroupKLaws
+import arrow.test.laws.SemigroupLaws
+import arrow.test.laws.ShowLaws
+import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import io.kotlintest.KTestJUnitRunner
-import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
 
@@ -103,6 +112,17 @@ class EitherTest : UnitSpec() {
           && Right(a).filterOrElse({ it > a + 1 }, { b }) == Left(b)
           && left.filterOrElse({ it > a - 1 }, { b }) == Left(a)
           && left.filterOrElse({ it > a + 1 }, { b }) == Left(a)
+      }
+    }
+
+    "filterOrOther should filter values" {
+      forAll { a: Int, b: Int ->
+        val left: Either<Int, Int> = Left(a)
+
+        Right(a).filterOrOther({ it > a - 1 }, { it -> b + a }) == Right(a)
+                && Right(a).filterOrOther({ it > a + 1 }, { it -> b + a }) == Left(b + a)
+                && left.filterOrOther({ it > a - 1 }, { it -> b + a }) == Left(a)
+                && left.filterOrOther({ it > a + 1 }, { it -> b + a }) == Left(a)
       }
     }
 


### PR DESCRIPTION
…des value to 'default' for error context

filterOrElse is very useful for validating (filtering) a value and returning error info in the Left, BUT
it's nice to include context from the value in the Left error object. filterOrElse doesn't pass anything to
the 'default' function, so this PR adds `filterOrOther` that functions exactly like `filterOrElse` but also
passes the value to the default function so that context can be extracted from the value without having to
explicitly define it in an outer scope

@raulraja @pakoito 
Note that I accidentally closed the other PR, and this comes from a branch in my fork rather than from master.

I've added the ank, and an executable block into the comments. If that isn't quite what's meant, then I'll require a bit more guidance.