### PR TITLE
Fix IOFrame usage in IOBracket

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -11,11 +11,20 @@ import arrow.recursion.Coalgebra
 import arrow.recursion.typeclasses.Corecursive
 import arrow.recursion.typeclasses.Recursive
 import arrow.typeclasses.Applicative
+import arrow.typeclasses.ApplicativeError
 import io.kotlintest.properties.Gen
 import java.util.concurrent.TimeUnit
 
 fun <F, A> genApplicative(valueGen: Gen<A>, AP: Applicative<F>): Gen<Kind<F, A>> =
    valueGen.map { AP.just(it) }
+
+fun <F, A, E> genApplicativeError(valueGen: Gen<A>, errorGen: Gen<E>, AP: ApplicativeError<F, E>): Gen<Kind<F, A>> =
+  Gen.oneOf<Either<E, A>>(valueGen.map(::Right), errorGen.map(::Left)).map {
+    it.fold(AP::raiseError, AP::just)
+  }
+
+fun <F, A> genApplicativeError(valueGen: Gen<A>, AP: ApplicativeError<F, Throwable>): Gen<Kind<F, A>> =
+  genApplicativeError(valueGen, genThrowable(), AP)
 
 fun <A, B> genFunctionAToB(genB: Gen<B>): Gen<(A) -> B> = genB.map { b:B -> { _: A -> b } }
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
@@ -7,9 +7,7 @@ import arrow.core.Right
 import arrow.effects.Promise
 import arrow.effects.typeclasses.Async
 import arrow.effects.typeclasses.ExitCase
-import arrow.test.generators.genEither
-import arrow.test.generators.genIntSmall
-import arrow.test.generators.genThrowable
+import arrow.test.generators.*
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -84,19 +82,18 @@ object AsyncLaws {
     }
 
   fun <F> Async<F>.bracketReleaseIscalledOnCompletedOrError(EQ: Eq<Kind<F, Int>>): Unit {
-    val async = this
-    forAll(Gen.string().map(::just), Gen.int()) { fa, b ->
-      Promise.uncancelable<F, Int>(async).flatMap { promise ->
+    forAll(genApplicativeError(Gen.string(), this), Gen.int()) { fa, b ->
+      Promise.uncancelable<F, Int>(this@bracketReleaseIscalledOnCompletedOrError).flatMap { promise ->
         val br = delay { promise }.bracketCase(use = { fa }, release = { r, exitCase ->
           when (exitCase) {
             is ExitCase.Completed -> r.complete(b)
-            is ExitCase.Error     -> r.complete(b)
-            else                  -> just<Unit>(Unit)
+            is ExitCase.Error -> r.complete(b)
+            else -> just<Unit>(Unit)
           }
         })
-        asyncF<Unit> { cb ->
-          br.flatMap { delay { cb(Right(Unit)) } }
-        }.flatMap { promise.get() }
+
+        asyncF<Unit> { cb -> delay { cb(Right(Unit)) }.flatMap { br.attempt().`as`(Unit) } }
+          .flatMap { promise.get() }
       }.equalUnderTheLaw(just(b), EQ)
     }
   }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/BracketLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/BracketLaws.kt
@@ -8,6 +8,7 @@ import arrow.test.generators.*
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import java.util.concurrent.atomic.AtomicReference
 
 object BracketLaws {
 
@@ -31,14 +32,14 @@ object BracketLaws {
     )
 
   fun <F> Bracket<F, Throwable>.bracketCaseWithJustUnitEqvMap(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this), genFunctionAToB<Int,Int>(Gen.int())
+    forAll(genApplicativeError(Gen.int(), this), genFunctionAToB<Int, Int>(Gen.int())
     ) { fa: Kind<F, Int>, f: (Int) -> Int ->
       fa.bracketCase(release = { _, _ -> just<Unit>(Unit) }, use = { a -> just(f(a)) }).equalUnderTheLaw(fa.map(f), EQ)
     }
 
   fun <F> Bracket<F, Throwable>.bracketCaseWithJustUnitIsUncancelable(
     EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
+    forAll(genApplicativeError(Gen.int(), this)) { fa: Kind<F, Int> ->
       fa.bracketCase(release = { _, _ -> just<Unit>(Unit) }, use = { just(it) }).equalUnderTheLaw(fa.uncancelable().flatMap { just(it) }, EQ)
     }
 
@@ -50,7 +51,7 @@ object BracketLaws {
 
   fun <F> Bracket<F, Throwable>.bracketIsDerivedFromBracketCase(
     EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
+    forAll(genApplicativeError(Gen.int(), this)) { fa: Kind<F, Int> ->
       fa.bracket(release = { just<Unit>(Unit) }, use = { just(it) }).equalUnderTheLaw(fa.bracketCase(release = { _, _ -> just<Unit>(Unit) }, use = { just(it) }), EQ)
     }
 
@@ -58,7 +59,7 @@ object BracketLaws {
     onCancel: Kind<F, Unit>,
     onFinish: Kind<F, Unit>,
     EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
+    forAll(genApplicativeError(Gen.int(), this)) { fa: Kind<F, Int> ->
       just(Unit).bracketCase(use = { fa }, release = { _, b ->
         if (b == ExitCase.Canceled) onCancel else onFinish
       }).uncancelable().equalUnderTheLaw(fa.guarantee(onFinish), EQ)
@@ -67,39 +68,43 @@ object BracketLaws {
   fun <F> Bracket<F, Throwable>.acquireAndReleaseAreUncancelable(
     release: (Int) -> Kind<F, Unit>,
     EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
+    forAll(genApplicativeError(Gen.int(), this)) { fa: Kind<F, Int> ->
       fa.uncancelable().bracket({ a -> release(a).uncancelable() }) { just(it) }.equalUnderTheLaw(fa.bracket(release) { just(it) }, EQ)
     }
 
   fun <F> Bracket<F, Throwable>.guaranteeIsDerivedFromBracket(
     finalizer: Kind<F, Unit>,
     EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
-      fa.guarantee(finalizer).equalUnderTheLaw(just(Unit).bracket({ finalizer }) { fa }, EQ)
+    forAll(genApplicativeError(Gen.int(), this)) { fa: Kind<F, Int> ->
+      fa.guarantee(finalizer).equalUnderTheLaw(just(Unit).bracket({ finalizer }, use = { fa }), EQ)
     }
 
   fun <F> Bracket<F, Throwable>.guaranteeCaseIsDerivedFromBracketCase(
     finalizer: (ExitCase<Throwable>) -> Kind<F, Unit>,
     EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.int(), this)) { fa: Kind<F, Int> ->
+    forAll(genApplicativeError(Gen.int(), this)) { fa: Kind<F, Int> ->
       fa.guaranteeCase(finalizer).equalUnderTheLaw(just(Unit).bracketCase({ _, e -> finalizer(e) }) { fa }, EQ)
     }
 
   fun <F> Bracket<F, Throwable>.bracketPropagatesTransformerEffects(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(genApplicative(Gen.string(), this),
-      genFunctionAToB<String, Kind<F, Int>>(genApplicative(Gen.int(), this)),
+    forAll(genApplicativeError(Gen.string(), this),
+      genFunctionAToB<String, Kind<F, Int>>(genApplicativeError(Gen.int(), this)),
       genFunctionAToB<String, Kind<F, Unit>>(Gen.create { just(Unit) })) { acquire, use, release ->
       acquire.bracket(use = use, release = release).equalUnderTheLaw(
         acquire.flatMap { a -> use(a).flatMap { b -> release(a).map { b } } }
         , EQ)
     }
 
-  fun <F> Bracket<F, Throwable>.bracketMustRunReleaseTask(EQ: Eq<Kind<F, Int>>): Unit {
-    var r = 0
-
-    just(r).bracket(use = { just(Unit) }, release = { r = 1; just(Unit) })
-      .map { r }
-      .equalUnderTheLaw(just(1), EQ)
+  fun <F> Bracket<F, Throwable>.bracketMustRunReleaseTask(EQ: Eq<Kind<F, Int>>): Unit =
+    forAll(Gen.int(), genApplicativeError(Gen.int(), this)) { i, fa ->
+      val msg: AtomicReference<Int> = AtomicReference(0)
+      just(i).bracket<Int, Int>(
+        release = { ii -> msg.set(ii); unit() },
+        use = { throw Throwable("Boom!") }
+      )
+        .attempt()
+        .map { msg.get() }
+        .equalUnderTheLaw(just(i), EQ)
   }
 
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IOFrame.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IOFrame.kt
@@ -3,6 +3,17 @@ package arrow.effects
 import arrow.core.Either
 import arrow.effects.IO.Pure
 
+/**
+ * An [IOFrame] knows how to [recover] from a [Throwable] and how to map a value [A] to [R].
+ *
+ * Internal to `IO`'s implementations, used to specify
+ * error handlers in their respective `Bind` internal states.
+ *
+ * To use an [IOFrame] you must use [IO.Bind] instead of `flatMap` or the [IOFrame]
+ * is **not guaranteed** to execute.
+ *
+ * It's used to implement [attempt], [handleErrorWith] and [arrow.effects.internal.IOBracket]
+ */
 internal interface IOFrame<in A, out R> : (A) -> R {
   override operator fun invoke(a: A): R
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/IOBracket.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/IOBracket.kt
@@ -60,10 +60,11 @@ internal object IOBracket {
             val onNext = {
               val fb = try {
                 use(a)
-              } catch (nonFatal: Exception) {
-                IO.raiseError<B>(nonFatal)
+              } catch (e: Throwable) {
+                IO.raiseError<B>(e)
               }
-              fb.fix().flatMap(frame)
+
+              IO.Bind(fb.fix(), frame)
             }
 
             // Registering our cancelable token ensures that in case cancellation is detected, release gets called

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/IOTest.kt
@@ -14,10 +14,13 @@ import arrow.test.UnitSpec
 import arrow.test.concurrency.SideEffect
 import arrow.test.laws.ConcurrentLaws
 import io.kotlintest.fail
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
 import io.kotlintest.runner.junit4.KotlinTestRunner
 import io.kotlintest.shouldBe
 import kotlinx.coroutines.newSingleThreadContext
 import org.junit.runner.RunWith
+import java.lang.RuntimeException
 
 @RunWith(KotlinTestRunner::class)
 class IOTest : UnitSpec() {
@@ -331,6 +334,20 @@ class IOTest : UnitSpec() {
         IO(newSingleThreadContext("CancelThread")) { }
           .unsafeRunAsync { cancel() }
       }.unsafeRunTimed(2.seconds) shouldBe Some(OnCancel.CancellationException)
+    }
+
+    "IOFrame should always be called when using IO.Bind" {
+      val ThrowableAsStringFrame = object : IOFrame<Any?, IOOf<String>> {
+        override fun invoke(a: Any?) = just(a.toString())
+
+        override fun recover(e: Throwable) = just(e.message ?: "")
+
+      }
+
+      forAll(Gen.string()) { message ->
+        IO.Bind(IO.raiseError(RuntimeException(message)), ThrowableAsStringFrame as (Int) -> IO<String>)
+          .unsafeRunSync() == message
+      }
     }
 
     "unsafeRunAsyncCancellable can cancel even for infinite asyncs" {


### PR DESCRIPTION
`IOFrame` was not correctly called unless manually wrapped in `IO.Bind`. It did not run using `flatMap` like Cats-effect's `IO` because `IO.RaiseError` is overridden to short-circuit `flatMap` like this `override fun <B> flatMap(f: (Nothing) -> IOOf<B>): IO<B> = this`

To leave the overridden function as explicit as it currently is I opted to elaborate in the `IOFrame` docs how to properly use it. Also, I added a test for this and changed the usage in `IOBracket`.

Do we want to keep it like this or shall we override `IO.RaiseError#flatMap` as follows to prevent similar bugs by miss-use in the future?

```
override fun <B> flatMap(f: (Nothing) -> IOOf<B>): IO<B> =
      if (f is IOFrame) Bind(this, f as (Nothing) -> IO<B>) else this
```