### PR TITLE
handleErrorWith for Either

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -367,3 +367,16 @@ fun <A, B> B?.rightIfNotNull(default: () -> A): Either<A, B> = when (this) {
   null -> Either.Left(default())
   else -> Either.Right(this)
 }
+
+
+/**
+ * Applies the given function `f` if this is a [Left], otherwise returns this if this is a [Right].
+ * This is like `flatMap` for the exception.
+ */
+fun <A, B> EitherOf<A, B>.handleErrorWith(f: (A) -> EitherOf<A, B>): Either<A, B> =
+  fix().let {
+    when (it) {
+      is Either.Left -> f(it.a).fix()
+      is Either.Right -> it
+    }
+  }

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -169,5 +169,12 @@ class EitherTest : UnitSpec() {
       }
     }
 
+    "handleErrorWith should handle left instance otherwise return Right" {
+      forAll { a: Int, b: Int ->
+        Left(a).handleErrorWith { Right(b) } == Right(b)
+          && Right(a).handleErrorWith { Right(b) } == Right(a)
+      }
+    }
+
   }
 }


### PR DESCRIPTION
fix for the task: #1324
-[ ] documentation does not contain example code to handling error ( `[Left]` ). Could be some example added.