### PR TITLE
Moved hkjs.kt to package arrow in order to enable java9+ support

### DIFF
--- a/modules/core/arrow-kindedj/src/main/kotlin/arrow/kindedj/Convert.kt
+++ b/modules/core/arrow-kindedj/src/main/kotlin/arrow/kindedj/Convert.kt
@@ -2,7 +2,7 @@ package arrow.kindedj
 
 import arrow.Kind
 import arrow.Kind2
-import io.kindedj.HkJ2
+import arrow.HkJ2
 import io.kindedj.Hk as HK_J
 
 class ForConvert private constructor()

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Resource.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Resource.kt
@@ -1,5 +1,6 @@
 package arrow.fx
 
+import arrow.HkJ3
 import arrow.Kind
 import arrow.core.Either
 import arrow.fx.typeclasses.Bracket
@@ -12,7 +13,7 @@ class ForResource private constructor() {
 }
 typealias ResourceOf<F, E, A> = arrow.Kind3<ForResource, F, E, A>
 typealias ResourcePartialOf<F, E> = arrow.Kind2<ForResource, F, E>
-typealias ResourceKindedJ<F, E, A> = io.kindedj.HkJ3<ForResource, F, E, A>
+typealias ResourceKindedJ<F, E, A> = HkJ3<ForResource, F, E, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 inline fun <F, E, A> ResourceOf<F, E, A>.fix(): Resource<F, E, A> =

--- a/modules/meta/arrow-annotations/src/main/java/arrow/hkjs.kt
+++ b/modules/meta/arrow-annotations/src/main/java/arrow/hkjs.kt
@@ -1,5 +1,5 @@
-@file:Suppress("UnusedImports")
-package io.kindedj
+@file:Suppress("UnusedImports","unused")
+package arrow
 
 import io.kindedj.Hk as HK_J
 


### PR DESCRIPTION
Moved hkjs.kt out of io.kindedj in order to not declare io.kindedj in more than one jar, see #1196 