### PR TITLE
Replace IO suspend with defer

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/effects/io/README.md
+++ b/modules/docs/arrow-docs/docs/docs/effects/io/README.md
@@ -172,12 +172,12 @@ IO.effect { throw RuntimeException("Boom!") }
   .unsafeRunSync()
 ```
 
-### suspend
+### defer
 
 Used to defer the evaluation of an existing `IO`.
 
 ```kotlin
-IO.suspend { IO.just(1) }
+IO.defer { IO.just(1) }
   .attempt()
   .unsafeRunSync()
 ```


### PR DESCRIPTION
This PR fixes the `IO.suspend` docs so they are up to date with the latest version (`0.9.0`). I think `suspend` was renamed to `defer` (my artifacts don't have a `suspend`) so the docs should be updated.