### PR TITLE
Revert "Bump to Kotlin 1.3.31 (#1482)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_7
         kotlinPoetVersion = '1.1.0'
         kotlinTestVersion = '3.3.1'
-        kotlinVersion = '1.3.31'
+        kotlinVersion = '1.3.21'
         kotlinxCollectionsImmutableVersion = '0.1'
         kotlinxCoroutinesVersion = '1.1.1'
         projectReactorVersion = '3.2.6.RELEASE'
@@ -117,7 +117,6 @@ subprojects { project ->
             suffix = "#L"
         }
 
-        noStdlibLink = true
     }
 
     task codeCoverageReport(type: JacocoReport) {

--- a/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/EffectsSuspendDSLTests.kt
+++ b/modules/effects/arrow-effects-data/src/test/kotlin/arrow/effects/EffectsSuspendDSLTests.kt
@@ -280,7 +280,7 @@ class EffectsSuspendDSLTests : UnitSpec() {
             suspend { 1 },
             suspend { 2 },
             suspend { 3 }
-          ).traverse { it }
+          ).traverse(::effectIdentity)
         }
       } shouldBe listOf(1, 2, 3)
     }


### PR DESCRIPTION
#1482 caused a failed build and needs to revert to the previous commit. 
https://app.bitrise.io/build/c302b0457b8867cd#?tab=log

The Author @ogolberg from #1482 may reopen his PR.
A rebuild did not fix the changes. 

Plausible reasons:
Due to the change to the kotlin version, it may have affected the way regex is processed in Kotlin. Maybe a fix in the [Ank interpreter](https://github.com/arrow-kt/arrow/blob/557b8c06d46d63145f43101cca0b4427bb9bd26e/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt#L219-L240) is needed. 

[Hence, this line is generated wrongly](https://github.com/arrow-kt/arrow/blob/62f692397ef44e6acde12af817d94a19d2ce9621/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt#L49)
Resulting in a string like this:
```
 fun main(args: Array<String>) {
  val result =
  //sampleStart
2 }
  //sampleEnd
  println(result)
 }
```
The aforementioned fix is outside the scope of this PR, this PR is solely to stabilize master.