### PR TITLE
Fix benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   include:
   - stage: build
     script:
-    - ./gradlew clean build
+    - ./gradlew clean build :arrow-benchmarks-effects:jmhClasses
   - stage: coverage-report
     script:
     - ./gradlew codeCoverageReport


### PR DESCRIPTION
This PR fixes the currently broken code in Benchmarks introduced by #1459, and introduces a CI step to compile the `jmh` classes to prevent this in the future.