### PR TITLE
Make Rx family covariant

### DIFF
--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableK.kt
@@ -24,7 +24,6 @@ class ForFlowableK private constructor() {
   companion object
 }
 typealias FlowableKOf<A> = arrow.Kind<ForFlowableK, A>
-typealias FlowableKKindedJ<A> = io.kindedj.Hk<ForFlowableK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 inline fun <A> FlowableKOf<A>.fix(): FlowableK<A> =
@@ -32,9 +31,9 @@ inline fun <A> FlowableKOf<A>.fix(): FlowableK<A> =
 
 fun <A> Flowable<A>.k(): FlowableK<A> = FlowableK(this)
 
-fun <A> FlowableKOf<A>.value(): Flowable<A> = fix().flowable
+fun <A> FlowableKOf<A>.value(): Flowable<A> = fix().flowable as Flowable<A>
 
-data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKindedJ<A> {
+data class FlowableK<out A>(val flowable: Flowable<out A>) : FlowableKOf<A> {
 
   fun <B> map(f: (A) -> B): FlowableK<B> =
     flowable.map(f).k()
@@ -132,9 +131,6 @@ data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKi
     foldRight(Eval.always { GA.just(Flowable.empty<B>().k()) }) { a, eval ->
       GA.run { f(a).map2Eval(eval) { Flowable.concat(Flowable.just<B>(it.a), it.b.flowable).k() } }
     }.value()
-
-  fun handleErrorWith(function: (Throwable) -> FlowableKOf<A>): FlowableK<A> =
-    flowable.onErrorResumeNext { t: Throwable -> function(t).value() }.k()
 
   fun continueOn(ctx: CoroutineContext): FlowableK<A> =
     flowable.observeOn(ctx.asScheduler()).k()
@@ -284,3 +280,7 @@ data class FlowableK<A>(val flowable: Flowable<A>) : FlowableKOf<A>, FlowableKKi
 
 fun <A, G> FlowableKOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, FlowableK<A>> =
   fix().traverse(GA, ::identity)
+
+fun <A> FlowableK<A>.handleErrorWith(function: (Throwable) -> FlowableKOf<A>): FlowableK<A> =
+  value().onErrorResumeNext { t: Throwable -> function(t).value() }.k()
+

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableK.kt
@@ -31,6 +31,7 @@ inline fun <A> FlowableKOf<A>.fix(): FlowableK<A> =
 
 fun <A> Flowable<A>.k(): FlowableK<A> = FlowableK(this)
 
+@Suppress("UNCHECKED_CAST")
 fun <A> FlowableKOf<A>.value(): Flowable<A> = fix().flowable as Flowable<A>
 
 data class FlowableK<out A>(val flowable: Flowable<out A>) : FlowableKOf<A> {
@@ -283,4 +284,3 @@ fun <A, G> FlowableKOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, Flowabl
 
 fun <A> FlowableK<A>.handleErrorWith(function: (Throwable) -> FlowableKOf<A>): FlowableK<A> =
   value().onErrorResumeNext { t: Throwable -> function(t).value() }.k()
-

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/ObservableK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/ObservableK.kt
@@ -23,7 +23,6 @@ class ForObservableK private constructor() {
   companion object
 }
 typealias ObservableKOf<A> = arrow.Kind<ForObservableK, A>
-typealias ObservableKKindedJ<A> = io.kindedj.Hk<ForObservableK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 inline fun <A> ObservableKOf<A>.fix(): ObservableK<A> =
@@ -31,10 +30,11 @@ inline fun <A> ObservableKOf<A>.fix(): ObservableK<A> =
 
 fun <A> Observable<A>.k(): ObservableK<A> = ObservableK(this)
 
+@Suppress("UNCHECKED_CAST")
 fun <A> ObservableKOf<A>.value(): Observable<A> =
-  fix().observable
+  fix().observable as Observable<A>
 
-data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, ObservableKKindedJ<A> {
+data class ObservableK<out A>(val observable: Observable<out A>) : ObservableKOf<A> {
 
   fun <B> map(f: (A) -> B): ObservableK<B> =
     observable.map(f).k()
@@ -137,9 +137,6 @@ data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, Obs
     foldRight(Eval.always { GA.just(Observable.empty<B>().k()) }) { a, eval ->
       GA.run { f(a).map2Eval(eval) { Observable.concat(Observable.just<B>(it.a), it.b.observable).k() } }
     }.value()
-
-  fun handleErrorWith(function: (Throwable) -> ObservableKOf<A>): ObservableK<A> =
-    value().onErrorResumeNext { t: Throwable -> function(t).value() }.k()
 
   fun continueOn(ctx: CoroutineContext): ObservableK<A> =
     observable.observeOn(ctx.asScheduler()).k()
@@ -316,3 +313,6 @@ data class ObservableK<A>(val observable: Observable<A>) : ObservableKOf<A>, Obs
 
 fun <A, G> ObservableKOf<Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, ObservableK<A>> =
   fix().traverse(GA, ::identity)
+
+fun <A> ObservableKOf<A>.handleErrorWith(function: (Throwable) -> ObservableKOf<A>): ObservableK<A> =
+  value().onErrorResumeNext { t: Throwable -> function(t).value() }.k()

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
@@ -21,7 +21,6 @@ class ForSingleK private constructor() {
   companion object
 }
 typealias SingleKOf<A> = arrow.Kind<ForSingleK, A>
-typealias SingleKKindedJ<A> = io.kindedj.Hk<ForSingleK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 inline fun <A> SingleKOf<A>.fix(): SingleK<A> =
@@ -29,9 +28,10 @@ inline fun <A> SingleKOf<A>.fix(): SingleK<A> =
 
 fun <A> Single<A>.k(): SingleK<A> = SingleK(this)
 
-fun <A> SingleKOf<A>.value(): Single<A> = fix().single
+@Suppress("UNCHECKED_CAST")
+fun <A> SingleKOf<A>.value(): Single<A> = fix().single as Single<A>
 
-data class SingleK<A>(val single: Single<A>) : SingleKOf<A>, SingleKKindedJ<A> {
+data class SingleK<out A>(val single: Single<out A>) : SingleKOf<A> {
 
   fun <B> map(f: (A) -> B): SingleK<B> =
     single.map(f).k()
@@ -109,9 +109,6 @@ data class SingleK<A>(val single: Single<A>) : SingleKOf<A>, SingleKKindedJ<A> {
           .value().subscribe(emitter::onSuccess) {}
       emitter.setCancellable { dispose.dispose() }
     }.k()
-
-  fun handleErrorWith(function: (Throwable) -> SingleKOf<A>): SingleK<A> =
-    single.onErrorResumeNext { t: Throwable -> function(t).value() }.k()
 
   fun continueOn(ctx: CoroutineContext): SingleK<A> =
     single.observeOn(ctx.asScheduler()).k()
@@ -325,3 +322,7 @@ fun <A> SingleKOf<A>.unsafeRunAsync(cb: (Either<Throwable, A>) -> Unit): Unit =
  */
 fun <A> SingleKOf<A>.unsafeRunSync(): A =
   value().blockingGet()
+
+fun <A> SingleK<A>.handleErrorWith(function: (Throwable) -> SingleKOf<A>): SingleK<A> =
+  value().onErrorResumeNext { t: Throwable -> function(t).value() }.k()
+

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
@@ -325,4 +325,3 @@ fun <A> SingleKOf<A>.unsafeRunSync(): A =
 
 fun <A> SingleK<A>.handleErrorWith(function: (Throwable) -> SingleKOf<A>): SingleK<A> =
   value().onErrorResumeNext { t: Throwable -> function(t).value() }.k()
-

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -53,6 +53,7 @@ import arrow.typeclasses.FunctorFilter
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.ReplaySubject
 import io.reactivex.disposables.Disposable as RxDisposable
+import arrow.fx.rx2.handleErrorWith as flowableHandleErrorWith
 
 @extension
 interface FlowableKFunctor : Functor<ForFlowableK> {
@@ -122,7 +123,7 @@ interface FlowableKApplicativeError :
     FlowableK.raiseError(e)
 
   override fun <A> FlowableKOf<A>.handleErrorWith(f: (Throwable) -> FlowableKOf<A>): FlowableK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().flowableHandleErrorWith { f(it).fix() }
 }
 
 @extension
@@ -133,7 +134,7 @@ interface FlowableKMonadError :
     FlowableK.raiseError(e)
 
   override fun <A> FlowableKOf<A>.handleErrorWith(f: (Throwable) -> FlowableKOf<A>): FlowableK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().flowableHandleErrorWith { f(it).fix() }
 }
 
 @extension

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -45,6 +45,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.ReplaySubject
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
+import arrow.fx.rx2.handleErrorWith as maybeHandleErrorWith
 
 @extension
 interface MaybeKFunctor : Functor<ForMaybeK> {
@@ -112,7 +113,7 @@ interface MaybeKApplicativeError :
     MaybeK.raiseError(e)
 
   override fun <A> MaybeKOf<A>.handleErrorWith(f: (Throwable) -> MaybeKOf<A>): MaybeK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().maybeHandleErrorWith { f(it).fix() }
 }
 
 @extension
@@ -123,7 +124,7 @@ interface MaybeKMonadError :
     MaybeK.raiseError(e)
 
   override fun <A> MaybeKOf<A>.handleErrorWith(f: (Throwable) -> MaybeKOf<A>): MaybeK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().maybeHandleErrorWith { f(it).fix() }
 }
 
 @extension

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -50,6 +50,7 @@ import io.reactivex.subjects.ReplaySubject
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import io.reactivex.disposables.Disposable as RxDisposable
+import arrow.fx.rx2.handleErrorWith as observableHandleErrorWith
 
 @extension
 interface ObservableKFunctor : Functor<ForObservableK> {
@@ -119,7 +120,7 @@ interface ObservableKApplicativeError :
     ObservableK.raiseError(e)
 
   override fun <A> ObservableKOf<A>.handleErrorWith(f: (Throwable) -> ObservableKOf<A>): ObservableK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().observableHandleErrorWith { f(it).fix() }
 }
 
 @extension
@@ -130,7 +131,7 @@ interface ObservableKMonadError :
     ObservableK.raiseError(e)
 
   override fun <A> ObservableKOf<A>.handleErrorWith(f: (Throwable) -> ObservableKOf<A>): ObservableK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().observableHandleErrorWith { f(it).fix() }
 }
 
 @extension

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
@@ -43,6 +43,7 @@ import io.reactivex.subjects.ReplaySubject
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import io.reactivex.disposables.Disposable as RxDisposable
+import arrow.fx.rx2.handleErrorWith as singleHandleErrorWith
 
 @extension
 interface SingleKFunctor : Functor<ForSingleK> {
@@ -88,7 +89,7 @@ interface SingleKApplicativeError :
     SingleK.raiseError(e)
 
   override fun <A> SingleKOf<A>.handleErrorWith(f: (Throwable) -> SingleKOf<A>): SingleK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().singleHandleErrorWith { f(it).fix() }
 }
 
 @extension
@@ -99,7 +100,7 @@ interface SingleKMonadError :
     SingleK.raiseError(e)
 
   override fun <A> SingleKOf<A>.handleErrorWith(f: (Throwable) -> SingleKOf<A>): SingleK<A> =
-    fix().handleErrorWith { f(it).fix() }
+    fix().singleHandleErrorWith { f(it).fix() }
 }
 
 @extension

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/ObservableKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/ObservableKTests.kt
@@ -132,7 +132,7 @@ class ObservableKTests : UnitSpec() {
               .subscribe()
               .dispose()
           }.flatMap { latch.get() }
-        }.observable
+        }.value()
         .test()
         .assertValue(Unit)
         .awaitTerminalEvent(100, TimeUnit.MILLISECONDS)

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
@@ -10,6 +10,7 @@ import arrow.fx.rx2.ObservableK
 import arrow.fx.rx2.extensions.observablek.applicativeError.applicativeError
 import arrow.fx.rx2.extensions.observablek.monadDefer.monadDefer
 import arrow.fx.rx2.fix
+import arrow.fx.rx2.value
 import arrow.integrations.retrofit.adapter.mock.ResponseMock
 import arrow.integrations.retrofit.adapter.retrofit.ApiClientTest
 import arrow.integrations.retrofit.adapter.retrofit.retrofit
@@ -57,7 +58,7 @@ class ProcCallBackTest : UnitSpec() {
           .flatMap { response ->
             response.unwrapBody(applicativeError()).fix()
           }
-          .observable
+          .value()
           .test()
           .assertValue(ResponseMock("hello, world!"))
       }


### PR DESCRIPTION
Here is my first try to fix #1609.
I only made `ObservableK` covariant this time, after making sure everything fine with `ObservableK` I'll continue to work on other types of Rx family.

P/S: I had to remove `ObservableKKindedJ<A>` from inherited list because `io.kindedj.Hk<ForObservableK, A>` is invariant.