### PR TITLE
Add benchmarks for IO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ buildscript {
         classpath 'org.ajoberstar:gradle-git-publish:2.0.0'
         classpath "net.rdrei.android.buildtimetracker:gradle-plugin:0.11.1"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
+        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.7"
+        classpath "gradle.plugin.io.morethan.jmhreport:gradle-jmh-report:0.9.0"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_version"
     }
 }

--- a/modules/benchmarks/arrow-benchmarks-effects/build.gradle
+++ b/modules/benchmarks/arrow-benchmarks-effects/build.gradle
@@ -15,18 +15,24 @@ apply plugin: "io.morethan.jmhreport"
 
 jmh {
     include = [
-//            'arrow.benchmarks.Pure',
-//            'arrow.benchmarks.Delay',
+            'arrow.benchmarks.Async',
+            'arrow.benchmarks.AttemptNonRaised',
+            'arrow.benchmarks.AttemptRaisedError',
+//            'arrow.benchmarks.Bracket',
+//            'arrow.benchmarks.Cancellable',
             'arrow.benchmarks.DeepBind',
-//            'arrow.benchmarks.MapStream',
 //            'arrow.benchmarks.Defer',
-//            'arrow.benchmarks.Delay',
-//            'arrow.benchmarks.Map',
-//            'arrow.benchmarks.Async',
-//            'arrow.benchmarks.AttemptNonRaised',
-//            'arrow.benchmarks.AttemptRaisedError',
+            'arrow.benchmarks.Delay',
+//            'arrow.benchmarks.ForkFiber',
 //            'arrow.benchmarks.HandleNonRaised',
-//            'arrow.benchmarks.HandleRaisedError'
+//            'arrow.benchmarks.HandleRaisedError',
+            'arrow.benchmarks.LeftBind',
+            'arrow.benchmarks.Map',
+            'arrow.benchmarks.MapStream',
+//            'arrow.benchmarks.ParMap',
+            'arrow.benchmarks.Pure',
+//            'arrow.benchmarks.RacePair',
+//            'arrow.benchmarks.Uncancellable'
     ]
     resultFormat = 'json'
     resultsFile = file('build/reports/benchmarks.json')

--- a/modules/benchmarks/arrow-benchmarks-effects/build.gradle
+++ b/modules/benchmarks/arrow-benchmarks-effects/build.gradle
@@ -1,0 +1,47 @@
+dependencies {
+    compile project(":arrow-effects-data")
+    compile project(":arrow-effects-extensions")
+    compile project(":arrow-effects-io-extensions")
+    compile project(":arrow-effects-rx2-extensions")
+    compile project(":arrow-effects-reactor-extensions")
+    compile project(":arrow-scala-benchmarks")
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
+    compileOnly "org.openjdk.jmh:jmh-core:1.21"
+}
+
+apply plugin: "me.champeau.gradle.jmh"
+apply plugin: "io.morethan.jmhreport"
+
+jmh {
+    include = [
+//            'arrow.benchmarks.Pure',
+//            'arrow.benchmarks.Delay',
+            'arrow.benchmarks.DeepBind',
+//            'arrow.benchmarks.MapStream',
+//            'arrow.benchmarks.Defer',
+//            'arrow.benchmarks.Delay',
+//            'arrow.benchmarks.Map',
+//            'arrow.benchmarks.Async',
+//            'arrow.benchmarks.AttemptNonRaised',
+//            'arrow.benchmarks.AttemptRaisedError',
+//            'arrow.benchmarks.HandleNonRaised',
+//            'arrow.benchmarks.HandleRaisedError'
+    ]
+    resultFormat = 'json'
+    resultsFile = file('build/reports/benchmarks.json')
+    timeOnIteration = '1s'
+    failOnError = true
+    if (project.hasProperty("jmhInclude"))
+        include = [jmhInclude]
+    if (project.hasProperty("jmhResultsFile"))
+        resultsFile = file(jmhResultsFile)
+
+}
+
+jmhReport {
+    jmhResultPath = project.file('build/reports/benchmarks.json')
+    jmhReportOutput = project.file('build/reports')
+}
+
+tasks.jmh.finalizedBy tasks.jmhReport

--- a/modules/benchmarks/arrow-benchmarks-effects/gradle.properties
+++ b/modules/benchmarks/arrow-benchmarks-effects/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow-Benchmarks-Effects
+POM_ARTIFACT_ID=arrow-benchmarks-effects
+POM_PACKAGING=jar

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Async.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Async.kt
@@ -1,0 +1,41 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import arrow.effects.IODispatchers
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Async {
+
+  @Param("3000")
+  var size: Int = 0
+
+  private fun ioAsyncLoop(i: Int): IO<Int> =
+    IO.unit.continueOn(IODispatchers.CommonPool).followedBy(
+      if (i > size) IO.just(i) else ioAsyncLoop(i + 1)
+    )
+
+  @Benchmark
+  fun io(): Int =
+    ioAsyncLoop(0).unsafeRunSync()
+
+  @Benchmark
+  fun catsIO(): Int =
+    arrow.benchmarks.effects.scala.cats.`Async$`.`MODULE$`.unsafeIOAsyncLoop(size, 0)
+
+  @Benchmark
+  fun scalazZIO(): Int =
+    arrow.benchmarks.effects.scala.zio.`Async$`.`MODULE$`.unsafeIOAsyncLoop(size, 0)
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/AttemptNonRaised.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/AttemptNonRaised.kt
@@ -1,0 +1,42 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class AttemptNonRaised {
+
+  @Param("10000")
+  var size: Int = 0
+
+  private fun ioLoopHappy(size: Int, i: Int): IO<Int> =
+    if (i < size) {
+      IO { i + 1 }.attempt().flatMap {
+        it.fold(IO.Companion::raiseError) { n -> ioLoopHappy(size, n) }
+      }
+    } else IO.just(1)
+
+  @Benchmark
+  fun io(): Int =
+    ioLoopHappy(size, 0).unsafeRunSync()
+
+  @Benchmark
+  fun cats(): Any =
+    arrow.benchmarks.effects.scala.cats.AttemptNonRaised.ioLoopHappy(size, 0).unsafeRunSync()
+
+  @Benchmark
+  fun zio(): Any =
+    arrow.benchmarks.effects.scala.zio.AttemptNonRaised.run(size)
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/AttemptRaisedError.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/AttemptRaisedError.kt
@@ -1,0 +1,47 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+val dummy = object : RuntimeException("dummy") {
+  override fun fillInStackTrace(): Throwable =
+    this
+}
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class AttemptRaisedError {
+
+  @Param("10000")
+  var size: Int = 0
+
+  private fun ioLoopNotHappy(size: Int, i: Int): IO<Int> =
+    if (i < size) {
+      IO { throw dummy }.attempt().flatMap {
+        it.fold({ ioLoopNotHappy(size, i + 1) }, IO.Companion::just)
+      }
+    } else IO.just(1)
+
+  @Benchmark
+  fun io(): Int =
+    ioLoopNotHappy(size, 0).unsafeRunSync()
+
+  @Benchmark
+  fun cats(): Any =
+    arrow.benchmarks.effects.scala.cats.AttemptRaisedError.ioLoopNotHappy(size, 0).unsafeRunSync()
+
+  @Benchmark
+  fun zio(): Any =
+    arrow.benchmarks.effects.scala.zio.AttemptRaisedError.run(size)
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Bracket.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Bracket.kt
@@ -1,0 +1,39 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import arrow.unsafe
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+import arrow.effects.extensions.io.unsafeRun.runBlocking as ioRunBlocking
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Bracket {
+
+  @Param("100")
+  var size: Int = 0
+
+  private fun ioBracketLoop(i: Int): IO<Int> =
+    if (i < size)
+      IO.just(i).bracket({ IO.unit }, { ib -> IO { ib + 1 } }).flatMap { ioBracketLoop(it) }
+    else
+      IO.just(i)
+
+  @Benchmark
+  fun io() =
+    unsafe {
+      ioRunBlocking {
+        ioBracketLoop(0)
+      }
+    }
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Cancellable.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Cancellable.kt
@@ -1,0 +1,40 @@
+package arrow.benchmarks
+
+import arrow.core.Right
+import arrow.effects.IO
+import arrow.effects.extensions.io.concurrent.concurrent
+import arrow.effects.fix
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Cancellable {
+
+  @Param("100")
+  var size: Int = 0
+
+  fun evalCancelable(n: Int): IO<Int> =
+    IO.concurrent().cancelable<Int> { cb ->
+      cb(Right(n))
+      IO.unit
+    }.fix()
+
+  fun cancelableLoop(i: Int): IO<Int> =
+    if (i < size) evalCancelable(i + 1).flatMap { cancelableLoop(it) }
+    else evalCancelable(i)
+
+  @Benchmark
+  fun io(): Int =
+    cancelableLoop(0).unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/DeepBind.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/DeepBind.kt
@@ -1,0 +1,41 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class DeepBind {
+
+  @Param("20")
+  var depth: Int = 0
+
+  fun ioFibLazy(n: Int): IO<Int> =
+    if (n <= 1) IO { n }
+    else ioFibLazy(n - 1).flatMap { a ->
+      ioFibLazy(n - 2).flatMap { b -> IO { a + b } }
+    }
+
+  @Benchmark
+  fun io(): Int =
+    ioFibLazy(depth).unsafeRunSync()
+
+  @Benchmark
+  fun cats(): Any =
+    arrow.benchmarks.effects.scala.cats.`DeepBind$`.`MODULE$`.fib(depth).unsafeRunSync()
+
+  @Benchmark
+  fun zio(): Any =
+    arrow.benchmarks.effects.scala.zio.`DeepBind$`.`MODULE$`.fib(depth)
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Defer.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Defer.kt
@@ -1,0 +1,32 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Defer {
+
+  @Param("3000")
+  var size: Int = 0
+
+  private fun ioDeferLoop(i: Int): IO<Int> =
+    IO.defer { IO.just(i) }.flatMap { j ->
+      if (j > size) IO.defer { IO.just(j) } else ioDeferLoop(j + 1)
+    }
+
+  @Benchmark
+  fun io(): Int =
+    ioDeferLoop(0).unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Delay.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Delay.kt
@@ -1,0 +1,40 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Delay {
+
+  @Param("3000")
+  var size: Int = 0
+
+  private fun ioDelayLoop(i: Int): IO<Int> =
+    IO { i }.flatMap { j ->
+      if (j > size) IO { j } else ioDelayLoop(j + 1)
+    }
+
+  @Benchmark
+  fun io(): Int =
+    ioDelayLoop(0).unsafeRunSync()
+
+  @Benchmark
+  fun catsIO(): Int =
+    arrow.benchmarks.effects.scala.cats.`Delay$`.`MODULE$`.unsafeIODelayLoop(size, 0)
+
+  @Benchmark
+  fun scalaZIO(): Int =
+    arrow.benchmarks.effects.scala.zio.`Delay$`.`MODULE$`.unsafeIODelayLoop(size, 0)
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/ForkFiber.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/ForkFiber.kt
@@ -1,0 +1,37 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import arrow.effects.IODispatchers
+import arrow.effects.fix
+import arrow.effects.startFiber
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class ForkFiber {
+
+  @Param("100")
+  var size: Int = 0
+
+  private fun ioStartLoop(i: Int): IO<Int> =
+    if (i < size) {
+      IO { i + 1 }.startFiber(IODispatchers.CommonPool).flatMap { fiber ->
+        fiber.join().fix().flatMap { ioStartLoop(it) }
+      }
+    } else IO.just(i)
+
+  @Benchmark
+  fun io(): Int =
+    ioStartLoop(0).unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/HandleNonRaised.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/HandleNonRaised.kt
@@ -1,0 +1,36 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+import arrow.effects.handleErrorWith as ioHandleErrorWith
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class HandleNonRaised {
+
+  @Param("10000")
+  var size: Int = 0
+
+  private fun ioHappyPathLoop(i: Int): IO<Int> =
+    if (i < size)
+      IO.just(i + 1)
+        .ioHandleErrorWith { IO.raiseError(it) }
+        .flatMap { ioHappyPathLoop(it) }
+    else
+      IO.just(i)
+
+  @Benchmark
+  fun io(): Int =
+    ioHappyPathLoop(0).unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/HandleRaisedError.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/HandleRaisedError.kt
@@ -1,0 +1,39 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+import arrow.effects.extensions.io.applicativeError.handleErrorWith as ioHandleError
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class HandleRaisedError {
+
+  @Param("10000")
+  var size: Int = 0
+
+  private val dummy = RuntimeException("dummy")
+
+  private fun ioErrorRaisedloop(i: Int): IO<Int> =
+    if (i < size)
+      IO.raiseError<Int>(dummy)
+        .flatMap { x -> IO.just(x + 1) }
+        .flatMap { x -> IO.just(x + 1) }
+        .ioHandleError { ioErrorRaisedloop(i + 1) }
+    else
+      IO.just(i)
+
+  @Benchmark
+  fun io(): Int =
+    ioErrorRaisedloop(0).unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/LeftBind.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/LeftBind.kt
@@ -1,0 +1,63 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class LeftBind {
+
+  @Param("10000")
+  var size: Int = 0
+
+  @Param("100")
+  var depth: Int = 0
+
+  fun ioLoop(i: Int): IO<Int> =
+    if (i % depth == 0) IO { i + 1 }.flatMap { ioLoop(it) }
+    else if (i < size) ioLoop(i + 1).flatMap { i -> IO.just(i) }
+    else IO.just(i)
+
+  @Benchmark
+  fun io(): Int =
+    IO.just(0).flatMap { ioLoop(it) }.unsafeRunSync()
+
+  @Benchmark
+  fun catsIO(): Int =
+    arrow.benchmarks.effects.scala.cats.`LeftBind$`.`MODULE$`.unsafeIOLeftBindLoop(depth, size, 0)
+
+  @Benchmark
+  fun scalazZIO(): Int =
+    arrow.benchmarks.effects.scala.zio.`LeftBind$`.`MODULE$`.unsafeIOLeftBindLoop(depth, size, 0)
+
+      // RxJava & Reactor are not stack-safe and overflow in the benchmark.
+
+//    fun monoLoop(i: Int): Mono<Int> =
+//    if (i % depth == 0) Mono.fromSupplier { i + 1 }.flatMap { monoLoop(it) }
+//    else if (i < size) monoLoop(i + 1).flatMap { ii -> Mono.fromSupplier { ii } }
+//    else Mono.fromSupplier { i }
+
+//    fun singleLoop(i: Int): Single<Int> =
+//    if (i % depth == 0) Single.fromCallable { i + 1 }.flatMap { singleLoop(it) }
+//    else if (i < size) singleLoop(i + 1).flatMap { i -> Single.just(i) }
+//    else Single.just(i)
+
+//    @Benchmark
+//  fun mono(): Int =
+//    Mono.fromSupplier { 0 }.flatMap { monoLoop(it) }.block()!!
+
+//  @Benchmark
+//  fun single(): Int =
+//    Single.just(0).flatMap { singleLoop(it) }.blockingGet()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Map.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Map.kt
@@ -1,0 +1,70 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Map {
+
+  @Benchmark
+  fun zioOne(): Long =
+    arrow.benchmarks.effects.scala.zio.`Map$`.`MODULE$`.zioMapTest(12000, 1)
+
+  @Benchmark
+  fun zioBatch30(): Long =
+    arrow.benchmarks.effects.scala.zio.`Map$`.`MODULE$`.zioMapTest(12000 / 30, 30)
+
+  @Benchmark
+  fun zioBatch120(): Long =
+    arrow.benchmarks.effects.scala.zio.`Map$`.`MODULE$`.zioMapTest(12000 / 120, 120)
+
+  @Benchmark
+  fun catsOne(): Long =
+    arrow.benchmarks.effects.scala.cats.`Map$`.`MODULE$`.catsIOMapTest(12000, 1)
+
+  @Benchmark
+  fun catsBatch30(): Long =
+    arrow.benchmarks.effects.scala.cats.`Map$`.`MODULE$`.catsIOMapTest(12000 / 30, 30)
+
+  @Benchmark
+  fun catsBatch120(): Long =
+    arrow.benchmarks.effects.scala.cats.`Map$`.`MODULE$`.catsIOMapTest(12000 / 120, 120)
+
+  @Benchmark
+  fun ioOne(): Long = ioTest(12000, 1)
+
+  @Benchmark
+  fun ioBatch30(): Long = ioTest(12000 / 30, 30)
+
+  @Benchmark
+  fun ioBatch120(): Long = ioTest(12000 / 120, 120)
+
+  private fun ioTest(iterations: Int, batch: Int): Long {
+    val f = { x: Int -> x + 1 }
+    var io = IO.just(0)
+
+    var j = 0
+    while (j < batch) {
+      io = io.map(f); j += 1
+    }
+
+    var sum = 0L
+    var i = 0
+    while (i < iterations) {
+      sum += io.unsafeRunSync()
+      i += 1
+    }
+    return sum
+  }
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/MapStream.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/MapStream.kt
@@ -1,0 +1,89 @@
+package arrow.benchmarks
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class MapStream {
+
+  @Benchmark
+  fun ioOne(): Long = IOStream.test(12000, 1).unsafeRunSync()
+
+  @Benchmark
+  fun io30(): Long = IOStream.test(1000, 30).unsafeRunSync()
+
+  @Benchmark
+  fun io120(): Long = IOStream.test(100, 120).unsafeRunSync()
+
+  @Benchmark
+  fun zioOne(): Long =
+    arrow.benchmarks.effects.scala.zio.`MapStream$`.`MODULE$`.test(12000, 1)
+
+  @Benchmark
+  fun zioBatch30(): Long =
+    arrow.benchmarks.effects.scala.zio.`MapStream$`.`MODULE$`.test(12000 / 30, 30)
+
+  @Benchmark
+  fun zioBatch120(): Long =
+    arrow.benchmarks.effects.scala.zio.`MapStream$`.`MODULE$`.test(12000 / 120, 120)
+
+  @Benchmark
+  fun catsOne(): Long =
+    arrow.benchmarks.effects.scala.cats.`MapStream$`.`MODULE$`.test(12000, 1)
+
+  @Benchmark
+  fun catsBatch30(): Long =
+    arrow.benchmarks.effects.scala.cats.`MapStream$`.`MODULE$`.test(12000 / 30, 30)
+
+  @Benchmark
+  fun catsBatch120(): Long =
+    arrow.benchmarks.effects.scala.cats.`MapStream$`.`MODULE$`.test(12000 / 120, 120)
+}
+
+object IOStream {
+  class Stream(val value: Int, val next: IO<Option<Stream>>)
+  val addOne: (Int) -> Int = { it + 1 }
+
+  fun test(times: Int, batchSize: Int): IO<Long> {
+    var stream = range(0, times)
+    var i = 0
+    while (i < batchSize) {
+      stream = mapStream(addOne)(stream)
+      i += 1
+    }
+
+    return sum(0)(stream)
+  }
+
+  private fun range(from: Int, until: Int): Option<Stream> =
+    if (from < until) Some(Stream(from, IO { range(from + 1, until) }))
+    else None
+
+  private fun mapStream(f: (Int) -> Int): (box: Option<Stream>) -> Option<Stream> = { box ->
+    when (box) {
+      is Some -> box.copy(Stream(f(box.t.value), box.t.next.map(mapStream(f))))
+      None -> None
+    }
+  }
+
+  private fun sum(acc: Long): (Option<Stream>) -> IO<Long> = { box ->
+    when (box) {
+      is Some -> box.t.next.flatMap(sum(acc + box.t.value))
+      None -> IO.just(acc)
+    }
+  }
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/ParMap.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/ParMap.kt
@@ -1,0 +1,35 @@
+package arrow.benchmarks
+
+import arrow.data.extensions.list.foldable.foldLeft
+import arrow.effects.IO
+import arrow.effects.IODispatchers
+import arrow.effects.extensions.io.concurrent.parMapN
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class ParMap {
+
+  @Param("100")
+  var size: Int = 0
+
+  private fun ioHelper(): IO<Int> =
+    (0 until size).toList().foldLeft(IO { 0 }) { acc, i ->
+      IODispatchers.CommonPool.parMapN(acc, IO { i }) { a, b -> a + b }
+    }
+
+  @Benchmark
+  fun io(): Int =
+    ioHelper().unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Pure.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Pure.kt
@@ -1,0 +1,40 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Pure {
+
+  @Param("3000")
+  var size: Int = 0
+
+  private fun ioPureLoop(i: Int): IO<Int> =
+    IO.just(i).flatMap { j ->
+      if (j > size) IO.just(j) else ioPureLoop(j + 1)
+    }
+
+  @Benchmark
+  fun io(): Int =
+    ioPureLoop(0).unsafeRunSync()
+
+  @Benchmark
+  fun catsIO(): Int =
+    arrow.benchmarks.effects.scala.cats.`Pure$`.`MODULE$`.unsafeIOPureLoop(size, 0)
+
+  @Benchmark
+  fun scalazZio(): Int =
+    arrow.benchmarks.effects.scala.zio.`Pure$`.`MODULE$`.unsafeIOPureLoop(size, 0)
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/RacePair.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/RacePair.kt
@@ -1,0 +1,40 @@
+package arrow.benchmarks
+
+import arrow.core.Either
+import arrow.data.extensions.list.foldable.foldLeft
+import arrow.effects.IO
+import arrow.effects.IODispatchers
+import arrow.effects.extensions.io.monad.map
+import arrow.effects.racePair
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class RacePair {
+
+  @Param("100")
+  var size: Int = 0
+
+  private fun racePairHelper(): IO<Int> = (0 until size).toList().foldLeft(IO { 0 }) { acc, _ ->
+    IO.racePair(IODispatchers.CommonPool, acc, IO { 1 }).flatMap { ei ->
+      when (ei) {
+        is Either.Left -> ei.a.b.cancel().map { ei.a.a }
+        is Either.Right -> ei.b.a.cancel().map { ei.b.b }
+      }
+    }
+  }
+
+  @Benchmark
+  fun io(): Int = racePairHelper().unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Uncancellable.kt
+++ b/modules/benchmarks/arrow-benchmarks-effects/src/jmh/kotlin/arrow/benchmarks/Uncancellable.kt
@@ -1,0 +1,30 @@
+package arrow.benchmarks
+
+import arrow.effects.IO
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.CompilerControl
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class Uncancellable {
+
+  @Param("100")
+  var size: Int = 0
+
+  fun ioUncancelableLoop(i: Int): IO<Int> =
+    if (i < size) IO { i + 1 }.uncancelable().flatMap { ioUncancelableLoop(it) }
+    else IO.just(i)
+
+  @Benchmark
+  fun io(): Int = ioUncancelableLoop(0).unsafeRunSync()
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/build.gradle
+++ b/modules/benchmarks/arrow-scala-benchmarks/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'scala'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.scala-lang:scala-library:2.12.8'
+    implementation 'org.typelevel:cats-effect_2.12:1.2.0'
+    implementation 'org.scalaz:scalaz-zio_2.12:1.0-RC4'
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/gradle.properties
+++ b/modules/benchmarks/arrow-scala-benchmarks/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow-Scala-Benchmarks
+POM_ARTIFACT_ID=arrow-scala-benchmarks
+POM_PACKAGING=jar

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Async.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Async.scala
@@ -1,0 +1,18 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.{ContextShift, IO}
+import cats.implicits._
+
+import scala.concurrent.ExecutionContext
+
+object Async {
+
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  def ioAsyncLoop(size: Int, i: Int): IO[Int] =
+    IO.shift *> (if (i > size) IO.pure(i) else ioAsyncLoop(size, i + 1))
+
+  def unsafeIOAsyncLoop(size: Int, i: Int): Int =
+    ioAsyncLoop(size, i).unsafeRunSync()
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/AttemptNonRaised.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/AttemptNonRaised.scala
@@ -1,0 +1,17 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object AttemptNonRaised {
+
+  def ioLoopHappy(size: Int, i: Int): IO[Int] =
+    if (i < size) {
+      IO {
+        i + 1
+      }.attempt
+        .flatMap { result =>
+          result.fold[IO[Int]](IO.raiseError[Int], ioLoopHappy(size, _))
+        }
+    } else IO.pure(1)
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/AttemptRaisedError.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/AttemptRaisedError.scala
@@ -1,0 +1,20 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object dummy extends RuntimeException {
+  override def fillInStackTrace(): Throwable = this
+}
+
+object AttemptRaisedError {
+
+  def ioLoopNotHappy(size: Int, i: Int): IO[Int] =
+    if (i < size) {
+      IO {
+        throw dummy
+      }.attempt.flatMap { it =>
+        it.fold(_ => ioLoopNotHappy(size, i + 1), IO.pure)
+      }
+    } else IO.pure(1)
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/DeepBind.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/DeepBind.scala
@@ -1,0 +1,13 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object DeepBind {
+
+  def fib(n: Int): IO[BigInt] =
+    if (n <= 1) IO(n)
+    else
+      fib(n - 1).flatMap { a =>
+        fib(n - 2).flatMap(b => IO(a + b))
+      }
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Delay.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Delay.scala
@@ -1,0 +1,15 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object Delay {
+
+  def ioDelayLoop(size: Int, i: Int): IO[Int] =
+    IO(i).flatMap { j =>
+      if (j > size) IO(j) else ioDelayLoop(size, j + 1)
+    }
+
+  def unsafeIODelayLoop(size: Int, i: Int): Int =
+    ioDelayLoop(size, i).unsafeRunSync()
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/LeftBind.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/LeftBind.scala
@@ -1,0 +1,15 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect._
+
+object LeftBind {
+
+  def loop(depth: Int, size: Int, i: Int): IO[Int] =
+    if (i % depth == 0) IO(i + 1).flatMap(loop(depth, size, _))
+    else if (i < size) loop(depth, size, i + 1).flatMap(i => IO(i))
+    else IO(i)
+
+  def unsafeIOLeftBindLoop(depth: Int, size: Int, i: Int): Int =
+    IO(0).flatMap(loop(depth, size, _)).unsafeRunSync
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Map.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Map.scala
@@ -1,0 +1,26 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object Map {
+
+  def catsIOMapTest(iterations: Int, batch: Int): Long = {
+    val f = { x: Int => x + 1 }
+    var fx = IO.pure(0)
+
+    var j = 0
+    while (j < batch) {
+      fx = fx.map(f)
+      j += 1
+    }
+
+    var sum = 0L
+    var i = 0
+    while (i < iterations) {
+      sum += fx.unsafeRunSync()
+      i += 1
+    }
+    sum
+  }
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/MapStream.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/MapStream.scala
@@ -1,0 +1,42 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object MapStream {
+
+  def test(times: Int, batchSize: Int): Long = {
+    var stream = range(0, times)
+    var i = 0
+    while (i < batchSize) {
+      stream = mapStream(addOne)(stream)
+      i += 1
+    }
+    sum(0)(stream).unsafeRunSync()
+  }
+
+  final case class Stream(value: Int, next: IO[Option[Stream]])
+
+  val addOne = (x: Int) => x + 1
+
+  def range(from: Int, until: Int): Option[Stream] =
+    if (from < until)
+      Some(Stream(from, IO(range(from + 1, until))))
+    else
+      None
+
+  def mapStream(f: Int => Int)(box: Option[Stream]): Option[Stream] =
+    box match {
+      case Some(Stream(value, next)) =>
+        Some(Stream(f(value), next.map(mapStream(f))))
+      case None =>
+        None
+    }
+
+  def sum(acc: Long)(box: Option[Stream]): IO[Long] =
+    box match {
+      case Some(Stream(value, next)) =>
+        next.flatMap(sum(acc + value))
+      case None =>
+        IO.pure(acc)
+    }
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Pure.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/cats/Pure.scala
@@ -1,0 +1,15 @@
+package arrow.benchmarks.effects.scala.cats
+
+import cats.effect.IO
+
+object Pure {
+
+  def ioPureLoop(size: Int, i: Int): IO[Int] =
+    IO.pure(i).flatMap { j =>
+      if (j > size) IO.pure(j) else ioPureLoop(size, j + 1)
+    }
+
+  def unsafeIOPureLoop(size: Int, i: Int): Int =
+    ioPureLoop(size, i).unsafeRunSync()
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Async.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Async.scala
@@ -1,0 +1,19 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+import scalaz.zio.internal.Executor
+
+import scala.concurrent.ExecutionContext
+
+object Async {
+
+  val executor: Executor =
+    Executor.fromExecutionContext(Int.MaxValue)(ExecutionContext.global)
+
+  def ioAsyncLoop(size: Int, i: Int): Task[Int] =
+    IO.lock(executor)(if (i > size) IO.succeed(i) else ioAsyncLoop(size, i + 1))
+
+  def unsafeIOAsyncLoop(size: Int, i: Int): Int =
+    ZIORTS.unsafeRun(ioAsyncLoop(size, i))
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/AttemptNonRaised.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/AttemptNonRaised.scala
@@ -1,0 +1,18 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object AttemptNonRaised {
+
+  def ioLoopHappy(size: Int, i: Int): Task[Int] =
+    if (i < size) {
+      IO.effect {
+        i + 1
+      }.either.flatMap { result =>
+          result.fold[Task[Int]](IO.fail, ioLoopHappy(size, _))
+        }
+    } else IO.succeed(1)
+
+  def run(size: Int) = ZIORTS.unsafeRun(ioLoopHappy(size, 0))
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/AttemptRaisedError.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/AttemptRaisedError.scala
@@ -1,0 +1,22 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object dummy extends RuntimeException {
+  override def fillInStackTrace(): Throwable = this
+}
+
+object AttemptRaisedError {
+
+  def ioLoopNotHappy(size: Int, i: Int): IO[Nothing, Int] =
+    if (i < size) {
+      IO.effect {
+        throw dummy
+      }.either.flatMap { it =>
+        it.fold(_ => ioLoopNotHappy(size, i + 1), IO.succeed)
+      }
+    } else IO.succeed(1)
+
+  def run(size: Int) = ZIORTS.unsafeRun(ioLoopNotHappy(size, 0))
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/DeepBind.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/DeepBind.scala
@@ -1,0 +1,15 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object DeepBind {
+
+  def loop(n: Int): Task[BigInt] =
+    if (n <= 1) ZIO.effect[BigInt](n)
+    else
+      loop(n - 1).flatMap { a =>
+        loop(n - 2).flatMap(b => ZIO.effect(a + b))
+      }
+
+  def fib(depth: Int): BigInt = ZIORTS.unsafeRun(loop(depth))
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Delay.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Delay.scala
@@ -1,0 +1,15 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object Delay {
+
+  def ioDelayLoop(size: Int, i: Int): Task[Int] =
+    ZIO.effect { i } .flatMap { j =>
+      if (j > size) ZIO.effect { j } else ioDelayLoop(size, j + 1)
+    }
+
+  def unsafeIODelayLoop(size: Int, i: Int): Int =
+    ZIORTS.unsafeRun(ioDelayLoop(size, i))
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/LeftBind.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/LeftBind.scala
@@ -1,0 +1,16 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object LeftBind {
+
+
+  def loop(depth: Int, size: Int, i: Int): UIO[Int] =
+    if (i % depth == 0) IO.succeedLazy[Int](i + 1).flatMap { loop(depth, size, _) }
+    else if (i < size) loop(depth, size, i + 1).flatMap(i => IO.succeedLazy(i))
+    else IO.succeedLazy(i)
+
+  def unsafeIOLeftBindLoop(depth: Int, size: Int, i: Int): Int =
+    ZIORTS.unsafeRun(loop(depth, size, i))
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Map.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Map.scala
@@ -1,0 +1,26 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object Map {
+
+  def zioMapTest(iterations: Int, batch: Int): Long = {
+    val f = { x: Int => x + 1 }
+    var fx = IO.succeed(0)
+
+    var j = 0
+    while (j < batch) {
+      fx = fx.map(f)
+      j += 1
+    }
+
+    var sum = 0L
+    var i = 0
+    while (i < iterations) {
+      sum += ZIORTS.unsafeRun(fx)
+      i += 1
+    }
+    sum
+  }
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/MapStream.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/MapStream.scala
@@ -1,0 +1,39 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio.Task
+
+object MapStream {
+
+  def test(times: Int, batchSize: Int): Long = {
+    var stream = range(0, times)
+    var i = 0
+    while (i < batchSize) {
+      stream = mapStream(addOne)(stream)
+      i += 1
+    }
+
+    ZIORTS.unsafeRun(sum(0)(stream))
+  }
+
+  final case class Stream(value: Int, next: Task[Option[Stream]])
+
+  val addOne = (x: Int) => x + 1
+
+  def range(from: Int, until: Int): Option[Stream] =
+    if (from < until) Some(Stream(from, Task(range(from + 1, until))))
+    else None
+
+  def mapStream(f: Int => Int)(box: Option[Stream]): Option[Stream] =
+    box match {
+      case Some(Stream(value, next)) => Some(Stream(f(value), next.map(mapStream(f))))
+      case None => None
+    }
+
+  def sum(acc: Long)(box: Option[Stream]): Task[Long] =
+    box match {
+      case Some(Stream(value, next)) => next.flatMap(sum(acc + value))
+      case None => Task.succeed(acc)
+    }
+
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Pure.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/Pure.scala
@@ -1,0 +1,15 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object Pure {
+
+  def ioPureLoop(size: Int, i: Int): IO[Nothing, Int] =
+    IO.succeed(i).flatMap { j =>
+      if (j > size) IO.succeed(j) else ioPureLoop(size, j + 1)
+    }
+
+  def unsafeIOPureLoop(size: Int, i: Int): Int =
+    ZIORTS.unsafeRun(ioPureLoop(size, i))
+
+}

--- a/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/ZIORTS.scala
+++ b/modules/benchmarks/arrow-scala-benchmarks/src/main/scala/zio/ZIORTS.scala
@@ -1,0 +1,5 @@
+package arrow.benchmarks.effects.scala.zio
+
+import scalaz.zio._
+
+object ZIORTS extends DefaultRuntime

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IO.kt
@@ -123,6 +123,8 @@ sealed class IO<out A> : IOOf<A> {
   open fun continueOn(ctx: CoroutineContext): IO<A> =
     ContinueOn(this, ctx)
 
+  fun <B> followedBy(fb: IOOf<B>) = flatMap { fb }
+
   fun attempt(): IO<Either<Throwable, A>> =
     Bind(this, IOFrame.any())
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -117,5 +117,10 @@ include {
         validation {
             _ 'validation'
         }
+
+        benchmarks {
+            _ 'scala-benchmarks'
+            _ 'benchmarks-effects'
+        }
     }
 }


### PR DESCRIPTION
This PR adds some benchmarks to compare `IO` to ZIO & Cats-effects IO.

Current benchmarks for master
----
```
Benchmark                (depth)  (size)   Mode  Cnt      Score      Error  Units
Async.catsIO                 N/A    3000  thrpt   20    630.151 ±   30.997  ops/s
Async.io                     N/A    3000  thrpt   20    288.924 ±    5.441  ops/s
Async.scalazZIO              N/A    3000  thrpt   20     73.125 ±    1.794  ops/s
AttemptNonRaised.cats        N/A   10000  thrpt   20   3090.557 ±  238.066  ops/s
AttemptNonRaised.io          N/A   10000  thrpt   20    626.064 ±    5.049  ops/s
AttemptNonRaised.zio         N/A   10000  thrpt   20    748.352 ±   10.707  ops/s
AttemptRaisedError.cats      N/A   10000  thrpt   20   2036.185 ±   13.411  ops/s
AttemptRaisedError.io        N/A   10000  thrpt   20    629.029 ±   11.266  ops/s
AttemptRaisedError.zio       N/A   10000  thrpt   20    616.422 ±    9.316  ops/s
DeepBind.cats                 20     N/A  thrpt   20   1750.239 ±  165.814  ops/s
DeepBind.io                   20     N/A  thrpt   20   1791.493 ±  134.721  ops/s
DeepBind.zio                  20     N/A  thrpt   20    391.899 ±   19.659  ops/s
Delay.catsIO                 N/A    3000  thrpt   20  24981.435 ± 1371.385  ops/s
Delay.io                     N/A    3000  thrpt   20  13214.503 ±  778.581  ops/s
Delay.scalaZIO               N/A    3000  thrpt   20   3305.119 ±  155.681  ops/s
LeftBind.catsIO              100   10000  thrpt   20   3838.405 ±  210.121  ops/s
LeftBind.io                  100   10000  thrpt   20   4283.897 ±  279.446  ops/s
LeftBind.scalazZIO           100   10000  thrpt   20   2280.020 ±  121.585  ops/s
Map.catsBatch120             N/A     N/A  thrpt    5  17915.374 ±  687.090  ops/s
Map.catsBatch30              N/A     N/A  thrpt    5  20509.410 ±  673.148  ops/s
Map.catsOne                  N/A     N/A  thrpt    5   8736.753 ±  671.124  ops/s
Map.ioBatch120               N/A     N/A  thrpt    5  15848.771 ± 1945.080  ops/s
Map.ioBatch30                N/A     N/A  thrpt    5  14375.938 ± 1354.229  ops/s
Map.ioOne                    N/A     N/A  thrpt    5  10563.813 ± 5926.909  ops/s
Map.zioBatch120              N/A     N/A  thrpt    5   3605.432 ±   52.699  ops/s
Map.zioBatch30               N/A     N/A  thrpt    5   2202.935 ±  470.560  ops/s
Map.zioOne                   N/A     N/A  thrpt    5    184.452 ±    6.199  ops/s
MapStream.catsBatch120       N/A     N/A  thrpt    5   4605.700 ±  586.543  ops/s
MapStream.catsBatch30        N/A     N/A  thrpt    5   4456.775 ± 1400.322  ops/s
MapStream.catsOne            N/A     N/A  thrpt    5   1748.620 ±  463.137  ops/s
MapStream.io120              N/A     N/A  thrpt    5   4054.677 ±  533.705  ops/s
MapStream.io30               N/A     N/A  thrpt    5   1286.876 ±  351.703  ops/s
MapStream.ioOne              N/A     N/A  thrpt    5    770.368 ±  176.172  ops/s
MapStream.zioBatch120        N/A     N/A  thrpt    5   1945.299 ±  227.479  ops/s
MapStream.zioBatch30         N/A     N/A  thrpt    5   1805.151 ±  401.594  ops/s
MapStream.zioOne             N/A     N/A  thrpt    5    540.759 ±   53.578  ops/s
Pure.catsIO                  N/A    3000  thrpt   20  30754.960 ± 1904.993  ops/s
Pure.io                      N/A    3000  thrpt   20  18403.120 ± 1254.367  ops/s
Pure.scalazZio               N/A    3000  thrpt   20  13859.745 ± 1884.992  ops/s
```