### PR TITLE
Adds Sliding, Dropping and Unbounded strategies to arrow.fx.Queue

### DIFF
--- a/modules/docs/arrow-docs/docs/_data/sidebar-fx.yml
+++ b/modules/docs/arrow-docs/docs/_data/sidebar-fx.yml
@@ -41,6 +41,9 @@ options:
       - title: Resource
         url: /docs/apidocs/arrow-fx/arrow.fx/-resource/
 
+      - title: Queue
+        url: /docs/effects/queue/
+
   - title: Type Classes
 
     nested_options:

--- a/modules/docs/arrow-docs/docs/docs/arrow-fx/queue/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-fx/queue/README.md
@@ -1,0 +1,213 @@
+---
+layout: docs
+title: Queue
+permalink: /docs/effects/queue/
+---
+
+## Queue
+
+{:.intermediate}
+intermediate
+
+A `Queue` is a lightweight, asynchronous first-in-first-out queue for holding arbitrary values within a `Concurrent`
+context. There are two primary means of working with an instance of a `Queue`: placing items via `offer` and removing
+items via `take`.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val q = !Queue.bounded<ForIO, Int>(10, IO.concurrent())
+      !q.offer(42)
+      !q.take()
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```
+
+Attempting to take a value from an empty `Queue` will cause the calling fiber to be suspended and will resume upon a new
+value being placed on the `Queue`.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val q = !Queue.bounded<ForIO, Int>(10, IO.concurrent())
+      val waiting = !q.take().fork()
+      !q.offer(42)
+      !waiting.join()
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```
+
+### Construction and capacity strategies
+
+When constructing a new `Queue` there are four different options to choose from which behave differently with respect to
+overflowing the configured capacity of the `Queue`:
+
+ * **Bounded**: Offering to a `bounded` queue at capacity will cause the fiber making the call to be suspended until the
+ queue has space to receive the offer value.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val capacity = 2
+      val q = !Queue.bounded<ForIO, Int>(capacity, IO.concurrent())
+      !q.offer(42)
+      !q.offer(43)
+      !q.offer(44).fork() // <-- This `offer` exceeds the capacity and will be suspended
+      val fortyTwo   = !q.take()
+      val fortyThree = !q.take()
+      val fortyFour  = !q.take()
+      listOf(fortyTwo, fortyThree, fortyFour)
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```
+
+ * **Dropping**: Offering to a `dropping` queue at capacity will cause the offered value to be discarded.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val capacity = 2
+      val q = !Queue.dropping<ForIO, Int>(capacity, IO.concurrent())
+      !q.offer(42)
+      !q.offer(43)
+      !q.offer(44) // <-- This `offer` exceeds the capacity and will be dropped immediately
+      val fortyTwo   = !q.take()
+      val fortyThree = !q.take()
+      !q.offer(45)
+      val fortyFive  = !q.take()
+      listOf(fortyTwo, fortyThree, fortyFive)
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```
+
+ * **Sliding**: Offering to a `sliding` queue at capacity will cause the oldest value at the front of the queue to be
+discarded, making room for the offered value. n.b. A `sliding` queue must have a capacity of at least 1.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val capacity = 2
+      val q = !Queue.sliding<ForIO, Int>(capacity, IO.concurrent())
+      !q.offer(42)
+      !q.offer(43)
+      !q.offer(44) // <-- This `offer` exceeds the capacity, causing the oldest value to be removed
+      val fortyThree = !q.take()
+      val fortyFour  = !q.take()
+      !q.offer(45)
+      val fortyFive  = !q.take()
+      listOf(fortyThree, fortyFour, fortyFive)
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```
+
+ * **Unbounded**: An `unbounded` queue has no notion of capacity and is bound only by exhausting the memory limits of
+the runtime.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val q = !Queue.unbounded<ForIO, Int>(IO.concurrent())
+      !q.offer(42)
+      // ...
+      !q.offer(42000000)
+      !q.take()
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```
+
+### Shutting down
+
+A `Queue` also has the ability to be `shutdown`, interrupting any future calls to `take` or `offer` with a
+`QueueShutdown` error and cancelling any suspended fibers waiting to `take` or `offer`.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val q = !Queue.bounded<ForIO, Int>(10, IO.concurrent())
+      val t = !q.take().fork()
+      !q.shutdown()
+      !t.join() // Attempting to `join` after `shutdown` results in a `QueueShutdown` error
+    }
+  //sampleEnd
+  println(result.attempt().unsafeRunSync())
+}
+```
+
+Consumers of the `Queue` can also track the event of a shutdown by calling `awaitShutdown` to receive a suspended
+`Concurrent<F>` that will resume once the `Queue` has been shutdown.
+
+```kotlin:ank:playground
+import arrow.fx.*
+import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.concurrent.concurrent
+
+fun main(args: Array<String>) {
+  val result =
+  //sampleStart
+    IO.fx {
+      val q = !Queue.bounded<ForIO, Int>(10, IO.concurrent())
+      val onShutdown = !q.awaitShutdown().fork()
+      !q.offer(42)
+      val fortyTwo = !q.take()
+      !q.shutdown()
+      !onShutdown.join()
+      fortyTwo
+    }
+  //sampleEnd
+  println(result.unsafeRunSync())
+}
+```

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Queue.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Queue.kt
@@ -13,10 +13,20 @@ import arrow.typeclasses.ApplicativeError
  * Lightweight, asynchronous queue for values of A in a Concurrent context F
  * A Queue can be implemented using 4 different strategies
  *
- * Bounded: Offering to a queue at capacity will cause the fiber making the call
- * to be suspended until the queue has space to receive the offer value
+ * Bounded: Offering to a bounded queue at capacity will cause the fiber making
+ * the call to be suspended until the queue has space to receive the offer value
  *
- * ported from Scala ZIO Queue implementation
+ * Dropping: Offering to a dropping queue at capacity will cause the offered
+ * value to be discarded
+ *
+ * Sliding: Offering to a sliding queue at capacity will cause the value at the
+ * front of the queue to be discarded to make room for the offered value
+ *
+ * Unbounded: An unbounded queue has no notion of capacity and is bound only by
+ * exhausting the memory limits of the runtime
+ *
+ * ported from [Scala ZIO Queue](https://zio.dev/docs/datatypes/datatypes_queue)
+ * implementation
  */
 class Queue<F, A> private constructor(private val strategy: SurplusStrategy<F, A>, private val ref: Ref<F, State<F, A>>, private val CF: Concurrent<F>) :
   Concurrent<F> by CF {
@@ -142,7 +152,28 @@ class Queue<F, A> private constructor(private val strategy: SurplusStrategy<F, A
      */
     fun <F, A> bounded(capacity: Int, CF: Concurrent<F>): Kind<F, Queue<F, A>> = CF.run {
       Ref<State<F, A>>(State.Surplus(IQueue.empty(), IQueue.empty(), this, unit())).map {
-        Queue(SurplusStrategy.Blocking(capacity, this), it, this)
+        Queue(SurplusStrategy.Bounded(capacity, this), it, this)
+      }
+    }
+
+    fun <F, A> sliding(capacity: Int, CF: Concurrent<F>): Kind<F, Queue<F, A>> = CF.fx.concurrent {
+      !just(capacity).ensure(
+        { IllegalArgumentException("Sliding queue must have a capacity greater than 0") },
+        { it > 0 }
+      )
+      val ref = !Ref<State<F, A>>(State.Surplus(IQueue.empty(), IQueue.empty(), CF, unit()))
+      Queue(SurplusStrategy.Sliding(capacity, CF), ref, CF)
+    }
+
+    fun <F, A> dropping(capacity: Int, CF: Concurrent<F>): Kind<F, Queue<F, A>> = CF.run {
+      Ref<State<F, A>>(State.Surplus(IQueue.empty(), IQueue.empty(), this, unit())).map {
+        Queue(SurplusStrategy.Dropping(capacity, this), it, this)
+      }
+    }
+
+    fun <F, A> unbounded(CF: Concurrent<F>): Kind<F, Queue<F, A>> = CF.run {
+      Ref<State<F, A>>(State.Surplus(IQueue.empty(), IQueue.empty(), this, unit())).map {
+        Queue(SurplusStrategy.Unbounded(this), it, this)
       }
     }
   }
@@ -176,18 +207,30 @@ class Queue<F, A> private constructor(private val strategy: SurplusStrategy<F, A
       )
     }
 
+  /**
+   * A Queue can be in three states
+   * Deficit:
+   *  Contains a queue of values and a queue of suspended fibers
+   *  waiting to take once a value becomes available
+   * Surplus:
+   *  Contains a queue of values and a queue of suspended fibers
+   *  waiting to offer once there is room (if the queue is bounded)
+   * Shutdown:
+   *  Holds no values or promises for suspended calls,
+   *  an offer or take in Shutdown state creates a QueueShutdown error
+   */
   private sealed class State<F, out A> {
     abstract fun size(): Kind<F, Int>
 
-    internal data class Deficit<F, A>(val takers: IQueue<Promise<F, A>>, val AP: Applicative<F>, val shutdownHook: Kind<F, Unit>) : State<F, A>() {
+    data class Deficit<F, A>(val takers: IQueue<Promise<F, A>>, val AP: Applicative<F>, val shutdownHook: Kind<F, Unit>) : State<F, A>() {
       override fun size(): Kind<F, Int> = AP.just(-takers.length())
     }
 
-    internal data class Surplus<F, A>(val queue: IQueue<A>, val putters: IQueue<Tuple2<A, Promise<F, Unit>>>, val AP: Applicative<F>, val shutdownHook: Kind<F, Unit>) : State<F, A>() {
+    data class Surplus<F, A>(val queue: IQueue<A>, val putters: IQueue<Tuple2<A, Promise<F, Unit>>>, val AP: Applicative<F>, val shutdownHook: Kind<F, Unit>) : State<F, A>() {
       override fun size(): Kind<F, Int> = AP.just(queue.length() + putters.length())
     }
 
-    internal data class Shutdown<F>(val AE: ApplicativeError<F, Throwable>) : State<F, Nothing>() {
+    data class Shutdown<F>(val AE: ApplicativeError<F, Throwable>) : State<F, Nothing>() {
       override fun size(): Kind<F, Int> = AE.raiseError(QueueShutdown)
     }
   }
@@ -195,13 +238,38 @@ class Queue<F, A> private constructor(private val strategy: SurplusStrategy<F, A
   private sealed class SurplusStrategy<F, A> {
     abstract fun handleSurplus(p: Promise<F, Unit>, surplus: State.Surplus<F, A>, a: A): Tuple2<Kind<F, Unit>, State<F, A>>
 
-    internal data class Blocking<F, A>(val capacity: Int, val AP: Applicative<F>) : SurplusStrategy<F, A>() {
+    data class Bounded<F, A>(val capacity: Int, val AP: Applicative<F>) : SurplusStrategy<F, A>() {
       override fun handleSurplus(p: Promise<F, Unit>, surplus: State.Surplus<F, A>, a: A): Tuple2<Kind<F, Unit>, State<F, A>> =
         surplus.run {
           if (queue.length() < capacity && putters.isEmpty())
             p.complete(Unit) toT copy(queue = queue.enqueue(a))
           else
             AP.unit() toT copy(putters = putters.enqueue(a toT p))
+        }
+    }
+
+    data class Sliding<F, A>(val capacity: Int, val AP: Applicative<F>) : SurplusStrategy<F, A>() {
+      override fun handleSurplus(p: Promise<F, Unit>, surplus: State.Surplus<F, A>, a: A): Tuple2<Kind<F, Unit>, State<F, A>> =
+        surplus.run {
+          val nextQueue =
+            if (queue.length() < capacity) queue.enqueue(a)
+            else queue.dequeue().b.enqueue(a)
+          p.complete(Unit) toT copy(queue = nextQueue)
+        }
+    }
+
+    data class Dropping<F, A>(val capacity: Int, val AP: Applicative<F>) : SurplusStrategy<F, A>() {
+      override fun handleSurplus(p: Promise<F, Unit>, surplus: State.Surplus<F, A>, a: A): Tuple2<Kind<F, Unit>, State<F, A>> =
+        surplus.run {
+          val nextQueue = if (queue.length() < capacity) queue.enqueue(a) else queue
+          p.complete(Unit) toT copy(queue = nextQueue)
+        }
+    }
+
+    data class Unbounded<F, A>(val AP: Applicative<F>) : SurplusStrategy<F, A>() {
+      override fun handleSurplus(p: Promise<F, Unit>, surplus: State.Surplus<F, A>, a: A): Tuple2<Kind<F, Unit>, State<F, A>> =
+        surplus.run {
+          p.complete(Unit) toT copy(queue = queue.enqueue(a))
         }
     }
   }

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
@@ -10,34 +10,38 @@ import arrow.core.fix
 import arrow.fx.extensions.fx
 import arrow.fx.extensions.io.applicative.applicative
 import arrow.fx.extensions.io.concurrent.concurrent
+import arrow.fx.extensions.io.dispatchers.dispatchers
+import arrow.fx.extensions.io.monad.monad
 import arrow.fx.typeclasses.milliseconds
 import arrow.test.UnitSpec
+import arrow.test.generators.nonEmptyList
 import arrow.test.generators.tuple2
 import arrow.test.generators.tuple3
+import io.kotlintest.fail
+import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe
-import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
 class QueueTest : UnitSpec() {
 
   init {
 
-    fun tests(
+    fun allStrategyTests(
       label: String,
-      ctx: CoroutineContext = Dispatchers.Default,
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Queue<ForIO, Int>>
     ) {
 
       "$label - make a queue the add values then retrieve in the same order" {
-        forAll(Gen.list(Gen.int())) { l ->
+        forAll(Gen.nonEmptyList(Gen.int())) { l ->
           IO.fx {
             val q = !queue(l.size)
             !l.traverse(IO.applicative(), q::offer)
             val nl = !(1..l.size).toList().traverse(IO.applicative()) { q.take() }
             nl.fix()
-          }.unsafeRunSync() == l
+          }.unsafeRunSync() == l.toList()
         }
       }
 
@@ -68,20 +72,6 @@ class QueueTest : UnitSpec() {
         }.unsafeRunSync()
       }
 
-      "$label - time out offering to a queue at capacity" {
-        IO.fx {
-          val q = !queue(1)
-          !q.offer(1)
-          val start = !effect { System.currentTimeMillis() }
-          val wontComplete = q.offer(2)
-          val received = !wontComplete.map { Some(it) }
-            .waitFor(100.milliseconds, default = just(None))
-          val elapsed = !effect { System.currentTimeMillis() - start }
-          !effect { received shouldBe None }
-          !effect { (elapsed >= 100) shouldBe true }
-        }.unsafeRunSync()
-      }
-
       "$label - suspended take calls on an empty queue complete when offer calls made to queue" {
         forAll(Gen.int()) { i ->
           IO.fx {
@@ -91,22 +81,6 @@ class QueueTest : UnitSpec() {
             !first.join()
           }.unsafeRunSync() == i
         }
-      }
-
-      "$label - offering to a 0 capacity queue in deficit honours blocking strategy" {
-          IO.fx {
-            val q = !queue(0)
-            val first = !q.take().fork(ctx)  // flip from initial Surplus state to Deficit
-            !q.offer(1)                      // then clear previous taker while staying in Deficit
-            !first.join()
-            val start = !effect { System.currentTimeMillis() }
-            val wontComplete = q.offer(2)
-            val received = !wontComplete.map { Some(it) }
-              .waitFor(100.milliseconds, default = just(None))
-            val elapsed = !effect { System.currentTimeMillis() - start }
-            !effect { received shouldBe None }
-            !effect { (elapsed >= 100) shouldBe true }
-          }.unsafeRunSync()
       }
 
       "$label - multiple take calls on an empty queue complete when until as many offer calls made to queue" {
@@ -123,34 +97,6 @@ class QueueTest : UnitSpec() {
             val secondValue = !second.join()
             val thirdValue = !third.join()
             setOf(firstValue, secondValue, thirdValue)
-          }.unsafeRunSync() == setOf(t.a, t.b, t.c)
-        }
-      }
-
-      "$label - suspended offers called on an full queue complete when take calls made to queue" {
-        forAll(Gen.tuple2(Gen.int(), Gen.int())) { t ->
-          IO.fx {
-            val q = !queue(1)
-            !q.offer(t.a)
-            !q.offer(t.b).fork(ctx)
-            val first = !q.take()
-            val second = !q.take()
-            Tuple2(first, second)
-          }.unsafeRunSync() == t
-        }
-      }
-
-      "$label - multiple offer calls on an full queue complete when as many take calls are made to queue" {
-        forAll(Gen.tuple3(Gen.int(), Gen.int(), Gen.int())) { t ->
-          IO.fx {
-            val q = !queue(1)
-            !q.offer(t.a)
-            !q.offer(t.b).fork(ctx)
-            !q.offer(t.c).fork(ctx)
-            val first = !q.take()
-            val second = !q.take()
-            val third = !q.take()
-            setOf(first, second, third)
           }.unsafeRunSync() == setOf(t.a, t.b, t.c)
         }
       }
@@ -176,25 +122,13 @@ class QueueTest : UnitSpec() {
         }
       }
 
-      "$label - joining a forked, incompleted take call on a shutdown queue creates a  QueueShutdown error" {
+      "$label - joining a forked, incomplete take call on a shutdown queue creates a QueueShutdown error" {
         IO.fx {
           val q = !queue(10)
           val t = !q.take().fork(ctx)
           !q.shutdown()
           !t.join()
         }.attempt().unsafeRunSync() shouldBe Left(QueueShutdown)
-      }
-
-      "$label - joining a forked offer call made to a shut down queue creates a QueueShutdown error" {
-        forAll(Gen.int()) { i ->
-          IO.fx {
-            val q = !queue(1)
-            !q.offer(i)
-            val o = !q.offer(i).fork(ctx)
-            !q.shutdown()
-            !o.join()
-          }.attempt().unsafeRunSync() == Left(QueueShutdown)
-        }
       }
 
       "$label - create a shutdown hook completing a promise, then shutdown the queue, the promise should be completed" {
@@ -230,7 +164,163 @@ class QueueTest : UnitSpec() {
       }
     }
 
-    tests("BoundedQueue", queue =
-    { capacity -> Queue.bounded<ForIO, Int>(capacity, IO.concurrent()).fix() })
+    fun boundedStrategyTests(
+      ctx: CoroutineContext = IO.dispatchers().default(),
+      queue: (Int) -> IO<Queue<ForIO, Int>>
+    ) {
+      val label = "BoundedQueue"
+      allStrategyTests(label, ctx, queue)
+
+      "$label - time out offering to a queue at capacity" {
+        IO.fx {
+          val q = !queue(1)
+          !q.offer(1)
+          val start = !effect { System.currentTimeMillis() }
+          val wontComplete = q.offer(2)
+          val received = !wontComplete.map { Some(it) }
+            .waitFor(100.milliseconds, default = just(None))
+          val elapsed = !effect { System.currentTimeMillis() - start }
+          !effect { received shouldBe None }
+          !effect { (elapsed >= 100) shouldBe true }
+        }.unsafeRunSync()
+      }
+
+      "$label - offering to a 0 capacity queue in deficit honours blocking strategy" {
+        IO.fx {
+          val q = !queue(0)
+          // flip from initial Surplus state to Deficit
+          val first = !q.take().fork(ctx)
+          // then clear previous taker while staying in Deficit
+          !q.offer(1)
+          !first.join()
+          val start = !effect { System.currentTimeMillis() }
+          val wontComplete = q.offer(2)
+          val received = !wontComplete.map { Some(it) }
+            .waitFor(100.milliseconds, default = just(None))
+          val elapsed = !effect { System.currentTimeMillis() - start }
+          !effect { received shouldBe None }
+          !effect { (elapsed >= 100) shouldBe true }
+        }.unsafeRunSync()
+      }
+
+      "$label - suspended offers called on an full queue complete when take calls made to queue" {
+        forAll(Gen.tuple2(Gen.int(), Gen.int())) { t ->
+          IO.fx {
+            val q = !queue(1)
+            !q.offer(t.a)
+            !q.offer(t.b).fork(ctx)
+            val first = !q.take()
+            val second = !q.take()
+            Tuple2(first, second)
+          }.unsafeRunSync() == t
+        }
+      }
+
+      "$label - multiple offer calls on an full queue complete when as many take calls are made to queue" {
+        forAll(Gen.tuple3(Gen.int(), Gen.int(), Gen.int())) { t ->
+          IO.fx {
+            val q = !queue(1)
+            !q.offer(t.a)
+            !q.offer(t.b).fork(ctx)
+            !q.offer(t.c).fork(ctx)
+            val first = !q.take()
+            val second = !q.take()
+            val third = !q.take()
+            setOf(first, second, third)
+          }.unsafeRunSync() == setOf(t.a, t.b, t.c)
+        }
+      }
+
+      "$label - joining a forked offer call made to a shut down queue creates a QueueShutdown error" {
+        forAll(Gen.int()) { i ->
+          IO.fx {
+            val q = !queue(1)
+            !q.offer(i)
+            val o = !q.offer(i).fork(ctx)
+            !q.shutdown()
+            !o.join()
+          }.attempt().unsafeRunSync() == Left(QueueShutdown)
+        }
+      }
+    }
+
+    fun slidingStrategyTests(
+      ctx: CoroutineContext = IO.dispatchers().default(),
+      queue: (Int) -> IO<Queue<ForIO, Int>>
+    ) {
+      val label = "SlidingQueue"
+      allStrategyTests(label, ctx, queue)
+
+      "$label - capacity must be a positive integer" {
+        queue(0).attempt().unsafeRunSync().fold(
+          { err -> err.shouldBeInstanceOf<IllegalArgumentException>() },
+          { fail("Expected Left<IllegalArgumentException>") }
+        )
+      }
+
+      "$label - removes first element after offering to a queue at capacity" {
+        forAll(Gen.int(), Gen.nonEmptyList(Gen.int())) { x, xs ->
+          IO.fx {
+            val q = !queue(xs.size)
+            !q.offer(x)
+            !xs.traverse(IO.applicative(), q::offer)
+            val taken = !(1..xs.size).toList().traverse(IO.applicative()) { q.take() }
+            taken.fix()
+          }.unsafeRunSync() == xs.toList()
+        }
+      }
+    }
+
+    fun droppingStrategyTests(
+      ctx: CoroutineContext = IO.dispatchers().default(),
+      queue: (Int) -> IO<Queue<ForIO, Int>>
+    ) {
+      val label = "DroppingQueue"
+
+      allStrategyTests(label, ctx, queue)
+
+      "$label - offering to a zero capacity queue with a pending taker" {
+        forAll(Gen.int()) { x ->
+          IO.fx {
+            val q = !queue(0)
+            val taker = !q.take().fork(ctx)
+            // Wait for the forked `take` to complete by checking the queue `size`,
+            // otherwise the test will suspend indefinitely if `take` occurs after `offer`.
+            !q.size().repeat<ForIO, Int, Int>(IO.concurrent(), Schedule.doUntil(IO.monad()) { it == -1 })
+            !q.offer(x)
+            !taker.join()
+          }.unsafeRunSync() == x
+        }
+      }
+
+      "$label - drops elements offered to a queue at capacity" {
+        forAll(Gen.int(), Gen.int(), Gen.nonEmptyList(Gen.int())) { x, x2, xs ->
+          IO.fx {
+            val q = !queue(xs.size)
+            !xs.traverse(IO.applicative(), q::offer)
+            !q.offer(x) // this `x` should be dropped
+            val taken = !(1..xs.size).toList().traverse(IO.applicative()) { q.take() }
+            !q.offer(x2)
+            val taken2 = !q.take()
+            taken.fix() + taken2
+          }.unsafeRunSync() == xs.toList() + x2
+        }
+      }
+    }
+
+    fun unboundedStrategyTests(
+      ctx: CoroutineContext = IO.dispatchers().default(),
+      queue: (Int) -> IO<Queue<ForIO, Int>>
+    ) {
+      allStrategyTests("UnboundedQueue", ctx, queue)
+    }
+
+    boundedStrategyTests { capacity -> Queue.bounded<ForIO, Int>(capacity, IO.concurrent()).fix() }
+
+    slidingStrategyTests { capacity -> Queue.sliding<ForIO, Int>(capacity, IO.concurrent()).fix() }
+
+    droppingStrategyTests { capacity -> Queue.dropping<ForIO, Int>(capacity, IO.concurrent()).fix() }
+
+    unboundedStrategyTests { Queue.unbounded<ForIO, Int>(IO.concurrent()).fix() }
   }
 }


### PR DESCRIPTION
This change adds Sliding, Dropping and Unbounded strategies to the `arrow.fx.Queue` implementation.

**Sliding** - *acts as a sliding window when at capacity, dropping oldest queue values to make room for newly offered values*

**Dropping** - *simply drops offered values if the queue is already at capacity*

**Unbounded** - *has no notion of capacity and will happily exhaust all memory of the runtime if given the opportunity*

Please be mindful that I am somewhat new to both Arrow and Kotlin, so I would welcome any feedback, especially regarding conventions :)