### PR TITLE
Fix FxSyntax parallelism issue

### DIFF
--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/FxSyntax.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/FxSyntax.kt
@@ -4,7 +4,6 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.OptionOf
 import arrow.core.TryOf
-import arrow.core.extensions.id.applicative.just
 import arrow.core.identity
 import arrow.data.extensions.list.traverse.sequence
 import arrow.data.extensions.listk.traverse.traverse
@@ -32,7 +31,7 @@ interface FxSyntax<F> : Concurrent<F>, BindSyntax<F> {
       release = { fibers, exit -> when (exit) {
         ExitCase.Canceled -> fibers.traverse(this@FxSyntax) { it.cancel() }.map { Unit }
         else -> Unit.just()
-      }}
+      } }
     ).map { it.fix() }
 
   fun <A> CoroutineContext.parSequence(effects: Iterable<Kind<F, A>>): Kind<F, List<A>> =

--- a/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/FxSyntax.kt
+++ b/modules/effects/arrow-effects-data/src/main/kotlin/arrow/effects/typeclasses/FxSyntax.kt
@@ -5,7 +5,8 @@ import arrow.core.Either
 import arrow.core.OptionOf
 import arrow.core.TryOf
 import arrow.core.identity
-import arrow.data.extensions.list.traverse.traverse
+import arrow.data.extensions.list.traverse.sequence
+import arrow.data.extensions.listk.traverse.traverse
 import arrow.data.fix
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Monad
@@ -25,8 +26,8 @@ interface FxSyntax<F> : Concurrent<F>, BindSyntax<F> {
   ): Kind<F, List<B>> =
     effects.fold(emptyList<Kind<F, Fiber<F, B>>>()) { acc, fa ->
       acc + startFiber(fa.map(f))
-    }.traverse(this@FxSyntax) { kind ->
-      kind.flatMap { it.join() }
+    }.sequence(this@FxSyntax).flatMap { fibers ->
+      fibers.traverse(this@FxSyntax) { it.join() }
     }.map { it.fix() }
 
   fun <A> CoroutineContext.parSequence(effects: Iterable<Kind<F, A>>): Kind<F, List<A>> =

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/EffectsSuspendDSLTests.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/EffectsSuspendDSLTests.kt
@@ -336,7 +336,7 @@ class EffectsSuspendDSLTests : UnitSpec() {
 
     "List.parTraverse should run effects in parallel" {
       fxTest {
-        fx {
+        IO.fx {
           val timeline = mutableListOf<String>()
           val tasks = (1..3).map {
             effect {

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/EffectsSuspendDSLTests.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/EffectsSuspendDSLTests.kt
@@ -349,7 +349,7 @@ class EffectsSuspendDSLTests : UnitSpec() {
           !newSingleThreadContext("A").parTraverse(tasks, ::identity)
           timeline
         }
-      } shouldBe listOf("start 3", "start 2", "start 1", "end 1", "end 2", "end 3")
+      } shouldBe listOf("start 1", "start 2", "start 3", "end 1", "end 2", "end 3")
     }
 
     "FX supports polymorphism" {


### PR DESCRIPTION
This fix a issue with current FxSyntax.parTraverse implementation, where effects are run in sequential fashion, instead of being run in parallel. I left a comment in #1414 providing a way to reproduce the issue. The github issue was already closed, but the issue seems to be still present in 0.9.1-SNAPSHOT

It appears that in parTraverse (in case of IO), we were traversing a sequence of startFiber() immediatly "flatMapped" with join(), IO Applicative used by traverse (while representing mapping independant computations) does not perform IO in parallel (it is probably implemented in terms of flatMap).

This implementation perform the traversal twice, one for starting all fibers, one for joining them all, achieving real parallelism.

