### PR TITLE
ComonadLaws uses GenK for testdata generation

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/BimonadLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/BimonadLaws.kt
@@ -39,13 +39,10 @@ object BimonadLaws {
     CM: Comonad<F>,
     GENK: GenK<F>,
     EQK: EqK<F>
-  ): List<Law> {
-    val GEN = GENK.genK(Gen.int())
-
-    return MonadLaws.laws(M, EQK) +
-      ComonadLaws.laws(CM, GEN, EQK) +
+  ): List<Law> =
+    MonadLaws.laws(M, EQK) +
+      ComonadLaws.laws(CM, GENK, EQK) +
       bimonadLaws(BF, EQK)
-  }
 
   fun <F> laws(
     BF: Bimonad<F>,
@@ -56,13 +53,10 @@ object BimonadLaws {
     SL: Selective<F>,
     GENK: GenK<F>,
     EQK: EqK<F>
-  ): List<Law> {
-    val GEN = GENK.genK(Gen.int())
-
-    return MonadLaws.laws(M, FF, AP, SL, EQK) +
-      ComonadLaws.laws(CM, GEN, EQK) +
+  ): List<Law> =
+    MonadLaws.laws(M, FF, AP, SL, EQK) +
+      ComonadLaws.laws(CM, GENK, EQK) +
       bimonadLaws(BF, EQK)
-  }
 
   fun <F, A> Bimonad<F>.extractIsIdentity(G: Gen<A>, EQ: Eq<A>): Unit =
     forAll(

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ComonadLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ComonadLaws.kt
@@ -13,24 +13,21 @@ import io.kotlintest.properties.forAll
 
 object ComonadLaws {
 
-  fun <F> laws(CM: Comonad<F>, GENK: GenK<F>, EQK: EqK<F>): List<Law> =
-    laws(CM, GENK.genK(Gen.int()), EQK)
-
-  @Deprecated("use the other laws function that provides GenK/EqK params instead of Gen/cf https://github.com/arrow-kt/arrow/issues/1819")
-  internal fun <F> laws(CM: Comonad<F>, GEN: Gen<Kind<F, Int>>, EQK: EqK<F>): List<Law> {
+  fun <F> laws(CM: Comonad<F>, GENK: GenK<F>, EQK: EqK<F>): List<Law> {
+    val GEN = GENK.genK(Gen.int())
     val EQ = EQK.liftEq(Int.eq())
 
     return FunctorLaws.laws(CM, GEN, EQK) + listOf(
-      Law("Comonad Laws: duplicate then extract is identity") { CM.duplicateThenExtractIsId(GEN, EQ) },
-      Law("Comonad Laws: duplicate then map into extract is identity") { CM.duplicateThenMapExtractIsId(GEN, EQ) },
-      Law("Comonad Laws: map and coflatMap are coherent") { CM.mapAndCoflatmapCoherence(GEN, EQ) },
-      Law("Comonad Laws: left identity") { CM.comonadLeftIdentity(GEN, EQ) },
-      Law("Comonad Laws: right identity") { CM.comonadRightIdentity(GEN, EQ) },
-      Law("Comonad Laws: cokleisli left identity") { CM.cokleisliLeftIdentity(GEN, EQ) },
-      Law("Comonad Laws: cokleisli right identity") { CM.cokleisliRightIdentity(GEN, EQ) }
-      // TODO: this test uses a wrpng assumption https://github.com/arrow-kt/arrow/issues/1857
-      // Law("Comonad Laws: cobinding") { CM.cobinding(G, EQ) }
-    )
+        Law("Comonad Laws: duplicate then extract is identity") { CM.duplicateThenExtractIsId(GEN, EQ) },
+        Law("Comonad Laws: duplicate then map into extract is identity") { CM.duplicateThenMapExtractIsId(GEN, EQ) },
+        Law("Comonad Laws: map and coflatMap are coherent") { CM.mapAndCoflatmapCoherence(GEN, EQ) },
+        Law("Comonad Laws: left identity") { CM.comonadLeftIdentity(GEN, EQ) },
+        Law("Comonad Laws: right identity") { CM.comonadRightIdentity(GEN, EQ) },
+        Law("Comonad Laws: cokleisli left identity") { CM.cokleisliLeftIdentity(GEN, EQ) },
+        Law("Comonad Laws: cokleisli right identity") { CM.cokleisliRightIdentity(GEN, EQ) }
+        // TODO: this test uses a wrpng assumption https://github.com/arrow-kt/arrow/issues/1857
+        // Law("Comonad Laws: cobinding") { CM.cobinding(G, EQ) }
+      )
   }
 
   fun <F> Comonad<F>.duplicateThenExtractIsId(G: Gen<Kind<F, Int>>, EQ: Eq<Kind<F, Int>>): Unit =

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ComonadLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ComonadLaws.kt
@@ -3,6 +3,7 @@ package arrow.test.laws
 import arrow.Kind
 import arrow.core.extensions.eq
 import arrow.mtl.Cokleisli
+import arrow.test.generators.GenK
 import arrow.test.generators.functionAToB
 import arrow.typeclasses.Comonad
 import arrow.typeclasses.Eq
@@ -12,17 +13,21 @@ import io.kotlintest.properties.forAll
 
 object ComonadLaws {
 
-  fun <F> laws(CM: Comonad<F>, G: Gen<Kind<F, Int>>, EQK: EqK<F>): List<Law> {
+  fun <F> laws(CM: Comonad<F>, GENK: GenK<F>, EQK: EqK<F>): List<Law> =
+    laws(CM, GENK.genK(Gen.int()), EQK)
+
+  @Deprecated("use the other laws function that provides GenK/EqK params instead of Gen/cf https://github.com/arrow-kt/arrow/issues/1819")
+  internal fun <F> laws(CM: Comonad<F>, GEN: Gen<Kind<F, Int>>, EQK: EqK<F>): List<Law> {
     val EQ = EQK.liftEq(Int.eq())
 
-    return FunctorLaws.laws(CM, G, EQK) + listOf(
-      Law("Comonad Laws: duplicate then extract is identity") { CM.duplicateThenExtractIsId(G, EQ) },
-      Law("Comonad Laws: duplicate then map into extract is identity") { CM.duplicateThenMapExtractIsId(G, EQ) },
-      Law("Comonad Laws: map and coflatMap are coherent") { CM.mapAndCoflatmapCoherence(G, EQ) },
-      Law("Comonad Laws: left identity") { CM.comonadLeftIdentity(G, EQ) },
-      Law("Comonad Laws: right identity") { CM.comonadRightIdentity(G, EQ) },
-      Law("Comonad Laws: cokleisli left identity") { CM.cokleisliLeftIdentity(G, EQ) },
-      Law("Comonad Laws: cokleisli right identity") { CM.cokleisliRightIdentity(G, EQ) }
+    return FunctorLaws.laws(CM, GEN, EQK) + listOf(
+      Law("Comonad Laws: duplicate then extract is identity") { CM.duplicateThenExtractIsId(GEN, EQ) },
+      Law("Comonad Laws: duplicate then map into extract is identity") { CM.duplicateThenMapExtractIsId(GEN, EQ) },
+      Law("Comonad Laws: map and coflatMap are coherent") { CM.mapAndCoflatmapCoherence(GEN, EQ) },
+      Law("Comonad Laws: left identity") { CM.comonadLeftIdentity(GEN, EQ) },
+      Law("Comonad Laws: right identity") { CM.comonadRightIdentity(GEN, EQ) },
+      Law("Comonad Laws: cokleisli left identity") { CM.cokleisliLeftIdentity(GEN, EQ) },
+      Law("Comonad Laws: cokleisli right identity") { CM.cokleisliRightIdentity(GEN, EQ) }
       // TODO: this test uses a wrpng assumption https://github.com/arrow-kt/arrow/issues/1857
       // Law("Comonad Laws: cobinding") { CM.cobinding(G, EQ) }
     )

--- a/modules/free/arrow-free-data/src/main/kotlin/arrow/free/Cofree.kt
+++ b/modules/free/arrow-free-data/src/main/kotlin/arrow/free/Cofree.kt
@@ -30,9 +30,9 @@ data class Cofree<S, A>(val FS: Functor<S>, val head: A, val tail: Eval<CofreeEv
     Cofree(this, head, tail.map { ce -> fk(ce).map { it.mapBranchingT(fk, this) } })
   }
 
-  fun <B> coflatMap(f: (Cofree<S, A>) -> B): Cofree<S, B> = Cofree(FS, f(this), tail.map { it.map { coflatMap(f) } })
+  fun <B> coflatMap(f: (Cofree<S, A>) -> B): Cofree<S, B> = Cofree(FS, f(this), tail.map { it.map { it.coflatMap(f) } })
 
-  fun duplicate(): Cofree<S, Cofree<S, A>> = Cofree(FS, this, tail.map { it.map { duplicate() } })
+  fun duplicate(): Cofree<S, Cofree<S, A>> = Cofree(FS, this, tail.map { it.map { it.duplicate() } })
 
   fun runTail(): Cofree<S, A> = Cofree(FS, head, Eval.now(tail.value()))
 

--- a/modules/free/arrow-free-data/src/test/kotlin/arrow/free/CofreeTest.kt
+++ b/modules/free/arrow-free-data/src/test/kotlin/arrow/free/CofreeTest.kt
@@ -8,6 +8,7 @@ import arrow.core.ForOption
 import arrow.core.FunctionK
 import arrow.core.Id
 import arrow.core.ListK
+import arrow.core.Nel
 import arrow.core.NonEmptyList
 import arrow.core.None
 import arrow.core.Option
@@ -30,6 +31,8 @@ import arrow.mtl.extensions.optiont.monad.monad
 import arrow.mtl.value
 import arrow.test.UnitSpec
 import arrow.test.concurrency.SideEffect
+import arrow.test.generators.GenK
+import arrow.test.generators.nonEmptyList
 import arrow.test.laws.ComonadLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
@@ -40,14 +43,16 @@ class CofreeTest : UnitSpec() {
 
   init {
 
-    val cf: (Int) -> Cofree<ForOption, Int> = {
-      val sideEffect = SideEffect()
-      unfold(Option.functor(), sideEffect.counter) {
-        sideEffect.increment()
-        if (it % 2 == 0) None else Some(it + 1)
-      }
+    val genk = object : GenK<CofreePartialOf<ForOption>> {
+      private fun <A> NonEmptyList<A>.toCofree(): Cofree<ForOption, A> =
+        Cofree(Option.functor(), this.head, Eval.later { Nel.fromList(this.tail).map { it.toCofree() } })
+
+      // question: test fail when nel gets bigger
+      override fun <A> genK(gen: Gen<A>): Gen<Kind<CofreePartialOf<ForOption>, A>> =
+        Gen.nonEmptyList(gen).filter { it.size < 3 }.map {
+          it.toCofree()
+        }
     }
-    val g = Gen.int().map(cf) as Gen<Kind<Kind<ForCofree, ForOption>, Int>>
 
     val eqk = object : EqK<CofreePartialOf<ForOption>> {
       override fun <A> Kind<CofreePartialOf<ForOption>, A>.eqK(other: Kind<CofreePartialOf<ForOption>, A>, EQ: Eq<A>): Boolean {
@@ -55,7 +60,7 @@ class CofreeTest : UnitSpec() {
       }
     }
 
-    testLaws(ComonadLaws.laws(Cofree.comonad(), g, eqk))
+    testLaws(ComonadLaws.laws(Cofree.comonad(), genk, eqk))
 
     "tailForced should evaluate and return" {
       val sideEffect = SideEffect()

--- a/modules/free/arrow-free-data/src/test/kotlin/arrow/free/CofreeTest.kt
+++ b/modules/free/arrow-free-data/src/test/kotlin/arrow/free/CofreeTest.kt
@@ -47,9 +47,8 @@ class CofreeTest : UnitSpec() {
       private fun <A> NonEmptyList<A>.toCofree(): Cofree<ForOption, A> =
         Cofree(Option.functor(), this.head, Eval.later { Nel.fromList(this.tail).map { it.toCofree() } })
 
-      // question: test fail when nel gets bigger
       override fun <A> genK(gen: Gen<A>): Gen<Kind<CofreePartialOf<ForOption>, A>> =
-        Gen.nonEmptyList(gen).filter { it.size < 3 }.map {
+        Gen.nonEmptyList(gen).map {
           it.toCofree()
         }
     }

--- a/modules/ui/arrow-ui-data/src/test/kotlin/arrow/ui/DayTest.kt
+++ b/modules/ui/arrow-ui-data/src/test/kotlin/arrow/ui/DayTest.kt
@@ -23,9 +23,6 @@ import io.kotlintest.shouldBe
 class DayTest : UnitSpec() {
   init {
 
-    val cf = { x: Int -> Day(Id(x), Id(0)) { xx, yy -> xx + yy } }
-    val g = Gen.int().map(cf) as Gen<Kind<Kind<Kind<ForDay, ForId>, ForId>, Int>>
-
     val EQK = object : EqK<DayPartialOf<ForId, ForId>> {
       override fun <A> Kind<DayPartialOf<ForId, ForId>, A>.eqK(other: Kind<DayPartialOf<ForId, ForId>, A>, EQ: Eq<A>): Boolean =
         (this.fix() to other.fix()).let {
@@ -48,9 +45,11 @@ class DayTest : UnitSpec() {
       }
     }
 
+    val gk = GENK(Id.genK(), Id.genK(), Gen.int(), Gen.int())
+
     testLaws(
-      ApplicativeLaws.laws(Day.applicative(Id.applicative(), Id.applicative()), GENK(Id.genK(), Id.genK(), Gen.int(), Gen.int()), EQK),
-      ComonadLaws.laws(Day.comonad(Id.comonad(), Id.comonad()), g, EQK)
+      ApplicativeLaws.laws(Day.applicative(Id.applicative(), Id.applicative()), gk, EQK),
+      ComonadLaws.laws(Day.comonad(Id.comonad(), Id.comonad()), gk, EQK)
     )
 
     val get: (Int, Int) -> Tuple2<Int, Int> = { left, right -> Tuple2(left, right) }

--- a/modules/ui/arrow-ui-data/src/test/kotlin/arrow/ui/SumTest.kt
+++ b/modules/ui/arrow-ui-data/src/test/kotlin/arrow/ui/SumTest.kt
@@ -40,8 +40,8 @@ class SumTest : UnitSpec() {
   }
 
   init {
-    val cfSumId = { x: Int -> Sum.left(Id.just(x), Id.just(x)) }
-    val genSumId = Gen.int().map(cfSumId) as Gen<Kind<Kind<Kind<ForSum, ForId>, ForId>, Int>>
+
+    val genkSumId = genk(Id.genK(), Id.genK())
 
     val sumIdEQK = Sum.eqK(Id.eqK(), Id.eqK())
     val IDEQ = Eq<Kind<ForId, Int>> { a, b -> Id.eq(Int.eq()).run { a.fix().eqv(b.fix()) } }
@@ -62,7 +62,7 @@ class SumTest : UnitSpec() {
         genSumConst,
         sumConstEQK
       ), */
-      ComonadLaws.laws(Sum.comonad(Id.comonad(), Id.comonad()), genSumId, sumIdEQK),
+      ComonadLaws.laws(Sum.comonad(Id.comonad(), Id.comonad()), genkSumId, sumIdEQK),
       HashLaws.laws(Sum.hash(IDH, IDH), Sum.eq(IDEQ, IDEQ), genSum())
     )
 


### PR DESCRIPTION
this PR changes ComonadLaws to use GenK for test data generation (#1858)

i tried to come up with a better GenK for Cofree as suggested here (https://github.com/arrow-kt/arrow/pull/1844/files#r358260447) 

However the tests fail if the Nel has a size > 1. Not sure if this is related to a wrong GenK or is actually a bug uncovered ...