### PR TITLE
deploys optics artifacts

### DIFF
--- a/modules/optics/arrow-optics-mtl/gradle.properties
+++ b/modules/optics/arrow-optics-mtl/gradle.properties
@@ -1,4 +1,4 @@
 # Maven publishing configuration
-POM_NAME=Arrow-Optics
-POM_ARTIFACT_ID=arrow-optics
+POM_NAME=Arrow Optics MTL
+POM_ARTIFACT_ID=arrow-optics-mtl
 POM_PACKAGING=jar

--- a/modules/optics/arrow-optics/gradle.properties
+++ b/modules/optics/arrow-optics/gradle.properties
@@ -1,4 +1,4 @@
 # Maven publishing configuration
-POM_NAME=Arrow-Optics
+POM_NAME=Arrow Optics
 POM_ARTIFACT_ID=arrow-optics
 POM_PACKAGING=jar


### PR DESCRIPTION
tries to fix this issue: https://github.com/arrow-kt/arrow/issues/1510

The problem before was that both modules were deployed under the same artifact name. Thus creating binary issues when deploying.