### PR TITLE
Small fix Deferred

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ buildscript {
         gradleVersionsPluginVersion = '0.20.0'
         javaVersion = JavaVersion.VERSION_1_7
         kotlinTestVersion = '2.0.7'
-        kotlinVersion = '1.3.0'
+        kotlinVersion = '1.3.11'
         daggerVersion = '2.17'
-        kotlinxCoroutinesVersion = '1.0.0'
+        kotlinxCoroutinesVersion = '1.1.0'
         kotlinxCollectionsImmutableVersion = '0.1'
         kotlinPoetVersion = '1.0.0-RC1'
         projectReactorVersion = '3.1.8.RELEASE'

--- a/modules/core/arrow-data/src/test/kotlin/arrow/data/OptionTTest.kt
+++ b/modules/core/arrow-data/src/test/kotlin/arrow/data/OptionTTest.kt
@@ -11,7 +11,6 @@ import arrow.effects.instances.io.applicativeError.attempt
 import arrow.effects.instances.io.async.async
 import arrow.effects.instances.optiont.async.async
 import arrow.instances.nonemptylist.monad.monad
-import arrow.instances.option.applicative.applicative
 import arrow.instances.option.monad.monad
 import arrow.instances.optiont.applicative.applicative
 import arrow.instances.optiont.monoidK.monoidK

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function0.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function0.kt
@@ -10,9 +10,7 @@ import arrow.typeclasses.*
 interface Function0SemigroupInstance<A> : Semigroup<Function0<A>> {
   fun SA(): Semigroup<A>
 
-  override fun Function0<A>.combine(b: Function0<A>): Function0<A> {
-    return { SA().run { invoke().combine(b.invoke()) } }.k()
-  }
+  override fun Function0<A>.combine(b: Function0<A>): Function0<A> = { SA().run { invoke().combine(b.invoke()) } }.k()
 }
 
 @extension
@@ -21,9 +19,7 @@ interface Function0MonoidInstance<A> : Monoid<Function0<A>>, Function0SemigroupI
 
   override fun SA() = MA()
 
-  override fun empty(): Function0<A> {
-    return { MA().run { empty() } }.k()
-  }
+  override fun empty(): Function0<A> = { MA().run { empty() } }.k()
 }
 
 @extension

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function1.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/function1.kt
@@ -11,9 +11,7 @@ import arrow.typeclasses.*
 interface Function1SemigroupInstance<A, B> : Semigroup<Function1<A, B>> {
   fun SB(): Semigroup<B>
 
-  override fun Function1<A, B>.combine(b: Function1<A, B>): Function1<A, B> {
-    return { a: A -> SB().run { invoke(a).combine(b(a)) } }.k()
-  }
+  override fun Function1<A, B>.combine(b: Function1<A, B>): Function1<A, B> = { a: A -> SB().run { invoke(a).combine(b(a)) } }.k()
 }
 
 @extension
@@ -22,9 +20,7 @@ interface Function1MonoidInstance<A, B> : Monoid<Function1<A, B>>, Function1Semi
 
   override fun SB() = MB()
 
-  override fun empty(): Function1<A, B> {
-    return Function1 { MB().run { empty() } }
-  }
+  override fun empty(): Function1<A, B> = Function1 { MB().run { empty() } }
 }
 
 @extension

--- a/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
+++ b/modules/core/arrow-instances-core/src/main/kotlin/arrow/instances/id.kt
@@ -11,9 +11,7 @@ import arrow.instances.traverse as idTraverse
 interface IdSemigroupInstance<A> : Semigroup<Id<A>> {
   fun SA(): Semigroup<A>
 
-  override fun Id<A>.combine(b: Id<A>): Id<A> {
-    return Id(SA().run { value().combine(b.value()) })
-  }
+  override fun Id<A>.combine(b: Id<A>): Id<A> = Id(SA().run { value().combine(b.value()) })
 }
 
 @extension

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
@@ -18,12 +18,11 @@ object AsyncLaws {
     AC: Async<F>,
     EQ: Eq<Kind<F, Int>>,
     EQ_EITHER: Eq<Kind<F, Either<Throwable, Int>>>,
-    EQERR: Eq<Kind<F, Int>> = EQ,
     testStackSafety: Boolean = true
   ): List<Law> =
-    MonadDeferLaws.laws(AC, EQERR, EQ_EITHER, testStackSafety = testStackSafety) + listOf(
+    MonadDeferLaws.laws(AC, EQ, EQ_EITHER, testStackSafety = testStackSafety) + listOf(
       Law("Async Laws: success equivalence") { AC.asyncSuccess(EQ) },
-      Law("Async Laws: error equivalence") { AC.asyncError(EQERR) },
+      Law("Async Laws: error equivalence") { AC.asyncError(EQ) },
       Law("Async Laws: continueOn jumps threads") { AC.continueOn(EQ) },
       Law("Async Laws: async constructor") { AC.asyncConstructor(EQ) },
       Law("Async Laws: continueOn on comprehensions") { AC.continueOnComprehension(EQ) }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/Law.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/Law.kt
@@ -1,12 +1,26 @@
 package arrow.test.laws
 
 import arrow.typeclasses.Eq
+import io.kotlintest.matchers.should
+import io.kotlintest.matchers.shouldBe
 import io.kotlintest.properties.Gen
+import kotlin.reflect.KClass
+
+fun throwableEq() = Eq { a: Throwable, b ->
+  a::class == b::class && a.message == b.message
+}
 
 data class Law(val name: String, val test: () -> Unit)
 
 fun <A> A.equalUnderTheLaw(b: A, eq: Eq<A>): Boolean =
   eq.run { eqv(b) }
+
+fun <A> A.shouldBe(b: A, eq: Eq<A>): Unit = eq.run {
+  this.should {
+    io.kotlintest.matchers.Result(eqv(b),
+      "Expected: $this but found: $b")
+  }
+}
 
 fun <A> forFew(amount: Int, gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
   for (k in 0..amount) {

--- a/modules/effects/arrow-effects-instances/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects-instances/src/test/kotlin/arrow/effects/IOTest.kt
@@ -16,12 +16,9 @@ import arrow.test.laws.AsyncLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.fail
-import io.kotlintest.matchers.should
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldEqual
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/main/kotlin/arrow/effects/DeferredKInstances.kt
@@ -81,7 +81,7 @@ interface DeferredKBracketInstance : Bracket<ForDeferredK, Throwable>, DeferredK
 @extension
 interface DeferredKMonadDeferInstance : MonadDefer<ForDeferredK>, DeferredKBracketInstance {
   override fun <A> defer(fa: () -> DeferredKOf<A>): DeferredK<A> =
-    DeferredK.defer(fa = { fa() })
+    DeferredK.defer(fa = fa)
 }
 
 @extension

--- a/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/test/kotlin/arrow/effects/DeferredTest.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-instances/src/test/kotlin/arrow/effects/DeferredTest.kt
@@ -84,7 +84,7 @@ class DeferredKTest : UnitSpec() {
 
     "should return exceptions within main block with unsafeRunAsync" {
       val exception = MyException()
-      val ioa = DeferredK<Int>(GlobalScope, Unconfined, CoroutineStart.DEFAULT) { throw exception }
+      val ioa = DeferredK<Int>(Unconfined, GlobalScope, CoroutineStart.DEFAULT) { throw exception }
       ioa.unsafeRunAsync { either ->
         either.fold({ it shouldBe exception }, { fail("") })
       }
@@ -93,7 +93,7 @@ class DeferredKTest : UnitSpec() {
     "should not catch exceptions within run block with unsafeRunAsync" {
       try {
         val exception = MyException()
-        val ioa = DeferredK<Int>(GlobalScope, Unconfined, CoroutineStart.DEFAULT) { throw exception }
+        val ioa = DeferredK<Int>(Unconfined, GlobalScope, CoroutineStart.DEFAULT) { throw exception }
         ioa.unsafeRunAsync { either ->
           either.fold({ throw exception }, { fail("") })
         }
@@ -115,7 +115,7 @@ class DeferredKTest : UnitSpec() {
 
     "should complete when running a return value with runAsync" {
       val expected = 0
-      DeferredK(GlobalScope, Unconfined, CoroutineStart.DEFAULT) { expected }.runAsync { either ->
+      DeferredK(Unconfined, GlobalScope, CoroutineStart.DEFAULT) { expected }.runAsync { either ->
         either.fold({ fail("") }, { DeferredK { it shouldBe expected } })
       }
     }
@@ -135,7 +135,7 @@ class DeferredKTest : UnitSpec() {
 
     "should return exceptions within main block with runAsync" {
       val exception = MyException()
-      val ioa = DeferredK<Int>(GlobalScope, Unconfined, CoroutineStart.DEFAULT) { throw exception }
+      val ioa = DeferredK<Int>(Unconfined, GlobalScope, CoroutineStart.DEFAULT) { throw exception }
       ioa.runAsync { either ->
         either.fold({ DeferredK { it shouldBe exception } }, { fail("") })
       }
@@ -144,7 +144,7 @@ class DeferredKTest : UnitSpec() {
     "should catch exceptions within run block with runAsync" {
       try {
         val exception = MyException()
-        val ioa = DeferredK<Int>(GlobalScope, Unconfined, CoroutineStart.DEFAULT) { throw MyException() }
+        val ioa = DeferredK<Int>(Unconfined, GlobalScope, CoroutineStart.DEFAULT) { throw MyException() }
         ioa.runAsync { either ->
           either.fold({ throw MyException() }, { fail("") })
         }.unsafeRunSync()
@@ -157,7 +157,7 @@ class DeferredKTest : UnitSpec() {
     "should catch exceptions within run block with runAsyncCancellable" {
       try {
         val exception = MyException()
-        val ioa = DeferredK<Int>(GlobalScope, Unconfined, CoroutineStart.DEFAULT) { throw exception }
+        val ioa = DeferredK<Int>(Unconfined, GlobalScope, CoroutineStart.DEFAULT) { throw exception }
         ioa.runAsyncCancellable { either ->
           either.fold({ throw it }, { fail("") })
         }.unsafeRunSync()

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -444,7 +444,7 @@ sealed class DeferredK<A>(
         if (e is CancellationException) release(a, ExitCase.Cancelled).await()
         else release(a, ExitCase.Error(e)).await()
       } catch (e2: Throwable) {
-        Platform.composeErrors(e, e2)
+        throw Platform.composeErrors(e, e2)
       }
       throw e
     }
@@ -695,7 +695,7 @@ sealed class DeferredK<A>(
     memoized.cancel()
 
   @ObsoleteCoroutinesApi override fun cancel(cause: Throwable?): Boolean =
-    memoized.cancel(cause)
+    memoized.cancel()
 
   @InternalCoroutinesApi override fun getCancellationException(): CancellationException =
     memoized.getCancellationException()

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -187,7 +187,6 @@ sealed class DeferredK<A>(
                                        scope: CoroutineScope = CoroutineScope(ctx),
                                        val generator: suspend () -> A) : Generated<A>(scope, scope.async(ctx, coroutineStart) { generator() }) {
 
-
       /**
        * Awaits either the memoized [Deferred] if it has not been run yet. Or creates a new one.
        *

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredK.kt
@@ -695,7 +695,7 @@ sealed class DeferredK<A>(
     memoized.cancel()
 
   @ObsoleteCoroutinesApi override fun cancel(cause: Throwable?): Boolean =
-    memoized.cancel()
+    memoized.cancel(cause)
 
   @InternalCoroutinesApi override fun getCancellationException(): CancellationException =
     memoized.getCancellationException()

--- a/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKConnection.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines/src/main/kotlin/arrow/effects/DeferredKConnection.kt
@@ -21,7 +21,7 @@ typealias DeferredKProc<A> = (DeferredKConnection, (Either<Throwable, A>) -> Uni
 @Suppress("FunctionName")
 fun DeferredKConnection(dummy: Unit = Unit): KindConnection<ForDeferredK> = KindConnection(object : MonadDefer<ForDeferredK> {
   override fun <A> defer(fa: () -> DeferredKOf<A>): DeferredK<A> =
-    DeferredK.defer(fa = { fa() })
+    DeferredK.defer(fa = fa)
 
   override fun <A> raiseError(e: Throwable): DeferredK<A> =
     DeferredK.raiseError(e)
@@ -33,7 +33,7 @@ fun DeferredKConnection(dummy: Unit = Unit): KindConnection<ForDeferredK> = Kind
     DeferredK.just(a)
 
   override fun <A, B> DeferredKOf<A>.flatMap(f: (A) -> DeferredKOf<B>): DeferredK<B> =
-    fix().flatMap { f(it) }
+    fix().flatMap(f)
 
   override fun <A, B> tailRecM(a: A, f: (A) -> DeferredKOf<Either<A, B>>): DeferredK<B> =
     DeferredK.tailRecM(a, f)

--- a/modules/effects/arrow-effects-reactor-instances/src/test/kotlin/arrow/effects/FluxKTests.kt
+++ b/modules/effects/arrow-effects-reactor-instances/src/test/kotlin/arrow/effects/FluxKTests.kt
@@ -17,7 +17,6 @@ import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.Spec
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldNotBe
-import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.startsWith
 import org.hamcrest.MatcherAssert.assertThat

--- a/modules/effects/arrow-effects-rx2-instances/src/test/kotlin/arrow/effects/MaybeKTests.kt
+++ b/modules/effects/arrow-effects-rx2-instances/src/test/kotlin/arrow/effects/MaybeKTests.kt
@@ -65,8 +65,8 @@ class MaybeKTests : UnitSpec() {
       MonadErrorLaws.laws(MaybeK.monadError(), EQ(), EQ(), EQ()),
       ApplicativeErrorLaws.laws(MaybeK.applicativeError(), EQ(), EQ(), EQ()),
       MonadDeferLaws.laws(MaybeK.monadDefer(), EQ(), EQ(), EQ(), testStackSafety = false),
-      AsyncLaws.laws(MaybeK.async(), EQ(), EQ(), EQ(), testStackSafety = false),
-      AsyncLaws.laws(MaybeK.effect(), EQ(), EQ(), EQ(), testStackSafety = false)
+      AsyncLaws.laws(MaybeK.async(), EQ(), EQ(), testStackSafety = false),
+      AsyncLaws.laws(MaybeK.effect(), EQ(), EQ(), testStackSafety = false)
     )
 
     "Multi-thread Maybes finish correctly" {

--- a/modules/effects/arrow-effects-rx2-instances/src/test/kotlin/arrow/effects/ObservableKTests.kt
+++ b/modules/effects/arrow-effects-rx2-instances/src/test/kotlin/arrow/effects/ObservableKTests.kt
@@ -11,7 +11,6 @@ import arrow.test.UnitSpec
 import arrow.test.laws.AsyncLaws
 import arrow.test.laws.FoldableLaws
 import arrow.test.laws.TraverseLaws
-import arrow.test.laws.equalUnderTheLaw
 import arrow.typeclasses.Eq
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.Spec

--- a/modules/effects/arrow-effects-rx2-instances/src/test/kotlin/arrow/effects/SingleKTests.kt
+++ b/modules/effects/arrow-effects-rx2-instances/src/test/kotlin/arrow/effects/SingleKTests.kt
@@ -17,7 +17,6 @@ import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.Spec
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.matchers.shouldNotBe
-import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import io.reactivex.schedulers.Schedulers
@@ -62,8 +61,8 @@ class SingleKTests : UnitSpec() {
       MonadLaws.laws(SingleK.monad(), EQ()),
       MonadErrorLaws.laws(SingleK.monadError(), EQ(), EQ(), EQ()),
       ApplicativeErrorLaws.laws(SingleK.applicativeError(), EQ(), EQ(), EQ()),
-      AsyncLaws.laws(SingleK.async(), EQ(), EQ(), EQ(), testStackSafety = false),
-      AsyncLaws.laws(SingleK.effect(), EQ(), EQ(), EQ(), testStackSafety = false)
+      AsyncLaws.laws(SingleK.async(), EQ(), EQ(), testStackSafety = false),
+      AsyncLaws.laws(SingleK.effect(), EQ(), EQ(), testStackSafety = false)
     )
 
     "Multi-thread Singles finish correctly" {


### PR DESCRIPTION
Address Code review of #1189 
Fixes build issues master
Fixes scoping issues:
`GlobalScope` should be avoided at all costs because it infers with cancellation and thus I removed it as the default value. This also wires the scopes correctly for nested hierarchies build using typeclasses.