### PR TITLE
Documentation: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <img height="100" src="https://avatars2.githubusercontent.com/u/29458023?v=4&amp;s=200" width="100">
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core-data/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Farrow-kt%2Farrow%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/arrow-kt/arrow/goto?ref=master)
-[![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
+[![Build Status](https://img.shields.io/endpoint.svg?label=build%20status&url=https%3A%2F%2Factions-badge.atrox.dev%2Farrow-kt%2Farrow%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/arrow-kt/arrow/goto?ref=master)
+[![Release Status](https://img.shields.io/travis/arrow-kt/arrow?label=release%20status)](https://travis-ci.org/arrow-kt/arrow/)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)]( http://stackoverflow.com/questions/tagged/arrow-kt )


### PR DESCRIPTION
## Purpose

Avoid the current misunderstanding between `build` with GitHub Actions and `release` with Travis CI.

## Proposal

Replace:

![Screenshot from 2019-10-28 01-02-00](https://user-images.githubusercontent.com/22792183/67644114-c3c03700-f91e-11e9-8b73-b3a00aaa9d5c.png)

by:

![Screenshot from 2019-10-28 01-15-51](https://user-images.githubusercontent.com/22792183/67644285-86f53f80-f920-11e9-9731-8f073c8b1c0b.png)


Instead of:
* `GitHub Actions`
* `build` (Travis CI)

it includes:
* `build status` (GitHub Actions)
* `release status` (Travis CI)

It also includes a badge for **latest snapshot**.