### PR TITLE
Using Eq typeclass NonZero class within validation module

### DIFF
--- a/modules/validation/arrow-validation/src/main/kotlin/arrow/validation/refinedTypes/numeric/NonZero.kt
+++ b/modules/validation/arrow-validation/src/main/kotlin/arrow/validation/refinedTypes/numeric/NonZero.kt
@@ -32,11 +32,12 @@ interface NonZero<F, A : Number> : Refinement<F, A> {
    * {: data-executable='true'}
    *
    * ```kotlin:ank
+   * import arrow.core.extensions.eq
    * import arrow.validation.refinedTypes.numeric.validated.nonZero.nonZero
    *
    * fun main(args: Array<String>) {
    *   //sampleStart
-   *   val result = 0.nonZero()
+   *   val result = 0.nonZero(Int.eq())
    *  //sampleEnd
    *
    *  println(result.isValid)

--- a/modules/validation/arrow-validation/src/main/kotlin/arrow/validation/refinedTypes/numeric/NonZero.kt
+++ b/modules/validation/arrow-validation/src/main/kotlin/arrow/validation/refinedTypes/numeric/NonZero.kt
@@ -11,17 +11,20 @@ import arrow.core.extensions.either.applicativeError.applicativeError
 import arrow.core.extensions.nonemptylist.semigroup.semigroup
 import arrow.core.extensions.validated.applicativeError.applicativeError
 import arrow.typeclasses.ApplicativeError
+import arrow.typeclasses.Eq
 import arrow.validation.RefinedPredicateException
 import arrow.validation.Refinement
 
-internal fun <A : Number> isNonZero(a: A): Boolean = a != 0
+internal fun <A : Number> isNonZero(EQ: Eq<A>, a: A): Boolean =
+  EQ.run { a.neqv(zero()) }
 
 /**
  * `NonZero` defines a subset of Numbers which are not 0
  */
 interface NonZero<F, A : Number> : Refinement<F, A> {
+  fun EQ(): Eq<A>
 
-  override fun A.refinement(): Boolean = isNonZero(this)
+  override fun A.refinement(): Boolean = isNonZero(EQ(), this)
 
   /**
    * Commented method or class
@@ -52,6 +55,8 @@ interface NonZero<F, A : Number> : Refinement<F, A> {
 @extension
 interface ValidatedNonZero<A : Number> :
   NonZero<ValidatedPartialOf<Nel<RefinedPredicateException>>, A> {
+  override fun EQ(): Eq<A>
+
   override fun applicativeError(): ApplicativeError<ValidatedPartialOf<Nel<RefinedPredicateException>>,
     Nel<RefinedPredicateException>> =
     Validated.applicativeError(Nel.semigroup())
@@ -62,6 +67,8 @@ interface ValidatedNonZero<A : Number> :
 @extension
 interface EitherNonZero<A : Number> :
   NonZero<EitherPartialOf<Nel<RefinedPredicateException>>, A> {
+  override fun EQ(): Eq<A>
+
   override fun applicativeError(): ApplicativeError<EitherPartialOf<Nel<RefinedPredicateException>>,
     Nel<RefinedPredicateException>> =
     Either.applicativeError()

--- a/modules/validation/arrow-validation/src/test/kotlin/arrow/validation/refinedTypes/numeric/NonZeroTest.kt
+++ b/modules/validation/arrow-validation/src/test/kotlin/arrow/validation/refinedTypes/numeric/NonZeroTest.kt
@@ -1,5 +1,6 @@
 package arrow.validation.refinedTypes.numeric
 
+import arrow.core.extensions.eq
 import arrow.test.UnitSpec
 import arrow.test.generators.nonZeroInt
 import arrow.validation.refinedTypes.numeric.validated.nonZero.nonZero
@@ -14,12 +15,12 @@ class NonZeroTest : UnitSpec() {
 
     "Can create NonZero from any number except 0" {
       forAll(Gen.nonZeroInt()) { x: Int ->
-        x.nonZero().isValid
+        x.nonZero(Int.eq()).isValid
       }
     }
 
     "Can not create NonZero from 0" {
-      0.nonZero().isInvalid
+      0.nonZero(Int.eq()).isInvalid
     }
   }
 }


### PR DESCRIPTION
Some people are getting this compilation error in the validation module when building the arrow project:
```
e: ~/arrow/modules/validation/arrow-validation/build/generated/source/kaptKotlin/main/extension/arrow/validation/refinedTypes/numeric/either/nonZero/EitherNonZero.kt: (18, 47): Type argument is not within its bounds: should be subtype of 'Number'
e: ~/arrow/modules/validation/arrow-validation/build/generated/source/kaptKotlin/main/extension/arrow/validation/refinedTypes/numeric/either/nonZero/EitherNonZero.kt: (18, 55): Type mismatch: inferred type is <no name provided> but EitherNonZero<Any?> was expected
```
It seems the issue is caused by the `isNonZero` function that compares a value of the generic type `A` with the literal int `0`.

This pull request proposes using the typeclass `Eq` provided by arrow to do the comparison.