### PR TITLE
Upgrade ktlint and disable no-unit-return rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@
 indent_size=2
 insert_final_newline=true
 max_line_length=off
+disabled_rules=import-ordering

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,4 +3,4 @@
 indent_size=2
 insert_final_newline=true
 max_line_length=off
-disabled_rules=import-ordering
+disabled_rules=import-ordering,no-unit-return

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         // Constants
         ankKotlinVersion = '1.3.11'
         dokka_version = '0.9.18'
+        ktlint_version = "0.34.2"
         ktlint_gradle_version = '8.2.0'
         gradleVersionsPluginVersion = '0.21.0'
         jUnitVersion = '4.12'
@@ -87,6 +88,10 @@ subprojects { project ->
     apply plugin: 'kotlin'
     apply plugin: 'org.jetbrains.dokka'
     apply plugin: "org.jlleitschuh.gradle.ktlint"
+
+    ktlint {
+        version = ktlint_version
+    }
 
     archivesBaseName = POM_ARTIFACT_ID
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         // Constants
         ankKotlinVersion = '1.3.11'
         dokka_version = '0.9.18'
-        ktlint_gradle_version = '7.3.0'
+        ktlint_gradle_version = '8.2.0'
         gradleVersionsPluginVersion = '0.21.0'
         jUnitVersion = '4.12'
         jUnitVintageVersion = '5.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         // Constants
         ankKotlinVersion = '1.3.11'
         dokka_version = '0.9.18'
-        ktlint_version = '7.3.0'
+        ktlint_gradle_version = '7.3.0'
         gradleVersionsPluginVersion = '0.21.0'
         jUnitVersion = '4.12'
         jUnitVintageVersion = '5.4.0'
@@ -56,7 +56,7 @@ buildscript {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.7"
         classpath "gradle.plugin.io.morethan.jmhreport:gradle-jmh-report:0.9.0"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_version"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_gradle_version"
     }
 }
 

--- a/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
+++ b/modules/ank/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
@@ -84,7 +84,9 @@ sealed class SnippetParserState {
 
 val interpreter: AnkOps = object : AnkOps {
 
-  override suspend fun printConsole(msg: String): Unit = println(msg)
+  override suspend fun printConsole(msg: String): Unit {
+    println(msg)
+  }
 
   private fun Path.containsAnkSnippets(): Boolean =
     toFile().bufferedReader().use {

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Bifunctor.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Bifunctor.kt
@@ -53,8 +53,7 @@ interface Bifunctor<F> {
    *
    * ```
    */
-  fun <A, B, C, D> lift(fl: (A) -> C, fr: (B) -> D): (Kind2<F, A, B>) -> Kind2<F, C, D> =
-    { kind2 ->
+  fun <A, B, C, D> lift(fl: (A) -> C, fr: (B) -> D): (Kind2<F, A, B>) -> Kind2<F, C, D> = { kind2 ->
       kind2.bimap(fl, fr)
     }
 

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Contravariant.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Contravariant.kt
@@ -8,8 +8,7 @@ import arrow.Kind
 interface Contravariant<F> : Invariant<F> {
     fun <A, B> Kind<F, A>.contramap(f: (B) -> A): Kind<F, B>
 
-    fun <A, B> lift(f: (A) -> B, dummy: Unit = Unit): (Kind<F, B>) -> Kind<F, A> =
-        { fb: Kind<F, B> ->
+    fun <A, B> lift(f: (A) -> B, dummy: Unit = Unit): (Kind<F, B>) -> Kind<F, A> = { fb: Kind<F, B> ->
             fb.contramap(f)
         }
 

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -215,8 +215,7 @@ interface Foldable<F> {
 
   companion object {
     @Deprecated("This function will be removed soon. Use Iterator.iterateRight from Eval.kt instead")
-    fun <A, B> iterateRight(it: Iterator<A>, lb: Eval<B>): (f: (A, Eval<B>) -> Eval<B>) -> Eval<B> =
-      { f: (A, Eval<B>) -> Eval<B> ->
+    fun <A, B> iterateRight(it: Iterator<A>, lb: Eval<B>): (f: (A, Eval<B>) -> Eval<B>) -> Eval<B> = { f: (A, Eval<B>) -> Eval<B> ->
         fun loop(): Eval<B> =
           Eval.defer { if (it.hasNext()) f(it.next(), loop()) else lb }
         loop()

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -109,8 +109,7 @@ interface Functor<F> : Invariant<F> {
    * }
    * ```
    */
-  fun <A, B> lift(f: (A) -> B): (Kind<F, A>) -> Kind<F, B> =
-    { fa: Kind<F, A> -> fa.map(f) }
+  fun <A, B> lift(f: (A) -> B): (Kind<F, A>) -> Kind<F, B> = { fa: Kind<F, A> -> fa.map(f) }
 
   /**
    * Discards the [A] value inside [F] signaling this container may be pointing to a noop

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/function0.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/function0.kt
@@ -27,8 +27,7 @@ import arrow.core.select as fun0Select
 interface Function0Semigroup<A> : Semigroup<Function0<A>> {
   fun SA(): Semigroup<A>
 
-  override fun Function0<A>.combine(b: Function0<A>): Function0<A> =
-    { SA().run { invoke().combine(b.invoke()) } }.k()
+  override fun Function0<A>.combine(b: Function0<A>): Function0<A> = { SA().run { invoke().combine(b.invoke()) } }.k()
 }
 
 @extension
@@ -37,8 +36,7 @@ interface Function0Monoid<A> : Monoid<Function0<A>>, Function0Semigroup<A> {
 
   override fun SA() = MA()
 
-  override fun empty(): Function0<A> =
-    { MA().run { empty() } }.k()
+  override fun empty(): Function0<A> = { MA().run { empty() } }.k()
 }
 
 @extension

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/ast/ast.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/ast/ast.kt
@@ -48,7 +48,8 @@ sealed class TypeName : Tree() {
     val variance: Modifier? = null,
     val reified: Boolean = false,
     val nullable: Boolean = false,
-    val annotations: List<Annotation> = emptyList()) : TypeName() {
+    val annotations: List<Annotation> = emptyList()
+  ) : TypeName() {
 
     override val simpleName: String
       get() = name
@@ -101,7 +102,8 @@ sealed class TypeName : Tree() {
     val rawType: Classy,
     val typeArguments: List<TypeName> = emptyList(),
     val nullable: Boolean = false,
-    val annotations: List<Annotation> = emptyList()) : TypeName() {
+    val annotations: List<Annotation> = emptyList()
+  ) : TypeName() {
 
     override val rawName: String
       get() = name.substringBefore("<")
@@ -117,7 +119,8 @@ sealed class TypeName : Tree() {
     val fqName: String,
     val pckg: PackageName,
     val nullable: Boolean = false,
-    val annotations: List<Annotation> = emptyList()) : TypeName() {
+    val annotations: List<Annotation> = emptyList()
+  ) : TypeName() {
 
     override val rawName: String
       get() = fqName
@@ -159,7 +162,8 @@ data class Parameter(
   val type: TypeName,
   val defaultValue: Code? = null,
   val annotations: List<Annotation> = emptyList(),
-  val modifiers: List<Modifier> = emptyList()) : Tree() {
+  val modifiers: List<Modifier> = emptyList()
+) : Tree() {
   companion object
 }
 
@@ -184,7 +188,8 @@ data class Property(
   val jvmPropertySignature: String? = null,
   val jvmFieldSignature: String? = null,
   val annotations: List<Annotation> = emptyList(),
-  val modifiers: List<Modifier> = emptyList()) : Tree() {
+  val modifiers: List<Modifier> = emptyList()
+) : Tree() {
   companion object
 }
 
@@ -254,7 +259,8 @@ data class Type(
   val properties: List<Property> = emptyList(),
   val declaredFunctions: List<Func> = emptyList(),
   val allFunctions: List<Func> = emptyList(),
-  val types: List<Type> = emptyList()) : Tree() {
+  val types: List<Type> = emptyList()
+) : Tree() {
 
   sealed class Shape {
     object Class : Shape()


### PR DESCRIPTION
### References

#1525

### Description

Upgrade ktlint to the latest version where rules can be globally disabled via `.editorconfig` and include `no-unit-return` so functions can declare `Unit` return type explicitly

### Implementation

Bump ktlint gradle plugin to latest version, from 7.3.0 to 8.2.0. This would set ktlint to use version 0.34.0. This version shipped with some bugs, so have forced ktlint to latest minor where they are fixed by setting the library version through KtlintExtension in `build.gradle`. 

This effectively bumps ktlint from 0.31.0 to 0.34.2, allowing `no-unit-return` to be disabled. Apart from it, the following rules have required attention in the codebase

#### import-ordering

Added on version `0.34.0` to the [standard rule set](https://github.com/pinterest/ktlint/commit/adb4d4d20a63ad0ab5c67e426429c273bbdec2ad#diff-ccd5a7f365eb13a0c3aea71168cf3bc6R15). It changes imports to follow alphabetical order. This will conflict with Intellij order and the reason why it has been **ignored**

```
./gradlew ktlintFormat

(...)
230 files changed, 536 insertions(+), 537 deletions(-)
```

#### curly-spacing

Already existed in the standard ruleset but must have some fixes/corrections in previous versions. Fixed the violations found in the project and **kept** the rule

```
./gradlew ktlintFormat

modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Bifunctor.kt     | 3 +--
modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Contravariant.kt | 3 +--
modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt      | 3 +--
modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt       | 3 +--
modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/function0.kt      | 6 ++----
5 files changed, 6 insertions(+), 12 deletions(-)
```

#### parameter-list-wrapping

Also existed in the standard ruleset but its implementation has changed in previous versions. Fixed the violations found in the project and **kept** the rule
```
./gradlew ktlintFormat

 modules/meta/arrow-meta/src/main/java/arrow/meta/ast/ast.kt | 18 ++++++++++++------
 1 file changed, 12 insertions(+), 6 deletions(-)
```
