### PR TITLE
Fix Jekyll deployment url

### DIFF
--- a/modules/docs/arrow-docs/README.md
+++ b/modules/docs/arrow-docs/README.md
@@ -126,7 +126,7 @@ bundle install --gemfile modules/docs/arrow-docs/Gemfile --path vendor/bundle
 BUNDLE_GEMFILE=modules/docs/arrow-docs/Gemfile bundle exec jekyll serve -s modules/docs/arrow-docs/build/site/
 ```
 
-This will install any needed dependencies locally, and will use it to launch the complete website in [127.0.0.1:4000](https://127.0.0.1:4000) so you can open it with a standard browser.
+This will install any needed dependencies locally, and will use it to launch the complete website in [127.0.0.1:4000](http://127.0.0.1:4000) so you can open it with a standard browser.
 
 
 ## Blog section contribution


### PR DESCRIPTION
Accessing the documentation with https://127.0.0.1:4000 returns a bad URI error. 
According to [Stack Overflow](https://stackoverflow.com/a/47057601/2050159) and [GitHub](https://github.com/jekyll/jekyll/issues/6507#issuecomment-340816350) the error occurs when accessing the URL via https.
