### PR TITLE
Test with semigroup and monoid laws

### DIFF
--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -3,10 +3,6 @@ package arrow.core
 import arrow.Kind
 import arrow.Kind2
 import arrow.core.extensions.combine
-import arrow.core.extensions.eq
-import arrow.core.extensions.hash
-import arrow.core.extensions.monoid
-import arrow.core.extensions.semigroup
 import arrow.core.extensions.either.applicative.applicative
 import arrow.core.extensions.either.applicativeError.handleErrorWith
 import arrow.core.extensions.either.bifunctor.bifunctor
@@ -15,22 +11,23 @@ import arrow.core.extensions.either.eq.eq
 import arrow.core.extensions.either.hash.hash
 import arrow.core.extensions.either.monadError.monadError
 import arrow.core.extensions.either.monoid.monoid
-import arrow.core.extensions.either.semigroup.semigroup
 import arrow.core.extensions.either.semigroupK.semigroupK
 import arrow.core.extensions.either.show.show
 import arrow.core.extensions.either.traverse.traverse
+import arrow.core.extensions.eq
+import arrow.core.extensions.hash
+import arrow.core.extensions.monoid
 import arrow.test.UnitSpec
 import arrow.test.generators.either
 import arrow.test.generators.intSmall
 import arrow.test.laws.BifunctorLaws
+import arrow.test.laws.BitraverseLaws
 import arrow.test.laws.HashLaws
 import arrow.test.laws.MonadErrorLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.SemigroupKLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
-import arrow.test.laws.BitraverseLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import io.kotlintest.properties.Gen
@@ -49,7 +46,6 @@ class EitherTest : UnitSpec() {
 
     testLaws(
       BifunctorLaws.laws(Either.bifunctor(), { Right(it) }, EQ2),
-      SemigroupLaws.laws(Either.semigroup(String.semigroup(), String.semigroup()), Either.right("1"), Either.right("2"), Either.right("3"), Either.eq(String.eq(), String.eq())),
       MonoidLaws.laws(Either.monoid(MOL = String.monoid(), MOR = Int.monoid()), Gen.either(Gen.string(), Gen.int()), Either.eq(String.eq(), Int.eq())),
       ShowLaws.laws(Either.show(), Either.eq(String.eq(), Int.eq())) { Right(it) },
       MonadErrorLaws.laws(Either.monadError(), Eq.any(), Eq.any()),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function0Test.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function0Test.kt
@@ -11,7 +11,6 @@ import arrow.core.extensions.semigroup
 import arrow.test.UnitSpec
 import arrow.test.laws.BimonadLaws
 import arrow.test.laws.MonoidLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -28,7 +27,6 @@ class Function0Test : UnitSpec() {
 
   init {
     testLaws(
-      SemigroupLaws.laws(Function0.semigroup(Int.semigroup()), { 1 }.k(), { 2 }.k(), { 3 }.k(), EQ1),
       MonoidLaws.laws(Function0.monoid(Int.monoid()), Gen.constant({ 1 }.k()), EQ1),
       BimonadLaws.laws(Function0.bimonad(), Function0.monad(), Function0.comonad(), { { it }.k() }, EQ1, EQ2, Eq.any())
     )

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function1Test.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function1Test.kt
@@ -15,7 +15,6 @@ import arrow.test.laws.DivisibleLaws
 import arrow.test.laws.MonadLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.ProfunctorLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.typeclasses.Conested
 import arrow.typeclasses.Eq
 import arrow.typeclasses.conest
@@ -34,7 +33,6 @@ class Function1Test : UnitSpec() {
 
   init {
     testLaws(
-      SemigroupLaws.laws(Function1.semigroup<Int, Int>(Int.semigroup()), { a: Int -> a + 1 }.k(), { a: Int -> a + 2 }.k(), { a: Int -> a + 3 }.k(), EQ),
       MonoidLaws.laws(Function1.monoid<Int, Int>(Int.monoid()), Gen.constant({ a: Int -> a + 1 }.k()), EQ),
       DivisibleLaws.laws(Function1.divisible(Int.monoid()), { Function1.just<Int, Int>(it).conest() }, ConestedEQ),
       ProfunctorLaws.laws(Function1.profunctor(), { Function1.just(it) }, EQ),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/IdTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/IdTest.kt
@@ -19,7 +19,6 @@ import arrow.test.UnitSpec
 import arrow.test.laws.BimonadLaws
 import arrow.test.laws.HashLaws
 import arrow.test.laws.MonoidLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -33,7 +32,6 @@ class IdTest : UnitSpec() {
 
   init {
     testLaws(
-      SemigroupLaws.laws(Id.semigroup(Int.semigroup()), Id(1), Id(2), Id(3), Id.eq(Int.eq())),
       MonoidLaws.laws(Id.monoid(Int.monoid()), Gen.constant(Id(1)), Id.eq(Int.eq())),
       ShowLaws.laws(Id.show(), Eq.any()) { Id(it) },
       TraverseLaws.laws(Id.traverse(), Id.applicative(), ::Id, Eq.any()),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -3,18 +3,17 @@ package arrow.core
 import arrow.Kind
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
-import arrow.core.extensions.tuple2.eq.eq
 import arrow.core.extensions.listk.applicative.applicative
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.listk.hash.hash
+import arrow.core.extensions.listk.monadCombine.monadCombine
+import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.listk.monoidK.monoidK
 import arrow.core.extensions.listk.monoidal.monoidal
 import arrow.core.extensions.listk.semigroupK.semigroupK
 import arrow.core.extensions.listk.show.show
 import arrow.core.extensions.listk.traverse.traverse
-import arrow.core.extensions.listk.monadCombine.monadCombine
-import arrow.core.extensions.listk.monoid.monoid
-import arrow.core.extensions.listk.semigroup.semigroup
+import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.generators.listK
 import arrow.test.laws.HashLaws
@@ -23,7 +22,6 @@ import arrow.test.laws.MonoidKLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
 import arrow.test.laws.SemigroupKLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -39,7 +37,6 @@ class ListKTest : UnitSpec() {
 
     testLaws(
       ShowLaws.laws(ListK.show(), eq) { listOf(it).k() },
-      SemigroupLaws.laws(ListK.semigroup(), listOf(1, 2, 3).k(), listOf(4, 5, 6).k(), listOf(7, 8, 9).k(), eq),
       MonoidLaws.laws(ListK.monoid(), Gen.listK(Gen.int()), ListK.eq(Int.eq())),
       SemigroupKLaws.laws(ListK.semigroupK(), applicative, Eq.any()),
       MonoidalLaws.laws(ListK.monoidal(), applicative, ListK.eq(Tuple2.eq(Int.eq(), Int.eq())), this::bijection, associativeSemigroupalEq),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -13,15 +13,21 @@ import arrow.core.extensions.listk.semigroupK.semigroupK
 import arrow.core.extensions.listk.show.show
 import arrow.core.extensions.listk.traverse.traverse
 import arrow.core.extensions.listk.monadCombine.monadCombine
+import arrow.core.extensions.listk.monoid.monoid
+import arrow.core.extensions.listk.semigroup.semigroup
 import arrow.test.UnitSpec
+import arrow.test.generators.listK
 import arrow.test.laws.HashLaws
 import arrow.test.laws.MonadCombineLaws
 import arrow.test.laws.MonoidKLaws
+import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
 import arrow.test.laws.SemigroupKLaws
+import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
+import io.kotlintest.properties.Gen
 
 class ListKTest : UnitSpec() {
   val applicative = ListK.applicative()
@@ -33,6 +39,8 @@ class ListKTest : UnitSpec() {
 
     testLaws(
       ShowLaws.laws(ListK.show(), eq) { listOf(it).k() },
+      SemigroupLaws.laws(ListK.semigroup(), listOf(1, 2, 3).k(), listOf(4, 5, 6).k(), listOf(7, 8, 9).k(), eq),
+      MonoidLaws.laws(ListK.monoid(), Gen.listK(Gen.int()), ListK.eq(Int.eq())),
       SemigroupKLaws.laws(ListK.semigroupK(), applicative, Eq.any()),
       MonoidalLaws.laws(ListK.monoidal(), applicative, ListK.eq(Tuple2.eq(Int.eq(), Int.eq())), this::bijection, associativeSemigroupalEq),
       MonoidKLaws.laws(ListK.monoidK(), applicative, Eq.any()),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -19,7 +19,6 @@ import arrow.test.laws.FoldableLaws
 import arrow.test.laws.FunctorFilterLaws
 import arrow.test.laws.HashLaws
 import arrow.test.laws.MonoidLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -42,11 +41,6 @@ class MapKTest : UnitSpec() {
       FoldableLaws.laws(MapK.foldable(), { a: Int -> mapOf("key" to a).k() }, Eq.any()),
       EqLaws.laws(EQ) { mapOf(it.toString() to it).k() },
       FunctorFilterLaws.laws(MapK.functorFilter(), { mapOf(it.toString() to it).k() }, EQ),
-      SemigroupLaws.laws(MapK.monoid<String, Int>(Int.semigroup()),
-        mapOf("key" to 1).k(),
-        mapOf("key" to 2).k(),
-        mapOf("key" to 3).k(),
-        EQ),
       HashLaws.laws(MapK.hash(String.hash(), Int.hash()), EQ_TC) { mapOf("key" to it).k() }
     )
   }

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/NonEmptyListTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/NonEmptyListTest.kt
@@ -38,7 +38,7 @@ class NonEmptyListTest : UnitSpec() {
         Eq.any()),
       BimonadLaws.laws(NonEmptyList.bimonad(), NonEmptyList.monad(), NonEmptyList.comonad(), { NonEmptyList.of(it) }, Eq.any(), EQ2, Eq.any()),
       TraverseLaws.laws(NonEmptyList.traverse(), NonEmptyList.applicative(), { n: Int -> NonEmptyList.of(n) }, Eq.any()),
-      SemigroupLaws.laws(NonEmptyList.semigroup(), Nel(1, 2, 3), Nel(3, 4, 5), Nel(6, 7, 8), NonEmptyList.eq(Int.eq())),
+      SemigroupLaws.laws(NonEmptyList.semigroup(), Nel(1, 2, 3), Nel(3, 4, 5), Nel(6, 7, 8), EQ1),
       HashLaws.laws(NonEmptyList.hash(Int.hash()), EQ1) { Nel.of(it) }
     )
   }

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -11,7 +11,6 @@ import arrow.core.extensions.sequencek.monad.monad
 import arrow.core.extensions.sequencek.monoid.monoid
 import arrow.core.extensions.sequencek.monoidK.monoidK
 import arrow.core.extensions.sequencek.monoidal.monoidal
-import arrow.core.extensions.sequencek.semigroup.semigroup
 import arrow.core.extensions.sequencek.traverse.traverse
 import arrow.test.UnitSpec
 import arrow.test.generators.sequenceK
@@ -21,7 +20,6 @@ import arrow.test.laws.MonadLaws
 import arrow.test.laws.MonoidKLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -56,7 +54,6 @@ class SequenceKTest : UnitSpec() {
       ShowLaws.laws(show, eq) { sequenceOf(it).k() },
       MonadLaws.laws(SequenceK.monad(), eq),
       MonoidKLaws.laws(SequenceK.monoidK(), SequenceK.applicative(), eq),
-      SemigroupLaws.laws(SequenceK.semigroup(), sequenceOf(1, 2, 3).k(), sequenceOf(4, 5, 6).k(), sequenceOf(7, 8, 9).k(), eq),
       MonoidLaws.laws(SequenceK.monoid(), Gen.sequenceK(Gen.int()), eq),
       MonoidalLaws.laws(SequenceK.monoidal(), { SequenceK.just(it) }, tuple2Eq, this::bijection, associativeSemigroupalEq),
       TraverseLaws.laws(SequenceK.traverse(), SequenceK.applicative(), { n: Int -> SequenceK(sequenceOf(n)) }, eq),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -11,6 +11,7 @@ import arrow.core.extensions.sequencek.monad.monad
 import arrow.core.extensions.sequencek.monoid.monoid
 import arrow.core.extensions.sequencek.monoidK.monoidK
 import arrow.core.extensions.sequencek.monoidal.monoidal
+import arrow.core.extensions.sequencek.semigroup.semigroup
 import arrow.core.extensions.sequencek.traverse.traverse
 import arrow.test.UnitSpec
 import arrow.test.generators.sequenceK
@@ -20,6 +21,7 @@ import arrow.test.laws.MonadLaws
 import arrow.test.laws.MonoidKLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
+import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -54,6 +56,7 @@ class SequenceKTest : UnitSpec() {
       ShowLaws.laws(show, eq) { sequenceOf(it).k() },
       MonadLaws.laws(SequenceK.monad(), eq),
       MonoidKLaws.laws(SequenceK.monoidK(), SequenceK.applicative(), eq),
+      SemigroupLaws.laws(SequenceK.semigroup(), sequenceOf(1, 2, 3).k(), sequenceOf(4, 5, 6).k(), sequenceOf(7, 8, 9).k(), eq),
       MonoidLaws.laws(SequenceK.monoid(), Gen.sequenceK(Gen.int()), eq),
       MonoidalLaws.laws(SequenceK.monoidal(), { SequenceK.just(it) }, tuple2Eq, this::bijection, associativeSemigroupalEq),
       TraverseLaws.laws(SequenceK.traverse(), SequenceK.applicative(), { n: Int -> SequenceK(sequenceOf(n)) }, eq),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
@@ -6,19 +6,23 @@ import arrow.core.extensions.hash
 import arrow.core.extensions.setk.eq.eq
 import arrow.core.extensions.setk.foldable.foldable
 import arrow.core.extensions.setk.hash.hash
+import arrow.core.extensions.setk.monoid.monoid
 import arrow.core.extensions.setk.monoidK.monoidK
 import arrow.core.extensions.setk.monoidal.monoidal
 import arrow.core.extensions.setk.semigroupK.semigroupK
 import arrow.core.extensions.setk.show.show
 import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
+import arrow.test.generators.genSetK
 import arrow.test.laws.FoldableLaws
 import arrow.test.laws.HashLaws
 import arrow.test.laws.MonoidKLaws
+import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
 import arrow.test.laws.SemigroupKLaws
 import arrow.test.laws.ShowLaws
 import arrow.typeclasses.Eq
+import io.kotlintest.properties.Gen
 
 class SetKTest : UnitSpec() {
 
@@ -36,8 +40,7 @@ class SetKTest : UnitSpec() {
 
     testLaws(
       ShowLaws.laws(SetK.show(), EQ) { SetK.just(it) },
-      // Investigate - StackOverflowError
-      // MonoidLaws.laws(SetK.monoid(), Gen.genSetK(Gen.int()), EQ),
+      MonoidLaws.laws(SetK.monoid(), Gen.genSetK(Gen.int()), EQ),
       SemigroupKLaws.laws(SetK.semigroupK(), { SetK.just(it) }, Eq.any()),
       MonoidalLaws.laws(SetK.monoidal(), { SetK.just(it) }, Eq.any(), this::bijection, associativeSemigroupalEq),
       MonoidKLaws.laws(SetK.monoidK(), { SetK.just(it) }, Eq.any()),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
@@ -37,7 +37,6 @@ class SetKTest : UnitSpec() {
     testLaws(
       ShowLaws.laws(SetK.show(), EQ) { SetK.just(it) },
       // Investigate - StackOverflowError
-      // SemigroupLaws.laws(SetK.semigroup(), setOf(1, 2, 3).k(), setOf(4, 5, 6).k(), setOf(7, 8, 9).k(), EQ),
       // MonoidLaws.laws(SetK.monoid(), Gen.genSetK(Gen.int()), EQ),
       SemigroupKLaws.laws(SetK.semigroupK(), { SetK.just(it) }, Eq.any()),
       MonoidalLaws.laws(SetK.monoidal(), { SetK.just(it) }, Eq.any(), this::bijection, associativeSemigroupalEq),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
@@ -3,7 +3,6 @@ package arrow.core
 import arrow.Kind
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
-import arrow.core.extensions.tuple2.eq.eq
 import arrow.core.extensions.setk.eq.eq
 import arrow.core.extensions.setk.foldable.foldable
 import arrow.core.extensions.setk.hash.hash
@@ -11,6 +10,7 @@ import arrow.core.extensions.setk.monoidK.monoidK
 import arrow.core.extensions.setk.monoidal.monoidal
 import arrow.core.extensions.setk.semigroupK.semigroupK
 import arrow.core.extensions.setk.show.show
+import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.laws.FoldableLaws
 import arrow.test.laws.HashLaws
@@ -36,6 +36,9 @@ class SetKTest : UnitSpec() {
 
     testLaws(
       ShowLaws.laws(SetK.show(), EQ) { SetK.just(it) },
+      // Investigate - StackOverflowError
+      // SemigroupLaws.laws(SetK.semigroup(), setOf(1, 2, 3).k(), setOf(4, 5, 6).k(), setOf(7, 8, 9).k(), EQ),
+      // MonoidLaws.laws(SetK.monoid(), Gen.genSetK(Gen.int()), EQ),
       SemigroupKLaws.laws(SetK.semigroupK(), { SetK.just(it) }, Eq.any()),
       MonoidalLaws.laws(SetK.monoidal(), { SetK.just(it) }, Eq.any(), this::bijection, associativeSemigroupalEq),
       MonoidKLaws.laws(SetK.monoidK(), { SetK.just(it) }, Eq.any()),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SortedMapKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SortedMapKTest.kt
@@ -1,8 +1,8 @@
 package arrow.core
 
 import arrow.Kind2
-import arrow.core.extensions.monoid
 import arrow.core.extensions.functor
+import arrow.core.extensions.monoid
 import arrow.core.extensions.show
 import arrow.core.extensions.traverse
 import arrow.test.UnitSpec

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SortedMapKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SortedMapKTest.kt
@@ -8,7 +8,6 @@ import arrow.core.extensions.traverse
 import arrow.test.UnitSpec
 import arrow.test.generators.sortedMapK
 import arrow.test.laws.MonoidLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -26,11 +25,6 @@ class SortedMapKTest : UnitSpec() {
     testLaws(
       ShowLaws.laws(SortedMapK.show(), EQ) { sortedMapOf("key" to 1).k() },
       MonoidLaws.laws(SortedMapK.monoid<String, Int>(Int.monoid()), Gen.sortedMapK(Gen.string(), Gen.int()), EQ),
-      SemigroupLaws.laws(SortedMapK.monoid<String, Int>(Int.monoid()),
-        sortedMapOf("key" to 1).k(),
-        sortedMapOf("key" to 2).k(),
-        sortedMapOf("key" to 3).k(),
-        EQ),
       TraverseLaws.laws(
         SortedMapK.traverse<String>(),
         SortedMapK.functor<String>(),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/TryTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/TryTest.kt
@@ -6,20 +6,17 @@ import arrow.core.extensions.`try`.functor.functor
 import arrow.core.extensions.`try`.hash.hash
 import arrow.core.extensions.`try`.monadError.monadError
 import arrow.core.extensions.`try`.monoid.monoid
-import arrow.core.extensions.`try`.semigroup.semigroup
 import arrow.core.extensions.`try`.show.show
 import arrow.core.extensions.`try`.traverse.traverse
 import arrow.core.extensions.combine
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
 import arrow.core.extensions.monoid
-import arrow.core.extensions.semigroup
 import arrow.test.UnitSpec
 import arrow.test.generators.`try`
 import arrow.test.laws.HashLaws
 import arrow.test.laws.MonadErrorLaws
 import arrow.test.laws.MonoidLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -41,7 +38,6 @@ class TryTest : UnitSpec() {
     val EQ = Try.eq(Eq<Any> { a, b -> a::class == b::class }, Eq.any())
 
     testLaws(
-      SemigroupLaws.laws(Try.semigroup(Int.semigroup()), Try.just(1), Try.just(2), Try.just(3), EQ),
       MonoidLaws.laws(Try.monoid(MO = Int.monoid()), Gen.`try`(Gen.int()), EQ),
       ShowLaws.laws(Try.show(), EQ) { Try.just(it) },
       MonadErrorLaws.laws(Try.monadError(), Eq.any(), Eq.any()),

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/setk.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/setk.kt
@@ -23,7 +23,7 @@ import arrow.core.combineK as setCombineK
 @extension
 interface SetKSemigroup<A> : Semigroup<SetK<A>> {
   override fun SetK<A>.combine(b: SetK<A>): SetK<A> =
-    (this.plus(b)).k()
+    this.fix().setCombineK(b)
 }
 
 @extension

--- a/modules/core/arrow-generic/src/test/kotlin/arrow/generic/ProductTest.kt
+++ b/modules/core/arrow-generic/src/test/kotlin/arrow/generic/ProductTest.kt
@@ -4,11 +4,11 @@ import arrow.core.None
 import arrow.core.Option
 import arrow.core.Try
 import arrow.core.Tuple3
-import arrow.core.toT
 import arrow.core.extensions.`try`.applicative.applicative
 import arrow.core.extensions.option.applicative.applicative
 import arrow.core.extensions.option.monoid.monoid
 import arrow.core.some
+import arrow.core.toT
 import arrow.product
 import arrow.test.UnitSpec
 import arrow.test.generators.nonEmptyList
@@ -16,7 +16,6 @@ import arrow.test.generators.option
 import arrow.test.generators.tuple3
 import arrow.test.laws.EqLaws
 import arrow.test.laws.MonoidLaws
-import arrow.test.laws.SemigroupLaws
 import arrow.typeclasses.Applicative
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -133,7 +132,6 @@ class ProductTest : UnitSpec() {
 
     testLaws(
       EqLaws.laws(Person.eq(), getPersonWithAge),
-      SemigroupLaws.laws(Person.semigroup(), getPersonWithAge(1), getPersonWithAge(2), getPersonWithAge(3), Person.eq()),
       MonoidLaws.laws(Person.monoid(), genPerson(), Person.eq())
     )
   }

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/AndMonoidTest.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/AndMonoidTest.kt
@@ -1,0 +1,14 @@
+package arrow.optics
+
+import arrow.core.extensions.eq
+import arrow.test.UnitSpec
+import arrow.test.laws.MonoidLaws
+import io.kotlintest.properties.Gen
+
+class AndMonoidTest : UnitSpec() {
+  init {
+      testLaws(
+        MonoidLaws.laws(AndMonoid, Gen.bool(), Boolean.eq())
+      )
+  }
+}

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/std/StringTest.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/std/StringTest.kt
@@ -1,8 +1,10 @@
 package arrow.optics
 
+import arrow.core.extensions.monoid
 import arrow.test.UnitSpec
 import arrow.test.generators.char
 import arrow.test.laws.IsoLaws
+import arrow.test.laws.MonoidLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
 import io.kotlintest.properties.Gen
@@ -11,7 +13,9 @@ class StringTest : UnitSpec() {
 
   init {
 
-    testLaws(IsoLaws.laws(
+    testLaws(
+      MonoidLaws.laws(String.monoid(), Gen.string(), Eq.any()),
+      IsoLaws.laws(
       iso = String.toList(),
       aGen = Gen.string(),
       bGen = Gen.list(Gen.char()),

--- a/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/std/TupleTest.kt
+++ b/modules/optics/arrow-optics/src/test/kotlin/arrow/optics/std/TupleTest.kt
@@ -1,5 +1,6 @@
 package arrow.optics
 
+import arrow.core.ListK
 import arrow.core.Option
 import arrow.core.Tuple10
 import arrow.core.Tuple2
@@ -10,10 +11,10 @@ import arrow.core.Tuple6
 import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
-import arrow.core.extensions.monoid
 import arrow.core.extensions.listk.eq.eq
+import arrow.core.extensions.monoid
 import arrow.core.extensions.option.eq.eq
-import arrow.core.ListK
+import arrow.core.extensions.tuple2.monoid.monoid
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.generators.tuple10
@@ -26,6 +27,7 @@ import arrow.test.generators.tuple7
 import arrow.test.generators.tuple8
 import arrow.test.generators.tuple9
 import arrow.test.laws.LensLaws
+import arrow.test.laws.MonoidLaws
 import arrow.test.laws.TraversalLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
@@ -33,6 +35,14 @@ import io.kotlintest.properties.Gen
 class TupleTest : UnitSpec() {
 
   init {
+
+    testLaws(
+      MonoidLaws.laws(
+        M = Tuple2.monoid(Int.monoid(), String.monoid()),
+        A = Gen.tuple2(Gen.int(), Gen.string()),
+        EQ = Eq.any()
+      )
+    )
 
     testLaws(
       LensLaws.laws(


### PR DESCRIPTION
This PR addresses https://github.com/arrow-kt/arrow/issues/460

The following tests have been updated to use semigroup or monoid laws:
- [x] ListKTest
- [x] SequenceKTest
- [x] SetKTest
- [x] TupleTest
- [x] StringTest
- [x] AndMonoid
- [x] ~all extensions in numbers.kt~ all tests already covered in `NumberSemiringTest`