### PR TITLE
excluded arrow dependencies from kotlintest in arrow-test.

### DIFF
--- a/modules/core/arrow-test/build.gradle
+++ b/modules/core/arrow-test/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
     testRuntime("org.junit.vintage:junit-vintage-engine:$jUnitVintageVersion")
-    compile "io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion"
+    compile("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion") {
+        exclude group: "io.arrow-kt"
+    }
     kapt project(':arrow-meta')
 }
 


### PR DESCRIPTION
...as the transitive arrow dependencies from kotlintest is older and have different artifact names, which would pollute the client's classpath