### PR TITLE
Add Kotliners ArrowFx talk and fix android sample project link

### DIFF
--- a/modules/docs/arrow-docs/docs/_posts/2019-06-07-kotliners-arrow-fx.md
+++ b/modules/docs/arrow-docs/docs/_posts/2019-06-07-kotliners-arrow-fx.md
@@ -1,0 +1,8 @@
+---
+title: Kotliners 2019 - ArrowFx: Functional Programming for the masses
+icon: /img/icon-video.svg
+header-image: https://img.youtube.com/vi/uyqqoooKpmI/maxresdefault.jpg
+category: media
+link: https://www.youtube.com/watch?v=uyqqoooKpmI
+---
+In this talk we recap about the imminent future of Functional Programming in Kotlin. With ArrowFx you are able to encode “effectful” programs in a controlled way following the FP principles through a direct syntax. You’ll think you’re writing imperative code!

--- a/modules/docs/arrow-docs/docs/docs/quickstart/projects/README.md
+++ b/modules/docs/arrow-docs/docs/docs/quickstart/projects/README.md
@@ -24,7 +24,7 @@ Note: This section keeps on growing! Keep an eye on it from time to time.
 
 [Guardiola31337/uiagesturegen](https://github.com/Guardiola31337/uiagesturegen): UI Automator Gesture Generation DSL
 
-[JorgeCastilloPrz/KotlinAndroidFunctional](https://github.com/JorgeCastilloPrz/KotlinAndroidFunctional): Functional Programing based architectures
+[JorgeCastilloPrz/ArrowAndroidSamples](https://github.com/JorgeCastilloPrz/ArrowAndroidSamples/): Android architecture samples using Arrow
 
 [dcampogiani/AndroidFunctionalValidation](https://github.com/dcampogiani/AndroidFunctionalValidation): Simple form validation using Arrow
 


### PR DESCRIPTION
## Goal

Add Kotliners ArrowFx talk to the blog page in the media category, plus fix the `ArrowAndroidSamples` repo link since it was outdated.