### PR TITLE
IO trampoline async

### DIFF
--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IO.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IO.kt
@@ -202,7 +202,7 @@ sealed class IO<out A> : IOOf<A> {
     override fun unsafeRunTimedTotal(limit: Duration): Option<A> = throw AssertionError("Unreachable")
   }
 
-  internal data class Async<out A>(val k: IOProc<A>) : IO<A>() {
+  internal data class Async<out A>(val shouldTrampoline: Boolean = false, val k: IOProc<A>) : IO<A>() {
     override fun unsafeRunTimedTotal(limit: Duration): Option<A> = unsafeResync(this, limit)
   }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -373,9 +373,9 @@ internal object IORunLoop {
     private var bRest: CallStack? = null
 
     private var contIndex: Int = 0
-    private inline val shouldTrampoline inline get() = contIndex == Platform.maxStackDepthSize
+    private var trampolineAfter: Boolean = false
+    private inline val shouldTrampoline inline get() = trampolineAfter || contIndex == Platform.maxStackDepthSize
 
-    // Used in combination with trampolineAfter = true
     private var value: IO<Any?>? = null
 
     fun contextSwitch(conn: IOConnection) {
@@ -391,6 +391,7 @@ internal object IORunLoop {
 
     fun start(async: IO.Async<Any?>, bFirst: BindF?, bRest: CallStack?) {
       prepare(bFirst, bRest)
+      trampolineAfter = async.shouldTrampoline
       async.k(conn, this)
     }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORunLoop.kt
@@ -6,6 +6,7 @@ import arrow.core.NonFatal
 import arrow.core.Right
 import arrow.core.nonFatalOrThrow
 import arrow.effects.internal.ArrowInternalException
+import arrow.effects.internal.Platform
 import arrow.effects.internal.Platform.ArrayStack
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -64,7 +65,7 @@ internal object IORunLoop {
             hasResult = true
             currentIO = null
           } catch (t: Throwable) {
-              currentIO = IO.RaiseError(t.nonFatalOrThrow())
+            currentIO = IO.RaiseError(t.nonFatalOrThrow())
           }
         }
         is IO.Async -> {
@@ -371,6 +372,12 @@ internal object IORunLoop {
     private var bFirst: BindF? = null
     private var bRest: CallStack? = null
 
+    private var contIndex: Int = 0
+    private inline val shouldTrampoline inline get() = contIndex == Platform.maxStackDepthSize
+
+    // Used in combination with trampolineAfter = true
+    private var value: IO<Any?>? = null
+
     fun contextSwitch(conn: IOConnection) {
       this.conn = conn
     }
@@ -379,6 +386,7 @@ internal object IORunLoop {
       canCall = true
       this.bFirst = bFirst
       this.bRest = bRest
+      contIndex++
     }
 
     fun start(async: IO.Async<Any?>, bFirst: BindF?, bRest: CallStack?) {
@@ -392,12 +400,30 @@ internal object IORunLoop {
       effect.effect.startCoroutine(this)
     }
 
+    private fun signal(result: IO<Any?>) {
+      // Allow GC to collect
+      val bFirst = this.bFirst
+      val bRest = this.bRest
+      this.bFirst = null
+      this.bRest = null
+      this._context = EmptyCoroutineContext
+
+      loop(result, conn, cb, this, bFirst, bRest)
+    }
+
     override operator fun invoke(either: Either<Throwable, Any?>) {
       if (canCall) {
         canCall = false
         when (either) {
-          is Either.Left -> loop(IO.RaiseError(either.a), conn, cb, this, bFirst, bRest)
-          is Either.Right -> loop(IO.Pure(either.b), conn, cb, this, bFirst, bRest)
+          is Either.Left -> IO.RaiseError(either.a)
+          is Either.Right -> IO.Pure(either.b)
+        }.let { r ->
+          if (shouldTrampoline) {
+            this.value = r
+            Platform.trampoline { trampoline() }
+          } else {
+            signal(r)
+          }
         }
       }
     }
@@ -406,10 +432,24 @@ internal object IORunLoop {
       if (canCall) {
         canCall = false
         result.fold(
-          { a -> loop(IO.Pure(a), conn, cb, this, bFirst, bRest) },
-          { e -> loop(IO.RaiseError(e), conn, cb, this, bFirst, bRest) }
-        )
+          { a -> IO.Pure(a) },
+          { e -> IO.RaiseError(e) }
+        ).let { r ->
+          if (shouldTrampoline) {
+            this.value = r
+            Platform.trampoline { trampoline() }
+          } else {
+            signal(r)
+          }
+        }
       }
+    }
+
+    fun trampoline() {
+      val v = value
+      value = null
+      contIndex = 0
+      signal(v!!)
     }
   }
 

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/Utils.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/internal/Utils.kt
@@ -162,9 +162,7 @@ object Platform {
       latch.tryAcquireSharedNanos(1, limit.nanoseconds)
     }
 
-    val eitherRef = ref
-
-    return when (eitherRef) {
+    return when (val eitherRef = ref) {
       null -> None
       is Either.Left -> throw eitherRef.a
       is Either.Right -> Some(eitherRef.b)
@@ -207,7 +205,7 @@ object Platform {
 
   @PublishedApi
   internal class TrampolineExecutor(val underlying: Executor) {
-    private var immediateQueue = Platform.ArrayStack<Runnable>()
+    private var immediateQueue = ArrayStack<Runnable>()
     @Volatile
     private var withinLoop = false
 
@@ -225,7 +223,7 @@ object Platform {
       else immediateQueue.push(runnable)
 
     private fun forkTheRest() {
-      class ResumeRun(val head: Runnable, val rest: Platform.ArrayStack<Runnable>) : Runnable {
+      class ResumeRun(val head: Runnable, val rest: ArrayStack<Runnable>) : Runnable {
         override fun run() {
           immediateQueue.pushAll(rest)
           immediateLoop(head)
@@ -235,7 +233,7 @@ object Platform {
       val head = immediateQueue.pop()
       if (head != null) {
         val rest = immediateQueue
-        immediateQueue = Platform.ArrayStack()
+        immediateQueue = ArrayStack()
         underlying.execute(ResumeRun(head, rest))
       }
     }


### PR DESCRIPTION
Adds trampoline capabilities to `Async`.

This can be used to build in fairness #1429 (w/o involving coroutines).