### PR TITLE
Fix IOParMap3 null bug

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ConcurrentParMap2.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ConcurrentParMap2.kt
@@ -4,7 +4,7 @@ import arrow.Kind
 import arrow.fx.typeclasses.Concurrent
 import kotlin.coroutines.CoroutineContext
 
-fun <F, A, B, C> Concurrent<F>.parMap2(
+internal fun <F, A, B, C> Concurrent<F>.parMap2(
   ctx: CoroutineContext,
   fa: Kind<F, A>,
   fb: Kind<F, B>,

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ConcurrentParMap3.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ConcurrentParMap3.kt
@@ -4,7 +4,7 @@ import arrow.Kind
 import arrow.fx.typeclasses.Concurrent
 import kotlin.coroutines.CoroutineContext
 
-fun <F, A, B, C, D> Concurrent<F>.parMap3(ctx: CoroutineContext, fa: Kind<F, A>, fb: Kind<F, B>, fc: Kind<F, C>, f: (A, B, C) -> D): Kind<F, D> = ctx.run {
+internal fun <F, A, B, C, D> Concurrent<F>.parMap3(ctx: CoroutineContext, fa: Kind<F, A>, fb: Kind<F, B>, fc: Kind<F, C>, f: (A, B, C) -> D): Kind<F, D> = ctx.run {
   tupled(fb.fork(this), fa.fork(this), fc.fork(this)).bracket(use = { (fiberB, fiberA, fiberC) ->
     raceTriple(fiberA.join().attempt(), fiberB.join().attempt(), fiberC.join().attempt()).flatMap { tripleResult ->
       tripleResult.fold({ attemptedA, fiberB, fiberC ->

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -8,12 +8,16 @@ import arrow.core.Some
 import arrow.core.Tuple4
 import arrow.core.right
 import arrow.fx.IO.Companion.just
+import arrow.fx.IO.Companion.parMapN
 import arrow.fx.extensions.fx
 import arrow.fx.extensions.io.async.async
 import arrow.fx.extensions.io.concurrent.concurrent
 import arrow.fx.extensions.io.concurrent.parMapN
+import arrow.fx.extensions.io.dispatchers.dispatchers
 import arrow.fx.extensions.io.monad.flatMap
 import arrow.fx.extensions.io.monad.map
+import arrow.fx.internal.parMap2
+import arrow.fx.internal.parMap3
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.milliseconds
 import arrow.fx.typeclasses.seconds
@@ -37,6 +41,7 @@ class IOTest : UnitSpec() {
 
   private val other = newSingleThreadContext("other")
   private val all = newSingleThreadContext("all")
+  private val NonBlocking = IO.dispatchers().default()
 
   init {
     testLaws(ConcurrentLaws.laws(IO.concurrent(), EQ(), EQ(), EQ()))
@@ -541,6 +546,56 @@ class IOTest : UnitSpec() {
       }
 
       just(1).flatMap(::ioAsync).unsafeRunSync() shouldBe size
+    }
+
+    "IOParMap2 left handles null" {
+      parMapN(NonBlocking, IO.just<Int?>(null), IO.unit) { _, unit -> unit }
+        .unsafeRunSync() shouldBe Unit
+    }
+
+    "IOParMap2 right handles null" {
+      parMapN(NonBlocking, IO.unit, IO.just<Int?>(null)) { unit, _ -> unit }
+        .unsafeRunSync() shouldBe Unit
+    }
+
+    "IOParMap3 left handles null" {
+      parMapN(NonBlocking, IO.just<Int?>(null), IO.unit, IO.unit) { _, unit, _ -> unit }
+        .unsafeRunSync() shouldBe Unit
+    }
+
+    "IOParMap3 middle handles null" {
+      parMapN(NonBlocking, IO.unit, IO.just<Int?>(null), IO.unit) { unit, _, _ -> unit }
+        .unsafeRunSync() shouldBe Unit
+    }
+
+    "IOParMap3 right handles null" {
+      parMapN(NonBlocking, IO.unit, IO.unit, IO.just<Int?>(null)) { unit, _, _ -> unit }
+        .unsafeRunSync() shouldBe Unit
+    }
+
+    "ConcurrentParMap2 left handles null" {
+      IO.concurrent().parMap2(NonBlocking, IO.just<Int?>(null), IO.unit) { _, unit -> unit }
+        .fix().unsafeRunSync() shouldBe Unit
+    }
+
+    "ConcurrentParMap2 right handles null" {
+      IO.concurrent().parMap2(NonBlocking, IO.unit, IO.just<Int?>(null)) { unit, _ -> unit }
+        .fix().unsafeRunSync() shouldBe Unit
+    }
+
+    "ConcurrentParMap3 left handles null" {
+      IO.concurrent().parMap3(NonBlocking, IO.just<Int?>(null), IO.unit, IO.unit) { _, unit, _ -> unit }
+        .fix().unsafeRunSync() shouldBe Unit
+    }
+
+    "ConcurrentParMap3 middle handles null" {
+      IO.concurrent().parMap3(NonBlocking, IO.unit, IO.just<Int?>(null), IO.unit) { unit, _, _ -> unit }
+        .fix().unsafeRunSync() shouldBe Unit
+    }
+
+    "ConcurrentParMap3 right handles null" {
+      IO.concurrent().parMap3(NonBlocking, IO.unit, IO.unit, IO.just<Int?>(null)) { unit, _, _ -> unit }
+        .fix().unsafeRunSync() shouldBe Unit
     }
   }
 }


### PR DESCRIPTION
Fixes a null related bug in IOParMap3 that makes a param of `IO.just(null)` makes the code hang.