### PR TITLE
Ensure effect order is preserved with Traversable

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -764,7 +764,7 @@ fun <E, A> ValidatedOf<E, A>.orElse(default: () -> Validated<E, A>): Validated<E
  */
 fun <E, A, B> ValidatedOf<E, A>.ap(SE: Semigroup<E>, f: Validated<E, (A) -> B>): Validated<E, B> =
   fix().fold(
-    { e -> f.fold({ Invalid(SE.run { it.combine(e) }) }, { Invalid(e) }) },
+    { e -> f.fold({ Invalid(SE.run { e.combine(it) }) }, { Invalid(e) }) },
     { a -> f.fold(::Invalid) { Valid(it(a)) } }
   )
 

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Apply.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Apply.kt
@@ -153,7 +153,7 @@ interface Apply<F> : Functor<F> {
     fb.map { fc -> map2(fc, f) }
 
   fun <A, B> Kind<F, A>.product(fb: Kind<F, B>): Kind<F, Tuple2<A, B>> =
-    fb.ap(this.map { a: A -> { b: B -> Tuple2(a, b) } })
+    ap(fb.map { b: B -> { a: A -> Tuple2(a, b) } })
 
   fun <A, B, Z> Kind<F, Tuple2<A, B>>.product(
     other: Kind<F, Z>,


### PR DESCRIPTION
I discovered as part of #1832 that the recent changes to introduce `lazyAp` has resulted in the effects of `NonEmptyList.traverse` to no longer maintain their order, causing some of the `Queue` tests to fail.

My assumption was that it was desirable to maintain the effect order with the order of the elements being traversed, so I have included a new law to `Traversable` to compare effect order using a mutable `Ref` with evaluation order of the resulting values.

Upon introducing the new law, `FluxK`, ObservableK`, `FlowableK` were also failing to preserve the ordering of the effects, so I have included changes for those too. I'm not too familiar with these specific types, so it would be worth double checking that the intended semantics have been maintained.