### PR TITLE
Move the Documentation for `Id` from README.md to the Id.kt

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
@@ -30,7 +30,6 @@ fun <A> IdOf<A>.value(): A = this.fix().extract()
  * ```kotlin:ank:playground
  * import arrow.core.Id
  *
- *
  * //sampleStart
  * fun idPlusThree(value: Int) =
  *  Id.just(value)

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
@@ -5,6 +5,44 @@ import arrow.higherkind
 
 fun <A> IdOf<A>.value(): A = this.fix().extract()
 
+/**
+ *
+ * The identity monad can be seen as the ambient monad that encodes the effect of having no effect.
+ * It is ambient in the sense that plain pure values are values of `Id`.
+ *
+ * ```kotlin:ank:playground
+ *  //sampleStart
+ * import arrow.*
+ * import arrow.core.*
+ *
+ * Id("hello")
+ * //sampleEnd
+ * ```
+ *
+ * Using this type declaration, we can treat our Id type constructor as a `Monad` and as a `Comonad`.
+ * The `just` method, which has type `A -> Id<A>` just becomes the identity function. The `map` method
+ * from `Functor` just becomes function application
+ *
+ * ``kotlin:ank:playground
+ * //sampleStart
+ * val id: Id<Int> = Id.just(3)
+ * id.map{it + 3}
+ * //sampleEnd
+ * ```
+ *
+ * ### Supported type classes
+ *
+ * ``kotlin:ank:playground
+ * //sampleStart
+ * import arrow.reflect.*
+ * import arrow.data.*
+ * import arrow.core.*
+ *
+ * DataType(Id::class).tcMarkdownList()
+ * //sampleEnd
+ * ```
+ */
+
 @higherkind
 data class Id<out A>(private val value: A) : IdOf<A> {
 

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
@@ -25,7 +25,7 @@ fun <A> IdOf<A>.value(): A = this.fix().extract()
  *
  * Using this type declaration, we can treat our Id type constructor as a `Monad` and as a `Comonad`.
  * The `just` method, which has type `A -> Id<A>` just becomes the identity function. The `map` method
- * from `Functor` just becomes function application
+ * from `Functor` just becomes function application.
  *
  * ```kotlin:ank:playground
  * import arrow.core.Id

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
@@ -10,8 +10,17 @@ fun <A> IdOf<A>.value(): A = this.fix().extract()
  * The identity monad can be seen as the ambient monad that encodes the effect of having no effect.
  * It is ambient in the sense that plain pure values are values of `Id`.
  *
- * ```
- * Id("hello")
+ * ```kotlin:ank:playground
+ * import arrow.core.Id
+ *
+ * fun getId() =
+ * //sampleStart
+ *  Id("hello")
+ * //sampleEnd
+ *
+ * fun main() {
+ *  println(getId())
+ * }
  * ```
  *
  * Using this type declaration, we can treat our Id type constructor as a `Monad` and as a `Comonad`.
@@ -21,18 +30,17 @@ fun <A> IdOf<A>.value(): A = this.fix().extract()
  * ```kotlin:ank:playground
  * import arrow.core.Id
  *
- * fun main() {
- * //sampleStart
- * val id: Id<Int> = Id.just(3)
- * id.map{it + 3}
- * //sampleEnd
- * System.out.print(id.map{it + 3}.extract())
- * }
- * ```
  *
- * ### Supported type classes
- * ```
- * DataType(Id::class).tcMarkdownList()
+ * //sampleStart
+ * fun idPlusThree(value: Int) =
+ *  Id.just(value)
+ *    .map { it + 3 }
+ * //sampleEnd
+ *
+ * fun main() {
+ *  val value = 3
+ *  println("idPlusThree($value) = ${idPlusThree(value)}")
+ * }
  * ```
  */
 

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Id.kt
@@ -10,36 +10,29 @@ fun <A> IdOf<A>.value(): A = this.fix().extract()
  * The identity monad can be seen as the ambient monad that encodes the effect of having no effect.
  * It is ambient in the sense that plain pure values are values of `Id`.
  *
- * ```kotlin:ank:playground
- *  //sampleStart
- * import arrow.*
- * import arrow.core.*
- *
+ * ```
  * Id("hello")
- * //sampleEnd
  * ```
  *
  * Using this type declaration, we can treat our Id type constructor as a `Monad` and as a `Comonad`.
  * The `just` method, which has type `A -> Id<A>` just becomes the identity function. The `map` method
  * from `Functor` just becomes function application
  *
- * ``kotlin:ank:playground
+ * ```kotlin:ank:playground
+ * import arrow.core.Id
+ *
+ * fun main() {
  * //sampleStart
  * val id: Id<Int> = Id.just(3)
  * id.map{it + 3}
  * //sampleEnd
+ * System.out.print(id.map{it + 3}.extract())
+ * }
  * ```
  *
  * ### Supported type classes
- *
- * ``kotlin:ank:playground
- * //sampleStart
- * import arrow.reflect.*
- * import arrow.data.*
- * import arrow.core.*
- *
+ * ```
  * DataType(Id::class).tcMarkdownList()
- * //sampleEnd
  * ```
  */
 

--- a/modules/docs/arrow-docs/docs/_data/sidebar.yml
+++ b/modules/docs/arrow-docs/docs/_data/sidebar.yml
@@ -164,7 +164,7 @@ options:
         url: /docs/arrow/data/ior/
 
       - title: Id
-        url: /docs/arrow/core/id/
+        url: /docs/apidocs/arrow-core-data/arrow.core/-id/
 
       - title: Reader
         url: /docs/arrow/data/reader/

--- a/modules/docs/arrow-docs/docs/docs/arrow/core/id/ru/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/core/id/ru/README.md
@@ -12,7 +12,7 @@ video: DBvVd1pfLMo
 {:.beginner}
 beginner
 
-[English](/docs/arrow/core/id/)
+[English](/docs/apidocs/arrow-core-data/arrow.core/-id/)
 
 Id (монада идентичности) должна рассматриваться, как монада, в которую вкладывается эффект отсутствия эффекта. Любое значение может являться значением `Id`.
 

--- a/modules/docs/arrow-docs/docs/docs/integrations/kindedj/README.md
+++ b/modules/docs/arrow-docs/docs/docs/integrations/kindedj/README.md
@@ -57,7 +57,7 @@ val idj2: io.kindedj.Hk<ForIdJ, A> = id.fromArrow()
 Using the conversion layer we're capable of using an intermediate representation of any Arrow datatype generically by converting it into a `io.kindedj.Hk2<ForConvert, F, A>`,
 where F is the [original representation of the container]({{ '/docs/patterns/glossary' | relative_url }}). Note that the typealias `io.kindedj.Hk2` is only available in Kotlin.
 
-Let's see an example using our type [`Id`]({{ '/docs/arrow/core/id' | relative_url }}):
+Let's see an example using our type [`Id`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-id/' | relative_url }}):
 
 ```kotlin
 data class IdK<out A>(val a: A)

--- a/modules/docs/arrow-docs/docs/docs/quickstart/libraries/README.md
+++ b/modules/docs/arrow-docs/docs/docs/quickstart/libraries/README.md
@@ -21,7 +21,7 @@ beginner
 The smallest set of [datatypes]({{ '/docs/datatypes/intro/' | relative_url }}) necessary to start in FP, and that other libraries can build upon.
 The focus here is on API design and abstracting small code patterns.
 
-Datatypes: [`Either`]({{ '/docs/arrow/core/either/' | relative_url }}), [`Option`]({{ '/docs/arrow/core/option/' | relative_url }}), [`Try`]({{ '/docs/arrow/core/try/' | relative_url }}), [`Eval`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-eval' | relative_url }}), [`Id`]({{ '/docs/arrow/core/id/' | relative_url }}), `TupleN`, `Function0`, `Function1`, `FunctionK`
+Datatypes: [`Either`]({{ '/docs/arrow/core/either/' | relative_url }}), [`Option`]({{ '/docs/arrow/core/option/' | relative_url }}), [`Try`]({{ '/docs/arrow/core/try/' | relative_url }}), [`Eval`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-eval' | relative_url }}), [`Id`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-id/' | relative_url }}), `TupleN`, `Function0`, `Function1`, `FunctionK`
 
 ### arrow-syntax
 


### PR DESCRIPTION
The Playground has been fixed. And also the existing links to id from other pages.

