### PR TITLE
Improve Try#filter documentation

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/arrow/core/try/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/core/try/README.md
@@ -93,8 +93,8 @@ lotteryTry.getOrElse { emptyList() }
 If you want to perform a check on a possible success, you can use `filter` to convert successful computations in failures if conditions aren't met:
 
 ```kotlin:ank
-lotteryTry.filter {
-    it.size < 4
+Try.just(0).filter {
+    it > 1
 }
 ```
 


### PR DESCRIPTION
I was just reading the documentation of `Try` and IMHO I think the `Try#filter` example can be slightly improved.
The documentation says "convert successful computations in failures" but the result of the code example is `Failure(exception=Line_1$AuthorizationException)`

<img width="503" alt="Bildschirmfoto 2019-08-07 um 14 37 33" src="https://user-images.githubusercontent.com/10738773/62598757-5c00de00-b925-11e9-817b-e5906548a91a.png">

This means the computation was never successful and I would also expect to see a `TryException.PredicateException` in the code example.

With this change the example in the documentation should return a `Failure(exception=PredicateException(message=Predicate does not hold for 0))`.

Image source: [https://arrow-kt.io/docs/arrow/core/try/](https://arrow-kt.io/docs/arrow/core/try/) (07.08.2019)
