### PR TITLE
Move cancelable to Concurrent

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
@@ -30,9 +30,7 @@ object AsyncLaws {
       Law("Async Laws: async constructor") { AC.asyncConstructor(EQ) },
       Law("Async Laws: async can be derived from asyncF") { AC.asyncCanBeDerivedFromAsyncF(EQ) },
       Law("Async Laws: bracket release is called on completed or error") { AC.bracketReleaseIscalledOnCompletedOrError(EQ) },
-      Law("Async Laws: continueOn on comprehensions") { AC.continueOnComprehension(EQ) },
-      Law("Async Laws: async cancelable coherence") { AC.asyncCancelableCoherence(EQ) },
-      Law("Async Laws: cancelable cancelableF coherence") { AC.cancelableCancelableFCoherence(EQ) }
+      Law("Async Laws: continueOn on comprehensions") { AC.continueOnComprehension(EQ) }
     )
 
   fun <F> Async<F>.asyncSuccess(EQ: Eq<Kind<F, Int>>): Unit =
@@ -100,18 +98,6 @@ object AsyncLaws {
       }.equalUnderTheLaw(just(b), EQ)
     }
   }
-
-  fun <F> Async<F>.asyncCancelableCoherence(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genEither(genThrowable(), Gen.int())) { eith ->
-      async<Int> { cb -> cb(eith) }
-        .equalUnderTheLaw(cancelable { cb -> cb(eith); just<Unit>(Unit) }, EQ)
-    }
-
-  fun <F> Async<F>.cancelableCancelableFCoherence(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genEither(genThrowable(), Gen.int())) { eith ->
-      cancelable<Int> { cb -> cb(eith); just<Unit>(Unit) }
-        .equalUnderTheLaw(cancelableF { cb -> delay { cb(eith); just<Unit>(Unit) } }, EQ)
-    }
 
   // Turns out that kotlinx.coroutines decides to rewrite thread names
   private fun getCurrentThread() =

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IOConnection.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IOConnection.kt
@@ -10,6 +10,7 @@ import arrow.effects.handleErrorWith as handleErrorW
 fun IOConnection.toDisposable(): Disposable = { cancel().fix().unsafeRunSync() }
 typealias IOConnection = KindConnection<ForIO>
 
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun IOConnection(dummy: Unit = Unit): IOConnection = KindConnection(MD) { it.fix().unsafeRunAsync { } }
 
 private val _uncancelable = KindConnection.uncancelable(MD)

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Semaphore.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Semaphore.kt
@@ -240,7 +240,7 @@ private fun <F> ApplicativeError<F, Throwable>.assertNonNegative(n: Long): Kind<
 
 internal class DefaultSemaphore<F>(private val state: Ref<F, State<F>>,
                                    private val promise: Kind<F, Promise<F, Unit>>,
-                                   AS: Async<F>) : Semaphore<F>, Async<F> by AS {
+                                   private val AS: Async<F>) : Semaphore<F>, Async<F> by AS {
 
   override fun available(): Kind<F, Long> =
     state.get().map { state ->
@@ -327,5 +327,13 @@ internal class DefaultSemaphore<F>(private val state: Ref<F, State<F>>,
 
   override fun <A> withPermit(t: Kind<F, A>): Kind<F, A> =
     acquire().bracket({ release() }, { t })
+
+  override fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B> = AS.run {
+    this@ap.ap(ff)
+  }
+
+  override fun <A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B> = AS.run {
+    this@map.map(f)
+  }
 
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/CancelablePromise.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/CancelablePromise.kt
@@ -9,7 +9,7 @@ import arrow.effects.typeclasses.mapUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.EmptyCoroutineContext
 
-internal class CancelablePromise<F, A>(CF: Concurrent<F>) : Promise<F, A>, Concurrent<F> by CF {
+internal class CancelablePromise<F, A>(private val CF: Concurrent<F>) : Promise<F, A>, Concurrent<F> by CF {
 
   internal sealed class State<out A> {
     data class Pending<A>(val joiners: Map<Token, (Either<Throwable, A>) -> Unit>) : State<A>()
@@ -114,6 +114,14 @@ internal class CancelablePromise<F, A>(CF: Concurrent<F>) : Promise<F, A>, Concu
       if (state.compareAndSet(current, updated)) Unit
       else unregister(id)
     }
+  }
+
+  override fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B> = CF.run {
+    this@ap.ap(ff)
+  }
+
+  override fun <A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B> = CF.run {
+    this@map.map(f)
   }
 
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/IOBracket.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/IOBracket.kt
@@ -131,20 +131,20 @@ internal object IOBracket {
     override fun recover(e: Throwable): IO<B> = IO.ContextSwitch(applyRelease(ExitCase.Error(e)), makeUncancelable, disableUncancelableAndPop)
       .flatMap(ReleaseRecover(e))
 
-    override operator fun invoke(b: B): IO<B> =
+    override operator fun invoke(a: B): IO<B> =
     // Unregistering cancel token, otherwise we can have a memory leak
     // N.B. conn.pop() happens after the evaluation of `release`, because
     // otherwise we might have a conflict with the auto-cancellation logic
       IO.ContextSwitch(applyRelease(ExitCase.Completed), makeUncancelable, disableUncancelableAndPop)
-        .map { b }
+        .map { a }
   }
 
-  private class ReleaseRecover(val e: Throwable) : IOFrame<Unit, IO<Nothing>> {
+  private class ReleaseRecover(val error: Throwable) : IOFrame<Unit, IO<Nothing>> {
 
-    override fun recover(e2: Throwable): IO<Nothing> =
-      IO.raiseError(Platform.composeErrors(e, e2))
+    override fun recover(e: Throwable): IO<Nothing> =
+      IO.raiseError(Platform.composeErrors(error, e))
 
-    override fun invoke(a: Unit): IO<Nothing> = IO.raiseError(e)
+    override fun invoke(a: Unit): IO<Nothing> = IO.raiseError(error)
   }
 
   private val makeUncancelable: (IOConnection) -> IOConnection = { IOConnection.uncancelable }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/UncancelablePromise.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/UncancelablePromise.kt
@@ -6,7 +6,7 @@ import arrow.effects.Promise
 import arrow.effects.typeclasses.Async
 import java.util.concurrent.atomic.AtomicReference
 
-internal class UncancelablePromise<F, A>(AS: Async<F>) : Promise<F, A>, Async<F> by AS {
+internal class UncancelablePromise<F, A>(private val AS: Async<F>) : Promise<F, A>, Async<F> by AS {
 
   internal sealed class State<out A> {
     data class Pending<A>(val joiners: List<(Either<Throwable, A>) -> Unit>) : State<A>()
@@ -90,6 +90,14 @@ internal class UncancelablePromise<F, A>(AS: Async<F>) : Promise<F, A>, Async<F>
         } else just(true)
       } else unsafeTryError(error)
     }
+  }
+
+  override fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B> = AS.run {
+    this@ap.ap(ff)
+  }
+
+  override fun <A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B> = AS.run {
+    this@map.map(f)
   }
 
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Async.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Async.kt
@@ -2,11 +2,9 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.*
-import arrow.effects.CancelToken
 import arrow.core.Either
 import arrow.documented
 import arrow.typeclasses.MonadContinuation
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
 
 /** A asynchronous computation that might fail. **/
@@ -245,133 +243,6 @@ interface Async<F> : MonadDefer<F> {
    */
   fun <A> never(): Kind<F, A> =
     async { }
-
-  /**
-   * Creates a cancelable [F] instance that executes an asynchronous process on evaluation.
-   * Derived from [async] and [bracketCase] so does not require [F] to be cancelable.
-   *
-   * **NOTE**: Only for a cancelable type can [bracketCase] ever call `cancel` but that's of no concern for
-   * non-cancelable types as `cancel` never should be called.
-   *
-   * ```kotlin:ank:playground:extension
-   * _imports_
-   * _imports_monaddefer_
-   *
-   * import kotlinx.coroutines.Dispatchers.Default
-   * import kotlinx.coroutines.async
-   * import kotlinx.coroutines.GlobalScope
-   *
-   * object Account
-   *
-   * //Some impure API or code
-   * class NetworkService {
-   *   fun getAccounts(
-   *     successCallback: (List<Account>) -> Unit,
-   *     failureCallback: (Throwable) -> Unit) {
-   *
-   *       GlobalScope.async(Default) {
-   *         println("Making API call")
-   *         kotlinx.coroutines.delay(500)
-   *         successCallback(listOf(Account))
-   *       }
-   *   }
-   *
-   *   fun cancel(): Unit = kotlinx.coroutines.runBlocking {
-   *     println("Canceled, closing NetworkApi")
-   *     kotlinx.coroutines.delay(500)
-   *     println("Closed NetworkApi")
-   *   }
-   * }
-   *
-   * fun main(args: Array<String>) {
-   *   //sampleStart
-   *   val getAccounts = Default._shift_().flatMap {
-   *     _extensionFactory_.cancelable<List<Account>> { cb ->
-   *       val service = NetworkService()
-   *       service.getAccounts(
-   *         successCallback = { accs -> cb(Right(accs)) },
-   *         failureCallback = { e -> cb(Left(e)) })
-   *
-   *       _delay_({ service.cancel() })
-   *     }
-   *   }
-   *
-   *   //sampleEnd
-   * }
-   * ```
-   * @see cancelableF for a version that can safely suspend impure callback registration code.
-   *     F.asyncF[A] { cb =>
-   */
-  fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<F>): Kind<F, A> =
-    cancelableF { cb -> delay { k(cb) } }
-
-  /**
-   * Creates a cancelable [F] instance that executes an asynchronous process on evaluation.
-   * Derived from [async] and [bracketCase] so does not require [F] to be cancelable.
-   *
-   * **NOTE**: Only for a cancelable type can [bracketCase] ever call `cancel` but that's of no concern for
-   * non-cancelable types as `cancel` never should be called.
-   *
-   * ```kotlin:ank:playground:extension
-   * _imports_
-   * _imports_monaddefer_
-   * import kotlinx.coroutines.async
-   *
-   * fun main(args: Array<String>) {
-   *   //sampleStart
-   *   val result = _extensionFactory_.cancelableF<String> { cb ->
-   *     delay {
-   *       val deferred = kotlinx.coroutines.GlobalScope.async {
-   *         kotlinx.coroutines.delay(1000)
-   *         cb(Right("Hello from ${Thread.currentThread().name}"))
-   *       }
-   *
-   *       delay({ deferred.cancel().let { Unit } })
-   *     }
-   *   }
-   *
-   *   println(result) //Run with `fix().unsafeRunSync()`
-   *
-   *   val result2 = _extensionFactory_.cancelableF<Unit> { cb ->
-   *     delay {
-   *       println("Doing something that can be cancelled.")
-   *       delay({ println("Cancelling the task") })
-   *     }
-   *   }
-   *
-   *   println(result2) //Run with `fix().unsafeRunAsyncCancellable { }.invoke()`
-   *   //sampleEnd
-   * }
-   * ```
-   *
-   * @see cancelable for a simpler non-suspending version.
-   */
-  fun <A> cancelableF(k: ((Either<Throwable, A>) -> Unit) -> Kind<F, CancelToken<F>>): Kind<F, A> =
-    asyncF { cb ->
-      val state = AtomicReference<(Either<Throwable, Unit>) -> Unit>(null)
-      val cb1 = { r: Either<Throwable, A> ->
-        try {
-          cb(r)
-        } finally {
-          if (!state.compareAndSet(null, mapUnit)) {
-            val cb2 = state.get()
-            state.lazySet(null)
-            cb2(rightUnit)
-          }
-        }
-      }
-
-      k(cb1).bracketCase(use = {
-        async<Unit> { cb ->
-          if (!state.compareAndSet(null, cb)) cb(rightUnit)
-        }
-      }, release = { token, exitCase ->
-        when (exitCase) {
-          is ExitCase.Canceled -> token
-          else -> just(Unit)
-        }
-      })
-    }
 
 }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
@@ -645,6 +645,7 @@ typealias RacePair<F, A, B> = Either<Tuple2<A, Fiber<F, B>>, Tuple2<Fiber<F, A>,
 typealias RaceTriple<F, A, B, C> = Either<Tuple3<A, Fiber<F, B>, Fiber<F, C>>, Either<Tuple3<Fiber<F, A>, B, Fiber<F, C>>, Tuple3<Fiber<F, A>, Fiber<F, B>, C>>>
 
 /** A convenience [fold] method to provide a nicer API to work with race results. */
+@Suppress("UNUSED_PARAMETER")
 inline fun <F, A, B, C, D> RaceTriple<F, A, B, C>.fold(
   ifA: (Tuple3<A, Fiber<F, B>, Fiber<F, C>>) -> D,
   ifB: (Tuple3<Fiber<F, A>, B, Fiber<F, C>>) -> D,

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
@@ -2,7 +2,9 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.*
+import arrow.effects.CancelToken
 import arrow.effects.KindConnection
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
 
 /** A connected asynchronous computation that might fail. **/
@@ -16,16 +18,60 @@ typealias ConnectedProc<F, A> = (KindConnection<F>, ((Either<Throwable, A>) -> U
  */
 interface Concurrent<F> : Async<F> {
 
+  /**
+   * Creates a cancelable instance of [F] that executes an asynchronous process on evaluation.
+   * This combinator can be used to wrap callbacks or other similar impure code that requires cancellation code.
+   *
+   * ```kotlin:ank:playground:extension
+   * _imports_
+   * import java.lang.RuntimeException
+   *
+   * typealias Callback = (List<String>?, Throwable?) -> Unit
+   *
+   * class Id
+   * object GithubService {
+   *   private val listeners: MutableMap<Id, Callback> = mutableMapOf()
+   *   fun getUsernames(callback: (List<String>?, Throwable?) -> Unit): Id {
+   *     val id = Id()
+   *     listeners[id] = callback
+   *     //execute operation and call callback at some point in future
+   *     return id
+   *   }
+   *
+   *   fun unregisterCallback(id: Id): Unit {
+   *     listeners.remove(id)
+   *   }
+   * }
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   fun <F> Concurrent<F>.getUsernames(): Kind<F, List<String>> =
+   *     async { conn: KindConnection<F>, cb: (Either<Throwable, List<String>>) -> Unit ->
+   *       val id = GithubService.getUsernames { names, throwable ->
+   *         when {
+   *           names != null -> cb(Right(names))
+   *           throwable != null -> cb(Left(throwable))
+   *           else -> cb(Left(RuntimeException("Null result and no exception")))
+   *         }
+   *       }
+   *
+   *       conn.push(_delay_({ GithubService.unregisterCallback(id) }))
+   *       conn.push(_delay_({ println("Everything we push to the cancellation stack will execute on cancellation") }))
+   * }
+   *
+   *   val result = _extensionFactory_.getUsernames()
+   *   //sampleEnd
+   *   println(result)
+   * }
+   * ```
+   *
+   * @param fa an asynchronous computation that might fail typed as [Proc].
+   * @see asyncF for a version that can suspend side effects in the registration function.
+   */
   fun <A> async(fa: ConnectedProc<F, A>): Kind<F, A> =
     asyncF { conn, cb -> delay { fa(conn, cb) } }
 
-  fun <A> asyncF(k: ConnectedProcF<F, A>): Kind<F, A>
-
-  override fun <A> asyncF(k: ProcF<F, A>): Kind<F, A> =
-    asyncF { _, cb -> k(cb) }
-
-  override fun <A> async(fa: Proc<A>): Kind<F, A> =
-    async { _, cb -> fa(cb) }
+  fun <A> asyncF(fa: ConnectedProcF<F, A>): Kind<F, A>
 
   /**
    * Create a new [F] that upon execution starts the receiver [F] within a [Fiber] on [ctx].
@@ -127,6 +173,126 @@ interface Concurrent<F> : Async<F> {
    * @see [arrow.effects.typeclasses.Concurrent.raceN] for a simpler version that cancels losers.
    */
   fun <A, B, C> raceTriple(ctx: CoroutineContext, fa: Kind<F, A>, fb: Kind<F, B>, fc: Kind<F, C>): Kind<F, RaceTriple<F, A, B, C>>
+
+  /**
+   * Creates a cancelable [F] instance that executes an asynchronous process on evaluation.
+   * Derived from [async] and [bracketCase].
+   *
+   * ```kotlin:ank:playground:extension
+   * _imports_
+   * _imports_monaddefer_
+   *
+   * import kotlinx.coroutines.Dispatchers.Default
+   * import kotlinx.coroutines.async
+   * import kotlinx.coroutines.GlobalScope
+   *
+   * object Account
+   *
+   * //Some impure API or code
+   * class NetworkService {
+   *   fun getAccounts(
+   *     successCallback: (List<Account>) -> Unit,
+   *     failureCallback: (Throwable) -> Unit) {
+   *
+   *       GlobalScope.async(Default) {
+   *         println("Making API call")
+   *         kotlinx.coroutines.delay(500)
+   *         successCallback(listOf(Account))
+   *       }
+   *   }
+   *
+   *   fun cancel(): Unit = kotlinx.coroutines.runBlocking {
+   *     println("Canceled, closing NetworkApi")
+   *     kotlinx.coroutines.delay(500)
+   *     println("Closed NetworkApi")
+   *   }
+   * }
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val getAccounts = Default._shift_().flatMap {
+   *     _extensionFactory_.cancelable<List<Account>> { cb ->
+   *       val service = NetworkService()
+   *       service.getAccounts(
+   *         successCallback = { accs -> cb(Right(accs)) },
+   *         failureCallback = { e -> cb(Left(e)) })
+   *
+   *       _delay_({ service.cancel() })
+   *     }
+   *   }
+   *
+   *   //sampleEnd
+   * }
+   * ```
+   * @see cancelableF for a version that can safely suspend impure callback registration code.
+   */
+  fun <A> cancelable(k: ((Either<Throwable, A>) -> Unit) -> CancelToken<F>): Kind<F, A> =
+    cancelableF { cb -> delay { k(cb) } }
+
+  /**
+   * Builder to create a cancelable [F] instance that executes an asynchronous process on evaluation.
+   * Function derived from [async] and [bracketCase].
+   *
+   * ```kotlin:ank:playground:extension
+   * _imports_
+   * _imports_monaddefer_
+   * import kotlinx.coroutines.async
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val result = _extensionFactory_.cancelableF<String> { cb ->
+   *     delay {
+   *       val deferred = kotlinx.coroutines.GlobalScope.async {
+   *         kotlinx.coroutines.delay(1000)
+   *         cb(Right("Hello from ${Thread.currentThread().name}"))
+   *       }
+   *
+   *       delay({ deferred.cancel().let { Unit } })
+   *     }
+   *   }
+   *
+   *   println(result) //Run with `fix().unsafeRunSync()`
+   *
+   *   val result2 = _extensionFactory_.cancelableF<Unit> { cb ->
+   *     delay {
+   *       println("Doing something that can be cancelled.")
+   *       delay({ println("Cancelling the task") })
+   *     }
+   *   }
+   *
+   *   println(result2) //Run with `fix().unsafeRunAsyncCancellable { }.invoke()`
+   *   //sampleEnd
+   * }
+   * ```
+   *
+   * @see cancelable for a simpler non-suspending version.
+   */
+  fun <A> cancelableF(k: ((Either<Throwable, A>) -> Unit) -> Kind<F, CancelToken<F>>): Kind<F, A> =
+    asyncF { cb ->
+      val state = AtomicReference<(Either<Throwable, Unit>) -> Unit>(null)
+      val cb1 = { r: Either<Throwable, A> ->
+        try {
+          cb(r)
+        } finally {
+          if (!state.compareAndSet(null, mapUnit)) {
+            val cb2 = state.get()
+            state.lazySet(null)
+            cb2(rightUnit)
+          }
+        }
+      }
+
+      k(cb1).bracketCase(use = {
+        async<Unit> { cb ->
+          if (!state.compareAndSet(null, cb)) cb(rightUnit)
+        }
+      }, release = { token, exitCase ->
+        when (exitCase) {
+          is ExitCase.Canceled -> token
+          else -> just(Unit)
+        }
+      })
+    }
 
   /**
    * Map two tasks in parallel within a new [F] on [ctx].
@@ -453,6 +619,22 @@ interface Concurrent<F> : Async<F> {
       raceN(ctx, g, h),
       raceN(ctx, i, j)
     )
+
+  /**
+   * Overload for [Async.asyncF]
+   *
+   * @see [Async.asyncF]
+   */
+  override fun <A> asyncF(k: ProcF<F, A>): Kind<F, A> =
+    asyncF { _, cb -> k(cb) }
+
+  /**
+   * Overload for [Async.async]
+   *
+   * @see [Async.async]
+   */
+  override fun <A> async(fa: Proc<A>): Kind<F, A> =
+    async { _, cb -> fa(cb) }
 
 }
 

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/IOTest.kt
@@ -371,7 +371,7 @@ class IOTest : UnitSpec() {
 
     "Cancelable should run CancelToken" {
       Promise.uncancelable<ForIO, Unit>(IO.async()).flatMap { p ->
-        IO.async().cancelable<Unit> { _ ->
+        IO.concurrent().cancelable<Unit> { _ ->
           p.complete(Unit)
         }.fix()
           .unsafeRunAsyncCancellable { }
@@ -383,7 +383,7 @@ class IOTest : UnitSpec() {
 
     "CancelableF should run CancelToken" {
       Promise.uncancelable<ForIO, Unit>(IO.async()).flatMap { p ->
-        IO.async().cancelableF<Unit> { _ ->
+        IO.concurrent().cancelableF<Unit> { _ ->
           IO { p.complete(Unit) }
         }.fix()
           .unsafeRunAsyncCancellable { }

--- a/modules/effects/arrow-effects-kotlinx-coroutines-data/src/main/kotlin/arrow/effects/coroutines/DeferredKConnection.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-data/src/main/kotlin/arrow/effects/coroutines/DeferredKConnection.kt
@@ -21,6 +21,7 @@ typealias DeferredKProcF<A> = (DeferredKConnection, (Either<Throwable, A>) -> Un
  *
  * @see DeferredK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun DeferredKConnection(dummy: Unit = Unit): KindConnection<ForDeferredK> = KindConnection(object : MonadDefer<ForDeferredK> {
   override fun <A> defer(fa: () -> DeferredKOf<A>): DeferredK<A> =
     DeferredK.defer(fa = fa)

--- a/modules/effects/arrow-effects-kotlinx-coroutines-data/src/test/kotlin/arrow/effects/coroutines/DeferredKTest.kt
+++ b/modules/effects/arrow-effects-kotlinx-coroutines-data/src/test/kotlin/arrow/effects/coroutines/DeferredKTest.kt
@@ -35,14 +35,15 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(KotlinTestRunner::class)
 class DeferredKTest : UnitSpec() {
-  fun <A> EQ(): Eq<Kind<ForDeferredK, A>> = Eq { a, b ->
+
+  private fun <A> EQ(): Eq<Kind<ForDeferredK, A>> = Eq { a, b ->
     val other = b.unsafeAttemptSync()
     a.unsafeAttemptSync().fold(
       { eA -> other.fold({ eB -> throwableEq().run { eA.eqv(eB) } }, { false }) },
-      { a -> other.fold({ false }, { b -> a == b }) })
+      { aa -> other.fold({ false }, { b -> aa == b }) })
   }
 
-  suspend fun <F, A> checkAwaitAll(FF: Functor<F>, T: Traverse<F>, v: Kind<F, A>) = FF.run {
+  private suspend fun <F, A> checkAwaitAll(FF: Functor<F>, T: Traverse<F>, v: Kind<F, A>) = FF.run {
     v.map { DeferredK { it } }.awaitAll(T) == v
   }
 

--- a/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/FluxKConnection.kt
+++ b/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/FluxKConnection.kt
@@ -19,6 +19,7 @@ typealias FluxKProcF<A> = (FluxKConnection, (Either<Throwable, A>) -> Unit) -> F
  *
  * @see FluxK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun FluxKConnection(dummy: Unit = Unit): KindConnection<ForFluxK> = KindConnection(object : MonadDefer<ForFluxK> {
   override fun <A> defer(fa: () -> FluxKOf<A>): FluxK<A> =
     FluxK.defer(fa)

--- a/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/MonoKConnection.kt
+++ b/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/MonoKConnection.kt
@@ -19,6 +19,7 @@ typealias MonoKProcF<A> = (MonoKConnection, (Either<Throwable, A>) -> Unit) -> M
  *
  * @see MonoK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun MonoKConnection(dummy: Unit = Unit): KindConnection<ForMonoK> = KindConnection(object : MonadDefer<ForMonoK> {
   override fun <A> defer(fa: () -> MonoKOf<A>): MonoK<A> =
     MonoK.defer(fa)

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/FlowableKConnection.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/FlowableKConnection.kt
@@ -19,6 +19,7 @@ typealias FlowableKProcF<A> = (FlowableKConnection, (Either<Throwable, A>) -> Un
  *
  * @see FlowableK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun FlowableKConnection(dummy: Unit = Unit): KindConnection<ForFlowableK> = KindConnection(object : MonadDefer<ForFlowableK> {
   override fun <A> defer(fa: () -> FlowableKOf<A>): FlowableK<A> =
     FlowableK.defer(fa)

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/MaybeKConnection.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/MaybeKConnection.kt
@@ -20,6 +20,7 @@ typealias MaybeKProcF<A> = (MaybeKConnection, (Either<Throwable, A>) -> Unit) ->
  *
  * @see MaybeK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun MaybeKConnection(dummy: Unit = Unit): KindConnection<ForMaybeK> = KindConnection(object : MonadDefer<ForMaybeK> {
   override fun <A> defer(fa: () -> MaybeKOf<A>): MaybeK<A> =
     MaybeK.defer(fa)

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/ObservableKConnection.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/ObservableKConnection.kt
@@ -19,6 +19,7 @@ typealias ObservableKProcF<A> = (ObservableKConnection, (Either<Throwable, A>) -
  *
  * @see ObservableK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun ObservableKConnection(dummy: Unit = Unit): KindConnection<ForObservableK> = KindConnection(object : MonadDefer<ForObservableK> {
   override fun <A> defer(fa: () -> ObservableKOf<A>): ObservableK<A> =
     ObservableK.defer(fa)

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/SingleKConnection.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/SingleKConnection.kt
@@ -19,6 +19,7 @@ typealias SingleKProcF<A> = (SingleKConnection, (Either<Throwable, A>) -> Unit) 
  *
  * @see SingleK.async
  */
+@Suppress("UNUSED_PARAMETER", "FunctionName")
 fun SingleKConnection(dummy: Unit = Unit): KindConnection<ForSingleK> = KindConnection(object : MonadDefer<ForSingleK> {
   override fun <A> defer(fa: () -> SingleKOf<A>): SingleK<A> =
     SingleK.defer(fa)


### PR DESCRIPTION
This PR moves the `cancelable` and `cancelableF` builders to the `Concurrent` typeclass.

I originally placed them in `Async` since they can be derived with all combinators available in `Async` but after working on `Concurrent` I feel like this might confuse users regarding cancellation.

This PR also fixes all the current warnings for the effects modules, except our own currently deprecated methods.