### PR TITLE
Add alternative instances to datatypes

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Alternative.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Alternative.kt
@@ -46,4 +46,6 @@ interface Alternative<F> : Applicative<F>, MonoidK<F> {
    * @returns a combination of both computations.
    */
   fun <A> Kind<F, A>.orElse(b: Kind<F, A>): Kind<F, A>
+
+  override fun <A> Kind<F, A>.combineK(y: Kind<F, A>): Kind<F, A> = orElse(y)
 }

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -36,6 +36,7 @@ class ListKTest : UnitSpec() {
     val associativeSemigroupalEq: Eq<ListKOf<Tuple2<Int, Tuple2<Int, Int>>>> = ListK.eq(Tuple2.eq(Int.eq(), Tuple2.eq(Int.eq(), Int.eq())))
 
     testLaws(
+      MonadCombineLaws.laws(ListK.monadCombine(), { listOf(it).k() }, { i -> listOf({ j: Int -> j + i }).k() }, eq),
       ShowLaws.laws(ListK.show(), eq) { listOf(it).k() },
       MonoidLaws.laws(ListK.monoid(), Gen.listK(Gen.int()), ListK.eq(Int.eq())),
       SemigroupKLaws.laws(ListK.semigroupK(), applicative, Eq.any()),

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -7,16 +7,18 @@ import arrow.core.extensions.monoid
 import arrow.core.extensions.option.applicative.applicative
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.option.hash.hash
+import arrow.core.extensions.option.monadCombine.monadCombine
+import arrow.core.extensions.option.monadFilter.monadFilter
 import arrow.core.extensions.option.monoid.monoid
 import arrow.core.extensions.option.monoidal.monoidal
 import arrow.core.extensions.option.show.show
-import arrow.core.extensions.tuple2.eq.eq
-import arrow.core.extensions.option.monadFilter.monadFilter
 import arrow.core.extensions.option.traverseFilter.traverseFilter
+import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.generators.option
 import arrow.test.laws.FunctorFilterLaws
 import arrow.test.laws.HashLaws
+import arrow.test.laws.MonadCombineLaws
 import arrow.test.laws.MonadFilterLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
@@ -44,6 +46,7 @@ class OptionTest : UnitSpec() {
   init {
 
     testLaws(
+      MonadCombineLaws.laws(Option.monadCombine(), { it.some() }, { i: Int -> { j: Int -> i + j }.some() }, Eq.any()),
       ShowLaws.laws(Option.show(), Option.eq(Int.eq())) { Some(it) },
       MonoidLaws.laws(Option.monoid(Int.monoid()), Gen.option(Gen.int()), Option.eq(Int.eq())),
       // testLaws(MonadErrorLaws.laws(monadError<ForOption, Unit>(), Eq.any(), EQ_EITHER)) TODO reenable once the MonadErrorLaws are parametric to `E`

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -8,6 +8,7 @@ import arrow.core.extensions.sequencek.eq.eq
 import arrow.core.extensions.sequencek.functorFilter.functorFilter
 import arrow.core.extensions.sequencek.hash.hash
 import arrow.core.extensions.sequencek.monad.monad
+import arrow.core.extensions.sequencek.monadCombine.monadCombine
 import arrow.core.extensions.sequencek.monoid.monoid
 import arrow.core.extensions.sequencek.monoidK.monoidK
 import arrow.core.extensions.sequencek.monoidal.monoidal
@@ -16,6 +17,7 @@ import arrow.test.UnitSpec
 import arrow.test.generators.sequenceK
 import arrow.test.laws.FunctorFilterLaws
 import arrow.test.laws.HashLaws
+import arrow.test.laws.MonadCombineLaws
 import arrow.test.laws.MonadLaws
 import arrow.test.laws.MonoidKLaws
 import arrow.test.laws.MonoidLaws
@@ -51,6 +53,7 @@ class SequenceKTest : UnitSpec() {
     }
 
     testLaws(
+      MonadCombineLaws.laws(SequenceK.monadCombine(), { sequenceOf(it).k() }, { i -> sequenceOf({ j: Int -> i + j }).k() }, eq),
       ShowLaws.laws(show, eq) { sequenceOf(it).k() },
       MonadLaws.laws(SequenceK.monad(), eq),
       MonoidKLaws.laws(SequenceK.monoidK(), SequenceK.applicative(), eq),

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -14,6 +14,7 @@ import arrow.core.extensions.listk.semigroup.plus
 import arrow.core.fix
 import arrow.core.k
 import arrow.extension
+import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Eq
@@ -203,7 +204,7 @@ fun <A> ListK.Companion.fx(c: suspend MonadSyntax<ForListK>.() -> A): ListK<A> =
   ListK.monad().fx.monad(c).fix()
 
 @extension
-interface ListKMonadCombine : MonadCombine<ForListK> {
+interface ListKMonadCombine : MonadCombine<ForListK>, ListKAlternative {
   override fun <A> empty(): ListK<A> =
     ListK.empty()
 
@@ -227,12 +228,6 @@ interface ListKMonadCombine : MonadCombine<ForListK> {
 
   override fun <A> just(a: A): ListK<A> =
     ListK.just(a)
-
-  override fun <A> Kind<ForListK, A>.combineK(y: Kind<ForListK, A>): ListK<A> =
-    fix().listCombineK(y)
-
-  override fun <A> Kind<ForListK, A>.orElse(b: Kind<ForListK, A>): ListK<A> =
-    fix() + b.fix()
 
   override fun <A> Kind<ForListK, A>.some(): ListK<SequenceK<A>> =
     if (this.fix().isEmpty()) ListK.empty()
@@ -276,4 +271,11 @@ interface ListKMonadFilter : MonadFilter<ForListK> {
 
   override fun <A> just(a: A): ListK<A> =
     ListK.just(a)
+}
+
+@extension
+interface ListKAlternative : Alternative<ForListK>, ListKApplicative {
+  override fun <A> empty(): Kind<ForListK, A> = emptyList<A>().k()
+  override fun <A> Kind<ForListK, A>.orElse(b: Kind<ForListK, A>): Kind<ForListK, A> =
+    (this.fix() + b.fix()).k()
 }

--- a/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/typeclasses/Composed.kt
+++ b/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/typeclasses/Composed.kt
@@ -337,6 +337,9 @@ fun <F, G> Applicative<F>.compose(GA: Applicative<G>): Applicative<Nested<F, G>>
 interface ComposedAlternative<F, G> : Alternative<Nested<F, G>>, ComposedApplicative<F, G>, ComposedMonoidK<F, G> {
   override fun F(): Alternative<F>
 
+  override fun <A> Kind<Nested<F, G>, A>.combineK(y: Kind<Nested<F, G>, A>): Kind<Nested<F, G>, A> =
+    orElse(y)
+
   override fun <A> Kind<Nested<F, G>, A>.orElse(b: Kind<Nested<F, G>, A>): Kind<Nested<F, G>, A> =
     F().run { unnest().orElse(b.unnest()) }.nest()
 

--- a/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/KleisliTest.kt
+++ b/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/KleisliTest.kt
@@ -3,8 +3,10 @@ package arrow.mtl
 import arrow.Kind
 import arrow.core.Either
 import arrow.core.ForId
+import arrow.core.ForOption
 import arrow.core.ForTry
 import arrow.core.Id
+import arrow.core.Option
 import arrow.core.Try
 import arrow.fx.ForIO
 import arrow.fx.IO
@@ -15,10 +17,14 @@ import arrow.core.extensions.`try`.monadError.monadError
 import arrow.core.extensions.const.divisible.divisible
 import arrow.core.extensions.id.monad.monad
 import arrow.core.extensions.monoid
+import arrow.core.extensions.option.alternative.alternative
+import arrow.core.some
+import arrow.mtl.extensions.kleisli.alternative.alternative
 import arrow.mtl.extensions.kleisli.contravariant.contravariant
 import arrow.mtl.extensions.kleisli.divisible.divisible
 import arrow.mtl.extensions.kleisli.monadError.monadError
 import arrow.test.UnitSpec
+import arrow.test.laws.AlternativeLaws
 import arrow.test.laws.BracketLaws
 import arrow.test.laws.ContravariantLaws
 import arrow.test.laws.DivisibleLaws
@@ -53,6 +59,12 @@ class KleisliTest : UnitSpec() {
   init {
 
     testLaws(
+      AlternativeLaws.laws(
+        Kleisli.alternative<ForOption, Int>(Option.alternative()),
+        { i -> Kleisli { i.some() } },
+        { i -> Kleisli { { j: Int -> i + j }.some() } },
+        Eq { a, b -> a.fix().run(0) == b.fix().run(0) }
+      ),
       BracketLaws.laws(
         Kleisli.bracket<ForIO, Int, Throwable>(IO.bracket()),
         EQ = IOEQ(),

--- a/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/WriterTTest.kt
+++ b/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/WriterTTest.kt
@@ -16,6 +16,8 @@ import arrow.fx.extensions.io.async.async
 import arrow.fx.mtl.writert.async.async
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.monoidK.monoidK
+import arrow.core.extensions.option.alternative.alternative
+import arrow.core.extensions.option.applicative.applicative
 import arrow.core.extensions.option.monad.monad
 import arrow.core.fix
 import arrow.mtl.extensions.writert.applicative.applicative
@@ -23,11 +25,13 @@ import arrow.mtl.extensions.writert.divisible.divisible
 import arrow.mtl.extensions.writert.monad.monad
 import arrow.mtl.extensions.writert.monoidK.monoidK
 import arrow.core.extensions.option.monadFilter.monadFilter
+import arrow.mtl.extensions.writert.alternative.alternative
 import arrow.mtl.extensions.writert.monadFilter.monadFilter
 import arrow.mtl.extensions.writert.monadWriter.monadWriter
 import arrow.test.UnitSpec
 import arrow.test.generators.intSmall
 import arrow.test.generators.tuple2
+import arrow.test.laws.AlternativeLaws
 import arrow.test.laws.AsyncLaws
 import arrow.test.laws.DivisibleLaws
 import arrow.test.laws.MonadFilterLaws
@@ -53,6 +57,12 @@ class WriterTTest : UnitSpec() {
   init {
 
     testLaws(
+      AlternativeLaws.laws(
+        WriterT.alternative(Int.monoid(), Option.alternative()),
+        { i -> WriterT.just(Option.applicative(), Int.monoid(), i) },
+        { i -> WriterT.just(Option.applicative(), Int.monoid(), { j: Int -> i + j }) },
+        Eq { a, b -> a.value() == b.value() }
+      ),
       DivisibleLaws.laws(
         WriterT.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
         { WriterT(it.const()) },

--- a/modules/mtl/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/kleisli.kt
+++ b/modules/mtl/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/kleisli.kt
@@ -37,6 +37,7 @@ import arrow.typeclasses.conest
 import arrow.typeclasses.counnest
 import arrow.undocumented
 import arrow.extension
+import arrow.typeclasses.Alternative
 
 @extension
 interface KleisliFunctor<F, D> : Functor<KleisliPartialOf<F, D>> {
@@ -182,6 +183,16 @@ interface KleisliMonadError<F, D, E> : MonadError<KleisliPartialOf<F, D>, E>, Kl
 @undocumented
 interface KleisliMonadThrow<F, D> : MonadThrow<KleisliPartialOf<F, D>>, KleisliMonadError<F, D, Throwable> {
   override fun ME(): MonadError<F, Throwable>
+}
+
+@extension
+interface KleisliAlternative<F, D> : Alternative<KleisliPartialOf<F, D>>, KleisliApplicative<F, D> {
+  override fun AF(): Applicative<F> = AL()
+  fun AL(): Alternative<F>
+
+  override fun <A> empty(): Kind<KleisliPartialOf<F, D>, A> = Kleisli { AL().empty() }
+  override fun <A> Kind<KleisliPartialOf<F, D>, A>.orElse(b: Kind<KleisliPartialOf<F, D>, A>): Kind<KleisliPartialOf<F, D>, A> =
+    Kleisli { d -> AL().run { run(d).orElse(b.run(d)) } }
 }
 
 @extension

--- a/modules/mtl/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/statet.kt
+++ b/modules/mtl/arrow-mtl/src/main/kotlin/arrow/mtl/extensions/statet.kt
@@ -36,6 +36,8 @@ import arrow.typeclasses.MonadThrow
 import arrow.typeclasses.SemigroupK
 import arrow.undocumented
 import arrow.extension
+import arrow.typeclasses.Alternative
+import arrow.typeclasses.MonoidK
 
 @extension
 @undocumented
@@ -91,12 +93,22 @@ interface StateTMonad<F, S> : Monad<StateTPartialOf<F, S>>, StateTApplicative<F,
 @undocumented
 interface StateTSemigroupK<F, S> : SemigroupK<StateTPartialOf<F, S>> {
 
-  fun FF(): Monad<F>
+  fun MF(): Monad<F>
 
   fun SS(): SemigroupK<F>
 
   override fun <A> StateTOf<F, S, A>.combineK(y: StateTOf<F, S, A>): StateT<F, S, A> =
-    fix().combineK(FF(), SS(), y)
+    fix().combineK(MF(), SS(), y)
+}
+
+@extension
+@undocumented
+interface StateTMonoidK<F, S> : MonoidK<StateTPartialOf<F, S>>, StateTSemigroupK<F, S> {
+  override fun MF(): Monad<F>
+  fun MO(): MonoidK<F>
+  override fun SS(): SemigroupK<F> = MO()
+
+  override fun <A> empty(): Kind<StateTPartialOf<F, S>, A> = StateT.liftF(MF(), MO().empty<A>())
 }
 
 @extension
@@ -238,15 +250,14 @@ interface StateTMonadState<F, S> : MonadState<StateTPartialOf<F, S>, S>, StateTM
 }
 
 @extension
-interface StateTMonadCombine<F, S> : MonadCombine<StateTPartialOf<F, S>>, StateTMonad<F, S>, StateTSemigroupK<F, S> {
+interface StateTMonadCombine<F, S> : MonadCombine<StateTPartialOf<F, S>>, StateTMonad<F, S>, StateTMonoidK<F, S> {
 
   fun MC(): MonadCombine<F>
 
   override fun MF(): Monad<F> = MC()
 
   override fun FF(): Monad<F> = MC()
-
-  override fun SS(): SemigroupK<F> = MC()
+  override fun MO(): MonoidK<F> = MC()
 
   override fun <A> empty(): Kind<StateTPartialOf<F, S>, A> = liftT(MC().empty())
 
@@ -254,9 +265,31 @@ interface StateTMonadCombine<F, S> : MonadCombine<StateTPartialOf<F, S>>, StateT
     StateT(just({ s: S -> ma.map { a: A -> s toT a } }))
   }
 
+  override fun <A> StateTOf<F, S, A>.combineK(y: StateTOf<F, S, A>): StateT<F, S, A> =
+    fix().combineK(MF(), MO(), y)
+
   override fun <A> Kind<StateTPartialOf<F, S>, A>.orElse(b: Kind<StateTPartialOf<F, S>, A>): Kind<StateTPartialOf<F, S>, A> {
     val x = this.fix()
     val y = b.fix()
     return MC().run { StateT(just({ s: S -> x.run(this, s).orElse(y.run(this, s)) })) }
   }
+}
+
+@extension
+interface StateTAlternative<F, S> : Alternative<StateTPartialOf<F, S>>, StateTMonoidK<F, S>, StateTApplicative<F, S> {
+  override fun MF(): Monad<F>
+  override fun MO(): MonoidK<F> = AF()
+  fun AF(): Alternative<F>
+
+  override fun <A> empty(): Kind<StateTPartialOf<F, S>, A> = StateT.liftF(AF(), AF().empty<A>())
+
+  override fun <A> Kind<StateTPartialOf<F, S>, A>.orElse(b: Kind<StateTPartialOf<F, S>, A>): Kind<StateTPartialOf<F, S>, A> =
+    StateT(AF()) { s ->
+      AF().run {
+        runM(MF(), s).orElse(b.runM(MF(), s))
+      }
+    }
+
+  override fun <A> StateTOf<F, S, A>.combineK(y: StateTOf<F, S, A>): StateT<F, S, A> =
+    orElse(y).fix()
 }


### PR DESCRIPTION
Most of these were missing alternative instances, and those that had one via MonadCombine had either no tests or no explicit alternative instance.

I also made combineK default to orElse in alternatives since that is exactly the monoidal behaviour it is supposed to represent.

Btw is there any reason for Alternative laws to be that strict? Looks like a mix of MonadPlus and Alternative laws to me.