### PR TITLE
fix docs typos

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IOParMap2.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IOParMap2.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.CoroutineContext
 interface IOParMap2 {
 
   fun <A, B, C> parMapN(ctx: CoroutineContext, fa: IOOf<A>, fb: IOOf<B>, f: (A, B) -> C): IO<C> = IO.Async { conn, cb ->
-    // Used to store Throwable, Either<A, B> or empty (null). (No sealed class used for a slightly better preforming ParMap2)
+    // Used to store Throwable, Either<A, B> or empty (null). (No sealed class used for a slightly better performing ParMap2)
     val state = AtomicRefW<Any?>(null)
 
     val connA = IOConnection()

--- a/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/State.kt
+++ b/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/State.kt
@@ -36,7 +36,7 @@ typealias StatePartialOf<S> = StateTPartialOf<ForId, S>
 /**
  * `State<S, A>` is a stateful computation that yields a value of type `A`.
  *
- * @param S the state we are preforming computation upon.
+ * @param S the state we are performing computation upon.
  * @param A current value of computation.
  */
 typealias State<S, A> = StateT<ForId, S, A>

--- a/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/StateT.kt
+++ b/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/StateT.kt
@@ -29,7 +29,7 @@ typealias StateTFunOf<F, S, A> = Kind<F, StateTFun<F, S, A>>
  * Run the stateful computation within the context `F`.
  *
  * @param MF [Monad] for the context [F]
- * @param s initial state to run stateful computation
+ * @param initial state to start stateful computation
  */
 fun <F, S, A> StateTOf<F, S, A>.runM(MF: Monad<F>, initial: S): Kind<F, Tuple2<S, A>> = fix().run(MF, initial)
 
@@ -38,7 +38,7 @@ fun <F, S, A> StateTOf<F, S, A>.runM(MF: Monad<F>, initial: S): Kind<F, Tuple2<S
  * a value of type `A`. i.e. StateT<EitherPartialOf<E>, S, A> = Either<E, State<S, A>>
  *
  * @param F the context that wraps the stateful computation.
- * @param S the state we are preforming computation upon.
+ * @param S the state we are performing computation upon.
  * @param A current value of computation.
  * @param runF the stateful computation that is wrapped and managed by `StateT`
  */


### PR DESCRIPTION
Fixes typos in `State`, `StateT` and `IOParMap2` documentation.