### PR TITLE
Clean up and improve fragment provider update handling

### DIFF
--- a/modules/meta/arrow-meta-prototype/README.md
+++ b/modules/meta/arrow-meta-prototype/README.md
@@ -5,3 +5,22 @@
 ```
 ./gradlew clean gradle-plugin:publishArrowPluginMarkerMavenPublicationToMavenLocal gradle-plugin:publishPluginMavenPublicationToMavenLocal idea-plugin:runIde -Dorg.gradle.debug=true -Dkotlin.compiler.execution.strategy="in-process"
 ```
+
+## Logging
+Logging inside of an IntelliJ plugin is done via 
+```
+val LOG = com.intellij.openapi.diagnostic.Logger.getInstance("#arrow.yourLogChannel")
+// LOG.error, LOG.warn, LOG.info, LOG.debug, LOG.trace are available 
+```
+
+You can see the messages in IntelliJ's log file. The log file is available at `Help->Show Log in ...`. 
+debug and trace messages are not shown by default. To enable these, enter the full channel ID at 
+`Help->Debug Log Settings`, for example
+```
+#arrow.trace
+```
+
+To enable trace message, append `:trace` to a channel ID. For example:
+```
+#arrow.trace:trace
+```

--- a/modules/meta/arrow-meta-prototype/README.md
+++ b/modules/meta/arrow-meta-prototype/README.md
@@ -13,8 +13,9 @@ val LOG = com.intellij.openapi.diagnostic.Logger.getInstance("#arrow.yourLogChan
 // LOG.error, LOG.warn, LOG.info, LOG.debug, LOG.trace are available 
 ```
 
-You can see the messages in IntelliJ's log file. The log file is available at `Help->Show Log in ...`. 
-debug and trace messages are not shown by default. To enable these, enter the full channel ID at 
+You can now see the messages in IntelliJ's log file. The log file is available at `Help->Show Log in ...`.
+ 
+`debug` and `trace` messages are not shown by default. To show them, enter the full channel ID at 
 `Help->Debug Log Settings`, for example
 ```
 #arrow.trace

--- a/modules/meta/arrow-meta-prototype/idea-plugin/build.gradle
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/build.gradle
@@ -26,6 +26,8 @@ jar {
     }
 }
 
+buildSearchableOptions.enabled = false
+
 intellij {
     version = "2019.2.1"
     pluginName = "Arrow plugin"

--- a/modules/meta/arrow-meta-prototype/idea-plugin/build.gradle
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/build.gradle
@@ -37,3 +37,7 @@ patchPluginXml {
       Add change notes here.<br>
       <em>most HTML tags may be used</em>"""
 }
+
+runIde {
+    jvmArgs '-Xmx2G'
+}

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/MetaPluginRegistrarComponent.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/MetaPluginRegistrarComponent.kt
@@ -17,14 +17,13 @@ class MetaPluginRegistrarComponent(val project: Project) : ProjectComponent {
   override fun getComponentName(): String = "arrow.meta.registrar"
 
   override fun initComponent() {
-    LOG.warn("initComponent()")
+    LOG.info("initComponent()")
 
     val start = System.currentTimeMillis()
-    // fixme use CompilerConfiguration.EMPTY ?
     val configuration = CompilerConfiguration()
     metaPlugin.registerMetaComponents(project, configuration)
 
-    LOG.warn("initComponent() took ${System.currentTimeMillis() - start}ms")
+    LOG.info("initComponent() took ${System.currentTimeMillis() - start}ms")
   }
 
   override fun disposeComponent() {

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/MetaPluginRegistrarComponent.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/MetaPluginRegistrarComponent.kt
@@ -27,12 +27,10 @@ class MetaPluginRegistrarComponent(val project: Project) : ProjectComponent {
   }
 
   override fun disposeComponent() {
-    // fixme: make sure that all registered components are disposed
+    // TODO: make sure that all registered components are disposed
   }
 
-  override fun projectClosed() {
-  }
+  override fun projectClosed() {}
 
-  override fun projectOpened() {
-  }
+  override fun projectOpened() {}
 }

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/MetaPluginRegistrarComponent.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/MetaPluginRegistrarComponent.kt
@@ -1,0 +1,39 @@
+package arrow.meta.plugin.idea
+
+import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+/**
+ * This project component registers MetaPlugin for the current project.
+ */
+class MetaPluginRegistrarComponent(val project: Project) : ProjectComponent {
+  companion object {
+    val metaPlugin = IdeMetaPlugin()
+    private val LOG = Logger.getInstance("#arrow.metaRegistrar")
+  }
+
+  override fun getComponentName(): String = "arrow.meta.registrar"
+
+  override fun initComponent() {
+    LOG.warn("initComponent()")
+
+    val start = System.currentTimeMillis()
+    // fixme use CompilerConfiguration.EMPTY ?
+    val configuration = CompilerConfiguration()
+    metaPlugin.registerMetaComponents(project, configuration)
+
+    LOG.warn("initComponent() took ${System.currentTimeMillis() - start}ms")
+  }
+
+  override fun disposeComponent() {
+    // fixme: make sure that all registered components are disposed
+  }
+
+  override fun projectClosed() {
+  }
+
+  override fun projectOpened() {
+  }
+}

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/DiagnosticSuppressor.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/DiagnosticSuppressor.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 open class DiagnosticSuppressor : org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor {
   override fun isSuppressed(diagnostic: Diagnostic): Boolean {
-    //println("isSupressed: ${diagnostic.factory.name}: \n ${diagnostic.psiElement.text}")
+    LOG.debug("isSupressed: ${diagnostic.factory.name}: \n ${diagnostic.psiElement.text}")
     val result = diagnostic.suppressMetaDiagnostics()
     diagnostic.logSuppression(result)
     return result
@@ -53,6 +53,6 @@ open class DiagnosticSuppressor : org.jetbrains.kotlin.resolve.diagnostics.Diagn
   }
 
   private fun Diagnostic.logSuppression(result: Boolean) {
-    println("Suppressing ${factory.name} on: `${psiElement.text}`: $result")
+    LOG.debug("Suppressing ${factory.name} on: `${psiElement.text}`: $result")
   }
 }

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/DiagnosticSuppressor.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/DiagnosticSuppressor.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.checker.KotlinTypeChecker
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
-open class DiagnosticSuppressor : org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor {
+class DiagnosticSuppressor : org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor {
   override fun isSuppressed(diagnostic: Diagnostic): Boolean {
     LOG.debug("isSupressed: ${diagnostic.factory.name}: \n ${diagnostic.psiElement.text}")
     val result = diagnostic.suppressMetaDiagnostics()

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/DiagnosticSuppressor.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/DiagnosticSuppressor.kt
@@ -1,0 +1,58 @@
+package arrow.meta.plugin.idea.phases.resolve
+
+import org.jetbrains.kotlin.cfg.ClassMissingCase
+import org.jetbrains.kotlin.cfg.WhenMissingCase
+import org.jetbrains.kotlin.descriptors.VariableDescriptor
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.DiagnosticWithParameters1
+import org.jetbrains.kotlin.diagnostics.DiagnosticWithParameters2
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.checker.KotlinTypeChecker
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+open class DiagnosticSuppressor : org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor {
+  override fun isSuppressed(diagnostic: Diagnostic): Boolean {
+    //println("isSupressed: ${diagnostic.factory.name}: \n ${diagnostic.psiElement.text}")
+    val result = diagnostic.suppressMetaDiagnostics()
+    diagnostic.logSuppression(result)
+    return result
+  }
+
+  private fun Diagnostic.suppressMetaDiagnostics(): Boolean =
+    suppressInvisibleMember() ||
+      suppressNoElseInWhen() ||
+      kindsTypeMismatch() ||
+      suppressUnusedParameter()
+
+  private fun Diagnostic.suppressInvisibleMember(): Boolean =
+    factory == Errors.INVISIBLE_MEMBER
+
+  private fun Diagnostic.kindsTypeMismatch(): Boolean =
+    factory == Errors.TYPE_INFERENCE_EXPECTED_TYPE_MISMATCH && safeAs<DiagnosticWithParameters2<KtElement, KotlinType, KotlinType>>()?.let { diagnosticWithParameters ->
+      val a = diagnosticWithParameters.a
+      val b = diagnosticWithParameters.b
+      KotlinTypeChecker.DEFAULT.isSubtypeOf(a, b) //if this is the kind type checker then it will do the right thing otherwise this proceeds as usual with the regular type checker
+    } == true
+
+  private fun Diagnostic.suppressUnusedParameter(): Boolean =
+    factory == Errors.UNUSED_PARAMETER && safeAs<DiagnosticWithParameters1<KtParameter, VariableDescriptor>>()?.let { diagnosticWithParameters ->
+      diagnosticWithParameters.psiElement.defaultValue?.text == "given" //TODO move to typeclasses plugin
+    } == true
+
+  private fun Diagnostic.suppressNoElseInWhen(): Boolean {
+    val result = factory == Errors.NO_ELSE_IN_WHEN && safeAs<DiagnosticWithParameters1<KtWhenExpression, List<WhenMissingCase>>>()?.let { diagnosticWithParameters ->
+      val declaredCases = diagnosticWithParameters.psiElement.entries.flatMap { it.conditions.map { it.text } }.toSet()
+      val missingCases = diagnosticWithParameters.a.filterIsInstance<ClassMissingCase>().map { it.toString() }.toSet()
+      declaredCases.containsAll(missingCases)
+    } ?: false
+    return result
+  }
+
+  private fun Diagnostic.logSuppression(result: Boolean) {
+    println("Suppressing ${factory.name} on: `${psiElement.text}`: $result")
+  }
+}

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/FragmentProviderComponent.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/FragmentProviderComponent.kt
@@ -1,0 +1,41 @@
+package arrow.meta.plugin.idea.phases.resolve
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.AsyncFileListener
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+
+/**
+ * This project component controls the cache update of MetaSyntheticPackageFragmentProvider
+ * It initializes the cache when the project is opened and triggers an update
+ * when necessary.
+ */
+class FragmentProviderComponent(val project: Project) : ProjectComponent, AsyncFileListener, AsyncFileListener.ChangeApplier {
+
+  override fun getComponentName(): String = "arrow.meta.fragmentInitializer"
+
+  override fun initComponent() {
+    // dispose listener when project is disposed
+    VirtualFileManager.getInstance().addAsyncFileListener(this, project)
+  }
+
+  override fun projectOpened() {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      LOG.debug("Initializing cache of MetaSyntheticPackageFragmentProvider")
+      MetaSyntheticPackageFragmentProvider.getInstance(project).computeCache()
+    }
+  }
+
+  override fun prepareChange(events: MutableList<out VFileEvent>) = this
+
+  override fun beforeVfsChange() {
+    LOG.debug("MetaSyntheticPackageFragmentProvider.beforeVfsChange")
+  }
+
+  override fun afterVfsChange() {
+    LOG.debug("MetaSyntheticPackageFragmentProvider.afterVfsChange")
+    MetaSyntheticPackageFragmentProvider.getInstance(project).computeCache()
+  }
+}

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/FragmentProviderComponent.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/FragmentProviderComponent.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.vfs.newvfs.events.VFileEvent
  *
  * fixme: Vfs events are application-wide, this component has project-scope
  *   Therefore vfs events of files in project A also clear the cache of project B
- * /
  */
 class FragmentProviderComponent(val project: Project) : ProjectComponent, AsyncFileListener, AsyncFileListener.ChangeApplier {
 

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/FragmentProviderComponent.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/FragmentProviderComponent.kt
@@ -1,6 +1,5 @@
 package arrow.meta.plugin.idea.phases.resolve
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.AsyncFileListener
@@ -11,6 +10,10 @@ import com.intellij.openapi.vfs.newvfs.events.VFileEvent
  * This project component controls the cache update of MetaSyntheticPackageFragmentProvider
  * It initializes the cache when the project is opened and triggers an update
  * when necessary.
+ *
+ * fixme: Vfs events are application-wide, this component has project-scope
+ *   Therefore vfs events of files in project A also clear the cache of project B
+ * /
  */
 class FragmentProviderComponent(val project: Project) : ProjectComponent, AsyncFileListener, AsyncFileListener.ChangeApplier {
 
@@ -22,10 +25,8 @@ class FragmentProviderComponent(val project: Project) : ProjectComponent, AsyncF
   }
 
   override fun projectOpened() {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      LOG.debug("Initializing cache of MetaSyntheticPackageFragmentProvider")
-      MetaSyntheticPackageFragmentProvider.getInstance(project).computeCache()
-    }
+    LOG.debug("Initializing cache of MetaSyntheticPackageFragmentProvider")
+    MetaSyntheticPackageFragmentProvider.getInstance(project).computeCacheAsync()
   }
 
   override fun prepareChange(events: MutableList<out VFileEvent>) = this
@@ -36,6 +37,6 @@ class FragmentProviderComponent(val project: Project) : ProjectComponent, AsyncF
 
   override fun afterVfsChange() {
     LOG.debug("MetaSyntheticPackageFragmentProvider.afterVfsChange")
-    MetaSyntheticPackageFragmentProvider.getInstance(project).computeCache()
+    MetaSyntheticPackageFragmentProvider.getInstance(project).computeCacheAsync()
   }
 }

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/MetaSyntheticPackageFragmentProvider.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/MetaSyntheticPackageFragmentProvider.kt
@@ -17,7 +17,19 @@ import com.intellij.psi.impl.PsiManagerImpl
 import org.jetbrains.kotlin.analyzer.ModuleInfo
 import org.jetbrains.kotlin.caches.resolve.KotlinCacheService
 import org.jetbrains.kotlin.daemon.common.findWithTransform
-import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
+import org.jetbrains.kotlin.descriptors.PackageFragmentProvider
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
+import org.jetbrains.kotlin.descriptors.SourceElement
+import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.impl.PackageFragmentDescriptorImpl
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.idea.caches.resolve.analyzeAndGetResult
@@ -29,7 +41,18 @@ import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtPureClassOrObject
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
 import org.jetbrains.kotlin.psi.stubs.elements.KtFileStubBuilder
 import org.jetbrains.kotlin.psi.synthetics.SyntheticClassOrObjectDescriptor
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -53,7 +76,7 @@ import org.jetbrains.kotlin.types.isError
 import org.jetbrains.kotlin.utils.Printer
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import java.io.File
-import java.util.*
+import java.util.ArrayList
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
 
@@ -75,7 +98,7 @@ class MetaSyntheticPackageFragmentProvider(val project: Project) :
       try {
         block()
       } finally {
-          return System.currentTimeMillis() - start
+        return System.currentTimeMillis() - start
       }
     }
   }

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/package.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/package.kt
@@ -1,0 +1,8 @@
+package arrow.meta.plugin.idea.phases.resolve
+
+import com.intellij.openapi.diagnostic.Logger
+
+/**
+ * @author jansorg
+ */
+internal val LOG = Logger.getInstance("#arrow.resolve")

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/package.kt
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/kotlin/arrow/meta/plugin/idea/phases/resolve/package.kt
@@ -2,7 +2,4 @@ package arrow.meta.plugin.idea.phases.resolve
 
 import com.intellij.openapi.diagnostic.Logger
 
-/**
- * @author jansorg
- */
 internal val LOG = Logger.getInstance("#arrow.resolve")

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,9 @@
         <component>
             <implementation-class>arrow.meta.plugin.idea.MetaPluginRegistrarComponent</implementation-class>
         </component>
+        <component>
+            <implementation-class>arrow.meta.plugin.idea.phases.resolve.FragmentProviderComponent</implementation-class>
+        </component>
     </project-components>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/modules/meta/arrow-meta-prototype/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/modules/meta/arrow-meta-prototype/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -18,11 +18,17 @@
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.jetbrains.kotlin</depends>
 
+    <project-components>
+        <component>
+            <implementation-class>arrow.meta.plugin.idea.MetaPluginRegistrarComponent</implementation-class>
+        </component>
+    </project-components>
+
     <extensions defaultExtensionNs="org.jetbrains.kotlin">
         <gradleProjectImportHandler implementation="arrow.meta.plugin.idea.gradle.ArrowGradleImportHandler"/>
         <packageFragmentProviderExtension implementation="arrow.meta.plugin.idea.phases.resolve.MetaSyntheticPackageFragmentProvider" />
 <!--        <syntheticResolveExtension implementation="arrow.meta.plugin.idea.phases.resolve.MetaSyntheticPackageFragmentProvider" />-->
-        <diagnosticSuppressor implementation="arrow.meta.plugin.idea.phases.resolve.MetaSyntheticPackageFragmentProvider" />
+        <diagnosticSuppressor implementation="arrow.meta.plugin.idea.phases.resolve.DiagnosticSuppressor" />
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
CI isn't passing, but that's already the case with `rr-meta-prototype-integration`.

# Changes
- register MetaPlugin's plugins for each project when project is opened. Before this change it was done when the fragment provider was called for the first time. Now this work is done when the project is loaded (by using a `ProjectComponent`)
- scope cache per project. Before a global cache was shared between projects. Changes in one project clear the cache which then releases cached data needed for another project. The other project refreshes, too, and the cache could end up with incomplete content
- init cache once when project is opened and not when the fragment provider was called for the first time
- cache refresh is now handling dumb mode correctly, i.e.  `IndexNotReadyException` shouldn't be thrown anymore while refreshing the cache
- split vfs event handling from the actual fragment provider. Keeping this separate makes it clearer when a refresh is happening
- extract DiagnosticSuppressor from the fragment provider, don't keep two instances per project of the  provider doing different jobs. Before `MetaSyntheticPackageFragmentProvider` was instantiated once for `<packageFragmentProviderExtension>` and once for `<diagnosticSuppressor>`. Each used distinct parts of the class, but init code was called at least twice
- changed printing to stdout to proper IntelliJ logging. This way the level of detail is configurable at runtime and the output will be properly recorded in the idea.log file
