### PR TITLE
Add link to blogpost on Arrow and Webflux

### DIFF
--- a/modules/docs/arrow-docs/docs/_posts/2019-02-03-arrow-webflux.md
+++ b/modules/docs/arrow-docs/docs/_posts/2019-02-03-arrow-webflux.md
@@ -1,0 +1,9 @@
+---
+title: "Webflux with Kotlin and Arrow"
+icon: /img/icon-news.svg
+version: version 0.8.2
+header-image: /img/blog-image-header.png
+category: news
+link: http://www.smartjava.org/content/webflux-arrow/
+---
+[Webflux with Kotlin and Arrow](http://www.smartjava.org/content/webflux-arrow/) shows how you can use Arrow together with Spring Webflux to create a reactive REST application. This article explains how to use the `MonoK` and the `FluxK` Arrow extensions together with the `binding` function to make working with the `Mono` and `Flux` reactor constructs much easier and better understandable.


### PR DESCRIPTION
Wrote an article on how to use Arrow and Webflux together to create a Spring Webflux application where the nice binding approach provided by Arrow is used for sequencing reactive function calls.