### PR TITLE
IO incomplete `IORunLoop#step`

### DIFF
--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -415,10 +415,10 @@ internal object IORunLoop {
   }
 }
 
-object IORunLoopMissingStep : ArrowInternalException() {
+internal object IORunLoopMissingStep : ArrowInternalException() {
   override fun fillInStackTrace(): Throwable = this
 }
 
-object IORunLoopMissingLoop : ArrowInternalException() {
+internal object IORunLoopMissingLoop : ArrowInternalException() {
   override fun fillInStackTrace(): Throwable = this
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -111,7 +111,7 @@ internal object IORunLoop {
           return wrapInAsync(currentIO, bFirst, bRest) as IO<A>
         }
         null -> {
-          currentIO = IO.RaiseError(NullPointerException("Stepping on null IO"))
+          currentIO = IO.RaiseError(IORunLoopStepOnNull)
         }
         else -> {
           // Since we don't capture the value of `when` kotlin doesn't enforce exhaustiveness
@@ -269,7 +269,7 @@ internal object IORunLoop {
           }
         }
         null -> {
-          currentIO = IO.RaiseError(NullPointerException("Looping on null IO"))
+          currentIO = IO.RaiseError(IORunLoopOnNull)
         }
         else -> {
           // Since we don't capture the value of `when` kotlin doesn't enforce exhaustiveness
@@ -419,6 +419,14 @@ internal object IORunLoopMissingStep : ArrowInternalException() {
   override fun fillInStackTrace(): Throwable = this
 }
 
+internal object IORunLoopStepOnNull : ArrowInternalException() {
+  override fun fillInStackTrace(): Throwable = this
+}
+
 internal object IORunLoopMissingLoop : ArrowInternalException() {
+  override fun fillInStackTrace(): Throwable = this
+}
+
+internal object IORunLoopOnNull : ArrowInternalException() {
   override fun fillInStackTrace(): Throwable = this
 }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/Utils.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/Utils.kt
@@ -16,7 +16,7 @@ import kotlin.coroutines.CoroutineContext
 
 typealias JavaCancellationException = java.util.concurrent.CancellationException
 
-open class ArrowInternalException(
+internal open class ArrowInternalException(
   override val message: String =
     "Arrow-kt internal error. Please let us know and create a ticket at https://github.com/arrow-kt/arrow/issues/new/choose"
 ) : RuntimeException(message)

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/Utils.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/Utils.kt
@@ -16,7 +16,7 @@ import kotlin.coroutines.CoroutineContext
 
 typealias JavaCancellationException = java.util.concurrent.CancellationException
 
-class ArrowInternalException(
+open class ArrowInternalException(
   override val message: String =
     "Arrow-kt internal error. Please let us know and create a ticket at https://github.com/arrow-kt/arrow/issues/new/choose"
 ) : RuntimeException(message)

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/IOTest.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/IOTest.kt
@@ -83,6 +83,14 @@ class IOTest : UnitSpec() {
       }
     }
 
+    "should return immediate value by uncancelable" {
+      val run = IO.just(1).uncancelable().unsafeRunSync()
+
+      val expected = 1
+
+      run shouldBe expected
+    }
+
     "should time out on unending unsafeRunTimed" {
       val never = IO.async().never<Int>().fix()
       val start = System.currentTimeMillis()


### PR DESCRIPTION
Currently `IO.just(1).uncancelable().unsafeRunSync()` hangs, because `step` is a partial function. This adds the missing step.

* Is there a way to enforce exhaustiveness without capturing the value? And/or would the additional bytecode of capturing the value slow down the loop/step?