### PR TITLE
[#153] Control NonFatal Throwables

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
@@ -28,6 +28,7 @@ object NonFatal {
    *         2 -> throw OutOfMemoryError("Fatal")
    *         else -> "Hello"
    *    }
+   *
    * fun main(args: Array<String>) {
    *   val nonFatal: Either<Throwable, String> =
    *   //sampleStart
@@ -71,15 +72,14 @@ object NonFatal {
  *         2 -> throw OutOfMemoryError("Fatal")
  *         else -> "Hello"
  *    }
+ *
  * fun main(args: Array<String>) {
  *   val nonFatal: Either<Throwable, String> =
  *   //sampleStart
  *   try {
  *      Right(unsafeFunction(1))
  *   } catch (t: Throwable) {
- *     if (t.nonFatalOrThrow()) {
- *         Left(t)
- *     }
+*       Left(t.nonFatalOrThrow())
  *   }
  *   //sampleEnd
  *   println(nonFatal)

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
@@ -1,0 +1,24 @@
+package arrow.core
+
+/**
+ * Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
+ * (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
+ * `LinkageError`, `InterruptedException`.
+ */
+object NonFatal {
+  /**
+   * @return true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal
+   */
+  operator fun invoke(t: Throwable): Boolean =
+    when (t) {
+      is VirtualMachineError, is ThreadDeath, is InterruptedException, is LinkageError -> false
+      else -> true
+    }
+}
+
+/**
+ * @throw @receiver if it is fatal
+ * @return @receiver if it is non-fatal
+ */
+fun Throwable.nonFatal(): Throwable =
+  if (NonFatal(this)) this else throw this

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
@@ -1,13 +1,50 @@
 package arrow.core
 
+import arrow.documented
+
 /**
  * Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
  * (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
  * `LinkageError`, `InterruptedException`.
  */
+@documented
 object NonFatal {
+
   /**
+   * Checks whether the passed [t] Throwable is NonFatal.
+   *
+   * @param t the Throwable to check
    * @return true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal
+   * Kind<F, A> -> Kind<F, B>
+   *
+   * ```kotlin:ank:playground
+   * import arrow.*
+   * import arrow.core.*
+   * import arrow.data.*
+   *
+   * fun unsafeFunction(i: Int): String =
+   *    when (i) {
+   *         1 -> throw IllegalArgumentException("Non-Fatal")
+   *         2 -> throw OutOfMemoryError("Fatal")
+   *         else -> "Hello"
+   *    }
+   * fun main(args: Array<String>) {
+   *   val nonFatal: Either<Throwable, String> =
+   *   //sampleStart
+   *   try {
+   *      Right(unsafeFunction(1))
+   *   } catch (t: Throwable) {
+   *     if (NonFatal(t)) {
+   *         Left(t)
+   *     } else {
+   *         throw t
+   *     }
+   *   }
+   *   //sampleEnd
+   *   println(nonFatal)
+   * }
+   * ```
+   *
    */
   operator fun invoke(t: Throwable): Boolean =
     when (t) {
@@ -17,8 +54,38 @@ object NonFatal {
 }
 
 /**
- * @throw @receiver if it is fatal
- * @return @receiver if it is non-fatal
+ * Returns the Throwable if NonFatal and throws it otherwise.
+ *
+ * @throws Throwable the Throwable `this` if Fatal
+ * @return the Throwable `this` if NonFatal
+ * Kind<F, A> -> Kind<F, B>
+ *
+ * ```kotlin:ank:playground
+ * import arrow.*
+ * import arrow.core.*
+ * import arrow.data.*
+ *
+ * fun unsafeFunction(i: Int): String =
+ *    when (i) {
+ *         1 -> throw IllegalArgumentException("Non-Fatal")
+ *         2 -> throw OutOfMemoryError("Fatal")
+ *         else -> "Hello"
+ *    }
+ * fun main(args: Array<String>) {
+ *   val nonFatal: Either<Throwable, String> =
+ *   //sampleStart
+ *   try {
+ *      Right(unsafeFunction(1))
+ *   } catch (t: Throwable) {
+ *     if (t.nonFatalOrThrow()) {
+ *         Left(t)
+ *     }
+ *   }
+ *   //sampleEnd
+ *   println(nonFatal)
+ * }
+ * ```
+ *
  */
-fun Throwable.nonFatal(): Throwable =
+fun Throwable.nonFatalOrThrow(): Throwable =
   if (NonFatal(this)) this else throw this

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
@@ -1,13 +1,10 @@
 package arrow.core
 
-import arrow.documented
-
 /**
  * Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
  * (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
  * `LinkageError`, `InterruptedException`.
  */
-@documented
 object NonFatal {
 
   /**

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonFatal.kt
@@ -12,7 +12,6 @@ object NonFatal {
    *
    * @param t the Throwable to check
    * @return true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal
-   * Kind<F, A> -> Kind<F, B>
    *
    * ```kotlin:ank:playground
    * import arrow.*
@@ -56,7 +55,6 @@ object NonFatal {
  *
  * @throws Throwable the Throwable `this` if Fatal
  * @return the Throwable `this` if NonFatal
- * Kind<F, A> -> Kind<F, B>
  *
  * ```kotlin:ank:playground
  * import arrow.*

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
@@ -37,7 +37,11 @@ sealed class Try<out A> : TryOf<A> {
       try {
         Success(f())
       } catch (e: Throwable) {
-        Failure(e)
+        if (NonFatal(e)) {
+          Failure(e)
+        } else {
+          throw e
+        }
       }
 
     fun <A> raise(e: Throwable): Try<A> = Failure(e)

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/NonFatalTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/NonFatalTest.kt
@@ -22,9 +22,9 @@ class NonFatalTest : UnitSpec() {
         NonFatal(it) shouldBe true
       }
     }
-    "Test nonfatals using Throwable#nonFatal" {
+    "Test nonfatals using Throwable#nonFatalOrThrow" {
       nonFatals.forEach {
-        it.nonFatal() shouldBe it
+        it.nonFatalOrThrow() shouldBe it
       }
     }
 
@@ -44,10 +44,10 @@ class NonFatalTest : UnitSpec() {
         NonFatal(it) shouldBe false
       }
     }
-    "Test fatals using Throwable#nonFatal" {
+    "Test fatals using Throwable#nonFatalOrThrow" {
       fatals.forEach {
         shouldThrowAny {
-          it.nonFatal()
+          it.nonFatalOrThrow()
         }
       }
     }

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/NonFatalTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/NonFatalTest.kt
@@ -1,0 +1,55 @@
+package arrow.core
+
+import arrow.test.UnitSpec
+import io.kotlintest.runner.junit4.KotlinTestRunner
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrowAny
+import org.junit.runner.RunWith
+
+@RunWith(KotlinTestRunner::class)
+class NonFatalTest : UnitSpec() {
+  init {
+    val nonFatals: List<Throwable> =
+      listOf(
+        RuntimeException(),
+        Exception(),
+        Throwable(),
+        NotImplementedError()
+      )
+
+    "Test nonfatals using #invoke()" {
+      nonFatals.forEach {
+        NonFatal(it) shouldBe true
+      }
+    }
+    "Test nonfatals using Throwable#nonFatal" {
+      nonFatals.forEach {
+        it.nonFatal() shouldBe it
+      }
+    }
+
+    val fatals: List<Throwable> =
+      listOf(
+        InterruptedException(),
+        StackOverflowError(),
+        OutOfMemoryError(),
+        LinkageError(),
+        object : VirtualMachineError() {
+
+        }
+      )
+
+    "Test fatals using #invoke()" {
+      fatals.forEach {
+        NonFatal(it) shouldBe false
+      }
+    }
+    "Test fatals using Throwable#nonFatal" {
+      fatals.forEach {
+        shouldThrowAny {
+          it.nonFatal()
+        }
+      }
+    }
+  }
+}

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -31,6 +31,8 @@ fun <A> Gen.Companion.functionAAToA(gen: Gen<A>): Gen<(A, A) -> A> = gen.map { a
 
 fun Gen.Companion.throwable(): Gen<Throwable> = Gen.from(listOf(RuntimeException(), NoSuchElementException(), IllegalArgumentException()))
 
+fun Gen.Companion.fatalThrowable(): Gen<Throwable> = Gen.from(listOf(ThreadDeath(), StackOverflowError(), OutOfMemoryError(), InterruptedException()))
+
 fun Gen.Companion.intSmall(): Gen<Int> = Gen.oneOf(Gen.choose(Int.MIN_VALUE / 10000, -1), Gen.choose(0, Int.MAX_VALUE / 10000))
 
 fun <A, B> Gen.Companion.tuple2(genA: Gen<A>, genB: Gen<B>): Gen<Tuple2<A, B>> = Gen.bind(genA, genB) { a: A, b: B -> Tuple2(a, b) }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadErrorLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadErrorLaws.kt
@@ -5,15 +5,19 @@ import arrow.core.Either
 import arrow.test.generators.*
 import arrow.typeclasses.Eq
 import arrow.typeclasses.MonadError
+import io.kotlintest.fail
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import io.kotlintest.shouldThrowAny
 
 object MonadErrorLaws {
 
   fun <F> laws(M: MonadError<F, Throwable>, EQERR: Eq<Kind<F, Int>>, EQ_EITHER: Eq<Kind<F, Either<Throwable, Int>>>, EQ: Eq<Kind<F, Int>> = EQERR): List<Law> =
     MonadLaws.laws(M, EQ) + ApplicativeErrorLaws.laws(M, EQERR, EQ_EITHER, EQ) + listOf(
       Law("Monad Error Laws: left zero") { M.monadErrorLeftZero(EQERR) },
-      Law("Monad Error Laws: ensure consistency") { M.monadErrorEnsureConsistency(EQERR) }
+      Law("Monad Error Laws: ensure consistency") { M.monadErrorEnsureConsistency(EQERR) },
+      Law("Monad Error Laws: NonFatal is caught") { M.monadErrorCatchesNonFatalThrowables(EQERR) },
+      Law("Monad Error Laws: Fatal errors are thrown") { M.monadErrorThrowsFatalThrowables(EQERR) }
     )
 
   fun <F> MonadError<F, Throwable>.monadErrorLeftZero(EQ: Eq<Kind<F, Int>>): Unit =
@@ -25,4 +29,22 @@ object MonadErrorLaws {
     forAll(Gen.int().applicativeError(this), Gen.throwable(), Gen.functionAToB<Int, Boolean>(Gen.bool())) { fa: Kind<F, Int>, e: Throwable, p: (Int) -> Boolean ->
       fa.ensure({ e }, p).equalUnderTheLaw(fa.flatMap { a -> if (p(a)) just(a) else raiseError(e) }, EQ)
     }
+
+  fun <F> MonadError<F, Throwable>.monadErrorCatchesNonFatalThrowables(EQ: Eq<Kind<F, Int>>) {
+    forAll(Gen.throwable()) {nonFatal: Throwable ->
+      catch { throw nonFatal }.equalUnderTheLaw(raiseError(nonFatal), EQ)
+    }
+  }
+
+  fun <F> MonadError<F, Throwable>.monadErrorThrowsFatalThrowables(EQ: Eq<Kind<F, Int>>) {
+    forAll(Gen.fatalThrowable()) {fatal: Throwable ->
+      shouldThrowAny {
+        fun <A> itShouldNotComeThisFar(): Kind<F, A> {
+          fail("MonadError should rethrow the fatal Throwable: '$fatal'.")
+        }
+
+        catch { throw fatal }.equalUnderTheLaw(itShouldNotComeThisFar(), EQ)
+      } == fatal
+    }
+  }
 }

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ApplicativeError.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/ApplicativeError.kt
@@ -1,7 +1,14 @@
 package arrow.typeclasses
 
 import arrow.Kind
-import arrow.core.*
+import arrow.core.Either
+import arrow.core.Left
+import arrow.core.NonFatal
+import arrow.core.OptionOf
+import arrow.core.Right
+import arrow.core.TryOf
+import arrow.core.fix
+import arrow.core.identity
 
 /**
  * ank_macro_hierarchy(arrow.typeclasses.ApplicativeError)
@@ -36,7 +43,11 @@ interface ApplicativeError<F, E> : Applicative<F> {
     try {
       just(f())
     } catch (t: Throwable) {
-      raiseError<A>(recover(t))
+      if (NonFatal(t)) {
+        raiseError<A>(recover(t))
+      } else {
+        throw t
+      }
     }
 
   fun <A> ApplicativeError<F, Throwable>.catch(f: () -> A): Kind<F, A> =

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/MonadError.kt
@@ -1,6 +1,7 @@
 package arrow.typeclasses
 
 import arrow.Kind
+import arrow.core.NonFatal
 import arrow.documented
 import kotlin.coroutines.startCoroutine
 
@@ -141,4 +142,6 @@ interface MonadThrow<F> : MonadError<F, Throwable> {
   fun <A> fx(f: suspend MonadErrorContinuation<F, *>.() -> A, unit: Unit = Unit): Kind<F, A> =
     bindingCatch { f() }
 
+  fun <A> Throwable.raiseNonFatal(): Kind<F, A> =
+    if (NonFatal(this)) raiseError(this) else throw this
 }

--- a/modules/docs/arrow-docs/docs/docs/integrations/reactor/README.md
+++ b/modules/docs/arrow-docs/docs/docs/integrations/reactor/README.md
@@ -176,7 +176,7 @@ fun main() {
 }
 ```
 
-```kotlin:ank
+```kotlin:ank:fail
 import arrow.core.Try
 
 // This will result in a stack overflow

--- a/modules/docs/arrow-docs/docs/docs/integrations/rx2/README.md
+++ b/modules/docs/arrow-docs/docs/docs/integrations/rx2/README.md
@@ -211,7 +211,7 @@ fun main() {
 }
 ```
 
-```kotlin:ank
+```kotlin:ank:fail
 import arrow.core.Try
 // This will result in a stack overflow
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IO.kt
@@ -39,7 +39,11 @@ sealed class IO<out A> : IOOf<A> {
           try {
             k(conn, callback)
           } catch (throwable: Throwable) {
-            callback(Left(throwable))
+            if (NonFatal(throwable)) {
+              callback(Left(throwable))
+            } else {
+              throw throwable
+            }
           }
         }
       }
@@ -52,7 +56,11 @@ sealed class IO<out A> : IOOf<A> {
           val fa = try {
             k(conn2, callback)
           } catch (t: Throwable) {
-            IO { callback(Left(t)) }
+            if (NonFatal(t)) {
+              IO { callback(Left(t)) }
+            } else {
+              throw t
+            }
           }
 
           IORunLoop.startCancelable(fa, conn2) { result ->

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -3,6 +3,7 @@ package arrow.effects
 import arrow.core.Continuation
 import arrow.core.Either
 import arrow.core.Left
+import arrow.core.NonFatal
 import arrow.core.Right
 import arrow.effects.internal.Platform.ArrayStack
 import kotlin.coroutines.CoroutineContext
@@ -61,7 +62,11 @@ internal object IORunLoop {
             hasResult = true
             currentIO = null
           } catch (t: Throwable) {
-            currentIO = IO.RaiseError(t)
+            if (NonFatal(t)) {
+              currentIO = IO.RaiseError(t)
+            } else {
+              throw t
+            }
           }
         }
         is IO.Async -> {
@@ -199,7 +204,11 @@ internal object IORunLoop {
             hasResult = true
             currentIO = null
           } catch (t: Throwable) {
-            currentIO = IO.RaiseError(t)
+            if (NonFatal(t)) {
+              currentIO = IO.RaiseError(t)
+            } else {
+              throw t
+            }
           }
         }
         is IO.Async -> {
@@ -288,7 +297,11 @@ internal object IORunLoop {
     try {
       f().fix()
     } catch (e: Throwable) {
-      IO.RaiseError(e)
+      if (NonFatal(e)) {
+        IO.RaiseError(e)
+      } else {
+        throw e
+      }
     }
 
   /**

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/ForwardCancelable.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/ForwardCancelable.kt
@@ -1,6 +1,7 @@
 package arrow.effects.internal
 
 import arrow.core.Either
+import arrow.core.NonFatal
 import arrow.effects.*
 import arrow.effects.internal.ForwardCancelable.Companion.State.Active
 import arrow.effects.internal.ForwardCancelable.Companion.State.Empty
@@ -78,8 +79,12 @@ class ForwardCancelable {
           try {
             cb(r)
             acc
-          } catch (nonFatal: Throwable) {
-            acc + nonFatal
+          } catch (t: Throwable) {
+            if (NonFatal(t))  {
+              acc + t
+            } else {
+              throw t
+            }
           }
         }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/IOBracket.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/IOBracket.kt
@@ -1,6 +1,7 @@
 package arrow.effects.internal
 
 import arrow.core.Either
+import arrow.core.NonFatal
 import arrow.effects.*
 import arrow.effects.typeclasses.ExitCase
 import java.util.concurrent.atomic.AtomicBoolean
@@ -61,7 +62,11 @@ internal object IOBracket {
               val fb = try {
                 use(a)
               } catch (e: Throwable) {
-                IO.raiseError<B>(e)
+                if (NonFatal(e)) {
+                  IO.raiseError<B>(e)
+                } else {
+                  throw e
+                }
               }
 
               IO.Bind(fb.fix(), frame)

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Async.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Async.kt
@@ -2,6 +2,7 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.NonFatal
 import arrow.core.Right
 import arrow.documented
 import arrow.typeclasses.MonadContinuation
@@ -142,7 +143,7 @@ interface Async<F> : MonadDefer<F> {
       try {
         just(f())
       } catch (t: Throwable) {
-        raiseError<A>(t)
+        t.raiseNonFatal<A>()
       }
     }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Async.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Async.kt
@@ -2,7 +2,6 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.Either
-import arrow.core.NonFatal
 import arrow.core.Right
 import arrow.documented
 import arrow.typeclasses.MonadContinuation

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
@@ -2,7 +2,6 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.Either
-import arrow.core.NonFatal
 import arrow.core.Tuple2
 import arrow.core.toT
 import arrow.effects.data.internal.BindingCancellationException

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
@@ -2,6 +2,7 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.NonFatal
 import arrow.core.Tuple2
 import arrow.core.toT
 import arrow.effects.data.internal.BindingCancellationException
@@ -25,7 +26,7 @@ interface MonadDefer<F> : MonadThrow<F>, Bracket<F, Throwable> {
       try {
         just(f())
       } catch (t: Throwable) {
-        raiseError<A>(t)
+        t.raiseNonFatal<A>()
       }
     }
 
@@ -38,7 +39,7 @@ interface MonadDefer<F> : MonadThrow<F>, Bracket<F, Throwable> {
       try {
         just(f())
       } catch (t: Throwable) {
-        raiseError<A>(t)
+        t.raiseNonFatal<A>()
       }
     }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDeferCancellableContinuations.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDeferCancellableContinuations.kt
@@ -2,6 +2,7 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.NonFatal
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.effects.typeclasses.suspended.MonadDeferSyntax
 import arrow.typeclasses.MonadContinuation
@@ -59,7 +60,7 @@ open class MonadDeferCancellableContinuation<F, A>(val SC: MonadDefer<F>, overri
       val datatype = try {
         just(m())
       } catch (t: Throwable) {
-        raiseError<B>(t)
+        t.raiseNonFatal<B>()
       }
       datatype.flatMap { xx: B ->
         c.stateStack = labelHere

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDeferCancellableContinuations.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDeferCancellableContinuations.kt
@@ -2,7 +2,6 @@ package arrow.effects.typeclasses
 
 import arrow.Kind
 import arrow.core.Either
-import arrow.core.NonFatal
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.effects.typeclasses.suspended.MonadDeferSyntax
 import arrow.typeclasses.MonadContinuation

--- a/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/FluxK.kt
+++ b/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/FluxK.kt
@@ -89,11 +89,15 @@ data class FluxK<A>(val flux: Flux<A>) : FluxKOf<A>, FluxKKindedJ<A> {
             })
           )
         } catch (e: Throwable) {
-          release(a, ExitCase.Error(e)).fix().flux.subscribe({
-            sink.error(e)
-          }, { e2 ->
-            sink.error(Platform.composeErrors(e, e2))
-          })
+          if (NonFatal(e)) {
+            release(a, ExitCase.Error(e)).fix().flux.subscribe({
+              sink.error(e)
+            }, { e2 ->
+              sink.error(Platform.composeErrors(e, e2))
+            })
+          } else {
+            throw e
+          }
         }
       }, sink::error, sink::complete)
     })

--- a/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/MonoK.kt
+++ b/modules/effects/arrow-effects-reactor-data/src/main/kotlin/arrow/effects/reactor/MonoK.kt
@@ -3,6 +3,7 @@ package arrow.effects.reactor
 import arrow.core.Either
 import arrow.core.Either.Left
 import arrow.core.Either.Right
+import arrow.core.NonFatal
 import arrow.effects.OnCancel
 import arrow.effects.internal.Platform
 import arrow.effects.reactor.CoroutineContextReactorScheduler.asScheduler
@@ -90,11 +91,15 @@ data class MonoK<A>(val mono: Mono<A>) : MonoKOf<A>, MonoKKindedJ<A> {
             .subscribe(sink::success, sink::error)
           )
         } catch (e: Throwable) {
-          release(a, ExitCase.Error(e)).fix().mono.subscribe({
-            sink.error(e)
-          }, { e2 ->
-            sink.error(Platform.composeErrors(e, e2))
-          })
+          if (NonFatal(e)) {
+            release(a, ExitCase.Error(e)).fix().mono.subscribe({
+              sink.error(e)
+            }, { e2 ->
+              sink.error(Platform.composeErrors(e, e2))
+            })
+          } else {
+            throw e
+          }
         }
       } else sink.success(null)
     })

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/FlowableK.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/FlowableK.kt
@@ -85,11 +85,15 @@ data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKi
             .doOnCancel { release(a, ExitCase.Canceled).fix().flowable.subscribe({}, emitter::onError) }
             .subscribe(emitter::onNext, emitter::onError))
         } catch (e: Throwable) {
-          release(a, ExitCase.Error(e)).fix().flowable.subscribe({
-            emitter.onError(e)
-          }, { e2 ->
-            emitter.onError(Platform.composeErrors(e, e2))
-          })
+          if (NonFatal(e)) {
+            release(a, ExitCase.Error(e)).fix().flowable.subscribe({
+              emitter.onError(e)
+            }, { e2 ->
+              emitter.onError(Platform.composeErrors(e, e2))
+            })
+          } else {
+            throw e
+          }
         }
       }, emitter::onError, emitter::onComplete)
     }, mode))

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/MaybeK.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/MaybeK.kt
@@ -82,11 +82,15 @@ data class MaybeK<A>(val maybe: Maybe<A>) : MaybeKOf<A>, MaybeKKindedJ<A> {
             .doOnDispose { release(a, ExitCase.Canceled).fix().maybe.subscribe({}, emitter::onError) }
             .subscribe(emitter::onSuccess, emitter::onError))
         } catch (e: Throwable) {
-          release(a, ExitCase.Error(e)).fix().maybe.subscribe({
-            emitter.onError(e)
-          }, { e2 ->
-            emitter.onError(Platform.composeErrors(e, e2))
-          })
+          if (NonFatal(e)) {
+            release(a, ExitCase.Error(e)).fix().maybe.subscribe({
+              emitter.onError(e)
+            }, { e2 ->
+              emitter.onError(Platform.composeErrors(e, e2))
+            })
+          } else {
+            throw e
+          }
         }
       }
     })

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/ObservableK.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/ObservableK.kt
@@ -85,11 +85,15 @@ data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, Obs
             .doOnDispose { release(a, ExitCase.Canceled).fix().observable.subscribe({}, emitter::onError) }
             .subscribe(emitter::onNext, emitter::onError))
         } catch (e: Throwable) {
-          release(a, ExitCase.Error(e)).fix().observable.subscribe({
-            emitter.onError(e)
-          }, { e2 ->
-            emitter.onError(Platform.composeErrors(e, e2))
-          })
+          if (NonFatal(e)) {
+            release(a, ExitCase.Error(e)).fix().observable.subscribe({
+              emitter.onError(e)
+            }, { e2 ->
+              emitter.onError(Platform.composeErrors(e, e2))
+            })
+          } else {
+            throw e
+          }
         }
       }, emitter::onError, emitter::onComplete)
     })

--- a/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/SingleK.kt
+++ b/modules/effects/arrow-effects-rx2-data/src/main/kotlin/arrow/effects/rx2/SingleK.kt
@@ -2,6 +2,7 @@ package arrow.effects.rx2
 
 import arrow.core.Either
 import arrow.core.Left
+import arrow.core.NonFatal
 import arrow.core.Right
 import arrow.effects.OnCancel
 import arrow.effects.internal.Platform
@@ -85,11 +86,15 @@ data class SingleK<A>(val single: Single<A>) : SingleKOf<A>, SingleKKindedJ<A> {
           .doOnDispose { release(a, ExitCase.Canceled).fix().single.subscribe({}, emitter::onError) }
           .subscribe(emitter::onSuccess, emitter::onError))
       } catch (e: Throwable) {
-        release(a, ExitCase.Error(e)).fix().single.subscribe({
-          emitter.onError(e)
-        }, { e2 ->
-          emitter.onError(Platform.composeErrors(e, e2))
-        })
+        if (NonFatal(e)) {
+          release(a, ExitCase.Error(e)).fix().single.subscribe({
+            emitter.onError(e)
+          }, { e2 ->
+            emitter.onError(Platform.composeErrors(e, e2))
+          })
+        } else {
+          throw e
+        }
       }
     })
 


### PR DESCRIPTION
As discussed in https://kotlinlang.slack.com/archives/C5UPMM0A0/p1550319070097800
Port of the Scala NonFatal.

I've hopefully found all places where it should be applied. I've searched with `catch \(.*:\s+Throwable\)` in all Production Files using IntelliJ.

Closes #153 