### PR TITLE
RxJava ConcurrentSyntax & Dispatchers

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/generators/Generators.kt
@@ -145,3 +145,6 @@ fun Gen.Companion.char(): Gen<Char> =
   Gen.from(('A'..'Z') + ('a'..'z') + ('0'..'9') + "!@#$%%^&*()_-~`,<.?/:;}{][±§".toList())
 
 fun <A> Gen.Companion.genSetK(genA: Gen<A>): Gen<SetK<A>> = Gen.set(genA).map { it.k() }
+
+fun Gen.Companion.unit(): Gen<Unit> =
+  create { Unit }

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoK.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoK.kt
@@ -13,6 +13,9 @@ import arrow.fx.typeclasses.ExitCase
 import reactor.core.publisher.Mono
 import reactor.core.publisher.MonoSink
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 class ForMonoK private constructor() {
   companion object
@@ -30,6 +33,11 @@ fun <A> MonoKOf<A>.value(): Mono<A> =
   this.fix().mono as Mono<A>
 
 data class MonoK<out A>(val mono: Mono<out A>) : MonoKOf<A> {
+
+  suspend fun suspended(): A? = suspendCoroutine { cont ->
+    value().subscribe(cont::resume, cont::resumeWithException) { cont.resume(null) }
+  }
+
   fun <B> map(f: (A) -> B): MonoK<B> =
     mono.map(f).k()
 

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/MaybeK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/MaybeK.kt
@@ -18,6 +18,9 @@ import arrow.fx.typeclasses.ExitCase.Error
 import io.reactivex.Maybe
 import io.reactivex.MaybeEmitter
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 class ForMaybeK private constructor() {
   companion object
@@ -34,6 +37,10 @@ fun <A> Maybe<A>.k(): MaybeK<A> = MaybeK(this)
 fun <A> MaybeKOf<A>.value(): Maybe<A> = fix().maybe as Maybe<A>
 
 data class MaybeK<out A>(val maybe: Maybe<out A>) : MaybeKOf<A> {
+
+  suspend fun suspended(): A? = suspendCoroutine { cont ->
+    value().subscribe(cont::resume, cont::resumeWithException) { cont.resume(null) }
+  }
 
   fun <B> map(f: (A) -> B): MaybeK<B> =
     maybe.map(f).k()

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
@@ -16,6 +16,9 @@ import arrow.fx.typeclasses.ExitCase.Error
 import io.reactivex.Single
 import io.reactivex.SingleEmitter
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 class ForSingleK private constructor() {
   companion object
@@ -32,6 +35,10 @@ fun <A> Single<A>.k(): SingleK<A> = SingleK(this)
 fun <A> SingleKOf<A>.value(): Single<A> = fix().single as Single<A>
 
 data class SingleK<out A>(val single: Single<out A>) : SingleKOf<A> {
+
+  suspend fun suspended(): A = suspendCoroutine { cont ->
+    value().subscribe(cont::resume, cont::resumeWithException)
+  }
 
   fun <B> map(f: (A) -> B): SingleK<B> =
     single.map(f).k()

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/dispatchers.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/dispatchers.kt
@@ -1,0 +1,33 @@
+package arrow.fx.rx2.extensions
+
+import io.reactivex.Scheduler
+import io.reactivex.schedulers.Schedulers
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+
+internal val ComputationScheduler: CoroutineContext =
+  Schedulers.computation().asCoroutineContext()
+
+fun Scheduler.asCoroutineContext(): CoroutineContext =
+  SchedulerContext(this)
+
+private class SchedulerContext(val scheduler: Scheduler) : AbstractCoroutineContextElement(ContinuationInterceptor), ContinuationInterceptor {
+  override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
+    SchedulerContinuation(scheduler, continuation.context.fold(continuation) { cont, element ->
+      if (element != this@SchedulerContext && element is ContinuationInterceptor)
+        element.interceptContinuation(cont) else cont
+    })
+}
+
+private class SchedulerContinuation<T>(
+  val scheduler: Scheduler,
+  val cont: Continuation<T>
+) : Continuation<T> {
+  override val context: CoroutineContext = cont.context
+
+  override fun resumeWith(result: Result<T>) {
+    scheduler.scheduleDirect { cont.resumeWith(result) }
+  }
+}

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -28,7 +28,6 @@ import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
 import arrow.fx.Timer
-import arrow.fx.typeclasses.AsyncSyntax
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Fiber
 import arrow.extension

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -18,7 +18,6 @@ import arrow.fx.rx2.fix
 import arrow.fx.rx2.k
 import arrow.fx.rx2.value
 import arrow.fx.typeclasses.Async
-import arrow.fx.typeclasses.AsyncSyntax
 import arrow.fx.typeclasses.Bracket
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Dispatchers
@@ -30,6 +29,8 @@ import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
 import arrow.extension
+import arrow.fx.rx2.extensions.maybek.dispatchers.dispatchers
+import arrow.fx.typeclasses.ConcurrentSyntax
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Foldable
@@ -236,8 +237,14 @@ interface MaybeKConcurrent : Concurrent<ForMaybeK>, MaybeKAsync {
     }
 }
 
-fun MaybeK.Companion.concurrent(dispatchers: Dispatchers<ForMaybeK>): Concurrent<ForMaybeK> = object : MaybeKConcurrent {
+fun MaybeK.Companion.concurrent(dispatchers: Dispatchers<ForMaybeK> = MaybeK.dispatchers()): Concurrent<ForMaybeK> = object : MaybeKConcurrent {
   override fun dispatchers(): Dispatchers<ForMaybeK> = dispatchers
+}
+
+@extension
+interface MaybeKDispatchers : Dispatchers<ForMaybeK> {
+  override fun default(): CoroutineContext =
+    ComputationScheduler
 }
 
 @extension
@@ -283,6 +290,5 @@ interface MaybeKMonadFilter : MonadFilter<ForMaybeK> {
     MaybeK.just(a)
 }
 
-// TODO MaybeK does not yet have a Concurrent instance
-fun <A> MaybeK.Companion.fx(c: suspend AsyncSyntax<ForMaybeK>.() -> A): MaybeK<A> =
-  defer { MaybeK.async().fx.async(c).fix() }
+fun <A> MaybeK.Companion.fx(c: suspend ConcurrentSyntax<ForMaybeK>.() -> A): MaybeK<A> =
+  defer { MaybeK.concurrent().fx.concurrent(c).fix() }

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -20,7 +20,6 @@ import arrow.fx.rx2.fix
 import arrow.fx.rx2.k
 import arrow.fx.rx2.value
 import arrow.fx.typeclasses.Async
-import arrow.fx.typeclasses.AsyncSyntax
 import arrow.fx.typeclasses.Bracket
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.ConcurrentEffect
@@ -34,6 +33,8 @@ import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
 import arrow.extension
+import arrow.fx.rx2.extensions.observablek.dispatchers.dispatchers
+import arrow.fx.typeclasses.ConcurrentSyntax
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Foldable
@@ -241,7 +242,13 @@ interface ObservableKConcurrent : Concurrent<ForObservableK>, ObservableKAsync {
     }
 }
 
-fun ObservableK.Companion.concurrent(dispatchers: Dispatchers<ForObservableK>): Concurrent<ForObservableK> = object : ObservableKConcurrent {
+@extension
+interface ObservableKDispatchers : Dispatchers<ForObservableK> {
+  override fun default(): CoroutineContext =
+    ComputationScheduler
+}
+
+fun ObservableK.Companion.concurrent(dispatchers: Dispatchers<ForObservableK> = ObservableK.dispatchers()): Concurrent<ForObservableK> = object : ObservableKConcurrent {
   override fun dispatchers(): Dispatchers<ForObservableK> = dispatchers
 }
 
@@ -275,9 +282,8 @@ fun ObservableK.Companion.monadErrorSwitch(): ObservableKMonadError = object : O
     fix().switchMap { f(it).fix() }
 }
 
-// TODO ObservableK does not yet have a Concurrent instance
-fun <A> ObservableK.Companion.fx(c: suspend AsyncSyntax<ForObservableK>.() -> A): ObservableK<A> =
-  defer { ObservableK.async().fx.async(c).fix() }
+fun <A> ObservableK.Companion.fx(c: suspend ConcurrentSyntax<ForObservableK>.() -> A): ObservableK<A> =
+  defer { ObservableK.concurrent().fx.concurrent(c).fix() }
 
 @extension
 interface ObservableKTimer : Timer<ForObservableK> {

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
@@ -1,6 +1,5 @@
 package arrow.fx
 
-import arrow.core.Either
 import arrow.fx.rx2.ForSingleK
 import arrow.fx.rx2.SingleK
 import arrow.fx.rx2.SingleKOf
@@ -34,8 +33,8 @@ class SingleKTests : RxJavaSpec() {
 
   fun <T> EQ(): Eq<SingleKOf<T>> = object : Eq<SingleKOf<T>> {
     override fun SingleKOf<T>.eqv(b: SingleKOf<T>): Boolean {
-      val res1: Either<Throwable, T> = attempt().value().timeout(5, TimeUnit.SECONDS).blockingGet()
-      val res2: Either<Throwable, T> = b.attempt().value().timeout(5, TimeUnit.SECONDS).blockingGet()
+      val res1 = attempt().value().timeout(5, TimeUnit.SECONDS).blockingGet()
+      val res2 = b.attempt().value().timeout(5, TimeUnit.SECONDS).blockingGet()
       return res1.fold({ t1 ->
         res2.fold({ t2 ->
           (t1::class.java == t2::class.java)
@@ -84,7 +83,7 @@ class SingleKTests : RxJavaSpec() {
           .let { true }
       }
     }
-    //
+
     "Multi-thread Singles should run on their required threads" {
       forFew(10, Gen.choose(10L, 50)) { delay ->
         val originalThread: Thread = Thread.currentThread()

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
@@ -1,11 +1,12 @@
 package arrow.fx
 
-import arrow.core.Try
+import arrow.core.Either
 import arrow.fx.rx2.ForSingleK
 import arrow.fx.rx2.SingleK
 import arrow.fx.rx2.SingleKOf
 import arrow.fx.rx2.extensions.concurrent
 import arrow.fx.rx2.extensions.fx
+import arrow.fx.rx2.extensions.singlek.applicativeError.attempt
 import arrow.fx.rx2.extensions.singlek.async.async
 import arrow.fx.rx2.extensions.singlek.monad.flatMap
 import arrow.fx.rx2.extensions.singlek.timer.timer
@@ -15,9 +16,10 @@ import arrow.fx.typeclasses.Dispatchers
 import arrow.fx.typeclasses.ExitCase
 import arrow.test.laws.ConcurrentLaws
 import arrow.test.laws.TimerLaws
+import arrow.test.laws.forFew
 import arrow.typeclasses.Eq
+import io.kotlintest.properties.Gen
 import io.kotlintest.shouldBe
-import io.kotlintest.shouldNotBe
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import io.reactivex.schedulers.Schedulers
@@ -28,10 +30,12 @@ import kotlin.coroutines.CoroutineContext
 
 class SingleKTests : RxJavaSpec() {
 
+  private val awaitDelay = 300L
+
   fun <T> EQ(): Eq<SingleKOf<T>> = object : Eq<SingleKOf<T>> {
     override fun SingleKOf<T>.eqv(b: SingleKOf<T>): Boolean {
-      val res1 = Try { value().timeout(5, TimeUnit.SECONDS).blockingGet() }
-      val res2 = arrow.core.Try { b.value().timeout(5, TimeUnit.SECONDS).blockingGet() }
+      val res1: Either<Throwable, T> = attempt().value().timeout(5, TimeUnit.SECONDS).blockingGet()
+      val res2: Either<Throwable, T> = b.attempt().value().timeout(5, TimeUnit.SECONDS).blockingGet()
       return res1.fold({ t1 ->
         res2.fold({ t2 ->
           (t1::class.java == t2::class.java)
@@ -66,50 +70,61 @@ class SingleKTests : RxJavaSpec() {
     }
 
     "Multi-thread Singles finish correctly" {
-      val value: Single<Long> = SingleK.fx {
-        val a = Single.timer(2, TimeUnit.SECONDS).k().bind()
-        a
-      }.value()
-
-      val test: TestObserver<Long> = value.test()
-      test.awaitDone(5, TimeUnit.SECONDS)
-      test.assertTerminated().assertComplete().assertNoErrors().assertValue(0)
+      forFew(10, Gen.choose(10L, 50)) { delay ->
+        SingleK.fx {
+          val a = Single.timer(delay, TimeUnit.MILLISECONDS).k().bind()
+          a
+        }.value()
+          .test()
+          .awaitDone(delay + awaitDelay, TimeUnit.MILLISECONDS)
+          .assertTerminated()
+          .assertComplete()
+          .assertNoErrors()
+          .assertValue(0)
+          .let { true }
+      }
     }
-
+    //
     "Multi-thread Singles should run on their required threads" {
-      val originalThread: Thread = Thread.currentThread()
-      var threadRef: Thread? = null
+      forFew(10, Gen.choose(10L, 50)) { delay ->
+        val originalThread: Thread = Thread.currentThread()
+        var threadRef: Thread? = null
 
-      val value: Single<Long> = SingleK.fx {
-        val a = Single.timer(2, TimeUnit.SECONDS, Schedulers.newThread()).k().bind()
-        threadRef = Thread.currentThread()
-        val b = Single.just(a).observeOn(Schedulers.newThread()).k().bind()
-        b
-      }.value()
+        val value: Single<Long> = SingleK.fx {
+          val a = Single.timer(delay, TimeUnit.MILLISECONDS, Schedulers.io()).k().bind()
+          threadRef = Thread.currentThread()
+          val b = Single.just(a).observeOn(Schedulers.computation()).k().bind()
+          b
+        }.value()
 
-      val test: TestObserver<Long> = value.test()
-      val lastThread: Thread = test.awaitDone(5, TimeUnit.SECONDS).lastThread()
-      val nextThread = (threadRef?.name ?: "")
+        val test: TestObserver<Long> = value.test()
+        val lastThread: Thread = test.awaitDone(delay + awaitDelay, TimeUnit.MILLISECONDS).lastThread()
+        val nextThread = (threadRef?.name ?: "")
 
-      nextThread shouldNotBe originalThread.name
-      lastThread.name shouldNotBe originalThread.name
-      lastThread.name shouldNotBe nextThread
+        nextThread != originalThread.name && lastThread.name != originalThread.name && lastThread.name != nextThread
+      }
     }
 
     "Single dispose forces binding to cancel without completing too" {
-      val value: Single<Long> = SingleK.fx {
-        val a = Single.timer(3, TimeUnit.SECONDS).k().bind()
-        a
-      }.value()
+      forFew(5, Gen.choose(10L, 50)) { delay ->
+        val value: Single<Long> = SingleK.fx {
+          val a = Single.timer(delay + awaitDelay, TimeUnit.MILLISECONDS).k().bind()
+          a
+        }.value()
 
-      val test: TestObserver<Long> = value.doOnSubscribe { subscription ->
-        Single.timer(1, TimeUnit.SECONDS).subscribe { _ ->
-          subscription.dispose()
-        }
-      }.test()
+        val test: TestObserver<Long> = value.doOnSubscribe { subscription ->
+          Single.timer(delay, TimeUnit.MILLISECONDS).subscribe { _ ->
+            subscription.dispose()
+          }
+        }.test()
 
-      test.awaitTerminalEvent(5, TimeUnit.SECONDS)
-      test.assertNotTerminated().assertNotComplete().assertNoErrors().assertNoValues()
+        test.awaitTerminalEvent(delay + (2 * awaitDelay), TimeUnit.MILLISECONDS)
+        test.assertNotTerminated()
+          .assertNotComplete()
+          .assertNoErrors()
+          .assertNoValues()
+          .let { true }
+      }
     }
 
     "SingleK bracket cancellation should release resource with cancel exit status" {


### PR DESCRIPTION
I was investigating #1776  but could not reproduce.

This PR enables `ConcurrentSyntax` syntax for `fx` instead of `AsyncSyntax`.
To do so it adds `Dispatchers` instances for all RxJava types and exposes a `(Scheduler) -> CoroutineContext` function.