### PR TITLE
Ank not fail fast

### DIFF
--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -14,9 +14,7 @@ import arrow.data.combine
 import arrow.data.extensions.list.foldable.reduceLeftOption
 import arrow.data.extensions.list.semigroup.List.semigroup
 import arrow.data.extensions.nonemptylist.semigroup.semigroup
-import arrow.data.fix
 import arrow.data.validNel
-import arrow.effects.typeclasses.Async
 import arrow.effects.typeclasses.Concurrent
 import java.nio.file.Path
 

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -1,7 +1,22 @@
 package arrow.ank
 
 import arrow.Kind
+import arrow.core.Either
+import arrow.core.getOrElse
 import arrow.core.toT
+import arrow.data.ListK
+import arrow.data.Nel
+import arrow.data.NonEmptyList
+import arrow.data.Valid
+import arrow.data.Validated
+import arrow.data.ValidatedNel
+import arrow.data.combine
+import arrow.data.extensions.list.foldable.reduceLeftOption
+import arrow.data.extensions.list.semigroup.List.semigroup
+import arrow.data.extensions.nonemptylist.semigroup.semigroup
+import arrow.data.fix
+import arrow.data.validNel
+import arrow.effects.typeclasses.Async
 import arrow.effects.typeclasses.Concurrent
 import java.nio.file.Path
 
@@ -16,6 +31,9 @@ fun Long.humanBytes(): String {
   return String.format("%.1f %sB", this / Math.pow(unit.toDouble(), exp.toDouble()), pre)
 }
 
+fun <A> toValidatedNel(a: Either<Throwable, A>): ValidatedNel<Throwable, A> =
+  a.fold({ e -> Validated.Invalid(NonEmptyList(e)) }, { a -> Validated.Valid(a) })
+
 fun <F> Concurrent<F>.ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkOps): Kind<F, Unit> = with(ankOps) {
   fx.concurrent {
     !effect { printConsole(colored(ANSI_PURPLE, AnkHeader)) }
@@ -24,9 +42,9 @@ fun <F> Concurrent<F>.ank(source: Path, target: Path, compilerArgs: List<String>
     !effect { printConsole("Current heap used: ${(heapSize - Runtime.getRuntime().freeMemory()).humanBytes()}") }
     !effect { printConsole("Starting ank with Heap Size: ${heapSize.humanBytes()}, Max Heap Size: ${heapMaxSize.humanBytes()}") }
     val path = !effect { createTargetDirectory(source, target) }
-    val paths = !!effect {
+    val validatedPaths = !effect {
       path.ankFiles().map { (index, p) ->
-        suspend {
+        effect(suspend {
           val totalHeap = Runtime.getRuntime().totalMemory()
           val usedHeap = totalHeap - Runtime.getRuntime().freeMemory()
           val message = "Ank Compile: [$index] ${path.relativize(p)} | Used Heap: ${usedHeap.humanBytes()}"
@@ -36,11 +54,36 @@ fun <F> Concurrent<F>.ank(source: Path, target: Path, compilerArgs: List<String>
           val compiledResult = compileCode(p toT snippets, compilerArgs)
           val result = replaceAnkToLang(processed, compiledResult)
           generateFile(p, result)
-        }
-      }.toList().sequence()
+        }).attempt().map(::toValidatedNel)
+      }.toList()
     }
 
-    val message = "Ank Processed ${paths.size} files"
-    !effect { printConsole(colored(ANSI_GREEN, message)) }
+    // We need to help compiler here a bit.
+    val empty: Kind<F, ValidatedNel<Nothing, List<Path>>> = just(emptyList<Path>().validNel())
+
+    val combinedResults = !!effect {
+      validatedPaths
+        .map { fa -> fa.map { validated -> validated.map { path -> ListK.just(path) } } } // wrap in ListK to accumulate Paths.
+        .reduceLeftOption { fa, fb ->
+          fa.map2(fb) { (a, b) ->
+            a.combine(Nel.semigroup(), semigroup(), b)
+          }
+        }.getOrElse { empty }
+    }
+
+    combinedResults.fold({ errors ->
+      val seperator = "\n----------------------------------------------------------------\n"
+      throw AnkFailedException(errors.all
+        .flatMap {
+          if (it is CompilationException) listOf(it)
+          else emptyList()
+        }.joinToString(prefix = seperator, separator = seperator) {
+          it.msg
+        }
+      )
+    }, { paths ->
+      val message = colored(ANSI_GREEN, "Ank Processed ${paths.size} files")
+      !effect { printConsole(message) }
+    })
   }
 }

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
@@ -48,7 +48,7 @@ data class CompilationException(
   override fun toString(): String = msg
 }
 
-data class AnkFailedException(val msg: String): NoStackTrace(msg) {
+data class AnkFailedException(val msg: String) : NoStackTrace(msg) {
   override fun toString(): String = msg
 }
 

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
@@ -48,6 +48,10 @@ data class CompilationException(
   override fun toString(): String = msg
 }
 
+data class AnkFailedException(val msg: String): NoStackTrace(msg) {
+  override fun toString(): String = msg
+}
+
 abstract class NoStackTrace(msg: String) : Throwable(msg, null, false, false)
 
 data class Snippet(
@@ -178,6 +182,7 @@ val interpreter: AnkOps = object : AnkOps {
         } else {
           println(colored(ANSI_RED, "[✗ ${snippets.a} [${i + 1}]"))
           throw CompilationException(snippets.a, snip, it, msg = "\n" + """
+                    | File located at: ${snippets.a}
                     |
                     |```
                     |${snip.code}


### PR DESCRIPTION
Given that we have quite some docs already, and we're doing some refactorings it's becoming increasingly hard to maintain docs. Luckily Ank is there to save us!

To make the task of updating the docs less annoying I thought it'd be better if we collected all incorrect docs instead of failing fast on the first one. Saves a bunch of build time.

Given that there is not feature roadmap for Ank I just did the simplest thing possible.