### PR TITLE
Fix permalink for Try Russian translation

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/arrow/core/try/README_RU.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/core/try/README_RU.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Try
-permalink: /docs/arrow/core/try/ru
+permalink: /docs/arrow/core/try/ru/
 redirect_from:
   - /docs/datatypes/try/ru
 video: XavztYVMUqI


### PR DESCRIPTION
* Fix permalink for Try Russian translation


The way permalinks work on our deploy system, they need to be set as trailing slash URLs for them to really point you to a non trailing slash URL. Sorry about that @dobrowins, I didn't noticed on your previews PRs