### PR TITLE
Make suspended IO cancelation aware

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -573,7 +573,9 @@ sealed class IO<out A> : IOOf<A> {
    * **BEWARE** this does **not** support cancelation since Kotlin has no cancelation support for `suspend` on the language level.
    */
   suspend fun suspended(): A = suspendCoroutine { cont ->
-    IORunLoop.start(this) {
+    val connection = cont.context[IOContext]?.connection
+
+    IORunLoop.startCancelable(this, connection ?: IOConnection.uncancelable) {
       it.fold(cont::resumeWithException, cont::resume)
     }
   }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IOConnection.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IOConnection.kt
@@ -1,14 +1,21 @@
 @file:Suppress("UnusedImports")
+
 package arrow.fx
 
 import arrow.core.Either
 import arrow.fx.typeclasses.Disposable
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 import arrow.fx.handleErrorWith as handleErrorW
 
 fun IOConnection.toDisposable(): Disposable = { cancel().fix().unsafeRunSync() }
 typealias IOConnection = KindConnection<ForIO>
+
+internal class IOContext(val connection: IOConnection) : AbstractCoroutineContextElement(IOContext) {
+  companion object Key : CoroutineContext.Key<IOContext>
+}
 
 @Suppress("UNUSED_PARAMETER", "FunctionName")
 fun IOConnection(dummy: Unit = Unit): IOConnection = KindConnection(MD) { it.fix().unsafeRunAsync { } }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORunLoop.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORunLoop.kt
@@ -21,14 +21,14 @@ private typealias Callback = (Either<Throwable, Any?>) -> Unit
 internal object IORunLoop {
 
   fun <A> start(source: IOOf<A>, cb: (Either<Throwable, A>) -> Unit): Unit =
-    loop(source, KindConnection.uncancelable, cb as Callback, null, null, null, EmptyCoroutineContext)
+    loop(source, KindConnection.uncancelable, cb as Callback, null, null, null, IOContext(KindConnection.uncancelable))
 
   /**
    * Evaluates the given `IO` reference, calling the given callback
    * with the result when completed.
    */
   fun <A> startCancelable(source: IOOf<A>, conn: IOConnection, cb: (Either<Throwable, A>) -> Unit): Unit =
-    loop(source, conn, cb as Callback, null, null, null, EmptyCoroutineContext)
+    loop(source, conn, cb as Callback, null, null, null, IOContext(conn))
 
   fun <A> step(source: IO<A>): IO<A> {
     var currentIO: Current? = source


### PR DESCRIPTION
This PR fixes the issue were IO loses its connection across `suspended` boundaries.

 - Currently if you transform an `IO` to `suspended` and then wrap it into another `IO` using `effect` or the default constructor it becomes uncancelable.
- This PR makes the CoroutineContext `IOContext` aware, so it can carry its `IOConnection` within the `CoroutineContext` and share it across multiple `IORunLoop` for the same `IO`.

This makes `suspendCoroutine` the equivalent of `RestartCallback` on the language level, where we can move between callbacks and direct values. This allows us to bridge the connection across the `IO` program since the `Continuation` instance is shared across the whole IO program just like `RestartCallback`.

This also allows for working with `IO` in a style more similar to `KotlinX`.