### PR TITLE
Improve racing APIs

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
@@ -482,8 +482,8 @@ object ConcurrentLaws {
       val received = ctx.raceTriple(fa, never, never).flatMap { either ->
         either.fold(
           { a, fiberB, fiberC -> fiberB.cancel().followedBy(fiberC.cancel()).map { a } },
-          { _, _ ,_ -> raiseError(AssertionError("never() finished race")) },
-          { _, _ ,_ -> raiseError(AssertionError("never() finished race")) })
+          { _, _, _ -> raiseError(AssertionError("never() finished race")) },
+          { _, _, _ -> raiseError(AssertionError("never() finished race")) })
       }
 
       received.equalUnderTheLaw(ctx.raceN(fa, never, never).map { it.fold(::identity, ::identity, ::identity) }, EQ)
@@ -496,7 +496,7 @@ object ConcurrentLaws {
         either.fold(
           { _, _, _ -> raiseError<Int>(AssertionError("never() finished race")) },
           { fiberA, b, fiberC -> fiberA.cancel().followedBy(fiberC.cancel()).map { b } },
-          { _, _ ,_ -> raiseError(AssertionError("never() finished race")) })
+          { _, _, _ -> raiseError(AssertionError("never() finished race")) })
       }
 
       received.equalUnderTheLaw(ctx.raceN(never, fa, never).map { it.fold(::identity, ::identity, ::identity) }, EQ)
@@ -557,7 +557,7 @@ object ConcurrentLaws {
       Promise<F, Int>(this@raceTripleCanJoinLeft).flatMap { p ->
         ctx.raceTriple(p.get(), just(Unit), never<Unit>()).flatMap { result ->
           result.fold(
-            { _, _ ,_ -> raiseError<Int>(AssertionError("Promise#get can never win race")) },
+            { _, _, _ -> raiseError<Int>(AssertionError("Promise#get can never win race")) },
             { fiber, _, _ -> p.complete(i).flatMap { fiber.join() } },
             { _, _, _ -> raiseError(AssertionError("never() can never win race")) }
           )

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
@@ -11,7 +11,6 @@ import arrow.effects.Promise
 import arrow.effects.Semaphore
 import arrow.effects.typeclasses.Concurrent
 import arrow.effects.typeclasses.ExitCase
-import arrow.effects.typeclasses.fold
 import arrow.test.generators.applicativeError
 import arrow.test.generators.either
 import arrow.test.generators.throwable
@@ -374,9 +373,9 @@ object ConcurrentLaws {
     forAll(Gen.int().applicativeError(this)) { fa ->
       val never = never<Int>()
       val received = ctx.racePair(fa, never).flatMap { either ->
-        either.fold({ (a, fiberB) ->
+        either.fold({ a, fiberB ->
           fiberB.cancel().map { a }
-        }, { raiseError(AssertionError("never() finished race")) })
+        }, { _, _ -> raiseError(AssertionError("never() finished race")) })
       }
 
       received.equalUnderTheLaw(ctx.raceN(fa, never).map { it.fold(::identity, ::identity) }, EQ)
@@ -386,9 +385,9 @@ object ConcurrentLaws {
     forAll(Gen.int().applicativeError(this)) { fa ->
       val never = never<Int>()
       val received = ctx.racePair(never, fa).flatMap { either ->
-        either.fold({
+        either.fold({ _, _ ->
           raiseError<Int>(AssertionError("never() finished race"))
-        }, { (fiberA, b) -> fiberA.cancel().map { b } })
+        }, { fiberA, b -> fiberA.cancel().map { b } })
       }
 
       received.equalUnderTheLaw(ctx.raceN(never, fa).map { it.fold(::identity, ::identity) }, EQ)
@@ -409,8 +408,8 @@ object ConcurrentLaws {
             attempt.fold({ p.get() },
               {
                 it.fold(
-                  { (_, fiberB) -> ctx.startFiber(fiberB.cancel()).flatMap { p.get() } },
-                  { (fiberA, _) -> ctx.startFiber(fiberA.cancel()).flatMap { p.get() } })
+                  { _, fiberB -> ctx.startFiber(fiberB.cancel()).flatMap { p.get() } },
+                  { fiberA, _ -> ctx.startFiber(fiberA.cancel()).flatMap { p.get() } })
               })
           }.bind()
       }
@@ -423,8 +422,8 @@ object ConcurrentLaws {
       Promise<F, Int>(this@racePairCanJoinLeft).flatMap { p ->
         ctx.racePair(p.get(), just(Unit)).flatMap { eith ->
           eith.fold(
-            { (unit, _) -> just(unit) },
-            { (fiber, _) -> p.complete(i).flatMap { fiber.join() } }
+            { unit, _ -> just(unit) },
+            { fiber, _ -> p.complete(i).flatMap { fiber.join() } }
           )
         }
       }.equalUnderTheLaw(just(i), EQ)
@@ -435,8 +434,8 @@ object ConcurrentLaws {
       Promise<F, Int>(this@racePairCanJoinRight).flatMap { p ->
         ctx.racePair(just(Unit), p.get()).flatMap { eith ->
           eith.fold(
-            { (_, fiber) -> p.complete(i).flatMap { fiber.join() } },
-            { (_, unit) -> just(unit) }
+            { _, fiber -> p.complete(i).flatMap { fiber.join() } },
+            { _, unit -> just(unit) }
           )
         }
       }.equalUnderTheLaw(just(i), EQ)
@@ -482,9 +481,9 @@ object ConcurrentLaws {
       val never = never<Int>()
       val received = ctx.raceTriple(fa, never, never).flatMap { either ->
         either.fold(
-          { (a, fiberB, fiberC) -> fiberB.cancel().followedBy(fiberC.cancel()).map { a } },
-          { raiseError(AssertionError("never() finished race")) },
-          { raiseError(AssertionError("never() finished race")) })
+          { a, fiberB, fiberC -> fiberB.cancel().followedBy(fiberC.cancel()).map { a } },
+          { _, _ ,_ -> raiseError(AssertionError("never() finished race")) },
+          { _, _ ,_ -> raiseError(AssertionError("never() finished race")) })
       }
 
       received.equalUnderTheLaw(ctx.raceN(fa, never, never).map { it.fold(::identity, ::identity, ::identity) }, EQ)
@@ -495,9 +494,9 @@ object ConcurrentLaws {
       val never = never<Int>()
       val received = ctx.raceTriple(never, fa, never).flatMap { either ->
         either.fold(
-          { raiseError<Int>(AssertionError("never() finished race")) },
-          { (fiberA, b, fiberC) -> fiberA.cancel().followedBy(fiberC.cancel()).map { b } },
-          { raiseError(AssertionError("never() finished race")) })
+          { _, _, _ -> raiseError<Int>(AssertionError("never() finished race")) },
+          { fiberA, b, fiberC -> fiberA.cancel().followedBy(fiberC.cancel()).map { b } },
+          { _, _ ,_ -> raiseError(AssertionError("never() finished race")) })
       }
 
       received.equalUnderTheLaw(ctx.raceN(never, fa, never).map { it.fold(::identity, ::identity, ::identity) }, EQ)
@@ -508,9 +507,9 @@ object ConcurrentLaws {
       val never = never<Int>()
       val received = ctx.raceTriple(never, never, fa).flatMap { either ->
         either.fold(
-          { raiseError<Int>(AssertionError("never() finished race")) },
-          { raiseError(AssertionError("never() finished race")) },
-          { (fiberA, fiberB, c) -> fiberA.cancel().followedBy(fiberB.cancel()).map { c } })
+          { _, _, _ -> raiseError<Int>(AssertionError("never() finished race")) },
+          { _, _, _ -> raiseError(AssertionError("never() finished race")) },
+          { fiberA, fiberB, c -> fiberA.cancel().followedBy(fiberB.cancel()).map { c } })
       }
 
       received.equalUnderTheLaw(ctx.raceN(never, never, fa).map { it.fold(::identity, ::identity, ::identity) }, EQ)
@@ -540,11 +539,11 @@ object ConcurrentLaws {
             attempt.fold({ combinePromises },
               {
                 it.fold(
-                  { (_, fiberB, fiberC) ->
+                  { _, fiberB, fiberC ->
                     ctx.startFiber(fiberB.cancel().followedBy(fiberC.cancel())).flatMap { combinePromises } },
-                  { (fiberA, _, fiberC) ->
+                  { fiberA, _, fiberC ->
                     ctx.startFiber(fiberA.cancel().followedBy(fiberC.cancel())).flatMap { combinePromises } },
-                  { (fiberA, fiberB, _) ->
+                  { fiberA, fiberB, _ ->
                     ctx.startFiber(fiberA.cancel().followedBy(fiberB.cancel())).flatMap { combinePromises } })
               })
           }.bind()
@@ -558,9 +557,9 @@ object ConcurrentLaws {
       Promise<F, Int>(this@raceTripleCanJoinLeft).flatMap { p ->
         ctx.raceTriple(p.get(), just(Unit), never<Unit>()).flatMap { result ->
           result.fold(
-            { raiseError<Int>(AssertionError("Promise#get can never win race")) },
-            { (fiber, _, _) -> p.complete(i).flatMap { fiber.join() } },
-            { raiseError(AssertionError("never() can never win race")) }
+            { _, _ ,_ -> raiseError<Int>(AssertionError("Promise#get can never win race")) },
+            { fiber, _, _ -> p.complete(i).flatMap { fiber.join() } },
+            { _, _, _ -> raiseError(AssertionError("never() can never win race")) }
           )
         }
       }.equalUnderTheLaw(just(i), EQ)
@@ -571,9 +570,9 @@ object ConcurrentLaws {
       Promise<F, Int>(this@raceTripleCanJoinMiddle).flatMap { p ->
         ctx.raceTriple(just(Unit), p.get(), never<Unit>()).flatMap { result ->
           result.fold(
-            { (_, fiber, _) -> p.complete(i).flatMap { fiber.join() } },
-            { raiseError(AssertionError("Promise#get can never win race")) },
-            { raiseError(AssertionError("never() can never win race")) }
+            { _, fiber, _ -> p.complete(i).flatMap { fiber.join() } },
+            { _, _, _ -> raiseError(AssertionError("Promise#get can never win race")) },
+            { _, _, _ -> raiseError(AssertionError("never() can never win race")) }
           )
         }
       }.equalUnderTheLaw(just(i), EQ)
@@ -584,9 +583,9 @@ object ConcurrentLaws {
       Promise<F, Int>(this@raceTripleCanJoinRight).flatMap { p ->
         ctx.raceTriple(just(Unit), never<Unit>(), p.get()).flatMap { result ->
           result.fold(
-            { (_, _, fiber) -> p.complete(i).flatMap { fiber.join() } },
-            { raiseError(AssertionError("never() can never win race")) },
-            { raiseError(AssertionError("Promise#get can never win race")) }
+            { _, _, fiber -> p.complete(i).flatMap { fiber.join() } },
+            { _, _, _ -> raiseError(AssertionError("never() can never win race")) },
+            { _, _, _ -> raiseError(AssertionError("Promise#get can never win race")) }
           )
         }
       }.equalUnderTheLaw(just(i), EQ)

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORacePair.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORacePair.kt
@@ -30,8 +30,8 @@ import kotlin.coroutines.CoroutineContext
  *     val promise = Promise.uncancelable<ForIO, Int>(IO.async()).bind()
  *     val eitherGetOrUnit = Dispatchers.Default.racePair(promise.get(), IO.unit).bind()
  *     eitherGetOrUnit.fold(
- *       { IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
- *       { (a: Fiber<ForIO, Int>, _) -> promise.complete(1).flatMap { a.join() } }
+ *       { _, _ -> IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
+ *       { a: Fiber<ForIO, Int>, _ -> promise.complete(1).flatMap { a.join() } }
  *     ).bind()
  *   }.unsafeRunSync() == 1
  *   //sampleEnd

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORaceTriple.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORaceTriple.kt
@@ -3,13 +3,11 @@ package arrow.effects
 import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
-import arrow.core.Tuple3
 import arrow.effects.internal.IOFiber
 import arrow.effects.internal.IOForkedStart
 import arrow.effects.internal.Platform
 import arrow.effects.internal.UnsafePromise
 import arrow.effects.typeclasses.Fiber
-import arrow.effects.typeclasses.RaceTriple
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 
@@ -88,7 +86,7 @@ fun <A, B, C> IO.Companion.raceTriple(ctx: CoroutineContext, ioA: IOOf<A>, ioB: 
       }, { a ->
         if (active.getAndSet(false)) {
           conn.pop()
-          cb(Right(Left(Tuple3(a, IOFiber(promiseB, connB), IOFiber(promiseC, connC)))))
+          cb(Right(RaceTriple.First(a, IOFiber(promiseB, connB), IOFiber(promiseC, connC))))
         } else {
           promiseA.complete(Right(a))
         }
@@ -115,7 +113,7 @@ fun <A, B, C> IO.Companion.raceTriple(ctx: CoroutineContext, ioA: IOOf<A>, ioB: 
       }, { b ->
         if (active.getAndSet(false)) {
           conn.pop()
-          cb(Right(Right(Left(Tuple3(IOFiber(promiseA, connA), b, IOFiber(promiseC, connC))))))
+          cb(Right(RaceTriple.Second(IOFiber(promiseA, connA), b, IOFiber(promiseC, connC))))
         } else {
           promiseB.complete(Right(b))
         }
@@ -142,7 +140,7 @@ fun <A, B, C> IO.Companion.raceTriple(ctx: CoroutineContext, ioA: IOOf<A>, ioB: 
       }, { c ->
         if (active.getAndSet(false)) {
           conn.pop()
-          cb(Right(Right(Right(Tuple3(IOFiber(promiseA, connA), IOFiber(promiseB, connB), c)))))
+          cb(Right(RaceTriple.Third(IOFiber(promiseA, connA), IOFiber(promiseB, connB), c)))
         } else {
           promiseC.complete(Right(c))
         }

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORaceTriple.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/IORaceTriple.kt
@@ -29,9 +29,9 @@ import kotlin.coroutines.CoroutineContext
  *     val promise = Promise.uncancelable<ForIO, Int>(IO.async()).bind()
  *     val raceTriple = IO.raceTriple(Dispatchers.Default, promise.get(), IO.unit, IO.never).bind()
  *     raceTriple.fold(
- *       { IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
- *       { (a: Fiber<ForIO, Int>, _, _) -> promise.complete(1).flatMap { a.join() } },
- *       { IO.raiseError<Int>(RuntimeException("never cannot win before complete")) }
+ *       { _, _, _ -> IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
+ *       { a: Fiber<ForIO, Int>, _, _ -> promise.complete(1).flatMap { a.join() } },
+ *       { _, _, _ -> IO.raiseError<Int>(RuntimeException("never cannot win before complete")) }
  *     ).bind()
  *   }.unsafeRunSync() == 1
  *   //sampleEnd

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/RaceModels.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/RaceModels.kt
@@ -1,0 +1,202 @@
+package arrow.effects
+
+import arrow.core.Either
+import arrow.core.Tuple2
+import arrow.effects.typeclasses.Fiber
+
+/** Alias for `Either` structure to provide consistent signature for race methods. */
+typealias RacePair<F, A, B> = Either<Tuple2<A, Fiber<F, B>>, Tuple2<Fiber<F, A>, B>>
+
+sealed class RaceTriple<F, A, B, C> {
+  data class First<F, A, B, C>(val winner: A, val fiberB: Fiber<F, B>, val fiberC: Fiber<F, C>): RaceTriple<F, A, B, C>()
+  data class Second<F, A, B, C>(val fiberA: Fiber<F, A>, val winner: B, val fiberC: Fiber<F, C>): RaceTriple<F, A, B, C>()
+  data class Third<F, A, B, C>(val fiberB: Fiber<F, B>, val fiberA: Fiber<F, A>, val winner: C): RaceTriple<F, A, B, C>()
+
+  fun <D> fold(
+    ifA: (A, Fiber<F, B>, Fiber<F, C>) -> D,
+    ifB: (Fiber<F, A>, B, Fiber<F, C>) -> D,
+    ifC: (Fiber<F, A>, Fiber<F, B>, C) -> D
+  ): D = when(this) {
+    is First -> ifA(winner, fiberB, fiberC)
+    is Second -> ifB(fiberA, winner, fiberC)
+    is Third -> ifC(fiberA, fiberB, winner)
+  }
+}
+
+/** Alias for `Either` structure to provide consistent signature for race methods. */
+typealias Race2<A, B> = Either<A, B>
+
+sealed class Race3 <A, B, C> {
+  data class First<A>(val winner: A): Race3<A, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race3<Nothing, B, Nothing>()
+  data class Third<C>(val winner: C): Race3<Nothing, Nothing, C>()
+
+  fun <D> fold(
+    ifA: (A) -> D,
+    ifB: (B) -> D,
+    ifC: (C) -> D
+  ): D = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+  }
+}
+
+sealed class Race4 <A, B, C, D> {
+  data class First<A>(val winner: A): Race4<A, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race4<Nothing, B, Nothing, Nothing>()
+  data class Third<C>(val winner: C): Race4<Nothing, Nothing, C, Nothing>()
+  data class Fourth<D>(val winner: D): Race4<Nothing, Nothing, Nothing, D>()
+
+  fun <E> fold(
+    ifA: (A) -> E,
+    ifB: (B) -> E,
+    ifC: (C) -> E,
+    ifD: (D) -> E
+  ): E = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+    is Fourth -> ifD(winner)
+  }
+}
+
+sealed class Race5 <A, B, C, D, E> {
+  data class First<A>(val winner: A): Race5<A, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race5<Nothing, B, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C): Race5<Nothing, Nothing, C, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D): Race5<Nothing, Nothing, Nothing, D, Nothing>()
+  data class Fifth<E>(val winner: E): Race5<Nothing, Nothing, Nothing, Nothing, E>()
+
+  fun <F> fold(
+    ifA: (A) -> F,
+    ifB: (B) -> F,
+    ifC: (C) -> F,
+    ifD: (D) -> F,
+    ifE: (E) -> F
+  ): F = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+    is Fourth -> ifD(winner)
+    is Fifth -> ifE(winner)
+  }
+}
+
+sealed class Race6 <A, B, C, D, E, F> {
+  data class First<A>(val winner: A): Race6<A, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race6<Nothing, B, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C): Race6<Nothing, Nothing, C, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D): Race6<Nothing, Nothing, Nothing, D, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E): Race6<Nothing, Nothing, Nothing, Nothing, E, Nothing>()
+  data class Sixth<F>(val winner: F): Race6<Nothing, Nothing, Nothing, Nothing, Nothing, F>()
+
+  fun <G> fold(
+    ifA: (A) -> G,
+    ifB: (B) -> G,
+    ifC: (C) -> G,
+    ifD: (D) -> G,
+    ifE: (E) -> G,
+    ifF: (F) -> G
+  ): G = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+    is Fourth -> ifD(winner)
+    is Fifth -> ifE(winner)
+    is Sixth -> ifF(winner)
+  }
+}
+
+sealed class Race7 <A, B, C, D, E, F, G> {
+  data class First<A>(val winner: A): Race7<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race7<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C): Race7<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D): Race7<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E): Race7<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing>()
+  data class Sixth<F>(val winner: F): Race7<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing>()
+  data class Seventh<G>(val winner: G): Race7<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G>()
+
+  fun <H> fold(
+    ifA: (A) -> H,
+    ifB: (B) -> H,
+    ifC: (C) -> H,
+    ifD: (D) -> H,
+    ifE: (E) -> H,
+    ifF: (F) -> H,
+    ifG: (G) -> H
+  ): H = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+    is Fourth -> ifD(winner)
+    is Fifth -> ifE(winner)
+    is Sixth -> ifF(winner)
+    is Seventh -> ifG(winner)
+  }
+}
+
+sealed class Race8 <A, B, C, D, E, F, G, H> {
+  data class First<A>(val winner: A): Race8<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race8<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C): Race8<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D): Race8<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E): Race8<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing, Nothing>()
+  data class Sixth<F>(val winner: F): Race8<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing, Nothing>()
+  data class Seventh<G>(val winner: G): Race8<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G, Nothing>()
+  data class Eighth<H>(val winner: H): Race8<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, H>()
+
+  fun <I> fold(
+    ifA: (A) -> I,
+    ifB: (B) -> I,
+    ifC: (C) -> I,
+    ifD: (D) -> I,
+    ifE: (E) -> I,
+    ifF: (F) -> I,
+    ifG: (G) -> I,
+    ifH: (H) -> I
+  ): I = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+    is Fourth -> ifD(winner)
+    is Fifth -> ifE(winner)
+    is Sixth -> ifF(winner)
+    is Seventh -> ifG(winner)
+    is Eighth -> ifH(winner)
+  }
+}
+
+sealed class Race9 <A, B, C, D, E, F, G, H, I> {
+  data class First<A>(val winner: A): Race9<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B): Race9<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C): Race9<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D): Race9<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E): Race9<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing, Nothing, Nothing>()
+  data class Sixth<F>(val winner: F): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing, Nothing, Nothing>()
+  data class Seventh<G>(val winner: G): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G, Nothing, Nothing>()
+  data class Eighth<H>(val winner: H): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, H, Nothing>()
+  data class Ninth<I>(val winner: I): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, I>()
+
+  fun <J> fold(
+    ifA: (A) -> J,
+    ifB: (B) -> J,
+    ifC: (C) -> J,
+    ifD: (D) -> J,
+    ifE: (E) -> J,
+    ifF: (F) -> J,
+    ifG: (G) -> J,
+    ifH: (H) -> J,
+    ifI: (I) -> J
+  ): J = when(this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+    is Fourth -> ifD(winner)
+    is Fifth -> ifE(winner)
+    is Sixth -> ifF(winner)
+    is Seventh -> ifG(winner)
+    is Eighth -> ifH(winner)
+    is Ninth -> ifI(winner)
+  }
+}

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/RaceModels.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/RaceModels.kt
@@ -1,22 +1,32 @@
 package arrow.effects
 
 import arrow.core.Either
-import arrow.core.Tuple2
 import arrow.effects.typeclasses.Fiber
 
 /** Alias for `Either` structure to provide consistent signature for race methods. */
-typealias RacePair<F, A, B> = Either<Tuple2<A, Fiber<F, B>>, Tuple2<Fiber<F, A>, B>>
+sealed class RacePair<F, A, B> {
+  data class First<F, A, B>(val winner: A, val fiberB: Fiber<F, B>) : RacePair<F, A, B>()
+  data class Second<F, A, B>(val fiberA: Fiber<F, A>, val winner: B) : RacePair<F, A, B>()
+
+  fun <C> fold(
+    ifA: (A, Fiber<F, B>) -> C,
+    ifB: (Fiber<F, A>, B) -> C
+  ): C = when (this) {
+    is First -> ifA(winner, fiberB)
+    is Second -> ifB(fiberA, winner)
+  }
+}
 
 sealed class RaceTriple<F, A, B, C> {
-  data class First<F, A, B, C>(val winner: A, val fiberB: Fiber<F, B>, val fiberC: Fiber<F, C>): RaceTriple<F, A, B, C>()
-  data class Second<F, A, B, C>(val fiberA: Fiber<F, A>, val winner: B, val fiberC: Fiber<F, C>): RaceTriple<F, A, B, C>()
-  data class Third<F, A, B, C>(val fiberB: Fiber<F, B>, val fiberA: Fiber<F, A>, val winner: C): RaceTriple<F, A, B, C>()
+  data class First<F, A, B, C>(val winner: A, val fiberB: Fiber<F, B>, val fiberC: Fiber<F, C>) : RaceTriple<F, A, B, C>()
+  data class Second<F, A, B, C>(val fiberA: Fiber<F, A>, val winner: B, val fiberC: Fiber<F, C>) : RaceTriple<F, A, B, C>()
+  data class Third<F, A, B, C>(val fiberA: Fiber<F, A>, val fiberB: Fiber<F, B>, val winner: C) : RaceTriple<F, A, B, C>()
 
   fun <D> fold(
     ifA: (A, Fiber<F, B>, Fiber<F, C>) -> D,
     ifB: (Fiber<F, A>, B, Fiber<F, C>) -> D,
     ifC: (Fiber<F, A>, Fiber<F, B>, C) -> D
-  ): D = when(this) {
+  ): D = when (this) {
     is First -> ifA(winner, fiberB, fiberC)
     is Second -> ifB(fiberA, winner, fiberC)
     is Third -> ifC(fiberA, fiberB, winner)
@@ -27,15 +37,15 @@ sealed class RaceTriple<F, A, B, C> {
 typealias Race2<A, B> = Either<A, B>
 
 sealed class Race3 <A, B, C> {
-  data class First<A>(val winner: A): Race3<A, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race3<Nothing, B, Nothing>()
-  data class Third<C>(val winner: C): Race3<Nothing, Nothing, C>()
+  data class First<A>(val winner: A) : Race3<A, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race3<Nothing, B, Nothing>()
+  data class Third<C>(val winner: C) : Race3<Nothing, Nothing, C>()
 
   fun <D> fold(
     ifA: (A) -> D,
     ifB: (B) -> D,
     ifC: (C) -> D
-  ): D = when(this) {
+  ): D = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)
@@ -43,17 +53,17 @@ sealed class Race3 <A, B, C> {
 }
 
 sealed class Race4 <A, B, C, D> {
-  data class First<A>(val winner: A): Race4<A, Nothing, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race4<Nothing, B, Nothing, Nothing>()
-  data class Third<C>(val winner: C): Race4<Nothing, Nothing, C, Nothing>()
-  data class Fourth<D>(val winner: D): Race4<Nothing, Nothing, Nothing, D>()
+  data class First<A>(val winner: A) : Race4<A, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race4<Nothing, B, Nothing, Nothing>()
+  data class Third<C>(val winner: C) : Race4<Nothing, Nothing, C, Nothing>()
+  data class Fourth<D>(val winner: D) : Race4<Nothing, Nothing, Nothing, D>()
 
   fun <E> fold(
     ifA: (A) -> E,
     ifB: (B) -> E,
     ifC: (C) -> E,
     ifD: (D) -> E
-  ): E = when(this) {
+  ): E = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)
@@ -62,11 +72,11 @@ sealed class Race4 <A, B, C, D> {
 }
 
 sealed class Race5 <A, B, C, D, E> {
-  data class First<A>(val winner: A): Race5<A, Nothing, Nothing, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race5<Nothing, B, Nothing, Nothing, Nothing>()
-  data class Third<C>(val winner: C): Race5<Nothing, Nothing, C, Nothing, Nothing>()
-  data class Fourth<D>(val winner: D): Race5<Nothing, Nothing, Nothing, D, Nothing>()
-  data class Fifth<E>(val winner: E): Race5<Nothing, Nothing, Nothing, Nothing, E>()
+  data class First<A>(val winner: A) : Race5<A, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race5<Nothing, B, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C) : Race5<Nothing, Nothing, C, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D) : Race5<Nothing, Nothing, Nothing, D, Nothing>()
+  data class Fifth<E>(val winner: E) : Race5<Nothing, Nothing, Nothing, Nothing, E>()
 
   fun <F> fold(
     ifA: (A) -> F,
@@ -74,7 +84,7 @@ sealed class Race5 <A, B, C, D, E> {
     ifC: (C) -> F,
     ifD: (D) -> F,
     ifE: (E) -> F
-  ): F = when(this) {
+  ): F = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)
@@ -84,12 +94,12 @@ sealed class Race5 <A, B, C, D, E> {
 }
 
 sealed class Race6 <A, B, C, D, E, F> {
-  data class First<A>(val winner: A): Race6<A, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race6<Nothing, B, Nothing, Nothing, Nothing, Nothing>()
-  data class Third<C>(val winner: C): Race6<Nothing, Nothing, C, Nothing, Nothing, Nothing>()
-  data class Fourth<D>(val winner: D): Race6<Nothing, Nothing, Nothing, D, Nothing, Nothing>()
-  data class Fifth<E>(val winner: E): Race6<Nothing, Nothing, Nothing, Nothing, E, Nothing>()
-  data class Sixth<F>(val winner: F): Race6<Nothing, Nothing, Nothing, Nothing, Nothing, F>()
+  data class First<A>(val winner: A) : Race6<A, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race6<Nothing, B, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C) : Race6<Nothing, Nothing, C, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D) : Race6<Nothing, Nothing, Nothing, D, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E) : Race6<Nothing, Nothing, Nothing, Nothing, E, Nothing>()
+  data class Sixth<F>(val winner: F) : Race6<Nothing, Nothing, Nothing, Nothing, Nothing, F>()
 
   fun <G> fold(
     ifA: (A) -> G,
@@ -98,7 +108,7 @@ sealed class Race6 <A, B, C, D, E, F> {
     ifD: (D) -> G,
     ifE: (E) -> G,
     ifF: (F) -> G
-  ): G = when(this) {
+  ): G = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)
@@ -109,13 +119,13 @@ sealed class Race6 <A, B, C, D, E, F> {
 }
 
 sealed class Race7 <A, B, C, D, E, F, G> {
-  data class First<A>(val winner: A): Race7<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race7<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Third<C>(val winner: C): Race7<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing>()
-  data class Fourth<D>(val winner: D): Race7<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing>()
-  data class Fifth<E>(val winner: E): Race7<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing>()
-  data class Sixth<F>(val winner: F): Race7<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing>()
-  data class Seventh<G>(val winner: G): Race7<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G>()
+  data class First<A>(val winner: A) : Race7<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race7<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C) : Race7<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D) : Race7<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E) : Race7<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing>()
+  data class Sixth<F>(val winner: F) : Race7<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing>()
+  data class Seventh<G>(val winner: G) : Race7<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G>()
 
   fun <H> fold(
     ifA: (A) -> H,
@@ -125,7 +135,7 @@ sealed class Race7 <A, B, C, D, E, F, G> {
     ifE: (E) -> H,
     ifF: (F) -> H,
     ifG: (G) -> H
-  ): H = when(this) {
+  ): H = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)
@@ -137,14 +147,14 @@ sealed class Race7 <A, B, C, D, E, F, G> {
 }
 
 sealed class Race8 <A, B, C, D, E, F, G, H> {
-  data class First<A>(val winner: A): Race8<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race8<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Third<C>(val winner: C): Race8<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Fourth<D>(val winner: D): Race8<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing, Nothing>()
-  data class Fifth<E>(val winner: E): Race8<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing, Nothing>()
-  data class Sixth<F>(val winner: F): Race8<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing, Nothing>()
-  data class Seventh<G>(val winner: G): Race8<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G, Nothing>()
-  data class Eighth<H>(val winner: H): Race8<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, H>()
+  data class First<A>(val winner: A) : Race8<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race8<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C) : Race8<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D) : Race8<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E) : Race8<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing, Nothing>()
+  data class Sixth<F>(val winner: F) : Race8<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing, Nothing>()
+  data class Seventh<G>(val winner: G) : Race8<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G, Nothing>()
+  data class Eighth<H>(val winner: H) : Race8<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, H>()
 
   fun <I> fold(
     ifA: (A) -> I,
@@ -155,7 +165,7 @@ sealed class Race8 <A, B, C, D, E, F, G, H> {
     ifF: (F) -> I,
     ifG: (G) -> I,
     ifH: (H) -> I
-  ): I = when(this) {
+  ): I = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)
@@ -168,15 +178,15 @@ sealed class Race8 <A, B, C, D, E, F, G, H> {
 }
 
 sealed class Race9 <A, B, C, D, E, F, G, H, I> {
-  data class First<A>(val winner: A): Race9<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Second<B>(val winner: B): Race9<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Third<C>(val winner: C): Race9<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Fourth<D>(val winner: D): Race9<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing, Nothing, Nothing>()
-  data class Fifth<E>(val winner: E): Race9<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing, Nothing, Nothing>()
-  data class Sixth<F>(val winner: F): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing, Nothing, Nothing>()
-  data class Seventh<G>(val winner: G): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G, Nothing, Nothing>()
-  data class Eighth<H>(val winner: H): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, H, Nothing>()
-  data class Ninth<I>(val winner: I): Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, I>()
+  data class First<A>(val winner: A) : Race9<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race9<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Third<C>(val winner: C) : Race9<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Fourth<D>(val winner: D) : Race9<Nothing, Nothing, Nothing, D, Nothing, Nothing, Nothing, Nothing, Nothing>()
+  data class Fifth<E>(val winner: E) : Race9<Nothing, Nothing, Nothing, Nothing, E, Nothing, Nothing, Nothing, Nothing>()
+  data class Sixth<F>(val winner: F) : Race9<Nothing, Nothing, Nothing, Nothing, Nothing, F, Nothing, Nothing, Nothing>()
+  data class Seventh<G>(val winner: G) : Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, G, Nothing, Nothing>()
+  data class Eighth<H>(val winner: H) : Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, H, Nothing>()
+  data class Ninth<I>(val winner: I) : Race9<Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, I>()
 
   fun <J> fold(
     ifA: (A) -> J,
@@ -188,7 +198,7 @@ sealed class Race9 <A, B, C, D, E, F, G, H, I> {
     ifG: (G) -> J,
     ifH: (H) -> J,
     ifI: (I) -> J
-  ): J = when(this) {
+  ): J = when (this) {
     is First -> ifA(winner)
     is Second -> ifB(winner)
     is Third -> ifC(winner)

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
@@ -195,7 +195,7 @@ interface Concurrent<F> : Async<F> {
    *     val promise = Promise.uncancelable<ForIO, Int>(IO.async()).bind()
    *     val racePair = IO.racePair(Dispatchers.Default, promise.get(), IO.unit).bind()
    *     racePair.fold(
-   *       { IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
+   *       { _, _ -> IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
    *       { a: Fiber<ForIO, Int>, _ -> promise.complete(1).flatMap { a.join() } }
    *     ).bind()
    *   }.unsafeRunSync() == 1
@@ -231,9 +231,9 @@ interface Concurrent<F> : Async<F> {
    *     val promise = Promise.uncancelable<ForIO, Int>(IO.async()).bind()
    *     val raceTriple = IO.raceTriple(Dispatchers.Default, promise.get(), IO.unit, IO.never).bind()
    *     raceTriple.fold(
-   *       { IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
+   *       { _, _, _ -> IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
    *       { a: Fiber<ForIO, Int>, _, _ -> promise.complete(1).flatMap { a.join() } },
-   *       { IO.raiseError<Int>(RuntimeException("never cannot win before complete")) }
+   *       { _, _, _ -> IO.raiseError<Int>(RuntimeException("never cannot win before complete")) }
    *     ).bind()
    *   }.unsafeRunSync() == 1
    *   //sampleEnd

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/Concurrent.kt
@@ -6,12 +6,20 @@ import arrow.core.Left
 import arrow.core.Right
 import arrow.core.Tuple2
 import arrow.core.Tuple3
-import arrow.core.left
-import arrow.core.right
 import arrow.core.toT
 import arrow.effects.CancelToken
 import arrow.effects.KindConnection
 import arrow.effects.MVar
+import arrow.effects.Race2
+import arrow.effects.Race3
+import arrow.effects.Race4
+import arrow.effects.Race5
+import arrow.effects.Race6
+import arrow.effects.Race7
+import arrow.effects.Race8
+import arrow.effects.Race9
+import arrow.effects.RacePair
+import arrow.effects.RaceTriple
 import arrow.effects.data.internal.BindingCancellationException
 import arrow.effects.internal.ConcurrentSleep
 import arrow.effects.internal.TimeoutException
@@ -224,7 +232,7 @@ interface Concurrent<F> : Async<F> {
    *     val raceTriple = IO.raceTriple(Dispatchers.Default, promise.get(), IO.unit, IO.never).bind()
    *     raceTriple.fold(
    *       { IO.raiseError<Int>(RuntimeException("Promise.get cannot win before complete")) },
-   *       { (a: Fiber<ForIO, Int>, _, _) -> promise.complete(1).flatMap { a.join() } },
+   *       { a: Fiber<ForIO, Int>, _, _ -> promise.complete(1).flatMap { a.join() } },
    *       { IO.raiseError<Int>(RuntimeException("never cannot win before complete")) }
    *     ).bind()
    *   }.unsafeRunSync() == 1
@@ -409,9 +417,9 @@ interface Concurrent<F> : Async<F> {
   fun <A, B, C, D> CoroutineContext.parMapN(fa: Kind<F, A>, fb: Kind<F, B>, fc: Kind<F, C>, f: (A, B, C) -> D): Kind<F, D> =
     raceTriple(fa, fb, fc).flatMap {
       it.fold(
-        { (a, fiberB, fiberC) -> fiberB.join().flatMap { b -> fiberC.join().map { c -> f(a, b, c) } } },
-        { (fiberA, b, fiberC) -> fiberA.join().flatMap { a -> fiberC.join().map { c -> f(a, b, c) } } },
-        { (fiberA, fiberB, c) -> fiberA.join().flatMap { a -> fiberB.join().map { b -> f(a, b, c) } } }
+        { a, fiberB, fiberC -> fiberB.join().flatMap { b -> fiberC.join().map { c -> f(a, b, c) } } },
+        { fiberA, b, fiberC -> fiberA.join().flatMap { a -> fiberC.join().map { c -> f(a, b, c) } } },
+        { fiberA, fiberB, c -> fiberA.join().flatMap { a -> fiberB.join().map { b -> f(a, b, c) } } }
       )
     }
 
@@ -425,7 +433,8 @@ interface Concurrent<F> : Async<F> {
     fd: Kind<F, D>,
     f: (A, B, C, D) -> E
   ): Kind<F, E> =
-    parMapN(parMapN(fa, fb, ::Tuple2),
+    parMapN(
+      parMapN(fa, fb, ::Tuple2),
       parMapN(fc, fd, ::Tuple2)
     ) { (a, b), (c, d) ->
       f(a, b, c, d)
@@ -564,9 +573,9 @@ interface Concurrent<F> : Async<F> {
   ): Kind<F, Race2<A, B>> =
     racePair(fa, fb).flatMap {
       it.fold({ (a, b) ->
-        b.cancel().map { a.left() }
+        b.cancel().map { Left(a) }
       }, { (a, b) ->
-        a.cancel().map { b.right() }
+        a.cancel().map { Right(b) }
       })
     }
 
@@ -577,12 +586,12 @@ interface Concurrent<F> : Async<F> {
     fa: Kind<F, A>,
     fb: Kind<F, B>,
     fc: Kind<F, C>
-  ): Kind<F, Race3<A, B, C>> =
+  ): Kind<F, Race3<out A, out B, out C>> =
     raceTriple(fa, fb, fc).flatMap {
       it.fold(
-        { (a, fiberB, fiberC) -> fiberB.cancel().flatMap { fiberC.cancel().map { Left(Left(a)) } } },
-        { (fiberA, b, fiberC) -> fiberA.cancel().flatMap { fiberC.cancel().map { Left(Right(b)) } } },
-        { (fiberA, fiberB, c) -> fiberA.cancel().flatMap { fiberB.cancel().map { Right(c) } } }
+        { a, fiberB, fiberC -> fiberB.cancel().flatMap { fiberC.cancel().map { Race3.First(a) } } },
+        { fiberA, b, fiberC -> fiberA.cancel().flatMap { fiberC.cancel().map { Race3.Second(b) } } },
+        { fiberA, fiberB, c -> fiberA.cancel().flatMap { fiberB.cancel().map { Race3.Third(c) } } }
       )
     }
 
@@ -594,10 +603,16 @@ interface Concurrent<F> : Async<F> {
     b: Kind<F, B>,
     c: Kind<F, C>,
     d: Kind<F, D>
-  ): Kind<F, Race4<A, B, C, D>> =
-    raceN(raceN(a, b),
+  ): Kind<F, Race4<out A, out B, out C, out D>> =
+    raceN(
+      raceN(a, b),
       raceN(c, d)
-    )
+    ).map { res ->
+      res.fold(
+        { it.fold({ a -> Race4.First(a) }, { b -> Race4.Second(b) }) },
+        { it.fold({ c -> Race4.Third(c) }, { d -> Race4.Fourth(d) }) }
+      )
+    }
 
   /**
    * @see raceN
@@ -608,10 +623,17 @@ interface Concurrent<F> : Async<F> {
     c: Kind<F, C>,
     d: Kind<F, D>,
     e: Kind<F, E>
-  ): Kind<F, Race5<A, B, C, D, E>> =
-    raceN(raceN(a, b, c),
+  ): Kind<F, Race5<out A, out B, out C, out D, out E>> =
+    raceN(
+      raceN(a, b, c),
       raceN(d, e)
-    )
+    ).map { res ->
+      res.fold({
+        it.fold({ a -> Race5.First(a) }, { b -> Race5.Second(b) }, { c -> Race5.Third(c) })
+      }, {
+        it.fold({ d -> Race5.Fourth(d) }, { e -> Race5.Fifth(e) })
+      })
+    }
 
   /**
    * @see raceN
@@ -623,10 +645,17 @@ interface Concurrent<F> : Async<F> {
     d: Kind<F, D>,
     e: Kind<F, E>,
     g: Kind<F, G>
-  ): Kind<F, Race6<A, B, C, D, E, G>> =
-    raceN(raceN(a, b, c),
+  ): Kind<F, Race6<out A, out B, out C, out D, out E, out G>> =
+    raceN(
+      raceN(a, b, c),
       raceN(d, e, g)
-    )
+    ).map { res ->
+      res.fold({
+        it.fold({ a -> Race6.First(a) }, { b -> Race6.Second(b) }, { c -> Race6.Third(c) })
+      }, {
+        it.fold({ d -> Race6.Fourth(d) }, { e -> Race6.Fifth(e) }, { g -> Race6.Sixth(g) })
+      })
+    }
 
   /**
    * @see raceN
@@ -639,11 +668,20 @@ interface Concurrent<F> : Async<F> {
     e: Kind<F, E>,
     g: Kind<F, G>,
     h: Kind<F, H>
-  ): Kind<F, Race7<A, B, C, D, E, G, H>> =
-    raceN(raceN(a, b, c),
+  ): Kind<F, Race7<out A, out B, out C, out D, out E, out G, out H>> =
+    raceN(
+      raceN(a, b, c),
       raceN(d, e),
       raceN(g, h)
-    )
+    ).map { res ->
+      res.fold({
+        it.fold({ a -> Race7.First(a) }, { b -> Race7.Second(b) }, { c -> Race7.Third(c) })
+      }, {
+        it.fold({ d -> Race7.Fourth(d) }, { e -> Race7.Fifth(e) })
+      }, {
+        it.fold({ g -> Race7.Sixth(g) }, { h -> Race7.Seventh(h) })
+      })
+    }
 
   /**
    * @see raceN
@@ -657,12 +695,23 @@ interface Concurrent<F> : Async<F> {
     g: Kind<F, G>,
     h: Kind<F, H>,
     i: Kind<F, I>
-  ): Kind<F, Race8<A, B, C, D, E, G, H, I>> =
-    raceN(raceN(a, b),
+  ): Kind<F, Race8<out A, out B, out C, out D, out E, out G, out H, out I>> =
+    raceN(
+      raceN(a, b),
       raceN(c, d),
       raceN(e, g),
       raceN(h, i)
-    )
+    ).map { res ->
+      res.fold({
+        it.fold({ a -> Race8.First(a) }, { b -> Race8.Second(b) })
+      }, {
+        it.fold({ c -> Race8.Third(c) }, { d -> Race8.Fourth(d) })
+      }, {
+        it.fold({ e -> Race8.Fifth(e) }, { g -> Race8.Sixth(g) })
+      }, {
+        it.fold({ h -> Race8.Seventh(h) }, { i -> Race8.Eighth(i) })
+      })
+    }
 
   /**
    * @see raceN
@@ -677,12 +726,23 @@ interface Concurrent<F> : Async<F> {
     h: Kind<F, H>,
     i: Kind<F, I>,
     j: Kind<F, J>
-  ): Kind<F, Race9<A, B, C, D, E, G, H, I, J>> =
-    raceN(raceN(a, b, c),
+  ): Kind<F, Race9<out A, out B, out C, out D, out E, out G, out H, out I, out J>> =
+    raceN(
+      raceN(a, b, c),
       raceN(d, e),
       raceN(g, h),
       raceN(i, j)
-    )
+    ).map { res ->
+      res.fold({
+        it.fold({ a -> Race9.First(a) }, { b -> Race9.Second(b) }, { c -> Race9.Third(c) })
+      }, {
+        it.fold({ d -> Race9.Fourth(d) }, { e -> Race9.Fifth(e) })
+      }, {
+        it.fold({ g -> Race9.Sixth(g) }, { h -> Race9.Seventh(h) })
+      }, {
+        it.fold({ i -> Race9.Eighth(i) }, { j -> Race9.Ninth(j) })
+      })
+    }
 
   /**
    * Creates a variable [MVar] to be used for thread-sharing, initialized to a value [a]
@@ -808,140 +868,4 @@ interface Concurrent<F> : Async<F> {
         { raiseError(TimeoutException(duration.toString())) }
       )
     }
-}
-
-/** Alias for `Either` structure to provide consistent signature for race methods. */
-typealias RacePair<F, A, B> = Either<Tuple2<A, Fiber<F, B>>, Tuple2<Fiber<F, A>, B>>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias RaceTriple<F, A, B, C> = Either<Tuple3<A, Fiber<F, B>, Fiber<F, C>>, Either<Tuple3<Fiber<F, A>, B, Fiber<F, C>>, Tuple3<Fiber<F, A>, Fiber<F, B>, C>>>
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-@Suppress("UNUSED_PARAMETER")
-inline fun <F, A, B, C, D> RaceTriple<F, A, B, C>.fold(
-  ifA: (Tuple3<A, Fiber<F, B>, Fiber<F, C>>) -> D,
-  ifB: (Tuple3<Fiber<F, A>, B, Fiber<F, C>>) -> D,
-  ifC: (Tuple3<Fiber<F, A>, Fiber<F, B>, C>) -> D,
-  dummy: Unit = Unit
-): D = when (this) {
-  is Either.Left -> ifA(this.a)
-  is Either.Right -> when (val b = this.b) {
-    is Either.Left -> ifB(b.a)
-    is Either.Right -> ifC(b.b)
-  }
-}
-
-/** Alias for `Either` structure to provide consistent signature for race methods. */
-typealias Race2<A, B> = Either<A, B>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race3<A, B, C> = Either<Either<A, B>, C>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race4<A, B, C, D> = Either<Either<A, B>, Either<C, D>>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race5<A, B, C, D, E> = Either<Race3<A, B, C>, Race2<D, E>>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race6<A, B, C, D, E, G> = Either<Race3<A, B, C>, Race3<D, E, G>>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race7<A, B, C, D, E, G, H> = Race3<Race3<A, B, C>, Race2<D, E>, Race2<G, H>>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race8<A, B, C, D, E, G, H, I> = Race4<Race2<A, B>, Race2<C, D>, Race2<E, G>, Race2<H, I>>
-
-/** Alias for nested `Either` structures to provide nicer signatures and overload with a convenience [fold] method. */
-typealias Race9<A, B, C, D, E, G, H, I, J> = Race4<Race3<A, B, C>, Race2<D, E>, Race2<G, H>, Race2<I, J>>
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D> Race3<A, B, C>.fold(
-  ifA: (A) -> D,
-  ifB: (B) -> D,
-  ifC: (C) -> D
-): D = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB)
-  is Either.Right -> ifC(this.b)
-}
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D, E> Race4<A, B, C, D>.fold(
-  ifA: (A) -> E,
-  ifB: (B) -> E,
-  ifC: (C) -> E,
-  ifD: (D) -> E
-): E = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB)
-  is Either.Right -> this.b.fold(ifC, ifD)
-}
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D, E, G> Race5<A, B, C, D, E>.fold(
-  ifA: (A) -> G,
-  ifB: (B) -> G,
-  ifC: (C) -> G,
-  ifD: (D) -> G,
-  ifE: (E) -> G
-): G = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB, ifC)
-  is Either.Right -> this.b.fold(ifD, ifE)
-}
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D, E, G, H> Race6<A, B, C, D, E, G>.fold(
-  ifA: (A) -> H,
-  ifB: (B) -> H,
-  ifC: (C) -> H,
-  ifD: (D) -> H,
-  ifE: (E) -> H,
-  ifG: (G) -> H
-): H = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB, ifC)
-  is Either.Right -> this.b.fold(ifD, ifE, ifG)
-}
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D, E, G, H, I> Race7<A, B, C, D, E, G, H>.fold(
-  ifA: (A) -> I,
-  ifB: (B) -> I,
-  ifC: (C) -> I,
-  ifD: (D) -> I,
-  ifE: (E) -> I,
-  ifG: (G) -> I,
-  ifH: (H) -> I
-): I = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB, ifC, ifD, ifE)
-  is Either.Right -> this.b.fold(ifG, ifH)
-}
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D, E, G, H, I, J> Race8<A, B, C, D, E, G, H, I>.fold(
-  ifA: (A) -> J,
-  ifB: (B) -> J,
-  ifC: (C) -> J,
-  ifD: (D) -> J,
-  ifE: (E) -> J,
-  ifG: (G) -> J,
-  ifH: (H) -> J,
-  ifI: (I) -> J
-): J = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB, ifC, ifD)
-  is Either.Right -> this.b.fold(ifE, ifG, ifH, ifI)
-}
-
-/** A convenience [fold] method to provide a nicer API to work with race results. */
-inline fun <A, B, C, D, E, G, H, I, J, K> Race9<A, B, C, D, E, G, H, I, J>.fold(
-  ifA: (A) -> K,
-  ifB: (B) -> K,
-  ifC: (C) -> K,
-  ifD: (D) -> K,
-  ifE: (E) -> K,
-  ifG: (G) -> K,
-  ifH: (H) -> K,
-  ifI: (I) -> K,
-  ifJ: (J) -> K
-): K = when (this) {
-  is Either.Left -> this.a.fold(ifA, ifB, ifC, ifD, ifE)
-  is Either.Right -> this.b.fold(ifG, ifH, ifI, ifJ)
 }

--- a/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/io.kt
+++ b/modules/effects/arrow-effects-extensions/src/main/kotlin/arrow/effects/extensions/io.kt
@@ -6,6 +6,8 @@ import arrow.effects.ForIO
 import arrow.effects.IO
 import arrow.effects.IOOf
 import arrow.effects.OnCancel
+import arrow.effects.RacePair
+import arrow.effects.RaceTriple
 import arrow.effects.fix
 import arrow.effects.racePair
 import arrow.effects.raceTriple
@@ -25,8 +27,6 @@ import arrow.effects.typeclasses.Fiber
 import arrow.effects.typeclasses.MonadDefer
 import arrow.effects.typeclasses.Proc
 import arrow.effects.typeclasses.ProcF
-import arrow.effects.typeclasses.RacePair
-import arrow.effects.typeclasses.RaceTriple
 import arrow.effects.typeclasses.UnsafeRun
 import arrow.extension
 import arrow.typeclasses.Applicative


### PR DESCRIPTION
Currently the race results are modeled as nested `Either`s, which means that if you try to call `fold` it'll use the instance method instead of the `fold` extension function.

The only solution AFAIK is defining actual models with a `fold` method.

One quirk is that you cannot ignore multi-param lambdas and it become mandatory to do
`_, _, _  -> raiseError(..)` but only affects `racePair` and `raceTriple`.