### PR TITLE
[WIP] bounded queue initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ gen-external-apklibs
 .idea/**/gradle.xml
 .idea/**/libraries
 
+#Kotlintest
+**/.kotlintest
+
 # Mongo Explorer plugin:
 .idea/**/mongoSettings.xml
 

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Queue.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Queue.kt
@@ -1,0 +1,231 @@
+package arrow.fx
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.core.toT
+import arrow.core.identity
+import arrow.fx.internal.IQueue
+import arrow.fx.typeclasses.Concurrent
+import arrow.fx.typeclasses.Fiber
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.ApplicativeError
+import arrow.typeclasses.Monad
+
+/**
+ * Lightweight, asynchronous queue for values of A in a Concurrent context F
+ * A Queue can be implemented using 4 different strategies
+ *
+ * Bounded: Offering to a queue at capacity will cause the fiber making the call
+ * to be suspended until the queue has space to receive the offer value
+ *
+ * TODO: Unbound: Always places values from offer on the queue
+ *
+ * TODO: Sliding: Offering to a queue at capacity will cause the oldest value in
+ * the queue to be dropped before the offer value is enqueued
+ *
+ * TODO: Dropping Queue: Will fail to enqueue a value when queue at capacity returning false
+ *
+ * ported from Scala ZIO Queue implementation
+ */
+class Queue<F, A> private constructor(val capacity: Int, private val ref: Ref<F, State<F, A>>, private val CF: Concurrent<F>) :
+  Concurrent<F> by CF {
+
+  fun size(): Kind<F, Int> = ref.get().flatMap { it.size() }
+
+  /**
+   * A Queue can be in three states
+   * Deficit:
+   *  Contains a queue of values and a queue of suspended fibers
+   *  waiting to take once a value becomes available
+   * Surplus:
+   *  Contains a queue of values and a queue of suspended fibers
+   *  waiting to offer once there is room (if the queue is bounded)
+   * Shutdown:
+   *  Holds no values or promises for suspended calls,
+   *  an offer or take in Shutdown state creates a QueueShutdown error
+   */
+  internal sealed class State<F, out A> {
+    abstract fun size(): Kind<F, Int>
+
+    internal data class Deficit<F, A>(val takers: IQueue<Promise<F, A>>, val AP: Applicative<F>, val shutdownHook: Kind<F, Unit>) : State<F, A>() {
+      override fun size(): Kind<F, Int> = AP.just(-takers.length())
+    }
+
+    internal data class Surplus<F, A>(val queue: IQueue<A>, val putters: IQueue<Tuple2<A, Promise<F, Unit>>>, val AP: Applicative<F>, val shutdownHook: Kind<F, Unit>) : State<F, A>() {
+      override fun size(): Kind<F, Int> = AP.just(queue.length() + putters.length())
+    }
+
+    internal data class Shutdown<F>(val AE: ApplicativeError<F, Throwable>) : State<F, Nothing>() {
+      override fun size(): Kind<F, Int> = AE.raiseError(QueueShutdown)
+    }
+  }
+
+  fun offer(a: A): Kind<F, Unit> {
+    val use: (Promise<F, Unit>, State<F, A>) -> Tuple2<Kind<F, Unit>, State<F, A>> = { p, state ->
+      state.fold(
+        ifSurplus = {
+          it.run {
+            if (queue.length() < capacity && putters.isEmpty())
+              p.complete(Unit) toT copy(queue = queue.enqueue(a))
+            else
+              unit() toT it.copy(putters = putters.enqueue(a toT p))
+          }
+        },
+        ifDeficit = {
+          it.takers.dequeueOption().fold(
+            { p.complete(Unit) toT State.Surplus(IQueue.empty<A>().enqueue(a), IQueue.empty(), CF, it.shutdownHook) },
+            { (taker, takers) ->
+              taker.complete(a).followedBy(p.complete(Unit)) toT it.copy(takers = takers)
+            }
+          )
+        },
+        ifShutdown = { p.error(QueueShutdown) toT state }
+      )
+    }
+
+    val release: (Unit, Promise<F, Unit>) -> Kind<F, Unit> =
+      { _, p -> removePutter(p) }
+
+    return Promise.bracket(ref, use, release, CF)
+  }
+
+  fun take(): Kind<F, A> {
+    val use: (Promise<F, A>, State<F, A>) -> Tuple2<Kind<F, Unit>, State<F, A>> = { p, state ->
+      state.fold(
+        ifSurplus = { surplus ->
+          surplus.queue.dequeueOption().fold(
+            ifEmpty = {
+              surplus.putters.dequeueOption().fold(
+                { just(Unit) toT State.Deficit(IQueue.empty<Promise<F, A>>().enqueue(p), CF, surplus.shutdownHook) },
+                { (putter, putters) ->
+                  val (a, prom) = putter
+                  (prom.complete(Unit).followedBy(p.complete(a))) toT surplus.copy(
+                    queue = IQueue.empty(),
+                    putters = putters
+                  )
+                }
+              )
+            },
+            ifSome = { (a, q) ->
+              surplus.putters.dequeueOption().fold(
+                { p.complete(a) toT surplus.copy(queue = q) },
+                { (putter, putters) ->
+                  val (putVal, putProm) = putter
+                  (putProm.complete(Unit).followedBy(p.complete(a))) toT surplus.copy(
+                    queue = q.enqueue(putVal),
+                    putters = putters
+                  )
+                })
+            }
+          )
+        },
+        ifDeficit = { deficit -> just(Unit) toT deficit.copy(takers = deficit.takers.enqueue(p)) },
+        ifShutdown = { p.error(QueueShutdown) toT state }
+      )
+    }
+
+    val release: (Unit, Promise<F, A>) -> Kind<F, Unit> =
+      { _, p -> removeTaker(p) }
+    return Promise.bracket(ref, use, release, CF)
+  }
+
+  /**
+   * Waits until the queue is shutdown.
+   * The `IO` returned by this method will not resume until the queue has been shutdown.
+   * If the queue is already shutdown, the `IO` will resume right away.
+   */
+  fun awaitShutdown(): Kind<F, Unit> =
+    Promise<F, Unit>(CF).flatMap { promise ->
+      val io = promise.complete(Unit)
+      ref.modify { state ->
+        state.fold(
+          ifSurplus = { it.copy(shutdownHook = it.shutdownHook.followedBy(io.unit())) toT unit() },
+          ifDeficit = { it.copy(shutdownHook = it.shutdownHook.followedBy(io.unit())) toT unit() },
+          ifShutdown = { state toT io.unit() }
+        )
+      }.flatten().followedBy(promise.get())
+    }
+
+  /**
+   * Cancels any fibers that are suspended on `offer` or `take`.
+   * Future calls to `offer*` and `take*` will be interrupted immediately.
+   */
+  fun shutdown(): Kind<F, Unit> = ref.modify { state ->
+    state.fold(
+      ifSurplus = {
+        if (it.putters.isEmpty()) State.Shutdown(CF) toT it.shutdownHook
+        else {
+          val forked = forkAll(it.putters.toList()
+            .map { (_, p) -> p.error(QueueShutdown) }).flatMap { it.join() }
+          State.Shutdown(CF) toT (forked.followedBy(it.shutdownHook))
+        }
+      },
+      ifDeficit = {
+        if (it.takers.isEmpty()) State.Shutdown(CF) toT it.shutdownHook
+        else {
+          val forked = forkAll(it.takers.toList()
+            .map { it.error(QueueShutdown) }).flatMap { it.join() }
+          State.Shutdown(CF) toT (forked.followedBy(it.shutdownHook))
+        }
+      },
+      ifShutdown = { state toT unit() }
+    )
+  }.flatten()
+
+  companion object {
+    fun <F, A> bounded(capacity: Int, CF: Concurrent<F>): Kind<F, Queue<F, A>> = CF.run {
+      Ref<State<F, A>>(State.Surplus(IQueue.empty(), IQueue.empty(), this, unit())).map {
+        Queue(capacity, it, this)
+      }
+    }
+
+    internal fun <F, A, C> State<F, A>.fold(
+      ifSurplus: (State.Surplus<F, A>) -> C,
+      ifDeficit: (State.Deficit<F, A>) -> C,
+      ifShutdown: (State.Shutdown<F>) -> C
+    ) =
+      when (this) {
+        is State.Surplus -> ifSurplus(this)
+        is State.Deficit -> ifDeficit(this)
+        is State.Shutdown -> ifShutdown(this)
+      }
+  }
+
+  private fun <A> removeTaker(taker: Promise<F, A>): Kind<F, Unit> =
+    ref.update { state ->
+      state.fold(
+        ifSurplus = ::identity,
+        ifDeficit = { it.run { copy(takers.filterNot { t -> t == taker }) } },
+        ifShutdown = ::identity
+      )
+    }
+
+  private fun removePutter(putter: Promise<F, Unit>): Kind<F, Unit> =
+    ref.update { state ->
+      state.fold(
+        ifSurplus = { it.run { copy(putters = putters.filterNot { p -> p == putter }) } },
+        ifDeficit = ::identity,
+        ifShutdown = ::identity
+      )
+    }
+}
+
+object QueueShutdown : RuntimeException() {
+  override fun fillInStackTrace(): Throwable = this
+}
+
+// Write fiber Concurrent typeclass??
+fun <F, A, B, C> Fiber<F, A>.zipwith(fb: Fiber<F, B>, M: Monad<F>, f: (Tuple2<A, B>) -> C): Fiber<F, C> {
+  val fib: Kind<F, C> = M.map(this@zipwith.join(), fb.join(), f)
+  return Fiber(fib, M.run { this@zipwith.cancel().followedBy(fb.cancel()) })
+}
+
+// Move somewhere else??
+fun <F, A> Concurrent<F>.forkAll(iter: Iterable<Kind<F, A>>): Kind<F, Fiber<F, List<A>>> {
+  val initial = just(emptyList<A>()).fork()
+  return iter.fold(initial) { accFiberIO, elemIO ->
+    tupled(accFiberIO, elemIO.fork()).map { (asFiber, elem) ->
+      asFiber.zipwith(elem, this) { (xs, x) -> listOf(x) + xs }
+    }
+  }
+}

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/IQueue.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/IQueue.kt
@@ -1,0 +1,87 @@
+package arrow.fx.internal
+
+import arrow.core.Tuple2
+import arrow.core.Option
+import arrow.core.None
+import arrow.core.Some
+import arrow.core.toT
+import arrow.core.extensions.list.foldable.exists
+import arrow.core.extensions.list.foldable.nonEmpty
+
+/**
+ *  Port of `scala.collection.immutable.Queue`
+ * `Queue` objects implement data structures that allow to
+ *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+ *
+ *  `Queue` is implemented as a pair of `List`s, one containing the ''in'' elements and the other the ''out'' elements.
+ *  Elements are added to the ''in'' list and removed from the ''out'' list. When the ''out'' list runs dry, the
+ *  queue is pivoted by replacing the ''out'' list by ''in.reverse'', and ''in'' by ''Nil''.
+ *
+ */
+
+class IQueue<A> private constructor(val lIn: List<A>, val lOut: List<A>) {
+
+  private fun <A> Iterable<A>.head() = first()
+  private fun <A> Iterable<A>.tail() = drop(1)
+  private fun cons(a: A, l: List<A>): List<A> = listOf(a) + l
+
+  fun isEmpty(): Boolean = lIn.isEmpty() && lOut.isEmpty()
+  fun nonEmpty(): Boolean = lIn.nonEmpty() || lOut.nonEmpty()
+
+  fun head(): A =
+    when {
+      lOut.nonEmpty() -> lOut.head()
+      lIn.nonEmpty() -> lIn.last()
+      else -> throw NoSuchElementException("head on empty queue")
+    }
+
+  fun tail(): IQueue<A> =
+    when {
+      lOut.nonEmpty() -> IQueue(lIn, lOut.tail())
+      lIn.nonEmpty() -> IQueue(emptyList(), lIn.reversed().tail())
+      else -> throw NoSuchElementException("tail on empty queue")
+    }
+
+  fun forAll(p: (A) -> Boolean): Boolean =
+    lIn.all(p) && lOut.all(p)
+
+  fun exists(p: (A) -> Boolean): Boolean =
+    lIn.exists(p) || lOut.exists(p)
+
+  fun length(): Int = lIn.size + lOut.size
+
+  fun enqueue(elem: A) = IQueue(cons(elem, lIn), lOut)
+
+  fun enqueue(elems: Iterable<A>) = IQueue(elems.reversed() + lIn, lOut)
+
+  fun dequeue(): Tuple2<A, IQueue<A>> =
+    when {
+      lOut.isEmpty() && !lIn.isEmpty() -> {
+        val rev = lIn.reversed()
+        rev.head() toT IQueue(emptyList(), rev.tail())
+      }
+      lOut.nonEmpty() -> lOut.head() toT IQueue(lIn, lOut.tail())
+      else -> throw NoSuchElementException("dequeue on empty queue")
+    }
+
+  fun dequeueOption(): Option<Tuple2<A, IQueue<A>>> =
+    if (isEmpty()) None
+    else Some(dequeue())
+
+  fun front(): A = head()
+
+  fun filter(p: (A) -> Boolean): IQueue<A> =
+    IQueue(lIn.filter(p), lOut.filter(p))
+
+  fun filterNot(p: (A) -> Boolean): IQueue<A> =
+    IQueue(lIn.filterNot(p), lOut.filterNot(p))
+
+  override fun toString() = "Queue(${lIn.joinToString(separator = ", ")}, ${lOut.joinToString(separator = ", ")})"
+
+  companion object {
+    fun <A> empty(): IQueue<A> = IQueue(emptyList(), emptyList())
+    fun <A> invoke(vararg a: A): IQueue<A> = IQueue(emptyList(), a.toList())
+  }
+
+  fun toList() = lOut + lIn.reversed()
+}

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
@@ -1,0 +1,217 @@
+package arrow.fx
+
+import arrow.core.extensions.list.traverse.traverse
+import arrow.core.fix
+import arrow.core.Tuple3
+import arrow.core.Tuple2
+import arrow.core.Left
+import arrow.core.None
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.applicative.applicative
+import arrow.fx.extensions.io.concurrent.concurrent
+import arrow.fx.typeclasses.milliseconds
+import arrow.test.UnitSpec
+import arrow.test.generators.tuple2
+import arrow.test.generators.tuple3
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+import io.kotlintest.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
+
+class QueueTest : UnitSpec() {
+
+  init {
+
+    fun tests(
+      label: String,
+      ctx: CoroutineContext = Dispatchers.Default,
+      queue: (Int) -> IO<Queue<ForIO, Int>>
+    ) {
+
+      "$label - make a queue the add values then retrieve in the same order" {
+        forAll(Gen.list(Gen.int())) { l ->
+          IO.fx {
+            val q = !queue(l.size)
+            !l.traverse(IO.applicative(), q::offer)
+            val nl = !(1..l.size).toList().traverse(IO.applicative()) { q.take() }
+            nl.fix()
+          }.unsafeRunSync() == l
+        }
+      }
+
+      "$label - offer and take a number of values in the same order" {
+        forAll(Gen.tuple3(Gen.int(), Gen.int(), Gen.int())) { t ->
+          IO.fx {
+            val q = !queue(3)
+            !q.offer(t.a)
+            !q.offer(t.b)
+            !q.offer(t.c)
+            val first = !q.take()
+            val second = !q.take()
+            val third = !q.take()
+            Tuple3(first, second, third)
+          }.unsafeRunSync() == t
+        }
+      }
+
+      "$label - time out taking from an empty queue" {
+        val wontComplete = queue(10).flatMap(Queue<ForIO, Int>::take)
+        val start = System.currentTimeMillis()
+        val received = wontComplete.unsafeRunTimed(100.milliseconds)
+        val elapsed = System.currentTimeMillis() - start
+
+        received shouldBe None
+        (elapsed >= 100) shouldBe true
+      }
+
+      "$label - time out offering to a queue at capacity" {
+        val wontComplete = IO.fx {
+          val q = !queue(1)
+          !q.offer(1)
+          !q.offer(2)
+        }
+        val start = System.currentTimeMillis()
+        val received = wontComplete.unsafeRunTimed(100.milliseconds)
+        val elapsed = System.currentTimeMillis() - start
+
+        received shouldBe None
+        (elapsed >= 100) shouldBe true
+      }
+
+      "$label - suspended take calls on an empty queue complete when offer calls made to queue" {
+        forAll(Gen.int()) { i ->
+          IO.fx {
+            val q = !queue(3)
+            val first = !q.take().fork(ctx)
+            !q.offer(i)
+            !first.join()
+          }.unsafeRunSync() == i
+        }
+      }
+
+      "$label - multiple take calls on an empty queue complete when until as many offer calls made to queue" {
+        forAll(Gen.tuple3(Gen.int(), Gen.int(), Gen.int())) { t ->
+          IO.fx {
+            val q = !queue(3)
+            val first = !q.take().fork(ctx)
+            val second = !q.take().fork(ctx)
+            val third = !q.take().fork(ctx)
+            !q.offer(t.a)
+            !q.offer(t.b)
+            !q.offer(t.c)
+            val firstValue = !first.join()
+            val secondValue = !second.join()
+            val thirdValue = !third.join()
+            setOf(firstValue, secondValue, thirdValue)
+          }.unsafeRunSync() == setOf(t.a, t.b, t.c)
+        }
+      }
+
+      "$label - suspended offers called on an full queue complete when take calls made to queue" {
+        forAll(Gen.tuple2(Gen.int(), Gen.int())) { t ->
+          IO.fx {
+            val q = !queue(1)
+            !q.offer(t.a)
+            !q.offer(t.b).fork(ctx)
+            val first = !q.take()
+            val second = !q.take()
+            Tuple2(first, second)
+          }.unsafeRunSync() == t
+        }
+      }
+
+      "$label - multiple offer calls on an full queue complete when as many take calls are made to queue" {
+        forAll(Gen.tuple3(Gen.int(), Gen.int(), Gen.int())) { t ->
+          IO.fx {
+            val q = !queue(1)
+            !q.offer(t.a)
+            !q.offer(t.b).fork(ctx)
+            !q.offer(t.c).fork(ctx)
+            val first = !q.take()
+            val second = !q.take()
+            val third = !q.take()
+            setOf(first, second, third)
+          }.unsafeRunSync() == setOf(t.a, t.b, t.c)
+        }
+      }
+
+      "$label - taking from a shutdown queue creates a QueueShutdown error" {
+        forAll(Gen.int()) { i ->
+          IO.fx {
+            val q = !queue(10)
+            !q.offer(i)
+            !q.shutdown()
+            !q.take()
+          }.attempt().unsafeRunSync() == Left(QueueShutdown)
+        }
+      }
+
+      "$label - offering to a shutdown queue creates a QueueShutdown error" {
+        forAll(Gen.int()) { i ->
+          IO.fx {
+            val q = !queue(10)
+            !q.shutdown()
+            !q.offer(i)
+          }.attempt().unsafeRunSync() == Left(QueueShutdown)
+        }
+      }
+
+      "$label - joining a forked, incompleted take call on a shutdown queue creates a  QueueShutdown error" {
+        IO.fx {
+          val q = !queue(10)
+          val t = !q.take().fork(ctx)
+          !q.shutdown()
+          !t.join()
+        }.attempt().unsafeRunSync() shouldBe Left(QueueShutdown)
+      }
+
+      "$label - joining a forked offer call made to a shut down queue creates a QueueShutdown error" {
+        forAll(Gen.int()) { i ->
+          IO.fx {
+            val q = !queue(1)
+            !q.offer(i)
+            val o = !q.offer(i).fork(ctx)
+            !q.shutdown()
+            !o.join()
+          }.attempt().unsafeRunSync() == Left(QueueShutdown)
+        }
+      }
+
+      "$label - create a shutdown hook completing a promise, then shutdown the queue, the promise should be completed" {
+        IO.fx {
+          val q = !queue(10)
+          val p = !Promise<ForIO, Boolean>(IO.concurrent())
+          !(q.awaitShutdown().followedBy(p.complete(true))).fork()
+          !q.shutdown()
+          !p.get()
+        }.unsafeRunSync()
+      }
+
+      "$label - create a shutdown hook completing a promise twice, then shutdown the queue, both promises should be completed" {
+        IO.fx {
+          val q = !queue(10)
+          val p1 = !Promise<ForIO, Boolean>(IO.concurrent())
+          val p2 = !Promise<ForIO, Boolean>(IO.concurrent())
+          !(q.awaitShutdown().followedBy(p1.complete(true))).fork()
+          !(q.awaitShutdown().followedBy(p2.complete(true))).fork()
+          !q.shutdown()
+          !map(p1.get(), p2.get()) { (p1, p2) -> p1 && p2 }
+        }.unsafeRunSync()
+      }
+
+      "$label - shut it down, create a shutdown hook completing a promise, the promise should be completed immediately" {
+        IO.fx {
+          val q = !queue(10)
+          !q.shutdown()
+          val p = !Promise<ForIO, Boolean>(IO.concurrent())
+          !(q.awaitShutdown().followedBy(p.complete(true))).fork()
+          !p.get()
+        }.unsafeRunSync()
+      }
+    }
+
+    tests("BoundedQueue", queue =
+    { capacity -> Queue.bounded<ForIO, Int>(capacity, IO.concurrent()).fix() })
+  }
+}


### PR DESCRIPTION
 Lightweight, asynchronous queue for values of A in a Concurrent context F
 Offering to a bounded queue at capacity will cause the fiber making the call to be suspended until the queue has space to receive the offer value.
Taking from an empty queue will cause the fiber making the call to be suspended until a value is available to be taken from the queue.
 
Shutdown: Calling shutdown on a queue will cause all suspend fibers to complete in a QueueShutdownError. Offering or Taking from a queue that has been shutdown will also complete as a QueueShutdownError 

Also added a port of Scala Immutable Queue to be used in internal state

## TODO: 
### Other Queue functions
`fun offerAll(as: List<A>): Kind<F, Unit>` : more efficient to put multiple values 
`fun takeAll(): Kind<F, List<A>>` take all values from queue
`fun takeUpToN(n: Int): Kind<F, List<A>` returns up to N values from Queue
`fun removePutter(putter: Tuple2<A, Promise<F, Unit>>): Kind<F, Unit>` remove putter from queue
`fun removeTaker(taker: Promise<F, A>): Kind<F, Unit>` remove take from queue
`fun map(f:(A) -> B): Queue<F, B>`: returns a new  Queue with f applied to values
### Other Queue types
Unbound: Always places values from offer on the queue
 Sliding: Offering to a queue at capacity will cause the oldest value in
  the queue to be dropped before the offer value is enqueued
 Dropping Queue: Will fail to enqueue a value when queue at capacity returning false
 

  ported from Scala ZIO Queue implementation