### PR TITLE
Add arrow.syntax.unsafe Option.get() extension method

### DIFF
--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/unsafe/option.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/unsafe/option.kt
@@ -1,0 +1,11 @@
+package arrow.syntax.unsafe
+
+import arrow.core.Option
+
+/**
+ * Returns the [Option]'s value. This method should only be used in cases where the [Option] is not
+ * expected to be empty.
+ *
+ * @throws NoSuchElementException if the [Option] is empty.
+ */
+fun <T> Option<T>.get(): T = fold({ throw NoSuchElementException("None.get") }, { it })

--- a/modules/core/arrow-syntax/src/test/kotlin/arrow/syntax/test/option.kt
+++ b/modules/core/arrow-syntax/src/test/kotlin/arrow/syntax/test/option.kt
@@ -1,0 +1,28 @@
+package arrow.syntax.test
+
+import arrow.core.Option
+import arrow.core.Some
+import arrow.syntax.collections.firstOption
+import arrow.syntax.unsafe.get
+import arrow.test.UnitSpec
+import io.kotlintest.runner.junit4.KotlinTestRunner
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import org.junit.runner.RunWith
+
+@RunWith(KotlinTestRunner::class)
+class OptionSyntaxTest : UnitSpec() {
+    init {
+        "get throws NoSuchElementException if Option is empty" {
+            shouldThrow<NoSuchElementException> {
+                val option = Option.empty<Any>()
+                option.get()
+            }
+        }
+
+        "get returns value if Option is not empty" {
+            val option = Option.just("Foo")
+            option.get() shouldBe "Foo"
+        }
+    }
+}


### PR DESCRIPTION
From a conversation in [gitter](https://gitter.im/arrow-kt/Lobby?at=5c73c266e5eeec0d9bc1ecee):

> @raulraja: Arrow won't have an unsafe Option.get in core but as mentioned if anyone wants to maintain an unsafe module we are not opposed to. It just has to be outside of core or any of the other safe Arrow modules.

Let me know if I need to move this extension to a different location or make any other changes/additions 😎 