### PR TITLE
Release 0.10.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=io.arrow-kt
-VERSION_NAME=0.10.3-SNAPSHOT
+VERSION_NAME=0.10.3
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true

--- a/modules/docs/arrow-docs/docs/_data/doc-versions.yml
+++ b/modules/docs/arrow-docs/docs/_data/doc-versions.yml
@@ -1,14 +1,14 @@
 docVersions:
 
-    - title: "v0.10.1"
-      url: https://0-10-1.arrow-kt.io/
-      previous: https://0-10-0.arrow-kt.io/
+    - title: "v0.9.0"
+      url: https://0-9-0.arrow-kt.io/
+      previous: https://0-8-2.arrow-kt.io/
 
-    - title: "v0.10.2"
+    - title: "v0.10.3"
       url: https://arrow-kt.io/
-      previous: https://0-10-1.arrow-kt.io/
+      previous: https://0-9-0.arrow-kt.io/
 
-    - title: "v0.10.3-SNAPSHOT"
+    - title: "v0.10.4-SNAPSHOT"
       url: https://next.arrow-kt.io/
       previous: https://arrow-kt.io/
 

--- a/modules/docs/arrow-docs/docs/docs/quickstart/setup/README.md
+++ b/modules/docs/arrow-docs/docs/docs/quickstart/setup/README.md
@@ -8,7 +8,7 @@ permalink: /docs/quickstart/setup/
 
 ### Next development version
 
-If you want to try the last features, replace `0.10.2` by `0.10.3-SNAPSHOT` in the following guideline.
+If you want to try the last features, replace `0.10.3` by `0.10.4-SNAPSHOT` in the following guideline.
 
 ### JDK
 
@@ -38,7 +38,7 @@ Add the dependencies into the project's `build.gradle`:
 ```groovy
 apply plugin: 'kotlin-kapt'
 
-def arrow_version = "0.10.2"
+def arrow_version = "0.10.3"
 dependencies {
     implementation "io.arrow-kt:arrow-core:$arrow_version"
     implementation "io.arrow-kt:arrow-syntax:$arrow_version"
@@ -51,7 +51,7 @@ dependencies {
 ```groovy
 apply plugin: 'kotlin-kapt'
 
-def arrow_version = "0.10.2"
+def arrow_version = "0.10.3"
 dependencies {
     implementation "io.arrow-kt:arrow-optics:$arrow_version"
     implementation "io.arrow-kt:arrow-syntax:$arrow_version"
@@ -64,7 +64,7 @@ dependencies {
 ```groovy
 apply plugin: 'kotlin-kapt'
 
-def arrow_version = "0.10.2"
+def arrow_version = "0.10.3"
 dependencies {
     implementation "io.arrow-kt:arrow-fx:$arrow_version"
     implementation "io.arrow-kt:arrow-syntax:$arrow_version"
@@ -77,7 +77,7 @@ dependencies {
 ```groovy
 apply plugin: 'kotlin-kapt'
 
-def arrow_version = "0.10.2"
+def arrow_version = "0.10.3"
 dependencies {
     implementation "io.arrow-kt:arrow-fx:$arrow_version"
     implementation "io.arrow-kt:arrow-optics:$arrow_version"
@@ -101,7 +101,7 @@ Add the dependencies into the project's `build.gradle`
 apply plugin: 'kotlin-kapt' //optional
 apply from: rootProject.file('gradle/generated-kotlin-sources.gradle') //only for Android projects
 
-def arrow_version = "0.10.2"
+def arrow_version = "0.10.3"
 dependencies {
     ...
     kapt    'io.arrow-kt:arrow-meta:$arrow_version' //optional
@@ -143,7 +143,7 @@ Add to your pom.xml file the following properties:
 ```
 <properties>
     <kotlin.version>1.3.0</kotlin.version>
-     <arrow.version>0.10.2</arrow.version>
+     <arrow.version>0.10.3</arrow.version>
 </properties>
 ```
 


### PR DESCRIPTION
0.10.3 (2019-11-13)
-------------------
- Release 0.10.3 (#1792) [Francisco Diaz]
- Move `Const.kt` to `core` package (#1789) (#1791) [Stanislav Zemlyakov]
- CI: move from Bitrise to GitHub Actions (#1779) [Rachel M. Carmena]
- Fix broken link to Bracket.kt (#1790) [Sven Tennie]
- Implement Endo Monoid (#1781) [Flavio Corpa]
- Remove unused Fx (#1788) [Simon Vergauwen]
- Add io pool to dispatchers (#1787) [Simon Vergauwen]
- Add Fiber instances (#1783) [Simon Vergauwen]
- Add unsafeCancellableRun (#1784) [Paco]
- Add deprecation notice for unsafe catch (#1785) [Paco]
- RxJava ConcurrentSyntax & Dispatchers (#1782) [Simon Vergauwen]
- Fix the return type of flatMap (#1780) [tatsuyafujisaki]
- #1777: add extension function that converts an Either to an IO (#1778) [Alphonse Bendt]
- CI: move to GitHub Actions for release (#1771) [Rachel M. Carmena]
- Update README.md. (#1774) [Sebastian Raaphorst]
- Add replicate to applicative (#1768) [Jannis]
- Add alternative instances to datatypes (#1769) [Jannis]
- Correct link to Option class in Datatype intro (#1766) [Ro-Rams]
- Removed unused Readme files (#1763) [Miguel Angel Ruiz Lopez]
- More targets for extension annotation: (#1764) [Rachel M. Carmena]
- Add sequence birecursive instance and fix corecursive tests (#1750) [Jannis]
- arrow-annotations: migrate content from Arrow Meta (#1760) [Rachel M. Carmena]
- Make retrofit compatible with lower API versions (#1762) [junron]
- Check submodules for Android API compatibility (#1751) [junron]
- Add docs for cancelable IO (#1759) [Paco]
- Documentation: update badges (#1752) [Rachel M. Carmena]
- Update README.md (#1756) [Stephen Samuel]
- Slight tweaks to atomics (#1753) [Alberto Ballano]
- Move listk doc to kdoc (#1592) [Miguel Angel Ruiz Lopez]
- Remove arrow-meta-prototype (#1745) [Rachel M. Carmena]
- Fix typo and replace compile with implementation in various md files  (#1748) [Alberto Ballano]
- Implement suspend catch for ApplicativeError (#1744) [Thanh Le]
- Updates arrow version in README file (#1743) [Francisco Diaz]
- Next iteration 0.10.3-SNAPSHOT (#1741) [Francisco Diaz]