### PR TITLE
fixed links to Try translation

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/arrow/core/try/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/core/try/README.md
@@ -8,9 +8,11 @@ video: XavztYVMUqI
 ---
 
 ## Try
-[Русский](/docs/arrow/core/try/ru)
+
 {:.beginner}
 beginner
+
+[Перевод на русский](/docs/arrow/core/try/ru)
 
 Arrow has [lots of different types of error handling and reporting](http://arrow-kt.io/docs/patterns/error_handling/), which allows you to choose the best strategy for your situation.
 

--- a/modules/docs/arrow-docs/docs/docs/arrow/core/try/README_RU.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/core/try/README_RU.md
@@ -8,9 +8,11 @@ video: XavztYVMUqI
 ---
 
 ## Try
-[English](/docs/arrow/core/try)
+
 {:.beginner}
 beginner
+
+[English](/docs/arrow/core/try)
 
 В Arrow [есть множество способов для обработки ошибок](http://arrow-kt.io/docs/patterns/error_handling/), что позволяет выбрать оптимальную стратегию для любой ситуации.
 


### PR DESCRIPTION
Fixed link to Russian translation (and from Russian to English) — it hasn't been visible the first time.
My bad, my fix.