### PR TITLE
Generalizes `firstOption` and promotes it to `Foldable`.

### DIFF
--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/array.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/array.kt
@@ -4,38 +4,56 @@ import arrow.core.Option
 import arrow.core.Predicate
 import arrow.core.toOption
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> Array<out T>.firstOption(): Option<T> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun BooleanArray.firstOption(): Option<Boolean> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun ByteArray.firstOption(): Option<Byte> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun CharArray.firstOption(): Option<Char> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun DoubleArray.firstOption(): Option<Double> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun FloatArray.firstOption(): Option<Float> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun IntArray.firstOption(): Option<Int> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun LongArray.firstOption(): Option<Long> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun ShortArray.firstOption(): Option<Short> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> Array<out T>.firstOption(predicate: Predicate<T>): Option<T> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun BooleanArray.firstOption(predicate: Predicate<Boolean>): Option<Boolean> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun ByteArray.firstOption(predicate: Predicate<Byte>): Option<Byte> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun CharArray.firstOption(predicate: Predicate<Char>): Option<Char> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun DoubleArray.firstOption(predicate: Predicate<Double>): Option<Double> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun FloatArray.firstOption(predicate: Predicate<Float>): Option<Float> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun IntArray.firstOption(predicate: Predicate<Int>): Option<Int> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun LongArray.firstOption(predicate: Predicate<Long>): Option<Long> = firstOrNull(predicate).toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun ShortArray.firstOption(predicate: Predicate<Short>): Option<Short> = firstOrNull(predicate).toOption()

--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/iterable.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/iterable.kt
@@ -6,8 +6,10 @@ import arrow.core.Predicate
 import arrow.core.orElse
 import arrow.core.toOption
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> Iterable<T>.firstOption(): Option<T> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> Iterable<T>.firstOption(predicate: Predicate<T>): Option<T> = firstOrNull(predicate).toOption()
 
 @Deprecated("PartialFunction is an incomplete experiment due for removal. See https://github.com/arrow-kt/arrow/pull/1419#issue-273308228")

--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/list.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/list.kt
@@ -12,6 +12,7 @@ infix fun <T> T.prependTo(list: List<T>): List<T> = listOf(this) + list
 
 fun <T> List<T>.destructured(): Pair<T, List<T>> = first() to tail()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> List<T>.firstOption(): Option<T> = firstOrNull().toOption()
 
 fun <T> List<Option<T>>.flatten(): List<T> = flatMap { it.fold(::emptyList, ::listOf) }

--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/sequence.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/sequence.kt
@@ -4,6 +4,8 @@ import arrow.core.Option
 import arrow.core.Predicate
 import arrow.core.toOption
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> Sequence<T?>.firstOption(): Option<T> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun <T> Sequence<T>.firstOption(predicate: Predicate<T>): Option<T> = firstOrNull(predicate).toOption()

--- a/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/string.kt
+++ b/modules/core/arrow-syntax/src/main/kotlin/arrow/syntax/collections/string.kt
@@ -4,6 +4,8 @@ import arrow.core.Option
 import arrow.core.Predicate
 import arrow.core.toOption
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 fun String.firstOption(): Option<Char> = firstOrNull().toOption()
 
+@Deprecated(message = "`firstOption` is now part of the Foldable interface and generalized to all foldable data types")
 inline fun String.firstOption(predicate: Predicate<Char>): Option<Char> = firstOrNull(predicate).toOption()

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/FoldableLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/FoldableLaws.kt
@@ -26,6 +26,8 @@ object FoldableLaws {
       Law("Foldable Laws: ForAll is lazy") { FF.forAllIsLazy(cf, EQ) },
       Law("Foldable Laws: ForAll consistent with exists") { FF.forallConsistentWithExists(cf) },
       Law("Foldable Laws: ForAll returns true if isEmpty") { FF.forallReturnsTrueIfEmpty(cf) },
+      Law("Foldable Laws: FirstOption returns None if isEmpty") { FF.firstOptionReturnsNoneIfEmpty(cf) },
+      Law("Foldable Laws: FirstOption returns None if predicate fails") { FF.firstOptionReturnsNoneIfPredicateFails(cf) },
       Law("Foldable Laws: FoldM for Id is equivalent to fold left") { FF.foldMIdIsFoldL(cf, EQ) }
     )
 
@@ -85,6 +87,17 @@ object FoldableLaws {
   fun <F> Foldable<F>.forallReturnsTrueIfEmpty(cf: (Int) -> Kind<F, Int>) =
     forAll(Gen.intPredicate(), Gen.int().map(cf)) { f: (Int) -> Boolean, fa: Kind<F, Int> ->
       !fa.isEmpty() || fa.forAll(f)
+    }
+
+  fun <F> Foldable<F>.firstOptionReturnsNoneIfEmpty(cf: (Int) -> Kind<F, Int>) =
+    forAll(Gen.int().map(cf)) { fa: Kind<F, Int> ->
+      if (fa.isEmpty()) fa.firstOption().isEmpty()
+      else fa.firstOption().isDefined()
+    }
+
+  fun <F> Foldable<F>.firstOptionReturnsNoneIfPredicateFails(cf: (Int) -> Kind<F, Int>) =
+    forAll(Gen.int().map(cf)) { fa: Kind<F, Int> ->
+      fa.firstOption { false }.isEmpty()
     }
 
   fun <F> Foldable<F>.foldMIdIsFoldL(cf: (Int) -> Kind<F, Int>, EQ: Eq<Int>) =

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -208,7 +208,7 @@ interface Foldable<F> {
   fun <A> Kind<F, A>.firstOption(): Option<A> = get(0)
 
   /**
-   * Get the first element of the foldable or none
+   * Get the first element of the foldable or none if empty or the predicate does not match
    */
   fun <A> Kind<F, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
     get(0).filter(predicate)

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -1,16 +1,17 @@
 package arrow.typeclasses
 
 import arrow.Kind
+import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Eval.Companion.always
-import arrow.core.ForEither
 import arrow.core.Left
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Right
 import arrow.core.Some
-import arrow.core.fix
+import arrow.core.flatMap
 import arrow.core.identity
+import arrow.core.right
 
 /**
  * ank_macro_hierarchy(arrow.typeclasses.Foldable)
@@ -190,13 +191,27 @@ interface Foldable<F> {
   /**
    * Get the element at the index of the Foldable.
    */
-  fun <A> Kind<F, A>.get(M: Monad<Kind<ForEither, A>>, idx: Long): Option<A> =
+  fun <A> Kind<F, A>.get(idx: Long): Option<A> =
     if (idx < 0L)
       None
     else
-      foldM(M, 0L) { i, a ->
-        if (i == idx) Left(a) else Right(i + 1L)
-      }.fix().swap().toOption()
+      foldLeft<A, Either<A, Long>>(0L.right()) { i, a ->
+        i.flatMap {
+          if (it == idx) Left(a)
+          else Right(it + 1L)
+        }
+      }.swap().toOption()
+
+  /**
+   * Get the first element of the foldable or none
+   */
+  fun <A> Kind<F, A>.firstOption(): Option<A> = get(0)
+
+  /**
+   * Get the first element of the foldable or none
+   */
+  fun <A> Kind<F, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
+    get(0).filter(predicate)
 
   companion object {
     @Deprecated("Use Iterator.iterateRight from Eval.kt instead")

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Reducible.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Reducible.kt
@@ -2,7 +2,6 @@ package arrow.typeclasses
 
 import arrow.Kind
 import arrow.core.Eval
-import arrow.core.ForEither
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some

--- a/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Reducible.kt
+++ b/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Reducible.kt
@@ -143,11 +143,11 @@ interface NonEmptyReducible<F, G> : Reducible<F> {
     return 1 + tail.size(MN)
   }
 
-  override fun <A> Kind<F, A>.get(M: Monad<Kind<ForEither, A>>, idx: Long): Option<A> =
+  override fun <A> Kind<F, A>.get(idx: Long): Option<A> =
     if (idx == 0L)
       Some(this.split().a)
     else
-      FG().run { split().b.get(M, idx - 1L) }
+      FG().run { split().b.get(idx - 1L) }
 
   fun <A, B> Kind<F, A>.foldM_(M: Monad<G>, z: B, f: (B, A) -> Kind<G, B>): Kind<G, B> = M.run {
     val (a, ga) = split()

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/foldable/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/foldable/README.md
@@ -513,7 +513,7 @@ import arrow.core.extensions.either.foldable.foldable
 
 fun foldableGet(strKind: EitherOf<String, String>): Option<String> =
   with(Either.foldable<String>()) {
-    strKind.get(Either.monad(), 0)
+    strKind.get(0)
   }
 
 val rightStr = Either.right("abc") as Either<String, String>


### PR DESCRIPTION
- [x] Generalizes `firstOption` making it part of the `Foldable` algebra.
- [x] Removes the need to pass the `Either.monad()` constrain by implementing `get` in terms of `foldLeft` and using `Either`'s API directly.
- [x] Deprecates all usages of `firstOption` in `arrow-syntax`