### PR TITLE
Unalign typeclass with instances

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -1,6 +1,8 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.core.Ior.Left
+import arrow.core.Ior.Right
 import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Semigroup
@@ -268,6 +270,20 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
    * ```
    */
   fun toOption(): Option<B> = fold({ None }, { Some(it) }, { _, b -> Some(b) })
+
+  /**
+   * Returns a [Some] containing the [Left] value or `A` if this is [Left] or [Both]
+   * and [None] if this is a [Right].
+   *
+   * Example:
+   * ```
+   * Right(12).toLeftOption() // Result: None
+   * Left(12).toLeftOption()  // Result: Some(12)
+   * Both(12, "power").toLeftOption()  // Result: Some(12)
+   * ```
+   */
+  fun toLeftOption(): Option<A> =
+    fold({ Option.just(it) }, { Option.empty() }, { a, _ -> Option.just(a) })
 
   /**
    * Returns a [Validated.Valid] containing the [Right] value or `B` if this is [Right] or [Both]

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Semialign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Semialign.kt
@@ -30,7 +30,7 @@ interface Semialign<F> : Functor<F> {
    * }
    * ```
    */
-  fun <A, B> align(a: Kind<F, A>, b: Kind<F, B>): Kind<F, Ior<A, B>> = alignWith(::identity, a, b)
+  fun <A, B> align(a: Kind<F, A>, b: Kind<F, B>): Kind<F, Ior<A, B>> = alignWith(a, b, ::identity)
 
   /**
    * Combines two structures by taking the union of their shapes and combining the elements with the given function.
@@ -45,12 +45,14 @@ interface Semialign<F> : Functor<F> {
    * fun main(args: Array<String>) {
    *   //sampleStart
    *   val result = ListK.semialign().run {
-   *    alignWith({"$it"}, listOf("A", "B").k(), listOf(1, 2, 3).k())
+   *    alignWith(listOf("A", "B").k(), listOf(1, 2, 3).k()) {
+   *      "$it"
+   *    }
    *   }
    *   //sampleEnd
    *   println(result)
    * }
    * ```
    */
-  fun <A, B, C> alignWith(fa: (Ior<A, B>) -> C, a: Kind<F, A>, b: Kind<F, B>): Kind<F, C> = align(a, b).map(fa)
+  fun <A, B, C> alignWith(a: Kind<F, A>, b: Kind<F, B>, fa: (Ior<A, B>) -> C): Kind<F, C> = align(a, b).map(fa)
 }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
@@ -44,13 +44,15 @@ interface Unalign<F> : Semialign<F> {
    * fun main(args: Array<String>) {
    *   //sampleStart
    *   val result = ListK.unalign().run {
-   *    unalignWith({it.leftIor()}, listOf(1, 2, 3).k())
+   *      unalignWith(listOf(1, 2, 3).k()) {
+   *        it.leftIor()
+   *      }
    *   }
    *   //sampleEnd
    *   println(result)
    * }
    * ```
    */
-  fun <A, B, C> unalignWith(fa: (C) -> Ior<A, B>, c: Kind<F, C>): Tuple2<Kind<F, A>, Kind<F, B>> =
+  fun <A, B, C> unalignWith(c: Kind<F, C>, fa: (C) -> Ior<A, B>): Tuple2<Kind<F, A>, Kind<F, B>> =
     unalign(c.map(fa))
 }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
@@ -4,9 +4,53 @@ import arrow.Kind
 import arrow.core.Ior
 import arrow.core.Tuple2
 
+/**
+ * Unalign extends Semialign thereby supporting an inverse function to align: It splits an union shape
+ * into a tuple representing the component parts.
+ */
 interface Unalign<F> : Semialign<F> {
+  /**
+   * splits an union into its component parts.
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.core.extensions.*
+   * import arrow.core.extensions.listk.unalign.unalign
+   * import arrow.core.*
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val result = ListK.unalign().run {
+   *    unalign(listOf(1.leftIor(), 2.rightIor(), (1 toT 2).bothIor()).k())
+   *   }
+   *   //sampleEnd
+   *   println(result)
+   * }
+   * ```
+   */
   fun <A, B> unalign(ior: Kind<F, Ior<A, B>>): Tuple2<Kind<F, A>, Kind<F, B>>
 
+  /**
+   * after applying the given function, splits the resulting union shaped structure into its components parts
+   *
+   * {: data-executable='true'}
+   *
+   * ```kotlin:ank
+   * import arrow.core.extensions.*
+   * import arrow.core.extensions.listk.unalign.unalign
+   * import arrow.core.*
+   *
+   * fun main(args: Array<String>) {
+   *   //sampleStart
+   *   val result = ListK.unalign().run {
+   *    unalignWith(it.leftIor()}, listOf(1, 2, 3).k())
+   *   }
+   *   //sampleEnd
+   *   println(result)
+   * }
+   * ```
+   */
   fun <A, B, C> unalignWith(fa: (C) -> Ior<A, B>, c: Kind<F, C>): Tuple2<Kind<F, A>, Kind<F, B>> =
     unalign(c.map(fa))
 }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
@@ -10,7 +10,7 @@ import arrow.core.Tuple2
  */
 interface Unalign<F> : Semialign<F> {
   /**
-   * splits an union into its component parts.
+   * splits a union into its component parts.
    *
    * {: data-executable='true'}
    *

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
@@ -5,7 +5,7 @@ import arrow.core.Ior
 import arrow.core.Tuple2
 
 /**
- * Unalign extends Semialign thereby supporting an inverse function to align: It splits an union shape
+ * Unalign extends Semialign thereby supporting an inverse function to align: It splits a union shape
  * into a tuple representing the component parts.
  */
 interface Unalign<F> : Semialign<F> {

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
@@ -44,7 +44,7 @@ interface Unalign<F> : Semialign<F> {
    * fun main(args: Array<String>) {
    *   //sampleStart
    *   val result = ListK.unalign().run {
-   *    unalignWith(it.leftIor()}, listOf(1, 2, 3).k())
+   *    unalignWith({it.leftIor()}, listOf(1, 2, 3).k())
    *   }
    *   //sampleEnd
    *   println(result)

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Unalign.kt
@@ -1,0 +1,12 @@
+package arrow.typeclasses
+
+import arrow.Kind
+import arrow.core.Ior
+import arrow.core.Tuple2
+
+interface Unalign<F> : Semialign<F> {
+  fun <A, B> unalign(ior: Kind<F, Ior<A, B>>): Tuple2<Kind<F, A>, Kind<F, B>>
+
+  fun <A, B, C> unalignWith(fa: (C) -> Ior<A, B>, c: Kind<F, C>): Tuple2<Kind<F, A>, Kind<F, B>> =
+    unalign(c.map(fa))
+}

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -18,6 +18,7 @@ import arrow.core.extensions.listk.semialign.semialign
 import arrow.core.extensions.listk.semigroupK.semigroupK
 import arrow.core.extensions.listk.show.show
 import arrow.core.extensions.listk.traverse.traverse
+import arrow.core.extensions.listk.unalign.unalign
 import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.generators.listK
@@ -31,6 +32,7 @@ import arrow.test.laws.MonoidalLaws
 import arrow.test.laws.SemigroupKLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
+import arrow.test.laws.UnalignLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -69,6 +71,10 @@ class ListKTest : UnitSpec() {
         Gen.listK(Gen.int()) as Gen<Kind<ForListK, Int>>,
         ListK.eqK(),
         ListK.foldable()
+      ),
+      UnalignLaws.laws(ListK.unalign(),
+        Gen.listK(Gen.int()) as Gen<Kind<ForListK, Int>>,
+        ListK.eqK()
       )
     )
 

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -14,6 +14,7 @@ import arrow.core.extensions.mapk.monoid.monoid
 import arrow.core.extensions.mapk.semialign.semialign
 import arrow.core.extensions.mapk.show.show
 import arrow.core.extensions.mapk.traverse.traverse
+import arrow.core.extensions.mapk.unalign.unalign
 import arrow.core.extensions.semigroup
 import arrow.test.UnitSpec
 import arrow.test.generators.mapK
@@ -25,6 +26,7 @@ import arrow.test.laws.HashLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
+import arrow.test.laws.UnalignLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
@@ -57,7 +59,10 @@ class MapKTest : UnitSpec() {
         Gen.mapK(Gen.string(), Gen.int()) as Gen<Kind<MapKPartialOf<String>, Int>>,
         EQK,
         MapK.foldable()
-      )
+      ),
+      UnalignLaws.laws(MapK.unalign(),
+        Gen.mapK(Gen.string(), Gen.int()) as Gen<Kind<MapKPartialOf<String>, Int>>,
+        EQK)
     )
 
     "can align maps" {

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -188,6 +188,12 @@ class OptionTest : UnitSpec() {
       None or x shouldBe Some(2)
       None or None shouldBe None
     }
+
+    "toLeftOption" {
+      1.leftIor().toLeftOption() shouldBe Some(1)
+      2.rightIor().toLeftOption() shouldBe None
+      (1 toT 2).bothIor().toLeftOption() shouldBe Some(1)
+    }
   }
 
   private fun bijection(from: Kind<ForOption, Tuple2<Tuple2<Int, Int>, Int>>): Option<Tuple2<Int, Tuple2<Int, Int>>> {

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -16,6 +16,7 @@ import arrow.core.extensions.option.monoidal.monoidal
 import arrow.core.extensions.option.semialign.semialign
 import arrow.core.extensions.option.show.show
 import arrow.core.extensions.option.traverseFilter.traverseFilter
+import arrow.core.extensions.option.unalign.unalign
 import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.generators.option
@@ -29,6 +30,7 @@ import arrow.test.laws.MonoidalLaws
 import arrow.test.laws.SemialignLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseFilterLaws
+import arrow.test.laws.UnalignLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -71,6 +73,10 @@ class OptionTest : UnitSpec() {
         Gen.option(Gen.int()) as Gen<Kind<ForOption, Int>>,
         Option.eqK(),
         Option.foldable()
+      ),
+      UnalignLaws.laws(Option.unalign(),
+        Gen.option(Gen.int()) as Gen<Kind<ForOption, Int>>,
+        Option.eqK()
       )
     )
 

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -16,6 +16,7 @@ import arrow.core.extensions.sequencek.monoidK.monoidK
 import arrow.core.extensions.sequencek.monoidal.monoidal
 import arrow.core.extensions.sequencek.semialign.semialign
 import arrow.core.extensions.sequencek.traverse.traverse
+import arrow.core.extensions.sequencek.unalign.unalign
 import arrow.test.UnitSpec
 import arrow.test.generators.sequenceK
 import arrow.test.laws.AlignLaws
@@ -28,6 +29,7 @@ import arrow.test.laws.MonoidLaws
 import arrow.test.laws.MonoidalLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
+import arrow.test.laws.UnalignLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Show
@@ -80,6 +82,10 @@ class SequenceKTest : UnitSpec() {
         Gen.sequenceK(Gen.int()) as Gen<Kind<ForSequenceK, Int>>,
         EQK,
         SequenceK.foldable()
+      ),
+      UnalignLaws.laws(SequenceK.unalign(),
+        Gen.sequenceK(Gen.int()) as Gen<Kind<ForSequenceK, Int>>,
+        EQK
       )
     )
 

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SortedMapKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/SortedMapKTest.kt
@@ -13,6 +13,7 @@ import arrow.core.extensions.show
 import arrow.core.extensions.sortedmapk.eqK.eqK
 import arrow.core.extensions.sortedmapk.hash.hash
 import arrow.core.extensions.traverse
+import arrow.core.extensions.unalign
 import arrow.test.UnitSpec
 import arrow.test.generators.sortedMapK
 import arrow.test.laws.AlignLaws
@@ -20,6 +21,7 @@ import arrow.test.laws.HashLaws
 import arrow.test.laws.MonoidLaws
 import arrow.test.laws.ShowLaws
 import arrow.test.laws.TraverseLaws
+import arrow.test.laws.UnalignLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -45,7 +47,13 @@ class SortedMapKTest : UnitSpec() {
         Gen.sortedMapK(Gen.string(), Gen.int()) as Gen<Kind<SortedMapKPartialOf<String>, Int>>,
         SortedMapK.eqK(String.eq()),
         SortedMapK.foldable<String>()
-      ))
+      ),
+      UnalignLaws.laws(SortedMapK.unalign<String>(),
+        Gen.sortedMapK(Gen.string(), Gen.int()) as Gen<Kind<SortedMapKPartialOf<String>, Int>>,
+        SortedMapK.eqK(String.eq()),
+        SortedMapK.foldable<String>()
+      )
+    )
 
     "can align maps" {
       val gen = Gen.sortedMapK(Gen.string(), Gen.bool())

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/id.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/id.kt
@@ -218,6 +218,6 @@ interface IdEqK : EqK<ForId> {
 
 @extension
 interface IdSemialign : Semialign<ForId>, IdFunctor {
-  override fun <A, B, C> alignWith(fa: (Ior<A, B>) -> C, a: Kind<ForId, A>, b: Kind<ForId, B>): Kind<ForId, C> =
+  override fun <A, B, C> alignWith(a: Kind<ForId, A>, b: Kind<ForId, B>, fa: (Ior<A, B>) -> C): Kind<ForId, C> =
     Id.just(fa(Ior.Both(a.fix().extract(), b.fix().extract())))
 }

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -17,6 +17,7 @@ import arrow.core.fix
 import arrow.core.k
 import arrow.core.leftIor
 import arrow.core.rightIor
+import arrow.core.toT
 import arrow.extension
 import arrow.typeclasses.Align
 import arrow.typeclasses.Alternative
@@ -41,6 +42,7 @@ import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Semigroupal
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse
+import arrow.typeclasses.Unalign
 import arrow.core.combineK as listCombineK
 import kotlin.collections.plus as listPlus
 
@@ -322,4 +324,12 @@ interface ListKSemialign : Semialign<ForListK>, ListKFunctor {
 @extension
 interface ListKAlign : Align<ForListK>, ListKSemialign {
   override fun <A> empty(): Kind<ForListK, A> = ListK.empty()
+}
+
+@extension
+interface ListKUnalign : Unalign<ForListK>, ListKSemialign {
+  override fun <A, B> unalign(ior: Kind<ForListK, Ior<A, B>>): Tuple2<Kind<ForListK, A>, Kind<ForListK, B>> =
+    ior.fix().let { list ->
+      list.filterMap { it.toLeftOption() } toT list.filterMap { it.toOption() }
+    }
 }

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -330,6 +330,12 @@ interface ListKAlign : Align<ForListK>, ListKSemialign {
 interface ListKUnalign : Unalign<ForListK>, ListKSemialign {
   override fun <A, B> unalign(ior: Kind<ForListK, Ior<A, B>>): Tuple2<Kind<ForListK, A>, Kind<ForListK, B>> =
     ior.fix().let { list ->
-      list.filterMap { it.toLeftOption() } toT list.filterMap { it.toOption() }
+      list.fold(emptyList<A>() toT emptyList<B>()) { (l, r), x ->
+        x.fold(
+          { l.listPlus(it) toT r },
+          { l toT r.listPlus(it) },
+          { a, b -> l.listPlus(a) toT r.listPlus(b) }
+        )
+      }.bimap({ it.k() }, { it.k() })
     }
 }

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -310,12 +310,11 @@ interface SequenceKAlign : Align<ForSequenceK>, SequenceKSemialign {
 
 @extension
 interface SequenceKUnalign : Unalign<ForSequenceK>, SequenceKSemialign {
-  override fun <A, B> unalign(ior: Kind<ForSequenceK, Ior<A, B>>): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> {
-    return ior.fix().let { seq ->
+  override fun <A, B> unalign(ior: Kind<ForSequenceK, Ior<A, B>>): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> =
+    ior.fix().let { seq ->
       val ls = seq.sequence.filterMap { it.toLeftOption() }.k()
       val rs = seq.sequence.filterMap { it.toOption() }.k()
 
       ls toT rs
     }
-  }
 }

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -10,11 +10,13 @@ import arrow.core.SequenceK
 import arrow.core.SequenceKOf
 import arrow.core.Tuple2
 import arrow.core.extensions.sequence.foldable.isEmpty
+import arrow.core.extensions.sequence.monadFilter.filterMap
 import arrow.core.extensions.sequencek.monad.map
 import arrow.core.extensions.sequencek.monad.monad
 import arrow.core.fix
 import arrow.core.k
 import arrow.core.some
+import arrow.core.toT
 import arrow.extension
 import arrow.typeclasses.Align
 import arrow.typeclasses.Alternative
@@ -38,6 +40,7 @@ import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Semigroupal
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse
+import arrow.typeclasses.Unalign
 import arrow.core.combineK as sequenceCombineK
 
 @extension
@@ -303,4 +306,16 @@ interface SequenceKSemialign : Semialign<ForSequenceK>, SequenceKFunctor {
 @extension
 interface SequenceKAlign : Align<ForSequenceK>, SequenceKSemialign {
   override fun <A> empty(): Kind<ForSequenceK, A> = emptySequence<A>().k()
+}
+
+@extension
+interface SequenceKUnalign : Unalign<ForSequenceK>, SequenceKSemialign {
+  override fun <A, B> unalign(ior: Kind<ForSequenceK, Ior<A, B>>): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> {
+    return ior.fix().let { seq ->
+      val ls = seq.sequence.filterMap { it.toLeftOption() }.k()
+      val rs = seq.sequence.filterMap { it.toOption() }.k()
+
+      ls toT rs
+    }
+  }
 }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/SemialignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/SemialignLaws.kt
@@ -73,7 +73,7 @@ object SemialignLaws {
 
   fun <F, A> Semialign<F>.semialignWith(G: Gen<Kind<F, A>>, EQ: Eq<Kind<F, String>>) =
     forAll(G, G) { a: Kind<F, A>, b: Kind<F, A> ->
-      val left = alignWith({ "$it" }, a, b)
+      val left = alignWith(a, b) { "$it" }
       val right = align(a, b).map { "$it" }
 
       left.equalUnderTheLaw(right, EQ)

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/SemialignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/SemialignLaws.kt
@@ -3,9 +3,6 @@ package arrow.test.laws
 import arrow.Kind
 import arrow.core.Ior
 import arrow.core.ListK
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.Some
 import arrow.core.extensions.eq
 import arrow.core.extensions.ior.eq.eq
 import arrow.core.extensions.list.functorFilter.flattenOption
@@ -105,17 +102,14 @@ object SemialignLaws {
     val left: List<A> = toList(a)
 
     // toListOf (folded . here) (align x y)
-    val middle: List<A> = toList(align(a, b).map { it.justLeft() }).flattenOption()
+    val middle: List<A> = toList(align(a, b).map { it.toLeftOption() }).flattenOption()
 
     // mapMaybe justHere (toList (align x y))
-    val right: List<A> = toList(align(a, b)).filterMap { it.justLeft() }
+    val right: List<A> = toList(align(a, b)).filterMap { it.toLeftOption() }
 
     left == right && left == middle
   }
 }
-
-private fun <A, B> Ior<A, B>.justLeft(): Option<A> =
-  fold({ Some(it) }, { None }, { a, _ -> Some(a) })
 
 private fun <A, B, C> Ior<Ior<A, B>, C>.assoc(): Ior<A, Ior<B, C>> =
   when (this) {

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
@@ -1,0 +1,77 @@
+package arrow.test.laws
+
+import arrow.Kind
+import arrow.core.Ior
+import arrow.core.Tuple2
+import arrow.core.extensions.eq
+import arrow.core.extensions.ior.eq.eq
+import arrow.core.extensions.tuple2.eq.eq
+import arrow.core.toT
+import arrow.typeclasses.Eq
+import arrow.typeclasses.EqK
+import arrow.typeclasses.Semialign
+import arrow.typeclasses.Unalign
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+
+object UnalignLaws {
+  fun <F> laws(
+    UA: Unalign<F>,
+    gen: Gen<Kind<F, Int>>,
+    EQK: EqK<F>
+  ): List<Law> {
+
+    val iorIntEq = buildEq(EQK, Ior.eq(Int.eq(), Int.eq()))
+    val intEq = buildEq(EQK, Int.eq())
+    val tuple2Eq = Tuple2.eq(intEq, intEq)
+
+    return listOf(
+      Law("Unalign Laws: split union shape into its components 1") { UA.law1(gen, tuple2Eq) },
+      Law("Unalign Laws: split union shape into its components 2") {
+        UA.law2(iorGen(UA, gen, gen), iorIntEq)
+      }
+    )
+  }
+
+  private fun <F, A> buildEq(EQK: EqK<F>, EQ: Eq<A>): Eq<Kind<F, A>> =
+    Eq { a, b ->
+      EQK.run { a.eqK(b, EQ) }
+    }
+
+  fun <F, A> Unalign<F>.law1(G: Gen<Kind<F, A>>, EQ: Eq<Tuple2<Kind<F, A>, Kind<F, A>>>) =
+    forAll(G, G) { a, b ->
+      unalign(align(a, b)).equalUnderTheLaw(a toT b, EQ)
+    }
+
+  fun <F, A, B> Unalign<F>.law2(G: Gen<Kind<F, Ior<A, B>>>, EQ: Eq<Kind<F, Ior<A, B>>>) =
+    forAll(G) { xs ->
+      val alignTuple: (Tuple2<Kind<F, A>, Kind<F, B>>) -> Kind<F, Ior<A, B>> =
+        { (a, b) -> align(a, b) }
+      alignTuple(unalign(xs)).equalUnderTheLaw(xs, EQ)
+    }
+}
+
+private fun <F, A, B> iorGen(
+  SA: Semialign<F>,
+  genA: Gen<Kind<F, A>>,
+  genB: Gen<Kind<F, B>>
+): Gen<Kind<F, Ior<A, B>>> = object : Gen<Kind<F, Ior<A, B>>> {
+
+  override fun constants(): Iterable<Kind<F, Ior<A, B>>> =
+    genA.constants().zip(genB.constants()).map { SA.align(it.first, it.second) }
+
+  override fun random(): Sequence<Kind<F, Ior<A, B>>> = sequence {
+    val vsA = genA.random().iterator()
+    val vsB = genB.random().iterator()
+
+    while (vsA.hasNext()) {
+      val a = vsA.next()
+
+      if (vsB.hasNext()) {
+        val b = vsB.next()
+
+        yield(SA.align(a, b))
+      }
+    }
+  }
+}

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
@@ -39,9 +39,9 @@ object UnalignLaws {
     val tuple2Eq = Tuple2.eq(intEq, intEq)
 
     return listOf(
-      Law("Unalign Laws: split union shape into its components #1") { UA.law1(gen, tuple2Eq) },
-      Law("Unalign Laws: split union shape into its components #2") {
-        UA.law2(iorGen(UA, gen, gen), iorIntEq)
+      Law("Unalign Laws: unalign inverts align") { UA.unalignInvertsAlign(gen, tuple2Eq) },
+      Law("Unalign Laws: align inverts unalign") {
+        UA.alignInvertsUnalign(iorGen(UA, gen, gen), iorIntEq)
       }
     )
   }
@@ -51,16 +51,16 @@ object UnalignLaws {
       EQK.run { a.eqK(b, EQ) }
     }
 
-  fun <F, A> Unalign<F>.law1(G: Gen<Kind<F, A>>, EQ: Eq<Tuple2<Kind<F, A>, Kind<F, A>>>) =
-    forAll(G, G) { a, b ->
-      unalign(align(a, b)).equalUnderTheLaw(a toT b, EQ)
-    }
-
-  fun <F, A, B> Unalign<F>.law2(G: Gen<Kind<F, Ior<A, B>>>, EQ: Eq<Kind<F, Ior<A, B>>>) =
+  fun <F, A, B> Unalign<F>.alignInvertsUnalign(G: Gen<Kind<F, Ior<A, B>>>, EQ: Eq<Kind<F, Ior<A, B>>>) =
     forAll(G) { xs ->
       val alignTuple: (Tuple2<Kind<F, A>, Kind<F, B>>) -> Kind<F, Ior<A, B>> =
         { (a, b) -> align(a, b) }
       alignTuple(unalign(xs)).equalUnderTheLaw(xs, EQ)
+    }
+
+  fun <F, A> Unalign<F>.unalignInvertsAlign(G: Gen<Kind<F, A>>, EQ: Eq<Tuple2<Kind<F, A>, Kind<F, A>>>) =
+    forAll(G, G) { a, b ->
+      unalign(align(a, b)).equalUnderTheLaw(a toT b, EQ)
     }
 }
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
@@ -9,6 +9,7 @@ import arrow.core.extensions.tuple2.eq.eq
 import arrow.core.toT
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
+import arrow.typeclasses.Foldable
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Unalign
 import io.kotlintest.properties.Gen
@@ -19,8 +20,20 @@ object UnalignLaws {
     UA: Unalign<F>,
     gen: Gen<Kind<F, Int>>,
     EQK: EqK<F>
-  ): List<Law> {
+  ): List<Law> = SemialignLaws.laws(UA, gen, EQK) + unalignLaws(UA, gen, EQK)
 
+  fun <F> laws(
+    UA: Unalign<F>,
+    gen: Gen<Kind<F, Int>>,
+    EQK: EqK<F>,
+    FOLD: Foldable<F>
+  ): List<Law> = SemialignLaws.foldablelaws(UA, gen, EQK, FOLD) + unalignLaws(UA, gen, EQK)
+
+  private fun <F> unalignLaws(
+    UA: Unalign<F>,
+    gen: Gen<Kind<F, Int>>,
+    EQK: EqK<F>
+  ): List<Law> {
     val iorIntEq = buildEq(EQK, Ior.eq(Int.eq(), Int.eq()))
     val intEq = buildEq(EQK, Int.eq())
     val tuple2Eq = Tuple2.eq(intEq, intEq)

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
@@ -27,7 +27,7 @@ object UnalignLaws {
     gen: Gen<Kind<F, Int>>,
     EQK: EqK<F>,
     FOLD: Foldable<F>
-  ): List<Law> = SemialignLaws.foldablelaws(UA, gen, EQK, FOLD) + unalignLaws(UA, gen, EQK)
+  ): List<Law> = SemialignLaws.laws(UA, gen, EQK, FOLD) + unalignLaws(UA, gen, EQK)
 
   private fun <F> unalignLaws(
     UA: Unalign<F>,

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt
@@ -26,8 +26,8 @@ object UnalignLaws {
     val tuple2Eq = Tuple2.eq(intEq, intEq)
 
     return listOf(
-      Law("Unalign Laws: split union shape into its components 1") { UA.law1(gen, tuple2Eq) },
-      Law("Unalign Laws: split union shape into its components 2") {
+      Law("Unalign Laws: split union shape into its components #1") { UA.law1(gen, tuple2Eq) },
+      Law("Unalign Laws: split union shape into its components #2") {
         UA.law2(iorGen(UA, gen, gen), iorIntEq)
       }
     )

--- a/modules/docs/arrow-docs/docs/_data/sidebar.yml
+++ b/modules/docs/arrow-docs/docs/_data/sidebar.yml
@@ -345,6 +345,9 @@ options:
       - title: Align
         url: /docs/arrow/typeclasses/align/
 
+      - title: Unalign
+        url: /docs/arrow/typeclasses/unalign/
+
   - title: Effects
 
     nested_options:

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/semialign/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/semialign/README.md
@@ -38,7 +38,7 @@ ListK.semialign().run {
 
 combines two structures by taking the union of their shapes and combining the elements with the given function.
 
-`fun <A, B, C> alignWith(fa: (Ior<A, B>) -> C, a: Kind<F, A>, b: Kind<F, B>): Kind<F, C>`
+`fun <A, B, C> alignWith(a: Kind<F, A>, b: Kind<F, B>, fa: (Ior<A, B>) -> C): Kind<F, C>`
 
 ```kotlin:ank
 import arrow.core.extensions.*
@@ -46,7 +46,9 @@ import arrow.core.extensions.listk.semialign.semialign
 import arrow.core.*
 
 ListK.semialign().run {
-   alignWith({"$it"}, listOf("A", "B").k(), listOf(1, 2, 3).k())
+    alignWith(listOf("A", "B").k(), listOf(1, 2, 3).k()) {
+        "$it"
+    }
 }
 ```
 

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/unalign/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/unalign/README.md
@@ -11,16 +11,14 @@ redirect_from:
 {:.beginner}
 beginner
 
-The `Unlign` typeclass extends the `Semialign` typeclass with an inverse function to align: It splits an union shape
+The `Unlign` typeclass extends the `Semialign` typeclass with an inverse function to align: It splits a union shape
 into a tuple representing the component parts.
 
 ### Main Combinators
 
 #### unalign(ior: Kind<F, Ior<A, B>>): Tuple2<Kind<F, A>, Kind<F, B>>
 
-splits an union into its component parts.
-
-`fun <A> empty(): Kind<F, A>`
+splits a union into its component parts.
 
 ```kotlin:ank
 import arrow.core.extensions.*
@@ -32,7 +30,7 @@ ListK.unalign().run {
 }
 ```
 
-#### unalignWith(fa: (C) -> Ior<A, B>, c: Kind<F, C>): Tuple2<Kind<F, A>, Kind<F, B>>
+#### unalignWith(c: Kind<F, C>, fa: (C) -> Ior<A, B>): Tuple2<Kind<F, A>, Kind<F, B>>
 
 after applying the given function, splits the resulting union shaped structure into its components parts
 
@@ -42,7 +40,9 @@ import arrow.core.extensions.listk.unalign.unalign
 import arrow.core.*
 
 ListK.unalign().run {
-    unalignWith({it.leftIor()}, listOf(1, 2, 3).k())
+    unalignWith(listOf(1, 2, 3).k()) {
+        it.leftIor()
+    }
 }
 ```
 
@@ -57,7 +57,7 @@ and accomanying testcases for reference.
 
 See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | relative_url }})
 
-Additionally all instances of [`Unalign`]({{ '/docs/arrow/typeclasses/align' | relative_url }}) implement the `Semialign` typeclass directly
+Additionally all instances of [`Unalign`]({{ '/docs/arrow/typeclasses/unalign' | relative_url }}) implement the `Semialign` typeclass directly
 since they are all subtypes of `Semialign`
 
 ### Data types
@@ -69,7 +69,7 @@ import arrow.typeclasses.Unalign
 TypeClass(Unalign::class).dtMarkdownList()
 ```
 
-ank_macro_hierarchy(arrow.typeclasses.Align)
+ank_macro_hierarchy(arrow.typeclasses.Unalign)
 
 [functor_source]: https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Unalign.kt
 [functor_laws_source]: https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/unalign/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/unalign/README.md
@@ -42,7 +42,7 @@ import arrow.core.extensions.listk.unalign.unalign
 import arrow.core.*
 
 ListK.unalign().run {
-    unalignWith(it.leftIor()}, listOf(1, 2, 3).k())
+    unalignWith({it.leftIor()}, listOf(1, 2, 3).k())
 }
 ```
 

--- a/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/unalign/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow/typeclasses/unalign/README.md
@@ -1,0 +1,75 @@
+---
+layout: docs
+title: Unalign
+permalink: /docs/arrow/typeclasses/unalign/
+redirect_from:
+  - /docs/typeclasses/unalign/
+---
+
+## Unalign
+
+{:.beginner}
+beginner
+
+The `Unlign` typeclass extends the `Semialign` typeclass with an inverse function to align: It splits an union shape
+into a tuple representing the component parts.
+
+### Main Combinators
+
+#### unalign(ior: Kind<F, Ior<A, B>>): Tuple2<Kind<F, A>, Kind<F, B>>
+
+splits an union into its component parts.
+
+`fun <A> empty(): Kind<F, A>`
+
+```kotlin:ank
+import arrow.core.extensions.*
+import arrow.core.extensions.listk.unalign.unalign
+import arrow.core.*
+
+ListK.unalign().run {
+     unalign(listOf(1.leftIor(), 2.rightIor(), (1 toT 2).bothIor()).k())
+}
+```
+
+#### unalignWith(fa: (C) -> Ior<A, B>, c: Kind<F, C>): Tuple2<Kind<F, A>, Kind<F, B>>
+
+after applying the given function, splits the resulting union shaped structure into its components parts
+
+```kotlin:ank
+import arrow.core.extensions.*
+import arrow.core.extensions.listk.unalign.unalign
+import arrow.core.*
+
+ListK.unalign().run {
+    unalignWith(it.leftIor()}, listOf(1, 2, 3).k())
+}
+```
+
+### Laws
+
+Arrow provides [`UnalignLaws`][functor_laws_source]{:target="_blank"} in the form of test cases for internal verification of lawful instances and third party apps creating their own Unalign instances.
+
+#### Creating your own `Unalign` instances
+
+Arrow already provides Unalign instances for common datatypes (e.g. Option, ListK, MapK). See their implementations
+and accomanying testcases for reference.
+
+See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | relative_url }})
+
+Additionally all instances of [`Unalign`]({{ '/docs/arrow/typeclasses/align' | relative_url }}) implement the `Semialign` typeclass directly
+since they are all subtypes of `Semialign`
+
+### Data types
+
+```kotlin:ank:replace
+import arrow.reflect.*
+import arrow.typeclasses.Unalign
+
+TypeClass(Unalign::class).dtMarkdownList()
+```
+
+ank_macro_hierarchy(arrow.typeclasses.Align)
+
+[functor_source]: https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-typeclasses/src/main/kotlin/arrow/typeclasses/Unalign.kt
+[functor_laws_source]: https://github.com/arrow-kt/arrow/blob/master/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/UnalignLaws.kt


### PR DESCRIPTION
this adds the Unalign typeclass with instances for common arrow types.

as some instances required the functionality, i have added an extra function to Ior: `toLeftOption`. i hope this is acceptable.