### PR TITLE
Max and Min Shouldn't modify the Query value

### DIFF
--- a/modules/aql/arrow-aql/src/main/kotlin/arrow/aql/Max.kt
+++ b/modules/aql/arrow-aql/src/main/kotlin/arrow/aql/Max.kt
@@ -14,17 +14,17 @@ interface Max<F> {
 
   fun foldable(): Foldable<F>
 
-  fun <A, Y, Z> Query<F, A, Y>.max(ord: Order<Z>, f: A.() -> Z): Query<ForId, Option<Z>, Option<Z>> =
+  fun <A, Y, Z> Query<F, A, Y>.max(ord: Order<Z>, f: A.() -> Z): Query<ForId, Option<Y>, Option<Y>> =
     Query(
       select = ::identity,
       from = Id(foldable().run {
-        from.foldLeft(None) { acc: Option<Z>, a: A ->
-          acc.fold({ Some(f(a)) },
-            { Some(if (ord.run { it > f(a) }) it else f(a)) })
-        }
+        from.foldLeft(None) { acc: Option<A>, a: A ->
+          acc.fold({ Some(a) },
+            { Some(if (ord.run { f(it) > f(a) }) it else a) })
+        }.map(select)
       }))
 
-  fun <Z> Query<ForId, Option<Z>, Option<Z>>.value(): Option<Z> =
+  fun <A, Y> Query<ForId, Option<Y>, Option<Y>>.value(): Option<Y> =
     foldable().run {
       this@value.from.value()
     }

--- a/modules/aql/arrow-aql/src/main/kotlin/arrow/aql/Min.kt
+++ b/modules/aql/arrow-aql/src/main/kotlin/arrow/aql/Min.kt
@@ -14,17 +14,17 @@ interface Min<F> {
 
   fun foldable(): Foldable<F>
 
-  fun <A, Y, Z> Query<F, A, Y>.min(ord: Order<Z>, f: A.() -> Z): Query<ForId, Option<Z>, Option<Z>> =
+  fun <A, Y, Z> Query<F, A, Y>.min(ord: Order<Z>, f: A.() -> Z): Query<ForId, Option<Y>, Option<Y>> =
     Query(
       select = ::identity,
       from = Id(foldable().run {
-        from.foldLeft(None) { acc: Option<Z>, a: A ->
-          acc.fold({ Some(f(a)) },
-            { Some(if (ord.run { it < f(a) }) it else f(a)) })
-        }
+        from.foldLeft(None) { acc: Option<A>, a: A ->
+          acc.fold({ Some(a) },
+            { Some(if (ord.run { f(it) < f(a) }) it else a) })
+        }.map(select)
       }))
 
-  fun <Z> Query<ForId, Option<Z>, Option<Z>>.value(): Option<Z> =
+  fun <Y> Query<ForId, Option<Y>, Option<Y>>.value(): Option<Y> =
     foldable().run {
       this@value.from.value()
     }

--- a/modules/aql/arrow-aql/src/test/kotlin/arrow/aql/tests/AQLTests.kt
+++ b/modules/aql/arrow-aql/src/test/kotlin/arrow/aql/tests/AQLTests.kt
@@ -124,8 +124,14 @@ class AQLTests : UnitSpec() {
 
     "AQL is able to `max`" {
       listOf(john, jane, jack, chris).query {
-        selectAll().max(Long.order()) { age.toLong() }
-      }.value() shouldBe Some(40L)
+        selectAll().max(Int.order()) { age }
+      }.value() shouldBe Some(chris)
+    }
+
+    "AQL is able to `max` and return the select type" {
+      listOf(john, jane, jack, chris).query {
+        select { this.age }.max(Int.order()) { age }
+      }.value() shouldBe Some(40)
     }
 
     "AQL `max` call in an empty List returns None" {
@@ -137,7 +143,13 @@ class AQLTests : UnitSpec() {
     "AQL is able to `min`" {
       listOf(john, jane, jack, chris).query {
         selectAll().min(Long.order()) { age.toLong() }
-      }.value() shouldBe Some(30L)
+      }.value() shouldBe Some(john)
+    }
+
+    "AQL is able to `min` and return the select type" {
+      listOf(john, jane, jack, chris).query {
+        select { this.age }.min(Int.order()) { age }
+      }.value() shouldBe Some(30)
     }
 
     "AQL `min` in an empty List returns None" {


### PR DESCRIPTION
We need to use a value to define which row is max or min, but not necessarily this value has to be returned. 