### PR TITLE
Add new recommended constructor for Ref

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/effects/ref/README.md
+++ b/modules/docs/arrow-docs/docs/docs/effects/ref/README.md
@@ -21,7 +21,7 @@ Since the allocation of mutable state is not referentially transparent this side
 import arrow.effects.*
 import arrow.effects.extensions.io.monadDefer.monadDefer
 
-val ioRef: IO<Ref<ForIO, Int>> = Ref.of(1, IO.monadDefer()).fix()
+val ioRef: IO<Ref<ForIO, Int>> = Ref.of(IO.monadDefer()) { 1 }.fix()
 ```
 
 In case you want the side-effect to execute immediately and return the `Ref` instance you can use the `unsafe` function.

--- a/modules/docs/arrow-docs/docs/docs/effects/ref/README.md
+++ b/modules/docs/arrow-docs/docs/docs/effects/ref/README.md
@@ -21,7 +21,7 @@ Since the allocation of mutable state is not referentially transparent this side
 import arrow.effects.*
 import arrow.effects.extensions.io.monadDefer.monadDefer
 
-val ioRef: IO<Ref<ForIO, Int>> = Ref.of(IO.monadDefer()) { 1 }.fix()
+val ioRef: IO<Ref<ForIO, Int>> = Ref(IO.monadDefer()) { 1 }.fix()
 ```
 
 In case you want the side-effect to execute immediately and return the `Ref` instance you can use the `unsafe` function.
@@ -33,13 +33,13 @@ val unsafe: Ref<ForIO, Int> = Ref.unsafe(1, IO.monadDefer())
 As you can see above this fixed `Ref` to the type `Int` and initialised it with the value `1`.
 
 In the case you want to create a `Ref` for `F` but not fix the value type yet you can use the `Ref` constructor.
-This returns an interface `PartiallyAppliedRef` with a single method `of` to construct an actual `Ref`.
+This returns an interface `RefFactory` with a single method `delay` to construct an actual `Ref`.
 
 ```kotlin:ank:silent
-val ref: PartiallyAppliedRef<ForIO> = Ref(IO.monadDefer())
+val ref: RefFactory<ForIO> = Ref.factory(IO.monadDefer())
 
-val ref1: IO<Ref<ForIO, String>> = ref.of("Hello, World!").fix()
-val ref2: IO<Ref<ForIO, Int>> = ref.of(2).fix()
+val ref1: IO<Ref<ForIO, String>> = ref.delay { "Hello, World!" }.fix()
+val ref2: IO<Ref<ForIO, Int>> = ref.delay { 2 }.fix()
 ```
 
 ## Working with Ref

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
@@ -318,8 +318,8 @@ interface MVar<F, A> {
  *
  * fun main(args: Array<String>) {
  *   //sampleStart
- *   val mvarPartial: MVarPartialOf<ForIO> = MVar(IO.async())
- *   val intVar: IOOf<MVar<ForIO, Int>> = mvarPartial.of(5)
+ *   val mvarPartial: MVarFactory<ForIO> = MVar.factoryUncancelable(IO.async())
+ *   val intVar: IOOf<MVar<ForIO, Int>> = mvarPartial.just(5)
  *   val stringVar: IOOf<MVar<ForIO, String>> = mvarPartial.empty<String>()
  *   //sampleEnd
  * }
@@ -336,8 +336,8 @@ interface MVarFactory<F> {
    *
    * fun main(args: Array<String>) {
    *   //sampleStart
-   *   val mvarPartial: MVarPartialOf<ForIO> = MVar(IO.async())
-   *   val intVar: IOOf<MVar<ForIO, Int>> = mvarPartial.of(5)
+   *   val mvarPartial: MVarFactory<ForIO> = MVar.factoryUncancelable(IO.async())
+   *   val intVar: IOOf<MVar<ForIO, Int>> = mvarPartial.just(5)
    *   //sampleEnd
    * }
    * ```
@@ -353,7 +353,7 @@ interface MVarFactory<F> {
    *
    * fun main(args: Array<String>) {
    *   //sampleStart
-   *   val mvarPartial: MVarPartialOf<ForIO> = MVar(IO.async())
+   *   val mvarPartial: MVarFactory<ForIO> = MVar.factoryUncancelable(IO.async())
    *   val stringVar: IOOf<MVar<ForIO, String>> = mvarPartial.empty<String>()
    *   //sampleEnd
    * }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
@@ -26,13 +26,13 @@ interface MVar<F, A> {
    *
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
    * mvar.empty<Int>().flatMap { v ->
    *   v.isEmpty()
    * }.unsafeRunSync() == true
    *
-   * mvar.of(10).flatMap { v ->
+   * mvar.just(10).flatMap { v ->
    *   v.isEmpty()
    * }.unsafeRunSync() == false
    * //sampleEnd
@@ -51,9 +51,9 @@ interface MVar<F, A> {
    *
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
-   * mvar.of(10).flatMap { v ->
+   * mvar.just(10).flatMap { v ->
    *   v.isNotEmpty()
    * }.unsafeRunSync() == true
    *
@@ -77,7 +77,7 @@ interface MVar<F, A> {
    *
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
    * mvar.empty<Int>().flatMap { v ->
    *   v.put(5).flatMap {
@@ -101,13 +101,13 @@ interface MVar<F, A> {
    *
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
    * mvar.empty<Int>().flatMap { v ->
    *  v.tryPut(5)
    * }.unsafeRunSync() == true
    *
-   * mvar.of(5).flatMap { v ->
+   * mvar.just(5).flatMap { v ->
    *   v.tryPut(10)
    * }.unsafeRunSync() == false
    * //sampleEnd
@@ -126,9 +126,9 @@ interface MVar<F, A> {
    *
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
-   * mvar.of(5).flatMap { v ->
+   * mvar.just(5).flatMap { v ->
    * v.take()
    * }.unsafeRunSync() == 5
    *
@@ -152,9 +152,9 @@ interface MVar<F, A> {
    *
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
-   * mvar.of(5).flatMap { v ->
+   * mvar.just(5).flatMap { v ->
    *   v.tryTake()
    * }.unsafeRunSync() == Some(5)
    *
@@ -178,13 +178,13 @@ interface MVar<F, A> {
    * import arrow.effects.extensions.io.monad.map
    * fun main(args: Array<String>) {
    * //sampleStart
-   * val mvar = MVar(IO.async())
+   * val mvar = MVar.factoryUncancelable(IO.async())
    *
-   * mvar.of(5).flatMap { v ->
+   * mvar.just(5).flatMap { v ->
    *   v.read()
    * }.unsafeRunSync() == 5
    *
-   * mvar.of(5).flatMap { v ->
+   * mvar.just(5).flatMap { v ->
    *   v.read().flatMap { value ->
    *     v.isNotEmpty().map { isNotEmpty ->
    *       value toT isNotEmpty

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
@@ -288,18 +288,18 @@ interface MVar<F, A> {
     fun <F, A> uncancelableOf(initial: A, AS: Async<F>): Kind<F, MVar<F, A>> =
       UncancelableMVar(initial, AS)
 
-    operator fun <F> invoke(AS: Async<F>) = object : MVarPartialOf<F> {
+    operator fun <F> invoke(AS: Async<F>) = object : MVarFactory<F> {
 
-      override fun <A> of(a: A): Kind<F, MVar<F, A>> =
+      override fun <A> just(a: A): Kind<F, MVar<F, A>> =
         UncancelableMVar(a, AS)
 
       override fun <A> empty(): Kind<F, MVar<F, A>> =
         UncancelableMVar.empty(AS)
     }
 
-    operator fun <F> invoke(CF: Concurrent<F>) = object : MVarPartialOf<F> {
+    operator fun <F> invoke(CF: Concurrent<F>) = object : MVarFactory<F> {
 
-      override fun <A> of(a: A): Kind<F, MVar<F, A>> =
+      override fun <A> just(a: A): Kind<F, MVar<F, A>> =
         CancelableMVar(a, CF)
 
       override fun <A> empty(): Kind<F, MVar<F, A>> =
@@ -325,7 +325,7 @@ interface MVar<F, A> {
  * }
  * ```
  */
-interface MVarPartialOf<F> {
+interface MVarFactory<F> {
 
   /**
    * Builds a [MVar] with a value of type [A].
@@ -342,7 +342,7 @@ interface MVarPartialOf<F> {
    * }
    * ```
    */
-  fun <A> of(a: A): Kind<F, MVar<F, A>>
+  fun <A> just(a: A): Kind<F, MVar<F, A>>
 
   /**
    * Builds an empty [MVar] for type [A].

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/MVar.kt
@@ -221,7 +221,7 @@ interface MVar<F, A> {
       CancelableMVar.empty(CF)
 
     /**
-     * Create an uncancelable [MVar] that's initialized to an [initial] value.
+     * Create a cancelable [MVar] that's initialized to an [initial] value.
      *
      * ```kotlin:ank:playground
      * import arrow.effects.*
@@ -288,7 +288,7 @@ interface MVar<F, A> {
     fun <F, A> uncancelableOf(initial: A, AS: Async<F>): Kind<F, MVar<F, A>> =
       UncancelableMVar(initial, AS)
 
-    operator fun <F> invoke(AS: Async<F>) = object : MVarFactory<F> {
+    fun <F> factoryUncancelable(AS: Async<F>) = object : MVarFactory<F> {
 
       override fun <A> just(a: A): Kind<F, MVar<F, A>> =
         UncancelableMVar(a, AS)
@@ -297,7 +297,7 @@ interface MVar<F, A> {
         UncancelableMVar.empty(AS)
     }
 
-    operator fun <F> invoke(CF: Concurrent<F>) = object : MVarFactory<F> {
+    fun <F> factoryCancelable(CF: Concurrent<F>) = object : MVarFactory<F> {
 
       override fun <A> just(a: A): Kind<F, MVar<F, A>> =
         CancelableMVar(a, CF)

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
@@ -111,7 +111,7 @@ interface Ref<F, A> {
     }
 
     /**
-     * Like [of] but returns the newly allocated ref directly instead of wrapping it in [MonadDefer.invoke].
+     * Like [invoke] but returns the newly allocated ref directly instead of wrapping it in [MonadDefer.invoke].
      * This method is considered unsafe because it is not referentially transparent -- it allocates mutable state.
      *
      * @see [invoke]

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
@@ -97,23 +97,16 @@ interface Ref<F, A> {
      * Builds a [Ref] value for data types given a [MonadDefer] instance
      * without deciding the type of the Ref's value.
      *
-     * @see [of]
+     * @see [invoke]
      */
-    operator fun <F> invoke(MD: MonadDefer<F>): PartiallyAppliedRef<F> = object : PartiallyAppliedRef<F> {
-      override fun <A> of(a: A): Kind<F, Ref<F, A>> = Ref.of(a, MD)
-    }
-
-    /**
-     * Creates an asynchronous, concurrent mutable reference initialized to the supplied value.
-     */
-    fun <F, A> of(a: A, MD: MonadDefer<F>): Kind<F, Ref<F, A>> = MD.delay {
-      unsafe(a, MD)
+    fun <F> factory(MD: MonadDefer<F>): RefFactory<F> = object : RefFactory<F> {
+      override fun <A> delay(a: () -> A): Kind<F, Ref<F, A>> = invoke(MD, a)
     }
 
     /**
      * Creates an asynchronous, concurrent mutable reference initialized using the supplied function.
      */
-    fun <F, A> of(MD: MonadDefer<F>, f: () -> A): Kind<F, Ref<F, A>> = MD.delay {
+    operator fun <F, A> invoke(MD: MonadDefer<F>, f: () -> A): Kind<F, Ref<F, A>> = MD.delay {
       unsafe(f(), MD)
     }
 
@@ -192,8 +185,8 @@ interface Ref<F, A> {
 }
 
 /**
- * Intermediate interface to partially apply [F] to [Ref].
+ * Creates [Ref] for a kind [F] using a supplied function.
  */
-interface PartiallyAppliedRef<F> {
-  fun <A> of(a: A): Kind<F, Ref<F, A>>
+interface RefFactory<F> {
+  fun <A> delay(a: () -> A): Kind<F, Ref<F, A>>
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
@@ -109,6 +109,13 @@ interface Ref<F, A> {
     fun <F, A> of(a: A, MD: MonadDefer<F>): Kind<F, Ref<F, A>> = MD.delay {
       unsafe(a, MD)
     }
+    
+    /**
+     * Creates an asynchronous, concurrent mutable reference initialized using the supplied function.
+     */
+    fun <F, A> of(MD: MonadDefer<F>, f: () -> A): Kind<F, Ref<F, A>> = MD.delay {
+      unsafe(f(), MD)
+    }
 
     /**
      * Like [of] but returns the newly allocated ref directly instead of wrapping it in [MonadDefer.invoke].

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Ref.kt
@@ -109,7 +109,7 @@ interface Ref<F, A> {
     fun <F, A> of(a: A, MD: MonadDefer<F>): Kind<F, Ref<F, A>> = MD.delay {
       unsafe(a, MD)
     }
-    
+
     /**
      * Creates an asynchronous, concurrent mutable reference initialized using the supplied function.
      */

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Semaphore.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/Semaphore.kt
@@ -204,7 +204,7 @@ interface Semaphore<F> {
      */
     operator fun <F> invoke(n: Long, CF: Concurrent<F>): Kind<F, Semaphore<F>> = CF.run {
       assertNonNegative(n).flatMap {
-        Ref.of<F, State<F>>(Right(n), CF).map { ref ->
+        Ref<F, State<F>>(CF) { Right(n) }.map { ref ->
           DefaultSemaphore(ref, Promise(this), this)
         }
       }
@@ -226,7 +226,7 @@ interface Semaphore<F> {
      */
     fun <F> uncancelable(n: Long, AS: Async<F>): Kind<F, Semaphore<F>> = AS.run {
       assertNonNegative(n).flatMap {
-        Ref.of<F, State<F>>(Right(n), AS).map { ref ->
+        Ref<F, State<F>>(AS) { Right(n) }.map { ref ->
           DefaultSemaphore(ref, Promise.uncancelable(this), this)
         }
       }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
@@ -11,6 +11,7 @@ import arrow.core.right
 import arrow.core.toT
 import arrow.effects.CancelToken
 import arrow.effects.KindConnection
+import arrow.effects.MVar
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclasses.MonadContinuation
 import java.util.concurrent.atomic.AtomicReference
@@ -680,6 +681,11 @@ interface Concurrent<F> : Async<F> {
       raceN(g, h),
       raceN(i, j)
     )
+
+  /**
+   * Creates a variable [MVar] to be used for thread-sharing, initialized to a value [a]
+   */
+  fun <A> mVar(a: A): Kind<F, MVar<F, A>> = MVar(a, this)
 
   /**
    * Overload for [Async.asyncF]

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
@@ -4,7 +4,6 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Tuple2
 import arrow.core.toT
-import arrow.effects.MVar
 import arrow.effects.Ref
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclasses.MonadContinuation

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/MonadDefer.kt
@@ -4,6 +4,8 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Tuple2
 import arrow.core.toT
+import arrow.effects.MVar
+import arrow.effects.Ref
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.typeclasses.MonadContinuation
 import arrow.typeclasses.MonadError
@@ -35,6 +37,11 @@ interface MonadDefer<F> : MonadThrow<F>, Bracket<F, Throwable> {
 
   fun <A> delayOrRaise(f: () -> Either<Throwable, A>): Kind<F, A> =
     defer { f().fold({ raiseError<A>(it) }, { just(it) }) }
+
+  /**
+   * Creates a [Ref] to purely manage mutable state, initialized by the function [f]
+   */
+  fun <A> ref(f: () -> A): Kind<F, Ref<F, A>> = Ref(this, f)
 
   /**
    * Entry point for monad bindings which enables for comprehensions. The underlying impl is based on coroutines.

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/MVarTest.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/MVarTest.kt
@@ -160,7 +160,7 @@ class MVarTest : UnitSpec() {
       }
     }
 
-    tests("UncancelableMVar", MVar(IO.async()))
-    tests("CancelableMVar", MVar(IO.concurrent()))
+    tests("UncancelableMVar", MVar.factoryUncancelable(IO.async()))
+    tests("CancelableMVar", MVar.factoryUncancelable(IO.concurrent()))
   }
 }

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/MVarTest.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/MVarTest.kt
@@ -5,7 +5,6 @@ import arrow.core.Some
 import arrow.core.Tuple3
 import arrow.core.Tuple4
 import arrow.core.Tuple7
-import arrow.core.flatMap
 import arrow.core.toT
 import arrow.effects.extensions.io.async.async
 import arrow.effects.extensions.io.concurrent.concurrent
@@ -25,7 +24,7 @@ class MVarTest : UnitSpec() {
 
   init {
 
-    fun tests(label: String, mvar: MVarPartialOf<ForIO>) {
+    fun tests(label: String, mvar: MVarFactory<ForIO>) {
       "$label - empty; put; isNotEmpty; take; put; take" {
         forAll(Gen.int(), Gen.int()) { a, b ->
           binding {
@@ -118,7 +117,7 @@ class MVarTest : UnitSpec() {
       "$label - initial; isNotEmpty; take; put; take" {
         forAll(Gen.int(), Gen.int()) { a, b ->
           binding {
-            val av = mvar.of(a).bind()
+            val av = mvar.just(a).bind()
             val isNotEmpty = av.isNotEmpty().bind()
             val r1 = av.take().bind()
             av.put(b).bind()
@@ -132,7 +131,7 @@ class MVarTest : UnitSpec() {
       "$label - initial; read; take" {
         forAll(Gen.int()) { i ->
           binding {
-            val av = mvar.of(i).bind()
+            val av = mvar.just(i).bind()
             val read = av.read().bind()
             val take = av.take().bind()
             read toT take
@@ -156,7 +155,7 @@ class MVarTest : UnitSpec() {
             }
 
         val count = 10000
-        val task = mvar.of(1).flatMap { ch -> loop(count, 0, ch) }
+        val task = mvar.just(1).flatMap { ch -> loop(count, 0, ch) }
         task.equalUnderTheLaw(IO.just(count), EQ())
       }
     }

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/PromiseTest.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/PromiseTest.kt
@@ -4,8 +4,8 @@ import arrow.core.Left
 import arrow.core.None
 import arrow.core.Some
 import arrow.core.Tuple2
-import arrow.effects.extensions.io.apply.product
 import arrow.effects.extensions.io.applicativeError.attempt
+import arrow.effects.extensions.io.apply.product
 import arrow.effects.extensions.io.async.async
 import arrow.effects.extensions.io.concurrent.concurrent
 import arrow.effects.extensions.io.functor.tupleLeft
@@ -13,9 +13,9 @@ import arrow.effects.extensions.io.monad.flatMap
 import arrow.effects.extensions.io.monadDefer.monadDefer
 import arrow.test.UnitSpec
 import arrow.test.generators.throwable
-import io.kotlintest.runner.junit4.KotlinTestRunner
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import io.kotlintest.runner.junit4.KotlinTestRunner
 import io.kotlintest.shouldBe
 import kotlinx.coroutines.Dispatchers
 import org.junit.runner.RunWith
@@ -122,7 +122,7 @@ class PromiseTest : UnitSpec() {
       }
 
       "$label - get blocks until set" {
-        Ref.of(0, IO.monadDefer()).flatMap { state ->
+        Ref(IO.monadDefer()) { 0 }.flatMap { state ->
           promise.flatMap { modifyGate ->
             promise.flatMap { readGate ->
               modifyGate.get().flatMap { state.update { i -> i * 2 }.flatMap { readGate.complete(0) } }.startFiber(ctx).flatMap {

--- a/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/eithert.kt
+++ b/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/eithert.kt
@@ -42,7 +42,7 @@ interface EitherTBracket<F> : Bracket<EitherTPartialOf<F, Throwable>, Throwable>
     use: (A) -> EitherTOf<F, Throwable, B>
   ): EitherT<F, Throwable, B> = MDF().run {
 
-    EitherT.liftF<F, Throwable, Ref<F, Option<Throwable>>>(this, Ref.of(None, this)).flatMap(this) { ref ->
+    EitherT.liftF<F, Throwable, Ref<F, Option<Throwable>>>(this, Ref(this) { None }).flatMap(this) { ref ->
       EitherT(
         value().bracketCase(use = { eith ->
           when (eith) {

--- a/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/optiont.kt
+++ b/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/optiont.kt
@@ -27,7 +27,7 @@ interface OptionTBracket<F> : Bracket<OptionTPartialOf<F>, Throwable>, OptionTMo
   override fun ME(): MonadError<F, Throwable> = MD()
 
   override fun <A, B> OptionTOf<F, A>.bracketCase(release: (A, ExitCase<Throwable>) -> OptionTOf<F, Unit>, use: (A) -> OptionTOf<F, B>): OptionT<F, B> = MD().run {
-    OptionT(Ref.of(false, this).flatMap { ref ->
+    OptionT(Ref(this) { false }.flatMap { ref ->
       value().bracketCase(use = {
         it.fold(
           { just(None) },

--- a/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/statet.kt
+++ b/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/statet.kt
@@ -36,7 +36,7 @@ interface StateTBracket<F, S> : Bracket<StateTPartialOf<F, S>, Throwable>, State
     use: (A) -> StateTOf<F, S, B>
   ): StateT<F, S, B> = MD().run {
 
-    StateT.liftF<F, S, Ref<F, Option<S>>>(this, Ref.of(None, this)).flatMap { ref ->
+    StateT.liftF<F, S, Ref<F, Option<S>>>(this, Ref(this) { None }).flatMap { ref ->
       StateT<F, S, B>(this) { startS ->
         runM(this, startS).bracketCase(use = { (s, a) ->
           use(a).runM(this, s).flatMap { sa ->

--- a/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/writert.kt
+++ b/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/writert.kt
@@ -40,7 +40,7 @@ interface WriterTBracket<F, W> : Bracket<WriterTPartialOf<F, W>, Throwable>, Wri
     use: (A) -> WriterTOf<F, W, B>
   ): WriterT<F, W, B> = MM().run {
     MD().run {
-      WriterT(Ref.of(empty(), this).flatMap { ref ->
+      WriterT(Ref(this) { empty() }.flatMap { ref ->
         value().bracketCase(use = { wa ->
           WriterT(wa.just()).flatMap(use).value()
         }, release = { wa, exitCase ->


### PR DESCRIPTION
Making the allocation lazy so every call to `IO` generates a new one, and we prevent eager expensive operations unless needed.