### PR TITLE
Favor Either and IO instead of Try

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -189,6 +189,13 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     }
 
     fun <L, R> cond(test: Boolean, ifTrue: () -> R, ifFalse: () -> L): Either<L, R> = if (test) right(ifTrue()) else left(ifFalse())
+
+    fun <R> catch(f: () -> R): Either<Throwable, R> =
+      try {
+        f().right()
+      } catch (t: Throwable) {
+        t.nonFatalOrThrow().left()
+      }
   }
 }
 

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -190,10 +190,10 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
 
     fun <L, R> cond(test: Boolean, ifTrue: () -> R, ifFalse: () -> L): Either<L, R> = if (test) right(ifTrue()) else left(ifFalse())
 
-    fun <R> catch(f: () -> R): Either<Throwable, R> =
+    suspend fun <R> catch(f: suspend () -> R): Either<Throwable, R> =
       catch(::identity, f)
 
-    fun <L, R> catch(fe: (Throwable) -> L, f: () -> R): Either<L, R> =
+    suspend fun <L, R> catch(fe: (Throwable) -> L, f: suspend () -> R): Either<L, R> =
       try {
         f().right()
       } catch (t: Throwable) {

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -191,10 +191,13 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     fun <L, R> cond(test: Boolean, ifTrue: () -> R, ifFalse: () -> L): Either<L, R> = if (test) right(ifTrue()) else left(ifFalse())
 
     fun <R> catch(f: () -> R): Either<Throwable, R> =
+      catch(::identity, f)
+
+    fun <L, R> catch(fe: (Throwable) -> L, f: () -> R): Either<L, R> =
       try {
         f().right()
       } catch (t: Throwable) {
-        t.nonFatalOrThrow().left()
+        fe(t.nonFatalOrThrow()).left()
       }
   }
 }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
@@ -57,7 +57,7 @@ sealed class Try<out A> : TryOf<A> {
 
     @Deprecated(
       "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
-      ReplaceWith("Either.catch(f)")
+      ReplaceWith("Either.raiseError(e)")
     )
     fun raiseError(e: Throwable): Try<Nothing> = Failure(e)
   }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
@@ -17,13 +17,13 @@ sealed class Try<out A> : TryOf<A> {
   companion object {
 
     @Deprecated(
-      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      "Try promotes eager execution of effects, so it's better if you work with suspend Either constructors or a an effect handler like IO",
       ReplaceWith("Either.just(a)")
     )
     fun <A> just(a: A): Try<A> = Success(a)
 
     @Deprecated(
-      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      "Try promotes eager execution of effects, so it's better if you work with suspend Either constructors or a an effect handler like IO",
       ReplaceWith("Either.tailRecM(a, f)")
     )
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> TryOf<Either<A, B>>): Try<B> {
@@ -41,7 +41,7 @@ sealed class Try<out A> : TryOf<A> {
     }
 
     @Deprecated(
-      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      "Try promotes eager execution of effects, so it's better if you work with suspend Either constructors or a an effect handler like IO",
       ReplaceWith("Either.catch(f)")
     )
     inline operator fun <A> invoke(f: () -> A): Try<A> =
@@ -56,7 +56,7 @@ sealed class Try<out A> : TryOf<A> {
       }
 
     @Deprecated(
-      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      "Try promotes eager execution of effects, so it's better if you work with suspend Either constructors or a an effect handler like IO",
       ReplaceWith("Either.raiseError(e)")
     )
     fun raiseError(e: Throwable): Try<Nothing> = Failure(e)

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Try.kt
@@ -16,8 +16,16 @@ sealed class Try<out A> : TryOf<A> {
 
   companion object {
 
+    @Deprecated(
+      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      ReplaceWith("Either.just(a)")
+    )
     fun <A> just(a: A): Try<A> = Success(a)
 
+    @Deprecated(
+      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      ReplaceWith("Either.tailRecM(a, f)")
+    )
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> TryOf<Either<A, B>>): Try<B> {
       val ev: Try<Either<A, B>> = f(a).fix()
       return when (ev) {
@@ -32,6 +40,10 @@ sealed class Try<out A> : TryOf<A> {
       }
     }
 
+    @Deprecated(
+      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      ReplaceWith("Either.catch(f)")
+    )
     inline operator fun <A> invoke(f: () -> A): Try<A> =
       try {
         Success(f())
@@ -43,6 +55,10 @@ sealed class Try<out A> : TryOf<A> {
         }
       }
 
+    @Deprecated(
+      "Try promotes eager execution and works like Either, so it's better if you work with Either or a suspended type like IO",
+      ReplaceWith("Either.catch(f)")
+    )
     fun raiseError(e: Throwable): Try<Nothing> = Failure(e)
   }
 


### PR DESCRIPTION
This diff stabilizes a proposal that's been floating for a while. `Try` is a defective `Either` with a nice constructor. Let's promote using `Either` or `IO` instead.