### PR TITLE
Migrated to latest KotlinPoet stable 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         daggerVersion = '2.17'
         kotlinxCoroutinesVersion = '1.1.0'
         kotlinxCollectionsImmutableVersion = '0.1'
-        kotlinPoetVersion = '1.0.0-RC1'
+        kotlinPoetVersion = '1.1.0'
         projectReactorVersion = '3.1.8.RELEASE'
         rxJavaVersion = '2.2.1'
         dokka_version = '0.9.17'

--- a/modules/meta/arrow-meta/src/main/java/arrow/common/utils/AbstractProcessor.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/common/utils/AbstractProcessor.kt
@@ -37,7 +37,7 @@ abstract class AbstractProcessor : KotlinAbstractProcessor(), ProcessorUtils, Ko
         .readLines().joinToString("\n") {
           val line = it.substringAfter(" * ")
           if (line.trim() == "*") ""
-          else line
+          else line.replace(" ", "·")
         } + "\n"
     } catch (e: Exception) {
       null

--- a/modules/meta/arrow-meta/src/main/java/arrow/extensions/ExtensionProcessor.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/extensions/ExtensionProcessor.kt
@@ -233,7 +233,7 @@ class ExtensionProcessor : MetaProcessor<extension>(extension::class), PolyTempl
     companionOrFactory: TypeName,
     impl: String
   ): String =
-    """|return ${+companionOrFactory}.${typeClass.name.simpleName.decapitalize()}${+instance.typeVariables}(${requiredParameters.code { +it.name }}).run {
+    """|return ${+companionOrFactory}.${typeClass.name.simpleName.decapitalize()}${+instance.typeVariables}(${requiredParameters.code { +it.name }}).run·{
            |  $impl
            |}
            |

--- a/modules/meta/arrow-meta/src/main/java/arrow/generic/CoproductFileGenerator.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/generic/CoproductFileGenerator.kt
@@ -88,7 +88,7 @@ private fun FileSpec.Builder.addCoproductClassDeclaration(generics: List<String>
 private fun FileSpec.Builder.addCoproductOfConstructors(generics: List<String>): Unit {
     for (generic in generics) {
         val additionalParameterCount = generics.indexOf(generic)
-        val typeParameters = generics.joinToString(separator = ", ")
+        val typeParameters = generics.joinToString(separator = ",·")
         val replacementClassName = genericsToClassNames[generic]
 
         addFunction(
@@ -114,7 +114,7 @@ private fun FileSpec.Builder.addCoproductOfConstructors(generics: List<String>):
 private fun FileSpec.Builder.addCopExtensionConstructors(generics: List<String>): Unit {
     for (generic in generics) {
         val additionalParameterCount = generics.indexOf(generic)
-        val typeParameters = generics.joinToString(separator = ", ")
+        val typeParameters = generics.joinToString(separator = ",·")
         val replacementFunctionName = genericsToClassNames[generic]!!.toCamelCase()
 
         addFunction(
@@ -143,7 +143,7 @@ private fun FileSpec.Builder.addExtensionConstructors(generics: List<String>): U
                         .addKdoc(
                                 methodDocumentation(
                                         description = "Creates a Coproduct from the $generic type",
-                                        output = "A Coproduct${generics.size}<${generics.joinToString(separator = ", ")}> where the receiver is the $generic"
+                                        output = "A Coproduct${generics.size}<${generics.joinToString(separator = ",·")}> where the receiver is the $generic"
                                 )
                         )
                         .receiver(TypeVariableName(generic))

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/decoder/Decoder.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/decoder/Decoder.kt
@@ -19,9 +19,9 @@ import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
-import com.squareup.kotlinpoet.WildcardTypeName
 
 /**
  * Provides ways to go from a [Tree] to [Code] for the purposes of code gen and reporting
@@ -99,7 +99,9 @@ interface TypeDecoder : MetaDecoder<Type> {
     }
 
   fun Annotation.lyrics(): AnnotationSpec {
-    val className = if (type is TypeName.Classy) ClassName(type.pckg.value, type.simpleName) else ClassName.bestGuess(type.toString())
+    val className =
+      if (type is TypeName.Classy) ClassName(type.pckg.value, type.simpleName)
+      else ClassName.bestGuess(type.toString())
     val builder = AnnotationSpec.builder(className).useSiteTarget(useSiteTarget?.lyrics())
     return members.fold(builder) { b, member ->
       b.addMember(member.lyrics())
@@ -170,19 +172,19 @@ interface TypeDecoder : MetaDecoder<Type> {
     }
 
   fun TypeName.TypeVariable.lyrics(): TypeVariableName {
-    val name = TypeVariableName(name, variance?.lyrics())
-      .withBounds(bounds.map { it.lyrics() })
-      .reified(reified)
-    return if (nullable) name.asNullable()
-    else name.asNonNullable()
+    val bounds = bounds.map { it.lyrics() }
+
+    return (if (bounds.isNotEmpty()) TypeVariableName(this.name, *bounds.toTypedArray(), variance = variance?.lyrics())
+    else TypeVariableName(this.name, variance?.lyrics())
+      .copy(reified = reified, nullable = nullable))
   }
 
   fun TypeName.WildcardType.lyrics(): com.squareup.kotlinpoet.TypeName =
     when {
-      name == "*" -> WildcardTypeName.STAR
+      name == "*" -> STAR
       lowerBounds.isNotEmpty() -> lowerBounds[0].lyrics()
       upperBounds.isNotEmpty() -> upperBounds[0].lyrics()
-      else -> WildcardTypeName.STAR
+      else -> STAR
     }
 
   private fun String.removeVariance(): String =
@@ -194,16 +196,12 @@ interface TypeDecoder : MetaDecoder<Type> {
       className.parameterizedBy(*typeArguments.map { it.lyrics() }.toTypedArray())
     }
 
-  fun TypeName.FunctionLiteral.lyrics(): com.squareup.kotlinpoet.TypeName {
-    val lambdaName = LambdaTypeName.get(
+  fun TypeName.FunctionLiteral.lyrics(): com.squareup.kotlinpoet.TypeName =
+    LambdaTypeName.get(
       receiver = receiverType?.lyrics(),
       parameters = *parameters.map { it.lyrics() }.toTypedArray(),
-      returnType = returnType.lyrics())
-    return if (modifiers.contains(Modifier.Suspend))
-      lambdaName.asSuspending()
-    else
-      lambdaName
-  }
+      returnType = returnType.lyrics()
+    ).copy(suspending = modifiers.contains(Modifier.Suspend))
 
   fun TypeName.Classy.lyrics(): ClassName =
     ClassName(packageName = pckg.value, simpleName = simpleName)

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/decoder/Decoder.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/decoder/Decoder.kt
@@ -216,7 +216,7 @@ interface TypeDecoder : MetaDecoder<Type> {
     }
 
   operator fun Code.Companion.invoke(f: () -> String): Code =
-    Code(CodeBlock.of(f().trimMargin()).toString())
+    Code(f().trimMargin())
 
   operator fun TypeName?.unaryPlus(): Code =
     if (this != null) Code(CodeBlock.of("%T", this.lyrics()).toString())
@@ -257,7 +257,7 @@ interface TypeDecoder : MetaDecoder<Type> {
   }
 
   fun <A : Any> List<A>.joinToCode(separator: String): Code =
-    if (isEmpty()) Code(CodeBlock.of("").toString())
+    if (isEmpty()) Code("")
     else {
       val code = joinToString(", ") { separator }
       val args = map { it.resolveDynamicArg() }.toTypedArray()

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/decoder/Decoder.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/decoder/Decoder.kt
@@ -237,7 +237,7 @@ interface TypeDecoder : MetaDecoder<Type> {
   fun Iterable<Parameter>.code(f: (Parameter) -> Code = { Code(it.lyrics().toString()) }): Code {
     val list = toList()
     return if (list.isEmpty()) Code.empty
-    else Code(list.joinToString(", ") {
+    else Code(list.joinToString(",·") {
       f(it).toString()
     })
   }
@@ -259,7 +259,7 @@ interface TypeDecoder : MetaDecoder<Type> {
   fun <A : Any> List<A>.joinToCode(separator: String): Code =
     if (isEmpty()) Code("")
     else {
-      val code = joinToString(", ") { separator }
+      val code = joinToString(",·") { separator }
       val args = map { it.resolveDynamicArg() }.toTypedArray()
       Code((if (args.isEmpty()) CodeBlock.of(code) else CodeBlock.of(code, *args)).toString())
     }

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/KotlinPoetEncoder.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/KotlinPoetEncoder.kt
@@ -64,14 +64,14 @@ interface KotlinPoetEncoder {
     )
 
   fun com.squareup.kotlinpoet.AnnotationSpec.toMeta(): Annotation =
-    Annotation(type.toMeta(), members = members.map { it.toMeta() }, useSiteTarget = useSiteTarget?.toMeta())
+    Annotation(className.toMeta(), members = members.map { it.toMeta() }, useSiteTarget = useSiteTarget?.toMeta())
 
   private fun com.squareup.kotlinpoet.WildcardTypeName.toMeta(): TypeName.WildcardType =
     TypeName.WildcardType(
       name = toString().removeVariance().asKotlin(),
-      upperBounds = upperBounds.map { it.toMeta() },
-      lowerBounds = lowerBounds.map { it.toMeta() },
-      nullable = nullable,
+      upperBounds = outTypes.map { it.toMeta() },
+      lowerBounds = inTypes.map { it.toMeta() },
+      nullable = isNullable,
       annotations = annotations.map { it.toMeta() }
     )
 
@@ -80,14 +80,14 @@ interface KotlinPoetEncoder {
       simpleName = simpleName.asKotlin(),
       fqName = canonicalName.asKotlin(),
       annotations = annotations.map { it.toMeta() },
-      nullable = nullable,
+      nullable = isNullable,
       pckg = PackageName(packageName.asKotlin())
     )
 
   private fun com.squareup.kotlinpoet.ParameterizedTypeName.toMeta(): TypeName =
     TypeName.ParameterizedType(
       name = toString().removeVariance().asKotlin(),
-      nullable = nullable,
+      nullable = isNullable,
       annotations = annotations.map { it.toMeta() },
       enclosingType = null,
       rawType = rawType.toMeta(),
@@ -136,8 +136,8 @@ interface KotlinPoetEncoder {
       { metaApi().run { it.toMeta().removeConstrains() } },
       annotations = annotations.map
       { it.toMeta() },
-      nullable = nullable,
-      reified = reified,
+      nullable = isNullable,
+      reified = isReified,
       variance = variance?.toMeta()
     )
 


### PR DESCRIPTION
* This tries to migrate to latest KotlinPoet 1.1.0.
* Code changes seem equivalent to previous code (please comment if you see any issue), but it seems KotlinPoet is adding some extra new lines that break compilation.

* Example generated code for `ConstFunctor` before with KotlinPoet 1.0.0-RC1:
```
fun <A> Kind<Kind<ForConst, A>, A>.unit(): Const<A, Unit> = arrow.typeclasses.Const.functor<A>().run {
   this@unit.unit() as arrow.typeclasses.Const<A, kotlin.Unit>
}
```

* Example generated code for `ConstFunctor` now with KotlinPoet 1.1.0:
```
fun <A> Kind<Kind<ForConst, A>, A>.unit(): Const<A, Unit> = arrow.typeclasses.Const.functor<A>().run
          {
    this@unit.unit() as arrow.typeclasses.Const<A, kotlin.Unit>
  }
```

The new line before the brace causes the following compilation errors:
`.../arrow/modules/core/arrow-core-extensions/build/generated/source/kaptKotlin/main/extension/arrow/core/extensions/const/functor/ConstFunctor.kt: (130, 9): Expecting a top level declaration`
