### PR TITLE
Supress Rx onError logging

### DIFF
--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/FlowableKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/FlowableKTests.kt
@@ -20,7 +20,6 @@ import arrow.fx.rx2.extensions.fx
 import arrow.fx.rx2.value
 import arrow.fx.typeclasses.Dispatchers
 import arrow.fx.typeclasses.ExitCase
-import arrow.test.UnitSpec
 import arrow.test.laws.AsyncLaws
 import arrow.test.laws.ConcurrentLaws
 import arrow.test.laws.FunctorFilterLaws
@@ -39,7 +38,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
 @RunWith(KotlinTestRunner::class)
-class FlowableKTests : UnitSpec() {
+class FlowableKTests : RxJavaSpec() {
 
   fun <T> EQ(): Eq<FlowableKOf<T>> = object : Eq<FlowableKOf<T>> {
     override fun FlowableKOf<T>.eqv(b: FlowableKOf<T>): Boolean {

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/MaybeKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/MaybeKTests.kt
@@ -13,7 +13,6 @@ import arrow.fx.rx2.k
 import arrow.fx.rx2.value
 import arrow.fx.typeclasses.Dispatchers
 import arrow.fx.typeclasses.ExitCase
-import arrow.test.UnitSpec
 import arrow.test.laws.ConcurrentLaws
 import arrow.test.laws.FunctorFilterLaws
 import arrow.test.laws.TimerLaws
@@ -31,7 +30,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
 @RunWith(KotlinTestRunner::class)
-class MaybeKTests : UnitSpec() {
+class MaybeKTests : RxJavaSpec() {
 
   fun <T> EQ(): Eq<MaybeKOf<T>> = object : Eq<MaybeKOf<T>> {
     override fun MaybeKOf<T>.eqv(b: MaybeKOf<T>): Boolean {

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/ObservableKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/ObservableKTests.kt
@@ -16,7 +16,6 @@ import arrow.fx.rx2.k
 import arrow.fx.rx2.value
 import arrow.fx.typeclasses.Dispatchers
 import arrow.fx.typeclasses.ExitCase
-import arrow.test.UnitSpec
 import arrow.test.laws.ConcurrentLaws
 import arrow.test.laws.FunctorFilterLaws
 import arrow.test.laws.TimerLaws
@@ -35,7 +34,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 import kotlin.coroutines.CoroutineContext
 
 @RunWith(KotlinTestRunner::class)
-class ObservableKTests : UnitSpec() {
+class ObservableKTests : RxJavaSpec() {
 
   fun <T> EQ(): Eq<ObservableKOf<T>> = object : Eq<ObservableKOf<T>> {
     override fun ObservableKOf<T>.eqv(b: ObservableKOf<T>): Boolean {

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/RxJavaSpec.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/RxJavaSpec.kt
@@ -1,0 +1,18 @@
+package arrow.fx
+
+import arrow.test.UnitSpec
+import io.kotlintest.Spec
+import io.reactivex.plugins.RxJavaPlugins
+
+abstract class RxJavaSpec : UnitSpec() {
+
+  override fun beforeSpec(spec: Spec) {
+    super.beforeSpec(spec)
+    RxJavaPlugins.setErrorHandler { }
+  }
+
+  override fun afterSpec(spec: Spec) {
+    super.afterSpec(spec)
+    RxJavaPlugins.setErrorHandler(null)
+  }
+}

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
@@ -13,7 +13,6 @@ import arrow.fx.rx2.k
 import arrow.fx.rx2.value
 import arrow.fx.typeclasses.Dispatchers
 import arrow.fx.typeclasses.ExitCase
-import arrow.test.UnitSpec
 import arrow.test.laws.ConcurrentLaws
 import arrow.test.laws.TimerLaws
 import arrow.typeclasses.Eq
@@ -30,7 +29,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
 @RunWith(KotlinTestRunner::class)
-class SingleKTests : UnitSpec() {
+class SingleKTests : RxJavaSpec() {
 
   fun <T> EQ(): Eq<SingleKOf<T>> = object : Eq<SingleKOf<T>> {
     override fun SingleKOf<T>.eqv(b: SingleKOf<T>): Boolean {


### PR DESCRIPTION
Temporarily solution to keep RxJavaPlugins from flooding the CI logs and failing the build.

This should not result in any false positives since RxJava always calls `RxJavaPlugins` seperately from `observer.onError` so this just disables the logging done by `RxJavaPlugins`.