### PR TITLE
add missing data types section

### DIFF
--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/eqk/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/eqk/README.md
@@ -37,4 +37,13 @@ See the existing EqK instances implementations and accompanying tests for refere
 
 See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | relative_url }}) to provide your own `EqK` instances for custom datatypes.
 
+### Data types
+
+```kotlin:ank:replace
+import arrow.reflect.*
+import arrow.typeclasses.EqK
+
+TypeClass(EqK::class).dtMarkdownList()
+```
+
 ank_macro_hierarchy(arrow.typeclasses.EqK)


### PR DESCRIPTION
this adds the missing _data types_ section to the EqK doc 