### PR TITLE
Add regex to detect higherkind annotation

### DIFF
--- a/modules/meta/arrow-meta-prototype/compiler-plugin/src/main/kotlin/arrow/meta/plugins/higherkind/HigherKindPlugin.kt
+++ b/modules/meta/arrow-meta-prototype/compiler-plugin/src/main/kotlin/arrow/meta/plugins/higherkind/HigherKindPlugin.kt
@@ -75,7 +75,7 @@ private val KtClass.partialKindAritySuffix: String
   get() = (arity - 1).let { if (it > 1) "$it" else "" }
 
 fun isHigherKindedType(ktClass: KtClass): Boolean =
-  ktClass.annotationEntries.any { it.text.matches(Regex("@(arrow.)?higherkind")) } &&
+  ktClass.annotationEntries.any { it.text.matches(Regex("@(arrow\\.)?higherkind")) } &&
     ktClass.fqName?.asString()?.startsWith("arrow.Kind") != true &&
     !ktClass.isAnnotation() &&
     !ktClass.isNested() &&

--- a/modules/meta/arrow-meta-prototype/compiler-plugin/src/main/kotlin/arrow/meta/plugins/higherkind/HigherKindPlugin.kt
+++ b/modules/meta/arrow-meta-prototype/compiler-plugin/src/main/kotlin/arrow/meta/plugins/higherkind/HigherKindPlugin.kt
@@ -75,7 +75,7 @@ private val KtClass.partialKindAritySuffix: String
   get() = (arity - 1).let { if (it > 1) "$it" else "" }
 
 fun isHigherKindedType(ktClass: KtClass): Boolean =
-  ktClass.annotationEntries.any { it.text == "@higherkind" } &&
+  ktClass.annotationEntries.any { it.text.matches(Regex("@(arrow.)?higherkind")) } &&
     ktClass.fqName?.asString()?.startsWith("arrow.Kind") != true &&
     !ktClass.isAnnotation() &&
     !ktClass.isNested() &&


### PR DESCRIPTION
Pretty small change to detect `higherkind` annotation like:

```
@higherkind
```

or:

```
@arrow.higherkind
```