### PR TITLE
Ensure paths are compatible with windows

### DIFF
--- a/modules/meta/arrow-meta/src/main/java/arrow/common/utils/AbstractProcessor.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/common/utils/AbstractProcessor.kt
@@ -5,7 +5,6 @@ import arrow.common.messager.logW
 import arrow.documented
 import arrow.meta.encoder.jvm.KotlinMetatadataEncoder
 import me.eugeniomarletti.kotlin.metadata.kotlinMetadata
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.deserialization.receiverType
 import me.eugeniomarletti.kotlin.processing.KotlinAbstractProcessor
 import java.io.File
 import java.io.IOException
@@ -25,9 +24,11 @@ class KnownException(message: String, val element: Element?) : RuntimeException(
 abstract class AbstractProcessor : KotlinAbstractProcessor(), ProcessorUtils, KotlinMetatadataEncoder {
 
   private fun Element.kDocLocation(): File =
-    File(
-      System.getProperty("user.dir") +
-        "/build/kdocs/meta/"+ "${locationName().replace('.', '/')}.javadoc")
+      locationName()
+          .replacePackageSeparatorsToFolderSeparators()
+          .replaceInvalidPathCharacters()
+          .let { "$userDir/build/kdocs/meta/$it.javadoc" }
+          .let(::File)
 
   fun Element.kDoc(): String? =
     @Suppress("SwallowedException")
@@ -99,3 +100,7 @@ abstract class AbstractProcessor : KotlinAbstractProcessor(), ProcessorUtils, Ko
   protected abstract fun onProcess(annotations: Set<TypeElement>, roundEnv: RoundEnvironment)
 
 }
+
+private val userDir get() = System.getProperty("user.dir")
+private fun String.replacePackageSeparatorsToFolderSeparators() = replace('.', '/')
+private fun String.replaceInvalidPathCharacters() = replace('?', '_')


### PR DESCRIPTION
Windows is not very good with having `?` characters as part of a path. This, hopefully, fixes the issue for people trying to use the Annotation processor with Windows.