### PR TITLE
Added Boolean.rightIfTrue extension method. 

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -396,6 +396,31 @@ fun <A> Any?.rightIfNull(default: () -> A): Either<A, Nothing?> = when (this) {
   null -> Either.right(null)
   else -> Either.left(default())
 }
+
+/**
+ * Returns [Either.Right] if the Boolean value is true. otherwise the specified A value wrapped into an
+ * [Either.Left]
+ *
+ * Example:
+ * ```
+ * (true).rightIfTrue { "left" }   // Right(b="Nothing?")
+ * (false).rightIfTrue { "left" }  // Left(a="left")
+ * ```
+ */
+fun <A> Boolean.rightIfTrue(default: () -> A): Either<A, Nothing?> = rightIfTrue({ null }, default)
+
+/**
+ * Returns [Either.Right] if the Boolean value is true. otherwise the specified A value wrapped into an
+ * [Either.Left]
+ *
+ * Example:
+ * ```
+ * (true).rightIfTrue({ "right" }, { "left" })   // Right(b="right")
+ * (false).rightIfTrue({ "left" }, { "right" })  // Left(a="left")
+ * ```
+ */
+fun <L, R> Boolean.rightIfTrue(right: () -> R, left: () -> L): Either<L, R> = Either.cond(this, right, left)
+
 /**
  * Applies the given function `f` if this is a [Left], otherwise returns this if this is a [Right].
  * This is like `flatMap` for the exception.

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -151,6 +151,15 @@ class EitherTest : UnitSpec() {
       }
     }
 
+    "rightIfTrue should return Left if value is false or right when value is true" {
+      forAll { a: Int, b: Int ->
+        (false).rightIfTrue { b } == Left(b) &&
+          (true).rightIfTrue { a } == Right(null) &&
+          (false).rightIfTrue({ b }) { a } == Left(a) &&
+          (true).rightIfTrue({ b }) { a } == Right(b)
+      }
+    }
+
     "swap should interchange values" {
       forAll { a: Int ->
         Left(a).swap() == Right(a) &&

--- a/modules/docs/arrow-docs/docs/docs/arrow/core/either/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/core/either/README.md
@@ -256,6 +256,17 @@ Either.cond(true, { 42 }, { "Error" })
 Either.cond(false, { 42 }, { "Error" })
 ```
 
+A shorthand for `Either.cond()` is the Boolean rightIfTrue extension method which is 
+functionally equivalent. 
+
+```kotlin:ank
+(true).rightIfTrue({ 42 }, { "Error" })
+```
+
+```kotlin:ank
+(false).rightIfTrue({ 42 }, { "Error" })
+```
+
 Another operation is `fold`. This operation will extract the value from the Either, or provide a default if the value is `Left`
 
 ```kotlin:ank


### PR DESCRIPTION
## Changes
Added Boolean Extension method rightIfTrue.

Functionally the same as using Either.cond but simplified syntax. 

Example

```kotlin
( 1 == 2).rightIfTrue({"Success" }, { "Failure" })
```
Or

```kotlin
( 1 == 1).rightIfTrue({ "Failure" })
```
results in Either.Right(null)