### PR TITLE
Update kotlintest to version 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_7
         jUnitVersion = '4.12'
         jUnitVintageVersion = '5.2.0'
-        kotlinTestVersion = '3.1.5'
+        kotlinTestVersion = '3.3.1'
         kotlinVersion = '1.3.11'
         daggerVersion = '2.17'
         kotlinxCoroutinesVersion = '1.1.0'

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/extensions/NumberMonoidTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/extensions/NumberMonoidTest.kt
@@ -2,6 +2,9 @@ package arrow.extensions
 
 import arrow.core.extensions.monoid
 import arrow.test.UnitSpec
+import arrow.test.generators.byte
+import arrow.test.generators.short
+import io.kotlintest.properties.Gen
 import io.kotlintest.runner.junit4.KotlinTestRunner
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
@@ -10,60 +13,57 @@ import org.junit.runner.RunWith
 class NumberMonoidTest : UnitSpec() {
   init {
 
-    "should semigroup with the instance passed" {
-      "int" {
-        forAll { value: Int ->
-          val seen = Int.monoid().run { value.combine(value) }
-          val expected = value + value
+    "should semigroup with the instance passed - int" {
+      forAll { value: Int ->
+        val seen = Int.monoid().run { value.combine(value) }
+        val expected = value + value
 
-          expected == seen
-        }
+        expected == seen
       }
+    }
 
-      "float" {
-        forAll { value: Float ->
-          val seen = Float.monoid().run { value.combine(value) }
-          val expected = value + value
+    "should semigroup with the instance passed - float" {
+      forAll(Gen.numericFloats()) { value: Float ->
+        val seen = Float.monoid().run { value.combine(value) }
+        val expected = value + value
 
-          expected == seen
-        }
+        expected == seen
       }
+    }
 
-      "double" {
-        forAll { value: Double ->
-          val seen = Double.monoid().run { value.combine(value) }
-          val expected = value + value
+    "should semigroup with the instance passed - double" {
+      forAll(Gen.numericDoubles()) { value: Double ->
+        val seen = Double.monoid().run { value.combine(value) }
+        val expected = value + value
 
-          expected == seen
-        }
+        expected == seen
       }
+    }
 
-      "long" {
+    "should semigroup with the instance passed - long" {
+      forAll { value: Long ->
+        val seen = Long.monoid().run  { value.combine(value) }
+        val expected = value + value
 
-        forAll { value: Long ->
-          val seen = Long.monoid().run  { value.combine(value) }
-          val expected = value + value
-
-          expected == seen
-        }
+        expected == seen
       }
+    }
 
-      "short" {
-        forAll { value: Short ->
-          val seen = Short.monoid().run  { value.combine(value) }
-          val expected = (value + value).toShort()
+    "should semigroup with the instance passed - short" {
+      forAll(Gen.short()) { value: Short ->
+        val seen = Short.monoid().run  { value.combine(value) }
+        val expected = (value + value).toShort()
 
-          expected == seen
-        }
+        expected == seen
       }
+    }
 
-      "byte" {
-        forAll { value: Byte ->
-          val seen = Byte.monoid().run { value.combine(value) }
-          val expected = (value + value).toByte()
+    "should semigroup with the instance passed - byte" {
+      forAll(Gen.byte()) { value: Byte ->
+        val seen = Byte.monoid().run { value.combine(value) }
+        val expected = (value + value).toByte()
 
-          expected == seen
-        }
+        expected == seen
       }
     }
   }

--- a/modules/core/arrow-extras-data/src/main/kotlin/arrow/data/Moore.kt
+++ b/modules/core/arrow-extras-data/src/main/kotlin/arrow/data/Moore.kt
@@ -13,5 +13,7 @@ data class Moore<E, V>(val view: V, val handle: (E) -> Moore<E, V>) : MooreOf<E,
 
   fun extract(): V = view
 
+  override fun toString() = "Moore $view"
+
   companion object
 }

--- a/modules/core/arrow-extras-data/src/main/kotlin/arrow/data/Moore.kt
+++ b/modules/core/arrow-extras-data/src/main/kotlin/arrow/data/Moore.kt
@@ -13,7 +13,7 @@ data class Moore<E, V>(val view: V, val handle: (E) -> Moore<E, V>) : MooreOf<E,
 
   fun extract(): V = view
 
-  override fun toString() = "Moore $view"
+  override fun toString() = "Moore(view=$view, handle=(E) -> Moore<E, V>)"
 
   companion object
 }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -15,10 +15,10 @@ import io.kotlintest.properties.Gen
 import java.util.concurrent.TimeUnit
 
 fun Gen.Companion.short(): Gen<Short> =
-        Gen.int().filter { it >= Short.MIN_VALUE && it <= Short.MAX_VALUE }.map { it.toShort() }
+        Gen.choose(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).map { it.toShort() }
 
 fun Gen.Companion.byte(): Gen<Byte> =
-        Gen.int().filter { it >= Byte.MIN_VALUE && it <= Byte.MAX_VALUE }.map { it.toByte() }
+        Gen.choose(Byte.MIN_VALUE.toInt(), Byte.MAX_VALUE.toInt()).map { it.toByte() }
 
 fun <F, A> Gen<A>.applicative(AP: Applicative<F>): Gen<Kind<F, A>> =
   map { AP.just(it) }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -14,6 +14,12 @@ import arrow.typeclasses.ApplicativeError
 import io.kotlintest.properties.Gen
 import java.util.concurrent.TimeUnit
 
+fun Gen.Companion.short(): Gen<Short> =
+        Gen.int().filter { it >= Short.MIN_VALUE && it <= Short.MAX_VALUE }.map { it.toShort() }
+
+fun Gen.Companion.byte(): Gen<Byte> =
+        Gen.int().filter { it >= Byte.MIN_VALUE && it <= Byte.MAX_VALUE }.map { it.toByte() }
+
 fun <F, A> Gen<A>.applicative(AP: Applicative<F>): Gen<Kind<F, A>> =
   map { AP.just(it) }
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/Law.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/Law.kt
@@ -13,7 +13,7 @@ fun throwableEq() = Eq { a: Throwable, b ->
   a::class == b::class && a.message == b.message
 }
 
-data class Law(val name: String, val test: TestContext.() -> Unit)
+data class Law (val name: String, val test: suspend TestContext.() -> Unit)
 
 fun <A> A.equalUnderTheLaw(b: A, eq: Eq<A>): Boolean =
   eq.run { eqv(b) }

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/CallKindAdapterFactoryTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/CallKindAdapterFactoryTest.kt
@@ -3,7 +3,7 @@ package arrow.integrations.retrofit.adapter
 import arrow.effects.IO
 import arrow.integrations.retrofit.adapter.retrofit.retrofit
 import arrow.test.UnitSpec
-import com.google.common.reflect.TypeToken
+import com.google.gson.reflect.TypeToken
 import io.kotlintest.runner.junit4.KotlinTestRunner
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow


### PR DESCRIPTION
Law updated because the function has to be suspended.

NumberMonoid updated because nesting is not supported and I had to create some generators.

Moore updated because the default `toString` implementation breaks kotlin-reflect.

Fixes #1330

thanks @pakoito for the help :smile: 