### PR TITLE
Adding some docs for Alternative

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Alternative.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Alternative.kt
@@ -6,13 +6,44 @@ import arrow.core.k
 
 /**
  * ank_macro_hierarchy(arrow.typeclasses.Alternative)
+ *
+ * The Alternative type class is for Applicative functors which also have a monoid structure.
+ *
+ * @see <a href="http://arrow-kt.io/docs/arrow/typeclasses/alternative/">Alternative documentation</a>
  */
 interface Alternative<F> : Applicative<F>, MonoidK<F> {
+  /**
+   * Repeats the computation until it fails. Requires it to succeed at least once.
+   *
+   * @receiver computation to repeat.
+   * @returns the collection of results with at least 1 repetition.
+   */
   fun <A> Kind<F, A>.some(): Kind<F, ListK<A>> = map(this, many()) { (v, vs) -> (listOf(v) + vs).k() }
 
+  /**
+   * Repeats the computation until it fails. Does not requires it to succeed.
+   *
+   * @receiver computation to repeat.
+   * @returns the collection of results.
+   */
   fun <A> Kind<F, A>.many(): Kind<F, ListK<A>> = some().orElse(just(emptyList<A>().k()))
 
+  /**
+   * Combines two computations.
+   * Infix alias over [orElse].
+   *
+   * @receiver computation to combine with [b].
+   * @param b computation to combine with [this@orElse].
+   * @returns a combination of both computations.
+   */
   infix fun <A> Kind<F, A>.alt(b: Kind<F, A>): Kind<F, A> = this.orElse(b)
 
+  /**
+   * Combines two computations.
+   *
+   * @receiver computation to combine with [b].
+   * @param b computation to combine with [this@orElse].
+   * @returns a combination of both computations.
+   */
   fun <A> Kind<F, A>.orElse(b: Kind<F, A>): Kind<F, A>
 }

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/alternative/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/alternative/README.md
@@ -11,6 +11,60 @@ redirect_from:
 {:.intermediate}
 intermediate
 
+We use [`Option`]({{ '/docs/arrow/core/option' }}) to indicate a computation can fail somehow (that is, it can have either zero results or one result), and we use lists for computations that can have many possible results (ranging from zero to arbitrarily many results). In both of these cases, one useful operation is combining all possible results from multiple computations into a single computation. The `Alternative` type class captures this combination.
+
+`Alternative` is for [`Applicative`]({{ '/docs/arrow/typeclasses/applicative' }}) functors which also have a [`Monoid`]({{ '/docs/arrow/typeclasses/monoid' }}) structure.
+
+### Main Combinators
+
+#### Kind<F, A>.orElse
+
+Is a binary function which represents a choice between alternatives.
+
+`fun <A> Kind<F, A>.orElse(b: Kind<F, A>): Kind<F, A>`
+
+```kotlin:ank
+import arrow.core.Option
+import arrow.core.extensions.option.monadCombine.monadCombine
+
+Option.monadCombine().run {
+    val x = Option.just(1)
+    val y = Option.empty()
+    x.orElse(y)
+}
+```
+
+```kotlin:ank
+import arrow.core.ListK
+import arrow.core.extensions.listk.monadCombine.monadCombine
+import arrow.core.k
+
+ListK.monadCombine().run {
+    val x = listOf(1, 2).k()
+    val y = listOf(3, 4).k()
+    x.orElse(y)
+}
+```
+
+#### Kind<F, A>.alt
+
+It is just an infix alias over `orElse`.
+
+```kotlin:ank
+import arrow.core.Option
+import arrow.core.extensions.option.monadCombine.monadCombine
+
+Option.monadCombine().run {
+    val x = Option.just(1)
+    val y = Option.empty()
+    x alt y
+}
+```
+
+### Laws
+
+Arrow provides `AlternativeLaws` in the form of test cases for internal verifications of lawful instances and third party apps creating their own `Alternative` instances.
+
 ## Available Instances:
 
 ```kotlin:ank:replace
@@ -20,6 +74,6 @@ import arrow.typeclasses.Alternative
 TypeClass(Alternative::class).dtMarkdownList()
 ```
 
-ank_macro_hierarchy(arrow.typeclasses.Alternative)
+Additionally all the instances of [`MonadCombine`]({{ '/docs/arrow/typeclasses/monadcombine' | relative_url }}) implement the `Alternative` directly since it is subtype of `Alternative`.
 
-TODO. Meanwhile you can find a short description in the [intro to typeclasses]({{ '/docs/typeclasses/intro/' | relative_url }}).
+ank_macro_hierarchy(arrow.typeclasses.Alternative)


### PR DESCRIPTION
Docs taken from [here](https://en.wikibooks.org/wiki/Haskell/Alternative_and_MonadPlus) and [here](https://wiki.haskell.org/Typeclassopedia#Failure_and_choice:_Alternative.2C_MonadPlus.2C_ArrowPlus).

Two things that are weird for me.

One is we don't offer `Option.alternative()` and I have to use `Option.monadCombine()` which is subclass of Alternative but it can confuse readers.

The second thing is that one of the sources I've used for writing these docs says that `<|>` combines computations but the other says it is a choice between alternatives. And it seems depending on the instance it is both of those things. Maybe `orElse` is not a good name enough or we should try to explain it better in the docs 🤔.