### PR TITLE
Fix extension processor suspend fun args

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Async.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Async.kt
@@ -150,7 +150,7 @@ interface Async<F> : MonadDefer<F> {
    * fun main(args: Array<String>) {
    *   //sampleStart
    *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
-   *     _delay_(Dispatchers.Default, { Thread.currentThread().name })
+   *     _later_(Dispatchers.Default, { Thread.currentThread().name })
    *
    *   val result = _extensionFactory_.invokeOnDefaultDispatcher()
    *   //sampleEnd
@@ -320,6 +320,29 @@ interface Async<F> : MonadDefer<F> {
    */
   fun <A> never(): Kind<F, A> =
     async { }
+
+  /**
+   * Helper function that provides an easy way to construct a suspend effect
+   *
+   * ```kotlin:ank:playground:extension
+   * _imports_
+   * import kotlinx.coroutines.Dispatchers
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   suspend fun logAndIncrease(s: String): Int {
+   *      println(s)
+   *      return s.toInt() + 1
+   *   }
+   *
+   *   val result = _extensionFactory_.effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+   *   //sampleEnd
+   *   println(result)
+   * }
+   * ```
+   */
+  fun <A, B> Kind<F, A>.effectMap(f: suspend (A) -> B): Kind<F, B> =
+    flatMap { a -> effect { f(a) } }
 }
 
 internal val mapUnit: (Any?) -> Unit = { Unit }

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/TypeElementEncoder.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/TypeElementEncoder.kt
@@ -1,6 +1,6 @@
 package arrow.meta.encoder.jvm
 
-import  arrow.common.utils.ClassOrPackageDataWrapper
+import arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.ProcessorUtils
 import arrow.meta.Either
 import arrow.meta.ast.Annotation

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/TypeElementEncoder.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/TypeElementEncoder.kt
@@ -1,6 +1,6 @@
 package arrow.meta.encoder.jvm
 
-import arrow.common.utils.ClassOrPackageDataWrapper
+import  arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.ProcessorUtils
 import arrow.meta.Either
 import arrow.meta.ast.Annotation
@@ -186,21 +186,21 @@ interface TypeElementEncoder : KotlinMetatadataEncoder, KotlinPoetEncoder, Proce
       }
     )
 
-  fun TypeName.ParameterizedType.isSimpleContinuation(): Boolean =
-    (rawType.fqName == Function1::class.qualifiedName && typeArguments.size == 2 && {
-      val maybeContinuation = typeArguments[0]
-      when {
-        maybeContinuation is TypeName.WildcardType &&
-          maybeContinuation.lowerBounds.isNotEmpty() -> {
-          val lowerBoundsContinuation = maybeContinuation.lowerBounds[0]
-          lowerBoundsContinuation is TypeName.ParameterizedType &&
-            lowerBoundsContinuation.rawType.fqName == Continuation::class.qualifiedName
-        }
-        else -> false
-      }
-    }())
+  fun TypeName.ParameterizedType.isContinuation(): Boolean =
+    (rawType.fqName == Function1::class.qualifiedName || rawType.fqName == Function2::class.qualifiedName && typeArguments.size >= 2) && continuationType() != null
 
-  fun TypeName.ParameterizedType.isReceiverContinuation(): Boolean =
+  fun TypeName.ParameterizedType.continuationType(): TypeName.ParameterizedType? {
+    val wildcard = typeArguments.filterIsInstance<TypeName.WildcardType>().find {
+      it.lowerBounds.isNotEmpty() && {
+        val lowerBoundsContinuation = it.lowerBounds[0]
+        lowerBoundsContinuation is TypeName.ParameterizedType &&
+          lowerBoundsContinuation.isContinuationType()
+      }()
+    }
+    return wildcard?.lowerBounds?.get(0) as? TypeName.ParameterizedType
+  }
+
+  fun TypeName.ParameterizedType.isMonadContinuation(): Boolean =
     rawType.fqName == Function2::class.qualifiedName && typeArguments.size == 3 && {
       val maybeContinuation = typeArguments[1]
       when {
@@ -208,15 +208,18 @@ interface TypeElementEncoder : KotlinMetatadataEncoder, KotlinPoetEncoder, Proce
           maybeContinuation.lowerBounds.isNotEmpty() -> {
           val lowerBoundsContinuation = maybeContinuation.lowerBounds[0]
           lowerBoundsContinuation is TypeName.ParameterizedType &&
-            lowerBoundsContinuation.rawType.fqName == Continuation::class.qualifiedName
+            lowerBoundsContinuation.isContinuationType()
         }
         else -> false
       }
-    }()
+    }() && (name.contains("Monad.*Continuation".toRegex()) || name.contains("Concurrent.*Continuation".toRegex()))
+
+  fun TypeName.ParameterizedType.isContinuationType() =
+    rawType.fqName == Continuation::class.qualifiedName
 
   private fun TypeName.ParameterizedType.asSuspendedContinuation(): TypeName =
     when {
-      isReceiverContinuation() -> TypeName.FunctionLiteral(
+      isMonadContinuation() -> TypeName.FunctionLiteral(
         modifiers = listOf(arrow.meta.ast.Modifier.Suspend),
         receiverType = typeArguments[0],
         parameters = emptyList(),
@@ -226,16 +229,16 @@ interface TypeElementEncoder : KotlinMetatadataEncoder, KotlinPoetEncoder, Proce
           it.typeArguments[0]
         } ?: TypeName.Unit
       )
-      isSimpleContinuation() -> TypeName.FunctionLiteral(
-        receiverType = null,
-        modifiers = listOf(arrow.meta.ast.Modifier.Suspend),
-        parameters = emptyList(),
-        returnType = (typeArguments[0] as? TypeName.WildcardType)?.let {
-          it.lowerBounds[0] as? TypeName.ParameterizedType
-        }?.let {
-          it.typeArguments[0]
-        } ?: TypeName.Unit
-      )
+      isContinuation() -> {
+        val continuation = continuationType()
+        val params = typeArguments.filterIsInstance<TypeName.WildcardType>().takeWhile { it.lowerBounds[0] != continuation }
+        TypeName.FunctionLiteral(
+          receiverType = null,
+          modifiers = listOf(arrow.meta.ast.Modifier.Suspend),
+          parameters = params,
+          returnType = continuation?.typeArguments?.get(0) ?: TypeName.Unit
+        )
+      }
       else -> this
     }
 
@@ -272,7 +275,7 @@ interface TypeElementEncoder : KotlinMetatadataEncoder, KotlinPoetEncoder, Proce
     }
     return if (
       "kotlin/ExtensionFunctionType" in jvmTypeAnnotations && typeArguments.size >= 2)
-      if (isReceiverContinuation() || isSimpleContinuation()) asSuspendedContinuation()
+      if (isMonadContinuation() || isContinuation()) asSuspendedContinuation()
       else TypeName.FunctionLiteral(
         receiverType = typeArguments[0],
         parameters = typeArguments.drop(1).dropLast(1),


### PR DESCRIPTION
See #1485 
Fixes #1554

@FireZenk @nomisRev @pakoito meta generates now for functions like effectMap:
```kotlin
fun <A, B> Kind<ForIO, A>.effectMap(f: suspend (A) -> B): IO<B> = arrow.fx.IO.async().run {
  this@effectMap.effectMap<A, B>(f) as arrow.fx.IO<B>
}
```