### PR TITLE
cleanUp on "stable" webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img height="100" src="https://avatars2.githubusercontent.com/u/29458023?v=4&amp;s=200" width="100">
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-docs.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.arrow-kt%22%20AND%20a:%22arrow-docs%22)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![codecov](https://codecov.io/gh/arrow-kt/arrow/branch/master/graph/badge.svg)](https://codecov.io/gh/arrow-kt/arrow)
@@ -45,32 +44,12 @@ Add it in your root `build.gradle` at the end of repositories.
 ```groovy
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
+        maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
     }
 }
 ```
-
-# Dependency breakdown starting in Arrow 0.9.1
-
-Starting in 0.9.1, Arrow follows the following convention for artifact publication.
-
-The arrow modules are Core, Effects, Optics, Recursion, etc.
-
-An Arrow module is composed of data types and type classes.
-Arrow modules are exported and published with the following semantics.
-
-If we take for example `arrow-core`. 
-
-Arrow core contains the basic arrow type classes and data types and it's composed of 3 main artifacts that may be used a la carte:
-
-Recomended for most use cases:
-
-- `arrow-core` (Depends on data and extensions modules and exports both)
-
-Trimmed down versions:
-
-- `arrow-core-data` (Only data types)
-- `arrow-core-extensions` (Only type class extensions)
 
 # Current stable version 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ dependencies {
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-integration-retrofit-adapter:$arrow_version" //optional
 }
-
 ```
 
 # Additional Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img height="100" src="https://avatars2.githubusercontent.com/u/29458023?v=4&amp;s=200" width="100">
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-docs.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.arrow-kt%22%20AND%20a:%22arrow-docs%22)
+[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-core-data.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.arrow-kt%22%20AND%20a:%22arrow-core-data%22)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![codecov](https://codecov.io/gh/arrow-kt/arrow/branch/master/graph/badge.svg)](https://codecov.io/gh/arrow-kt/arrow)

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -4,8 +4,7 @@ title: Quick Start
 permalink: /docs/
 ---
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-docs.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.arrow-kt%22%20AND%20a:%22arrow-docs%22)[![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -41,47 +40,14 @@ allprojects {
         mavenCentral()
         jcenter()
         maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
-        maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     }
 }
 ```
-
-# Dependency breakdown starting in Arrow 0.9.1
-
-Starting in 0.9.1, Arrow follows the following convention for artifact publication.
-
-The arrow modules are Core, Effects, Optics, Recursion, etc.
-
-An Arrow module is composed of data types and type classes.
-Arrow modules are exported and published with the following semantics.
-
-If we take for example `arrow-core`.
-
-Arrow core contains the basic arrow type classes and data types and it's composed of 3 main artifacts that may be used a la carte:
-
-Recomended for most use cases:
-
-- `arrow-core` (Depends on data and extensions modules and exports both)
-
-Trimmed down versions:
-
-- `arrow-core-data` (Only data types)
-- `arrow-core-extensions` (Only type class extensions)
 
 # Current stable version 0.9.0
 
 ```groovy
 def arrow_version = "0.9.0"
-```
-
-You can find the dependencies necessary in the Basic Setup of the README at the 0.9.0 tag clicking [here](https://github.com/arrow-kt/arrow/blob/0.9.0/README.md#next-development-version-090).
-
-# Next development version 0.9.1
-
-Add the dependencies into the project's `build.gradle`
-
-```groovy
-def arrow_version = "0.9.1-SNAPSHOT"
 dependencies {
     compile "io.arrow-kt:arrow-core-data:$arrow_version"
     compile "io.arrow-kt:arrow-core-extensions:$arrow_version"
@@ -90,7 +56,7 @@ dependencies {
     compile "io.arrow-kt:arrow-extras-data:$arrow_version"
     compile "io.arrow-kt:arrow-extras-extensions:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
-
+    
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-data:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-extensions:$arrow_version" //optional
@@ -111,6 +77,7 @@ dependencies {
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-integration-retrofit-adapter:$arrow_version" //optional
 }
+
 ```
 
 # Additional Setup

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -56,6 +56,7 @@ dependencies {
     compile "io.arrow-kt:arrow-extras-data:$arrow_version"
     compile "io.arrow-kt:arrow-extras-extensions:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
+    
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-data:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-extensions:$arrow_version" //optional
@@ -76,7 +77,6 @@ dependencies {
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-integration-retrofit-adapter:$arrow_version" //optional
 }
-
 ```
 
 # Additional Setup

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -4,7 +4,7 @@ title: Quick Start
 permalink: /docs/
 ---
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-docs.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.arrow-kt%22%20AND%20a:%22arrow-docs%22)[![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-core-data.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.arrow-kt%22%20AND%20a:%22arrow-core-data%22)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -56,7 +56,6 @@ dependencies {
     compile "io.arrow-kt:arrow-extras-data:$arrow_version"
     compile "io.arrow-kt:arrow-extras-extensions:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
-    
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-data:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-extensions:$arrow_version" //optional

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -132,7 +132,7 @@ Add to your pom.xml file the following properties:
 ```
 <properties>
     <kotlin.version>1.3.0</kotlin.version>
-    <arrow.version>0.8.2</arrow.version>
+    <arrow.version>0.9.0</arrow.version>
 </properties>
 ```
 

--- a/modules/docs/arrow-docs/docs/docs/README.md
+++ b/modules/docs/arrow-docs/docs/docs/README.md
@@ -56,7 +56,7 @@ dependencies {
     compile "io.arrow-kt:arrow-extras-data:$arrow_version"
     compile "io.arrow-kt:arrow-extras-extensions:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
-    
+
     compile "io.arrow-kt:arrow-query-language:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-data:$arrow_version" //optional
     compile "io.arrow-kt:arrow-free-extensions:$arrow_version" //optional


### PR DESCRIPTION
fixes some webpage problems users have and deletes references to SnapShot builds. 