### PR TITLE
Fix AndThen#contramap doc

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/AndThen.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/AndThen.kt
@@ -115,7 +115,7 @@ sealed class AndThen<A, B> : (A) -> B, AndThenOf<A, B> {
     andThen(f)
 
   /**
-   * Alias for [andThen]
+   * Alias for [compose]
    *
    * @see compose
    */


### PR DESCRIPTION
`AndThen#contramap` seems not `andThen` alias. Correctly it is `compose` alias.