### PR TITLE
Add GitHub Actions to build the project and to get notifications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        architecture: x64
+    - name: Build with Gradle
+      env:
+        JAVA_OPTS: -Xms512m -Xmx1024m
+      run: |
+        java -version
+        ./gradlew -v
+        ./gradlew clean build :arrow-benchmarks-fx:jmhClasses

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ jdk:
 - oraclejdk8
 
 stages:
-- name: build
-- name: coverage-report
-  if: branch = master
 - name: deploy
   if: branch = master AND type != pull_request
 
@@ -18,9 +15,7 @@ env:
 
 jobs:
   include:
-  - stage: build
-    script:
-    - ./gradlew clean build :arrow-benchmarks-fx:jmhClasses
   - stage: deploy
     script:
+    - ./gradlew clean build :arrow-benchmarks-fx:jmhClasses
     - ./deploy-scripts/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ jobs:
   include:
   - stage: deploy
     script:
-    - ./gradlew clean build :arrow-benchmarks-fx:jmhClasses
+    - ./gradlew clean build
     - ./deploy-scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img height="100" src="https://avatars2.githubusercontent.com/u/29458023?v=4&amp;s=200" width="100">
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core-data/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
+[![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Farrow-kt%2Farrow%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/arrow-kt/arrow/goto?ref=master)
 [![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,8 +7,6 @@ trigger_map:
   workflow: deploy
 - push_branch: "*"
   workflow: build
-- pull_request_target_branch: "*"
-  workflow: build
 workflows:
   build:
     envs:


### PR DESCRIPTION
### Goal 

Add GitHub Actions to build the project.

The final list of checks would be:

* **Build**: GitHub Actions
* **Release**: Travis CI to Bintray
* **Documentation**: Bitrise

### Reason

There aren't notifications about failures with CI tasks.
Issue  #1678

### Note

This pull request doesn't change Travis CI because there is not an easy option to work with Oracle JDK from GitHub Actions (not convinced by the alternative of using a PPA).