### PR TITLE
Add documentation to disable explicit unit return error in ktlint

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/quickstart/linting/README.md
+++ b/modules/docs/arrow-docs/docs/docs/quickstart/linting/README.md
@@ -27,3 +27,7 @@ To make this explicit, these functions can return Unit. However, IDEA will show 
 You can disable this warning in Preferences > Editor > Inspections. Then search for the option Kotlin > Redundant constructs > Redundant Unit return type.
 
 ![gif](/img/linting/linting_unit_return_type.gif)
+
+If you are using [ktlint](https://ktlint.github.io/) as the linter of choice for your project, this scenario will reported as an error, making builds fail. 
+
+You can disable this errors. For that you must upgrade ktlint version to `0.34.0` or later and add `disabled_rules=no-unit-return` to the `.editorconfig` file. You can read more about this topic [here](https://github.com/pinterest/ktlint#editorconfig).


### PR DESCRIPTION
### References

* Fixes https://github.com/arrow-kt/arrow/issues/1502

### Description

[ktlint-v0.34.0](https://github.com/pinterest/ktlint/releases/tag/0.34.0) has been released and includes the new feature to globally disable rules from the `.editconfig` file. 

This PR includes a small guide to disable ktlint errors when `Unit` is used as an explicit return type in the existing section that explains why this is considered desireable when working with Arrow and FP
