### PR TITLE
remove codevoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ jobs:
   - stage: build
     script:
     - ./gradlew clean build :arrow-benchmarks-fx:jmhClasses
-  - stage: coverage-report
-    script:
-    - ./gradlew codeCoverageReport
-    - bash <(curl -s https://codecov.io/bash)
   - stage: deploy
     script:
     - ./deploy-scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![codecov](https://codecov.io/gh/arrow-kt/arrow/branch/master/graph/badge.svg)](https://codecov.io/gh/arrow-kt/arrow)
 [![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)]( http://stackoverflow.com/questions/tagged/arrow-kt )
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,15 +85,10 @@ subprojects { project ->
     version = VERSION_NAME
 
     apply plugin: 'kotlin'
-    apply plugin: 'jacoco'
     apply plugin: 'org.jetbrains.dokka'
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 
     archivesBaseName = POM_ARTIFACT_ID
-
-    jacoco {
-        toolVersion '0.8.2'
-    }
 
     //dokka log spam `Can't find node by signature` comes from https://github.com/Kotlin/dokka/issues/269
     dokka {
@@ -117,22 +112,6 @@ subprojects { project ->
             suffix = "#L"
         }
 
-    }
-
-    task codeCoverageReport(type: JacocoReport) {
-        reports {
-            xml.enabled true
-            xml.destination file("${buildDir}/reports/jacoco/report.xml")
-            html.enabled true
-            csv.enabled false
-        }
-
-        classDirectories = fileTree(
-                dir: 'build/classes/kotlin/main',
-        )
-
-        sourceDirectories = files('src/main/kotlin')
-        executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
     }
 
     apply plugin: 'com.jfrog.bintray'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-codecov:
-  notify:
-    require_ci_to_pass: yes
-coverage:
-  status:
-    project: off
-    patch: off
-comment:
-  require_changes: yes


### PR DESCRIPTION
### :tophat: What is the goal?

Talking with @JorgeCastilloPrz and @i-walker we don't see the needs of coverage reports until a stable version is released, codecov was disabled on #1108 but still executed as CI stage. 

This PR remove that stage on CI, badge on README.MD and codecov configuration file


### :memo: Notes
I still keep the codecov integration for the Arrow-kt organization, but without any repo access