### PR TITLE
selective functor extras

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Function0.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Function0.kt
@@ -39,4 +39,4 @@ data class Function0<out A>(internal val f: () -> A) : Function0Of<A> {
 }
 
 fun <A, B> Function0<Either<A, B>>.select(f: Function0Of<(A) -> B>): Function0<B> =
-  flatMap  { it.fold({l -> just(l).ap(f)}, {r -> just(identity(r))})}
+  flatMap  { it.fold({l -> just(l).ap(f)}, {r -> just(r)})}

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
@@ -46,4 +46,4 @@ data class Id<out A>(private val value: A) : IdOf<A> {
 }
 
 fun <A, B> Id<Either<A, B>>.select(f: IdOf<(A) -> B>): Id<B> =
-  flatMap { it.fold({ l -> just(l).ap(f) }, { r -> just(identity(r)) }) }
+  flatMap { it.fold({ l -> just(l).ap(f) }, { r -> just(r) }) }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -234,4 +234,4 @@ fun <T> Iterable<T>.lastOrNone(predicate: (T) -> Boolean): Option<T> = this.last
 fun <T> Iterable<T>.elementAtOrNone(index: Int): Option<T> = this.elementAtOrNull(index).toOption()
 
 fun <A, B> Option<Either<A, B>>.select(f: OptionOf<(A) -> B>): Option<B> =
-  flatMap { it.fold({ l -> Option.just(l).ap(f) }, { r -> Option.just(identity(r)) }) }
+  flatMap { it.fold({ l -> Option.just(l).ap(f) }, { r -> Option.just(r) }) }

--- a/modules/core/arrow-extras-data/src/test/kotlin/arrow/data/ValidatedTest.kt
+++ b/modules/core/arrow-extras-data/src/test/kotlin/arrow/data/ValidatedTest.kt
@@ -7,6 +7,7 @@ import arrow.core.extensions.semigroup
 import arrow.data.extensions.validated.applicative.applicative
 import arrow.data.extensions.validated.eq.eq
 import arrow.data.extensions.validated.functor.functor
+import arrow.data.extensions.validated.selective.selective
 import arrow.data.extensions.validated.semigroupK.semigroupK
 import arrow.data.extensions.validated.show.show
 import arrow.data.extensions.validated.traverse.traverse
@@ -33,7 +34,7 @@ class ValidatedTest : UnitSpec() {
     testLaws(
       EqLaws.laws(EQ) { Valid(it) },
       ShowLaws.laws(Validated.show(), EQ) { Valid(it) },
-      ApplicativeLaws.laws(Validated.applicative(String.semigroup()), Eq.any()),
+      SelectiveLaws.laws(Validated.selective(String.semigroup()), Eq.any()),
       TraverseLaws.laws(Validated.traverse(), Validated.functor(), ::Valid, Eq.any()),
       SemigroupKLaws.laws(
         Validated.semigroupK(String.semigroup()),

--- a/modules/core/arrow-extras-extensions/src/main/kotlin/arrow/data/extensions/validated.kt
+++ b/modules/core/arrow-extras-extensions/src/main/kotlin/arrow/data/extensions/validated.kt
@@ -1,6 +1,7 @@
 package arrow.data.extensions
 
 import arrow.Kind
+import arrow.core.Either
 import arrow.core.Eval
 import arrow.data.*
 
@@ -26,6 +27,15 @@ interface ValidatedApplicative<E> : Applicative<ValidatedPartialOf<E>>, Validate
 
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.ap(ff: Kind<ValidatedPartialOf<E>, (A) -> B>): Validated<E, B> = fix().ap(SE(), ff.fix())
 
+}
+
+@extension
+interface ValidatedSelective<E> : Selective<ValidatedPartialOf<E>>, ValidatedApplicative<E> {
+
+  override fun SE(): Semigroup<E>
+
+   override fun <A, B> Kind<ValidatedPartialOf<E>, Either<A, B>>.select(f: Kind<ValidatedPartialOf<E>, (A) -> B>): Kind<ValidatedPartialOf<E>, B> =
+    fix().fold({Invalid(it)}, { it.fold({ l -> f.map { ff -> ff(l) } }, { r -> just(r) })})
 }
 
 @extension

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/SelectiveLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/SelectiveLaws.kt
@@ -3,6 +3,8 @@ package arrow.test.laws
 import arrow.Kind
 import arrow.core.*
 import arrow.test.generators.either
+import arrow.test.generators.functionAToB
+import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Selective
 import io.kotlintest.properties.Gen
@@ -13,7 +15,9 @@ object SelectiveLaws {
   fun <F> laws(A: Selective<F>, EQ: Eq<Kind<F, Int>>): List<Law> =
     ApplicativeLaws.laws(A, EQ) + listOf(
       Law("Selective Laws: identity") { A.identityLaw(EQ) },
-      Law("Selective Laws: branch") { A.branchLaw(EQ) },
+      Law("Selective Laws: distributivity") { A.distributivity(EQ) },
+      Law("Selective Laws: associativity") { A.associativity(EQ) },
+      Law("Selective Laws: branch") { A.branch(EQ) },
       Law("Selective Laws: ifS") { A.ifSLaw(EQ) }
     )
 
@@ -25,10 +29,42 @@ object SelectiveLaws {
       )
     }
 
-  fun <F> Selective<F>.branchLaw(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(Gen.either(Gen.double(), Gen.float())) { either ->
-      val fl = just(Double::toInt)
-      val fr = just(Float::toInt)
+  fun <F, A, B> Applicative<F>.sequenceRight(fa: Kind<F, A>, fb: Kind<F, B>): Kind<F, B> =
+    fa.product(fb).map { (_, b) -> b }
+
+  fun <F> Selective<F>.distributivity(EQ: Eq<Kind<F, Int>>): Unit =
+    forAll(Gen.either(Gen.int(), Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int())) { either, ab1, ab2 ->
+      val fe = just(either)
+      val f = just(ab1)
+      val g = just(ab2)
+      fe.select(sequenceRight(f, g)).equalUnderTheLaw(sequenceRight(fe.select(f), fe.select(g)), EQ)
+    }
+
+
+  fun <F> Selective<F>.associativity(EQ: Eq<Kind<F, Int>>): Unit =
+    forAll(Gen.int(),
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int())) { a, ab1, ab2 ->
+
+      val x: Kind<F, Either<Int, Int>> = just(a.right())
+      val y: Kind<F, Either<Int, (Int) -> Int>> = just(ab1.right())
+      val z: Kind<F, (Int) -> (Int) -> Int> = just({ _: Int -> ab2 })
+
+      val p: Kind<F, Either<Int, Either<Tuple2<Int, Int>, Int>>> = x.map { e -> e.map(::Right) }
+      val q: Kind<F, (Int) -> Either<Tuple2<Int, Int>, Int>> =
+        y.map { e -> { i: Int -> e.bimap({ l -> l toT i }, { r -> r(i) }) } }
+      val r: Kind<F, (Tuple2<Int, Int>) -> Int> = z.map { { (t1, t2): Tuple2<Int, Int> -> it(t1)(t2) } }
+      x.select(y.select(z)).equalUnderTheLaw(p.select(q).select(r), EQ)
+    }
+
+  fun <F> Selective<F>.branch(EQ: Eq<Kind<F, Int>>): Unit =
+    forAll(Gen.functionAToB<Double, Int>(Gen.int()),
+      Gen.functionAToB<Float, Int>(Gen.int()),
+      Gen.either(Gen.double(), Gen.float())) { di, fi, either ->
+      val fl = just(di)
+      val fr = just(fi)
       either.fold(
         { l -> just(either).branch(fl, fr).equalUnderTheLaw(fl.map { ff -> ff(l) }, EQ) },
         { r -> just(either).branch(fl, fr).equalUnderTheLaw(fr.map { ff -> ff(r) }, EQ) }

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/selective/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/selective/README.md
@@ -83,7 +83,7 @@ TypeClass(Selective::class).dtMarkdownList()
 <canvas id="hierarchy-diagram" style="margin-top:120px"></canvas>
 
 <script>
-  drawNomNomlDiagram('hierarchy-diagram', 'monad.nomnol')
+  drawNomNomlDiagram('hierarchy-diagram', 'selective.nomnol')
 </script>
 
 ```kotlin:ank:outFile(selective.nomnol)


### PR DESCRIPTION
- docs fix for selective hierarchy diagram
- remove redundant identity calls 
- added selective instance for validated (all other instances so far also have monad instances)
- distributivity and accociativity laws from Selective paper added