### PR TITLE
fixes ["Request"] convenient Option.mapNotNull #1475

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -90,6 +90,18 @@ sealed class Option<out A> : OptionOf<A> {
   }
 
   /**
+   * Returns $none if the result of applying $f to this $option's value is null.
+   * Otherwise returns the result.
+   *
+   * @note This is similar to `.flatMap { Option.fromNullable(null)) }`
+   * and primarily for convenience.
+   *
+   * @param f the function to apply.
+   * */
+  fun <B> mapNotNull(f: (A) -> B?): Option<B> =
+    flatMap { a -> fromNullable(f(a)) }
+
+  /**
    * Returns the result of applying $f to this $option's value if
    * this $option is nonempty.
    * Returns $none if this $option is empty.
@@ -197,7 +209,8 @@ fun <T> Option<T>.getOrElse(default: () -> T): T = fold({ default() }, ::identit
  *
  * @param alternative the default option if this is empty.
  */
-inline fun <A> OptionOf<A>.orElse(alternative: () -> Option<A>): Option<A> = if (fix().isEmpty()) alternative() else fix()
+inline fun <A> OptionOf<A>.orElse(alternative: () -> Option<A>): Option<A> =
+  if (fix().isEmpty()) alternative() else fix()
 
 infix fun <T> OptionOf<T>.or(value: Option<T>): Option<T> = if (fix().isEmpty()) {
   value

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -209,8 +209,7 @@ fun <T> Option<T>.getOrElse(default: () -> T): T = fold({ default() }, ::identit
  *
  * @param alternative the default option if this is empty.
  */
-inline fun <A> OptionOf<A>.orElse(alternative: () -> Option<A>): Option<A> =
-  if (fix().isEmpty()) alternative() else fix()
+inline fun <A> OptionOf<A>.orElse(alternative: () -> Option<A>): Option<A> = if (fix().isEmpty()) alternative() else fix()
 
 infix fun <T> OptionOf<T>.or(value: Option<T>): Option<T> = if (fix().isEmpty()) {
   value

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -16,13 +16,7 @@ import arrow.mtl.extensions.option.traverseFilter.traverseFilter
 import arrow.syntax.collections.firstOption
 import arrow.test.UnitSpec
 import arrow.test.generators.option
-import arrow.test.laws.FunctorFilterLaws
-import arrow.test.laws.HashLaws
-import arrow.test.laws.MonadFilterLaws
-import arrow.test.laws.MonoidLaws
-import arrow.test.laws.MonoidalLaws
-import arrow.test.laws.ShowLaws
-import arrow.test.laws.TraverseFilterLaws
+import arrow.test.laws.*
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -84,6 +78,11 @@ class OptionTest : UnitSpec() {
     "map" {
       some.map(String::toUpperCase) shouldBe Some("KOTLIN")
       none.map(String::toUpperCase) shouldBe None
+    }
+
+    "mapNotNull" {
+      some.mapNotNull { it.toIntOrNull() } shouldBe None
+      some.mapNotNull { it.toUpperCase() } shouldBe Some("KOTLIN")
     }
 
     "fold" {

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -16,7 +16,13 @@ import arrow.mtl.extensions.option.traverseFilter.traverseFilter
 import arrow.syntax.collections.firstOption
 import arrow.test.UnitSpec
 import arrow.test.generators.option
-import arrow.test.laws.*
+import arrow.test.laws.FunctorFilterLaws
+import arrow.test.laws.HashLaws
+import arrow.test.laws.MonadFilterLaws
+import arrow.test.laws.MonoidLaws
+import arrow.test.laws.MonoidalLaws
+import arrow.test.laws.ShowLaws
+import arrow.test.laws.TraverseFilterLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll


### PR DESCRIPTION
As discussed in https://github.com/arrow-kt/arrow/issues/1475 this is a proposed fix to the issue.
A convenience method was added `mapNotNull` with KDoc and a corresponding UnitTest. 