### PR TITLE
Deprecate KindConnection from public API

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
@@ -9,10 +9,11 @@ import arrow.core.Tuple2
 import arrow.core.extensions.listk.traverse.traverse
 import arrow.core.identity
 import arrow.core.k
-import arrow.fx.CancelToken
+
 import arrow.fx.MVar
 import arrow.fx.Promise
 import arrow.fx.Semaphore
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.ExitCase
 import arrow.test.generators.applicativeError

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/FluxK.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/FluxK.kt
@@ -198,9 +198,8 @@ data class FluxK<out A>(val flux: Flux<out A>) : FluxKOf<A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val result = FluxK.async { conn: FluxKConnection, cb: (Either<Throwable, String>) -> Unit ->
+     *   val result = FluxK.async { cb: (Either<Throwable, String>) -> Unit ->
      *     val resource = Resource()
-     *     conn.push(FluxK { resource.close() })
      *     resource.asyncRead { value -> cb(value.right()) }
      *   }
      *   //sampleEnd

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/FluxK.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/FluxK.kt
@@ -8,9 +8,12 @@ import arrow.core.NonFatal
 import arrow.core.Option
 import arrow.core.Right
 import arrow.core.identity
+import arrow.core.internal.AtomicRefW
+import arrow.core.nonFatalOrThrow
 import arrow.fx.OnCancel
 import arrow.fx.internal.Platform
 import arrow.fx.reactor.CoroutineContextReactorScheduler.asScheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.ExitCase
 import arrow.typeclasses.Applicative
@@ -181,9 +184,7 @@ data class FluxK<out A>(val flux: Flux<out A>) : FluxKOf<A> {
     /**
      * Creates a [FluxK] that'll run [FluxKProc].
      *
-     * {: data-executable='true'}
-     *
-     * ```kotlin:ank
+     * ```kotlin:ank:playground
      * import arrow.core.Either
      * import arrow.core.right
      * import arrow.fx.reactor.FluxK
@@ -207,6 +208,9 @@ data class FluxK<out A>(val flux: Flux<out A>) : FluxKOf<A> {
      * }
      * ```
      */
+    @Deprecated(message =
+    "For wrapping cancelable operations you should use cancelable instead.\n" +
+      "For wrapping uncancelable operations you can use the non-deprecated async")
     fun <A> async(fa: FluxKProc<A>): FluxK<A> =
       Flux.create<A> { sink ->
         val conn = FluxKConnection()
@@ -225,6 +229,21 @@ data class FluxK<out A>(val flux: Flux<out A>) : FluxKOf<A> {
         }
       }.k()
 
+    fun <A> async(fa: ((Either<Throwable, A>) -> Unit) -> Unit): FluxK<A> =
+      Flux.create<A> { sink ->
+        fa { callback: Either<Throwable, A> ->
+          callback.fold({
+            sink.error(it)
+          }, {
+            sink.next(it)
+            sink.complete()
+          })
+        }
+      }.k()
+
+    @Deprecated(message =
+    "For wrapping cancelable operations you should use cancelableF instead.\n" +
+      "For wrapping uncancelable operations you can use the non-deprecated asyncF")
     fun <A> asyncF(fa: FluxKProcF<A>): FluxK<A> =
       Flux.create { sink: FluxSink<A> ->
         val conn = FluxKConnection()
@@ -241,6 +260,66 @@ data class FluxK<out A>(val flux: Flux<out A>) : FluxKOf<A> {
             sink.complete()
           })
         }.fix().flux.subscribe({}, sink::error)
+      }.k()
+
+    fun <A> asyncF(fa: ((Either<Throwable, A>) -> Unit) -> FluxKOf<Unit>): FluxK<A> =
+      Flux.create { sink: FluxSink<A> ->
+        fa { callback: Either<Throwable, A> ->
+          callback.fold({
+            sink.error(it)
+          }, {
+            sink.next(it)
+            sink.complete()
+          })
+        }.fix().flux.subscribe({}, sink::error)
+      }.k()
+
+    fun <A> cancelable(fa: ((Either<Throwable, A>) -> Unit) -> CancelToken<ForFluxK>): FluxK<A> =
+      Flux.create<A> { sink ->
+        val token = fa { either: Either<Throwable, A> ->
+          either.fold({ e ->
+            sink.error(e)
+          }, { a ->
+            sink.next(a)
+            sink.complete()
+          })
+        }
+        sink.onDispose { token.value().subscribe({}, sink::error) }
+      }.k()
+
+    fun <A> cancelableF(fa: ((Either<Throwable, A>) -> Unit) -> FluxKOf<CancelToken<ForFluxK>>): FluxK<A> =
+      Flux.create<A> { sink ->
+        val cb = { either: Either<Throwable, A> ->
+          either.fold({ e ->
+            sink.error(e)
+          }, { a ->
+            sink.next(a)
+            sink.complete()
+          })
+        }
+
+        val fa2 = try {
+          fa(cb)
+        } catch (t: Throwable) {
+          cb(Left(t.nonFatalOrThrow()))
+          just(just(Unit))
+        }
+
+        val cancelOrToken = AtomicRefW<Either<Unit, CancelToken<ForFluxK>>?>(null)
+        val disp = fa2.value().subscribe({ token ->
+          val cancel = cancelOrToken.getAndSet(Right(token))
+          cancel?.fold({
+            token.value().subscribe({}, sink::error)
+          }, { Unit })
+        }, sink::error)
+
+        sink.onDispose {
+          disp.dispose()
+          val token = cancelOrToken.getAndSet(Left(Unit))
+          token?.fold({}, {
+            it.value().subscribe({}, sink::error)
+          })
+        }
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> FluxKOf<Either<A, B>>): FluxK<B> {

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/FluxKConnection.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/FluxKConnection.kt
@@ -5,9 +5,10 @@ import arrow.fx.KindConnection
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
 
-typealias FluxKConnection = KindConnection<ForFluxK>
-typealias FluxKProc<A> = (FluxKConnection, (Either<Throwable, A>) -> Unit) -> Unit
-typealias FluxKProcF<A> = (FluxKConnection, (Either<Throwable, A>) -> Unit) -> FluxKOf<Unit>
+@Deprecated("Cancelation should be done with the cancelable combinator")
+typealias FluxKProc<A> = (KindConnection<ForFluxK>, (Either<Throwable, A>) -> Unit) -> Unit
+@Deprecated("Cancelation should be done with the cancelable combinator")
+typealias FluxKProcF<A> = (KindConnection<ForFluxK>, (Either<Throwable, A>) -> Unit) -> FluxKOf<Unit>
 
 /**
  * Connection for [FluxK].
@@ -20,6 +21,8 @@ typealias FluxKProcF<A> = (FluxKConnection, (Either<Throwable, A>) -> Unit) -> F
  * @see FluxK.async
  */
 @Suppress("UNUSED_PARAMETER", "FunctionName")
+@Deprecated(message = "Cancelling operations through FluxKConnection will not be supported anymore." +
+  "In case you need to cancel multiple processes can do so by using cancelable and composing cancel operations using zipWith or other parallel operators")
 fun FluxKConnection(dummy: Unit = Unit): KindConnection<ForFluxK> = KindConnection(object : MonadDefer<ForFluxK> {
   override fun <A> defer(fa: () -> FluxKOf<A>): FluxK<A> =
     FluxK.defer(fa)

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoK.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoK.kt
@@ -200,7 +200,6 @@ data class MonoK<out A>(val mono: Mono<out A>) : MonoKOf<A> {
      *   //sampleStart
      *   val result = MonoK.async { cb: (Either<Throwable, String>) -> Unit ->
      *     val resource = Resource()
-     *     conn.push(MonoK { resource.close() })
      *     resource.asyncRead { value -> cb(value.right()) }
      *   }
      *   //sampleEnd

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoK.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoK.kt
@@ -1,13 +1,16 @@
 package arrow.fx.reactor
 
 import arrow.core.Either
-import arrow.core.Either.Left
 import arrow.core.Either.Right
+import arrow.core.Left
 import arrow.core.NonFatal
 import arrow.core.internal.AtomicBooleanW
+import arrow.core.internal.AtomicRefW
+import arrow.core.nonFatalOrThrow
 import arrow.fx.OnCancel
 import arrow.fx.internal.Platform
 import arrow.fx.reactor.CoroutineContextReactorScheduler.asScheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.ExitCase
 import reactor.core.publisher.Mono
@@ -155,35 +158,9 @@ data class MonoK<out A>(val mono: Mono<out A>) : MonoKOf<A> {
     fun <A> defer(fa: () -> MonoKOf<A>): MonoK<A> =
       Mono.defer { fa().value() }.k()
 
-    /**
-     * Creates a [MonoK] that'll run [MonoKProc].
-     *
-     * {: data-executable='true'}
-     *
-     * ```kotlin:ank
-     * import arrow.core.Either
-     * import arrow.core.right
-     * import arrow.fx.reactor.MonoK
-     * import arrow.fx.reactor.MonoKConnection
-     * import arrow.fx.reactor.value
-     *
-     * class Resource {
-     *   fun asyncRead(f: (String) -> Unit): Unit = f("Some value of a resource")
-     *   fun close(): Unit = Unit
-     * }
-     *
-     * fun main(args: Array<String>) {
-     *   //sampleStart
-     *   val result = MonoK.async { conn: MonoKConnection, cb: (Either<Throwable, String>) -> Unit ->
-     *     val resource = Resource()
-     *     conn.push(MonoK { resource.close() })
-     *     resource.asyncRead { value -> cb(value.right()) }
-     *   }
-     *   //sampleEnd
-     *   result.value().subscribe(::println)
-     * }
-     * ```
-     */
+    @Deprecated(message =
+    "For wrapping cancelable operations you should use cancelable instead.\n" +
+      "For wrapping uncancelable operations you can use the non-deprecated async")
     fun <A> async(fa: MonoKProc<A>): MonoK<A> =
       Mono.create<A> { sink ->
         val conn = MonoKConnection()
@@ -203,6 +180,48 @@ data class MonoK<out A>(val mono: Mono<out A>) : MonoKOf<A> {
         }
       }.k()
 
+    /**
+     * Constructor for wrapping uncancelable async operations.
+     * It's safe to wrap unsafe operations in this constructor
+     *
+     * ```kotlin:ank:playground
+     * import arrow.core.Either
+     * import arrow.core.right
+     * import arrow.fx.reactor.MonoK
+     * import arrow.fx.reactor.MonoKConnection
+     * import arrow.fx.reactor.value
+     *
+     * class Resource {
+     *   fun asyncRead(f: (String) -> Unit): Unit = f("Some value of a resource")
+     *   fun close(): Unit = Unit
+     * }
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = MonoK.async { cb: (Either<Throwable, String>) -> Unit ->
+     *     val resource = Resource()
+     *     conn.push(MonoK { resource.close() })
+     *     resource.asyncRead { value -> cb(value.right()) }
+     *   }
+     *   //sampleEnd
+     *   result.value().subscribe(::println)
+     * }
+     * ```
+     */
+    fun <A> async(fa: ((Either<Throwable, A>) -> Unit) -> Unit): MonoK<A> =
+      Mono.create<A> { sink ->
+          fa { either: Either<Throwable, A> ->
+            either.fold({
+              sink.error(it)
+            }, {
+              sink.success(it)
+            })
+          }
+      }.k()
+
+    @Deprecated(message =
+    "For wrapping cancelable operations you should use cancelableF instead.\n" +
+      "For wrapping uncancelable operations you can use the non-deprecated asyncF")
     fun <A> asyncF(fa: MonoKProcF<A>): MonoK<A> =
       Mono.create { sink: MonoSink<A> ->
         val conn = MonoKConnection()
@@ -220,6 +239,90 @@ data class MonoK<out A>(val mono: Mono<out A>) : MonoKOf<A> {
             sink.success(it)
           })
         }.fix().mono.subscribe({}, sink::error)
+      }.k()
+
+    fun <A> asyncF(fa: ((Either<Throwable, A>) -> Unit) -> MonoKOf<Unit>): MonoK<A> =
+      Mono.create { sink: MonoSink<A> ->
+        fa { either: Either<Throwable, A> ->
+          either.fold({
+            sink.error(it)
+          }, {
+            sink.success(it)
+          })
+        }.fix().mono.subscribe({}, sink::error)
+      }.k()
+
+    /**
+     * Creates a [MonoK] that'll wraps/runs a cancelable operation.
+     *
+     * ```kotlin:ank:playground
+     * import arrow.core.*
+     * import arrow.fx.rx2.*
+     *
+     * typealias Disposable = () -> Unit
+     * class NetworkApi {
+     *   fun async(f: (String) -> Unit): Disposable {
+     *     f("Some value of a resource")
+     *     return { Unit }
+     *   }
+     * }
+     *
+     * fun main(args: Array<String>) {
+     *   //sampleStart
+     *   val result = SingleK.cancelable { cb: (Either<Throwable, String>) -> Unit ->
+     *     val nw = NetworkApi()
+     *     val disposable = nw.async { result -> cb(Right(result)) }
+     *     SingleK { disposable.invoke() }
+     *   }
+     *   //sampleEnd
+     *   result.value().subscribe(::println, ::println)
+     * }
+     * ```
+     */
+    fun <A> cancelable(fa: ((Either<Throwable, A>) -> Unit) -> CancelToken<ForMonoK>): MonoK<A> =
+      Mono.create { sink: MonoSink<A> ->
+        val cb = { either: Either<Throwable, A> ->
+          either.fold(sink::error, sink::success)
+        }
+
+        val token = try {
+          fa(cb)
+        } catch (t: Throwable) {
+          cb(Left(t.nonFatalOrThrow()))
+          just(Unit)
+        }
+
+        sink.onDispose { token.value().subscribe({}, sink::error) }
+      }.k()
+
+    fun <A> cancelableF(fa: ((Either<Throwable, A>) -> Unit) -> MonoKOf<CancelToken<ForMonoK>>): MonoK<A> =
+      Mono.create { sink: MonoSink<A> ->
+        val cb = { either: Either<Throwable, A> ->
+          either.fold(sink::error, sink::success)
+        }
+
+        val fa2 = try {
+          fa(cb)
+        } catch (t: Throwable) {
+          cb(Left(t.nonFatalOrThrow()))
+          just(just(Unit))
+        }
+
+        val cancelOrToken = AtomicRefW<Either<Unit, CancelToken<ForMonoK>>?>(null)
+        val disp = fa2.value().subscribe({ token ->
+          val cancel = cancelOrToken.getAndSet(Right(token))
+          cancel?.fold({
+            token.value().subscribe({}, sink::error)
+          }, { Unit })
+        }, sink::error)
+
+        sink.onDispose {
+          disp.dispose()
+          val token = cancelOrToken.getAndSet(Left(Unit))
+          token?.fold({}, {
+            it.value().subscribe({}, sink::error)
+          })
+        }
       }.k()
 
     tailrec fun <A, B> tailRecM(a: A, f: (A) -> MonoKOf<Either<A, B>>): MonoK<B> {

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoKConnection.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/MonoKConnection.kt
@@ -5,9 +5,10 @@ import arrow.fx.KindConnection
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
 
-typealias MonoKConnection = KindConnection<ForMonoK>
-typealias MonoKProc<A> = (MonoKConnection, (Either<Throwable, A>) -> Unit) -> Unit
-typealias MonoKProcF<A> = (MonoKConnection, (Either<Throwable, A>) -> Unit) -> MonoKOf<Unit>
+@Deprecated("Cancelation should be done with the cancelable combinator")
+typealias MonoKProc<A> = (KindConnection<ForMonoK>, (Either<Throwable, A>) -> Unit) -> Unit
+@Deprecated("Cancelation should be done with the cancelable combinator")
+typealias MonoKProcF<A> = (KindConnection<ForMonoK>, (Either<Throwable, A>) -> Unit) -> MonoKOf<Unit>
 
 /**
  * Connection for [MonoK].
@@ -20,6 +21,8 @@ typealias MonoKProcF<A> = (MonoKConnection, (Either<Throwable, A>) -> Unit) -> M
  * @see MonoK.async
  */
 @Suppress("UNUSED_PARAMETER", "FunctionName")
+@Deprecated(message = "Cancelling operations through MonoKConnection will not be supported anymore." +
+"In case you need to cancel multiple processes can do so by using cancelable and composing cancel operations using zipWith or other parallel operators")
 fun MonoKConnection(dummy: Unit = Unit): KindConnection<ForMonoK> = KindConnection(object : MonadDefer<ForMonoK> {
   override fun <A> defer(fa: () -> MonoKOf<A>): MonoK<A> =
     MonoK.defer(fa)

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/CoroutineContextRx2Scheduler.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/CoroutineContextRx2Scheduler.kt
@@ -8,49 +8,47 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
 
-object CoroutineContextRx2Scheduler {
-  private interface NonCancellableContinuation : Continuation<Unit>, Disposable
+private interface NonCancellableContinuation : Continuation<Unit>, Disposable
 
-  fun CoroutineContext.asScheduler(): Scheduler =
-    object : Scheduler() {
-      override fun createWorker(): Worker =
-        object : Worker() {
-          @Volatile
-          var once = false
+fun CoroutineContext.asScheduler(): Scheduler =
+  object : Scheduler() {
+    override fun createWorker(): Worker =
+      object : Worker() {
+        @Volatile
+        var once = false
 
-          override fun isDisposed(): Boolean = once
+        override fun isDisposed(): Boolean = once
 
-          override fun schedule(run: Runnable, delay: Long, unit: TimeUnit): Disposable {
-            if (once) {
-              return EmptyDisposable.INSTANCE
-            }
-
-            val a: suspend () -> Unit = { run.run() }
-            val completion: NonCancellableContinuation = simpleContinuation(this@asScheduler)
-            a.startCoroutine(completion)
-            return completion
+        override fun schedule(run: Runnable, delay: Long, unit: TimeUnit): Disposable {
+          if (once) {
+            return EmptyDisposable.INSTANCE
           }
 
-          override fun dispose() {
-            once = false
-          }
-
-          private fun simpleContinuation(context: CoroutineContext): NonCancellableContinuation =
-            object : NonCancellableContinuation {
-              override fun isDisposed(): Boolean = false
-
-              override fun dispose() {
-              }
-
-              override val context: CoroutineContext = context
-
-              override fun resume(value: Unit) {
-              }
-
-              override fun resumeWithException(exception: Throwable) {
-                throw exception
-              }
-            }
+          val a: suspend () -> Unit = { run.run() }
+          val completion: NonCancellableContinuation = simpleContinuation(this@asScheduler)
+          a.startCoroutine(completion)
+          return completion
         }
-    }
-}
+
+        override fun dispose() {
+          once = false
+        }
+
+        private fun simpleContinuation(context: CoroutineContext): NonCancellableContinuation =
+          object : NonCancellableContinuation {
+            override fun isDisposed(): Boolean = false
+
+            override fun dispose() {
+            }
+
+            override val context: CoroutineContext = context
+
+            override fun resume(value: Unit) {
+            }
+
+            override fun resumeWithException(exception: Throwable) {
+              throw exception
+            }
+          }
+      }
+  }

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableK.kt
@@ -9,9 +9,9 @@ import arrow.core.Right
 import arrow.core.internal.AtomicRefW
 import arrow.core.identity
 import arrow.core.nonFatalOrThrow
-import arrow.fx.CancelToken
+
 import arrow.fx.internal.Platform
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.ExitCase
 import arrow.typeclasses.Applicative
@@ -19,6 +19,9 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.FlowableEmitter
 import kotlin.coroutines.CoroutineContext
+
+typealias FlowableKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
+typealias FlowableKProcF<A> = ((Either<Throwable, A>) -> Unit) -> FlowableKOf<Unit>
 
 class ForFlowableK private constructor() {
   companion object

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableKConnection.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/FlowableKConnection.kt
@@ -5,10 +5,6 @@ import arrow.fx.KindConnection
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
 
-typealias FlowableKConnection = KindConnection<ForFlowableK>
-typealias FlowableKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
-typealias FlowableKProcF<A> = ((Either<Throwable, A>) -> Unit) -> FlowableKOf<Unit>
-
 /**
  * Connection for [FlowableK].
  *

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/MaybeK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/MaybeK.kt
@@ -1,5 +1,6 @@
 package arrow.fx.rx2
 
+import arrow.Kind
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Left
@@ -8,9 +9,9 @@ import arrow.core.Predicate
 import arrow.core.Right
 import arrow.core.internal.AtomicRefW
 import arrow.core.nonFatalOrThrow
-import arrow.fx.CancelToken
+
 import arrow.fx.internal.Platform
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.ExitCase.Canceled
 import arrow.fx.typeclasses.ExitCase.Completed
@@ -21,6 +22,9 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+
+typealias MaybeKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
+typealias MaybeKProcF<A> = ((Either<Throwable, A>) -> Unit) -> Kind<ForMaybeK, Unit>
 
 class ForMaybeK private constructor() {
   companion object

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/MaybeKConnection.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/MaybeKConnection.kt
@@ -1,13 +1,9 @@
 package arrow.fx.rx2
 
-import arrow.Kind
 import arrow.core.Either
 import arrow.fx.KindConnection
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
-
-typealias MaybeKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
-typealias MaybeKProcF<A> = ((Either<Throwable, A>) -> Unit) -> Kind<ForMaybeK, Unit>
 
 /**
  * Connection for [MaybeK].

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/ObservableK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/ObservableK.kt
@@ -9,15 +9,18 @@ import arrow.core.Right
 import arrow.core.internal.AtomicRefW
 import arrow.core.identity
 import arrow.core.nonFatalOrThrow
-import arrow.fx.CancelToken
+
 import arrow.fx.internal.Platform
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.ExitCase
 import arrow.typeclasses.Applicative
 import io.reactivex.Observable
 import io.reactivex.ObservableEmitter
 import kotlin.coroutines.CoroutineContext
+
+typealias ObservableKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
+typealias ObservableKProcF<A> = ((Either<Throwable, A>) -> Unit) -> ObservableKOf<Unit>
 
 class ForObservableK private constructor() {
   companion object

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/ObservableKConnection.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/ObservableKConnection.kt
@@ -5,9 +5,6 @@ import arrow.fx.KindConnection
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
 
-typealias ObservableKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
-typealias ObservableKProcF<A> = ((Either<Throwable, A>) -> Unit) -> ObservableKOf<Unit>
-
 /**
  * Connection for [ObservableK].
  *

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleK.kt
@@ -5,9 +5,9 @@ import arrow.core.Left
 import arrow.core.Right
 import arrow.core.internal.AtomicRefW
 import arrow.core.nonFatalOrThrow
-import arrow.fx.CancelToken
+
 import arrow.fx.internal.Platform
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.ExitCase.Canceled
@@ -19,6 +19,9 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+
+typealias SingleKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
+typealias SingleKProcF<A> = ((Either<Throwable, A>) -> Unit) -> SingleKOf<Unit>
 
 class ForSingleK private constructor() {
   companion object

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleKConnection.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/SingleKConnection.kt
@@ -5,9 +5,6 @@ import arrow.fx.KindConnection
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
 
-typealias SingleKProc<A> = ((Either<Throwable, A>) -> Unit) -> Unit
-typealias SingleKProcF<A> = ((Either<Throwable, A>) -> Unit) -> SingleKOf<Unit>
-
 /**
  * Connection for [SingleK].
  *

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -5,7 +5,7 @@ import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Option
 import arrow.core.Tuple2
-import arrow.fx.CancelToken
+
 import arrow.fx.RacePair
 import arrow.fx.RaceTriple
 import arrow.fx.rx2.FlowableK
@@ -44,10 +44,11 @@ import io.reactivex.Flowable
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import io.reactivex.functions.BiFunction
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
+import arrow.fx.rx2.asScheduler
 import arrow.fx.rx2.extensions.flowablek.dispatchers.dispatchers
 import arrow.fx.rx2.k
 import arrow.fx.rx2.value
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.ConcurrentSyntax
 import arrow.fx.typeclasses.Dispatchers
 import arrow.typeclasses.FunctorFilter

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -5,11 +5,10 @@ import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Option
 import arrow.core.Tuple2
-import arrow.fx.CancelToken
+
 import arrow.fx.RacePair
 import arrow.fx.RaceTriple
 import arrow.fx.Timer
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
 import arrow.fx.rx2.ForMaybeK
 import arrow.fx.rx2.MaybeK
 import arrow.fx.rx2.MaybeKOf
@@ -29,7 +28,9 @@ import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
 import arrow.extension
+import arrow.fx.rx2.asScheduler
 import arrow.fx.rx2.extensions.maybek.dispatchers.dispatchers
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.ConcurrentSyntax
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -5,11 +5,10 @@ import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Option
 import arrow.core.Tuple2
-import arrow.fx.CancelToken
+
 import arrow.fx.RacePair
 import arrow.fx.RaceTriple
 import arrow.fx.Timer
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
 import arrow.fx.rx2.ForObservableK
 import arrow.fx.rx2.ObservableK
 import arrow.fx.rx2.ObservableKOf
@@ -33,7 +32,9 @@ import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
 import arrow.extension
+import arrow.fx.rx2.asScheduler
 import arrow.fx.rx2.extensions.observablek.dispatchers.dispatchers
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.ConcurrentSyntax
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
@@ -3,11 +3,10 @@ package arrow.fx.rx2.extensions
 import arrow.Kind
 import arrow.core.Either
 import arrow.core.Tuple2
-import arrow.fx.CancelToken
+
 import arrow.fx.RacePair
 import arrow.fx.RaceTriple
 import arrow.fx.Timer
-import arrow.fx.rx2.CoroutineContextRx2Scheduler.asScheduler
 import arrow.fx.rx2.ForSingleK
 import arrow.fx.rx2.SingleK
 import arrow.fx.rx2.SingleKOf
@@ -29,9 +28,11 @@ import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
 import arrow.extension
+import arrow.fx.rx2.asScheduler
 import arrow.fx.rx2.extensions.singlek.dispatchers.dispatchers
 import arrow.fx.rx2.unsafeRunAsync
 import arrow.fx.rx2.unsafeRunSync
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.ConcurrentSyntax
 import arrow.fx.typeclasses.UnsafeRun
 import arrow.typeclasses.Applicative

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -23,6 +23,7 @@ import arrow.fx.internal.Platform.unsafeResync
 import arrow.fx.internal.ShiftTick
 import arrow.fx.internal.UnsafePromise
 import arrow.fx.internal.scheduler
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.Duration
 import arrow.fx.typeclasses.ExitCase
@@ -1041,7 +1042,7 @@ sealed class IO<out A> : IOOf<A> {
 
     companion object {
       // Internal reusable reference.
-      internal val makeUncancelable: (IOConnection) -> IOConnection = { IOConnection.uncancelable }
+      internal val makeUncancelable: (IOConnection) -> IOConnection = { KindConnection.uncancelable }
 
       internal val disableUncancelable: (Any?, Throwable?, IOConnection, IOConnection) -> IOConnection =
         { _, _, old, _ -> old }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORunLoop.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORunLoop.kt
@@ -21,7 +21,7 @@ private typealias Callback = (Either<Throwable, Any?>) -> Unit
 internal object IORunLoop {
 
   fun <A> start(source: IOOf<A>, cb: (Either<Throwable, A>) -> Unit): Unit =
-    loop(source, IOConnection.uncancelable, cb as Callback, null, null, null, EmptyCoroutineContext)
+    loop(source, KindConnection.uncancelable, cb as Callback, null, null, null, EmptyCoroutineContext)
 
   /**
    * Evaluates the given `IO` reference, calling the given callback

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/KindConnection.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/KindConnection.kt
@@ -2,12 +2,11 @@ package arrow.fx
 
 import arrow.Kind
 import arrow.fx.internal.JavaCancellationException
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.MonadDefer
 import arrow.typeclasses.Applicative
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
-
-typealias CancelToken<F> = Kind<F, Unit>
 
 enum class OnCancel { ThrowCancellationException, Silent;
 

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/KindConnection.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/KindConnection.kt
@@ -25,6 +25,8 @@ object ConnectionCancellationException : JavaCancellationException("User cancell
  *
  * The cancellation functions are maintained in a stack and executed in a FIFO order.
  */
+@Deprecated(message = "Cancelling operations through KindConnection will not be supported anymore." +
+  "In case you need to cancel multiple processes can do so by using cancelable and composing cancel operations using parMapN")
 sealed class KindConnection<F> {
 
   /**

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
@@ -4,7 +4,7 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.identity
 import arrow.extension
-import arrow.fx.CancelToken
+
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.IODispatchers
@@ -18,6 +18,7 @@ import arrow.fx.extensions.io.dispatchers.dispatchers
 import arrow.fx.fix
 import arrow.fx.typeclasses.Async
 import arrow.fx.typeclasses.Bracket
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.ConcurrentEffect
 import arrow.fx.typeclasses.ConcurrentSyntax

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/CancelableMVar.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/CancelableMVar.kt
@@ -7,10 +7,11 @@ import arrow.core.Option
 import arrow.core.Right
 import arrow.core.Some
 import arrow.core.Tuple2
-import arrow.fx.CancelToken
+
 import arrow.fx.MVar
 import arrow.fx.internal.CancelableMVar.Companion.State.WaitForPut
 import arrow.fx.internal.CancelableMVar.Companion.State.WaitForTake
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Fiber
 import arrow.fx.typeclasses.mapUnit

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ForwardCancelable.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ForwardCancelable.kt
@@ -2,7 +2,7 @@ package arrow.fx.internal
 
 import arrow.core.Either
 import arrow.core.NonFatal
-import arrow.fx.CancelToken
+
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.IOConnection
@@ -10,13 +10,14 @@ import arrow.fx.IORunLoop
 import arrow.fx.fix
 import arrow.fx.internal.ForwardCancelable.Companion.State.Active
 import arrow.fx.internal.ForwardCancelable.Companion.State.Empty
+import arrow.fx.typeclasses.CancelToken
 import kotlinx.atomicfu.atomic
 
 /**
  * A placeholder for a [CancelToken] that will be set at a later time, the equivalent of a
  * `Promise<ForIO, CancelToken<ForIO>>`. Used in the implementation of `bracket`, see [IOBracket].
  */
-class ForwardCancelable {
+internal class ForwardCancelable {
 
   private val state = atomic<State>(init)
 

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/IOBracket.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/IOBracket.kt
@@ -2,7 +2,6 @@ package arrow.fx.internal
 
 import arrow.core.Either
 import arrow.core.nonFatalOrThrow
-import arrow.fx.CancelToken
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.IOConnection
@@ -10,6 +9,7 @@ import arrow.fx.IOFrame
 import arrow.fx.IOOf
 import arrow.fx.IORunLoop
 import arrow.fx.fix
+import arrow.fx.typeclasses.CancelToken
 import arrow.fx.typeclasses.ExitCase
 import kotlinx.atomicfu.atomic
 

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/Utils.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/Utils.kt
@@ -8,8 +8,8 @@ import arrow.core.internal.AtomicBooleanW
 import arrow.core.left
 import arrow.core.right
 import arrow.fx.IO
+import arrow.fx.IOConnection
 import arrow.fx.IOOf
-import arrow.fx.KindConnection
 import arrow.fx.fix
 import arrow.fx.typeclasses.Duration
 import java.util.concurrent.Executor
@@ -139,7 +139,7 @@ object Platform {
     }
   }
 
-  inline fun <F, A> onceOnly(conn: KindConnection<F>, crossinline f: (A) -> Unit): (A) -> Unit {
+  internal inline fun <A> onceOnly(conn: IOConnection, crossinline f: (A) -> Unit): (A) -> Unit {
     val wasCalled = AtomicBooleanW(false)
 
     return { a ->

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
@@ -15,7 +15,6 @@ import arrow.core.k
 import arrow.fx.internal.parMap2
 import arrow.fx.internal.parMap3
 import arrow.typeclasses.Applicative
-import arrow.fx.CancelToken
 import arrow.fx.MVar
 import arrow.fx.Promise
 import arrow.fx.Race2
@@ -34,6 +33,8 @@ import arrow.fx.internal.TimeoutException
 import arrow.typeclasses.Traverse
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
+
+typealias CancelToken<F> = Kind<F, Unit>
 
 /**
  * ank_macro_hierarchy(arrow.fx.typeclasses.Concurrent)

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Fiber.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Fiber.kt
@@ -1,7 +1,7 @@
 package arrow.fx.typeclasses
 
 import arrow.Kind
-import arrow.fx.CancelToken
+
 import arrow.higherkind
 
 /**


### PR DESCRIPTION
This PR deprecates `KindConnection` from the public API so it can be completely removed in the next major release.

Exposing manual cancellation mechanism likes this has proofed to be error prone.