### PR TITLE
ensure NonEmptyList properties are immutable

### DIFF
--- a/modules/core/arrow-extras-data/src/main/kotlin/arrow/data/NonEmptyList.kt
+++ b/modules/core/arrow-extras-data/src/main/kotlin/arrow/data/NonEmptyList.kt
@@ -22,8 +22,8 @@ class NonEmptyList<out A> private constructor(
   val all: List<A>
 ) : NonEmptyListOf<A> {
 
-  constructor(head: A, tail: List<A>) : this(head, tail, listOf(head) + tail)
-  private constructor(list: List<A>) : this(list[0], list.drop(1), list)
+  constructor(head: A, tail: List<A>) : this(head, tail.toList(), listOf(head) + tail.toList())
+  private constructor(list: List<A>) : this(list[0], list.drop(1), list.toList())
 
   val size: Int = all.size
 


### PR DESCRIPTION
Fixes #1312

Call toList() on List constructor arguments to ensure that the new
object is unaffected by any mutations on its inputs.

Without this, a mutable list can be stored as either the `all` or `tail`
property of the NonEmptyList, which is affected by all changes, but is
then out of sync with the other properties.