### PR TITLE
DOC: add card image

### DIFF
--- a/modules/docs/arrow-docs/docs/_includes/_head-docs.html
+++ b/modules/docs/arrow-docs/docs/_includes/_head-docs.html
@@ -24,7 +24,7 @@
   <meta property="og:image" content="https://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.name}}" />
   <meta property="og:site_name" content="{{site.name}}" />
-  <meta property="og:url" content="{{site.url}}" />
+  <meta property="og:url" content="https://arrow-kt.io/" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="{{site.description}}" />
   <meta property="og:keywords" content="{{site.keywords}}" />

--- a/modules/docs/arrow-docs/docs/_includes/_head-docs.html
+++ b/modules/docs/arrow-docs/docs/_includes/_head-docs.html
@@ -21,7 +21,7 @@
   <meta name="description" content="{{site.description}}">
   <meta name="keywords" content="{{site.keywords}}">
 
-  <meta property="og:image" content="" />
+  <meta property="og:image" content="http://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.name}}" />
   <meta property="og:site_name" content="{{site.name}}" />
   <meta property="og:url" content="{{site.url}}" />
@@ -33,7 +33,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="{{site.twitter_handle}}">
   <meta name="twitter:creator" content="{{site.twitter_handle}}">
-  <meta name="twitter:image" content="" />
+  <meta name="twitter:image" content="http://arrow-kt.io/img/poster.png" />
 
   <!-- Favicon -->
   <link rel="shortcut icon" type="image/png" href="{{ '/img/favicon.png' | relative_url }}">

--- a/modules/docs/arrow-docs/docs/_includes/_head-docs.html
+++ b/modules/docs/arrow-docs/docs/_includes/_head-docs.html
@@ -21,7 +21,7 @@
   <meta name="description" content="{{site.description}}">
   <meta name="keywords" content="{{site.keywords}}">
 
-  <meta property="og:image" content="http://arrow-kt.io/img/poster.png" />
+  <meta property="og:image" content="https://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.name}}" />
   <meta property="og:site_name" content="{{site.name}}" />
   <meta property="og:url" content="{{site.url}}" />
@@ -33,7 +33,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="{{site.twitter_handle}}">
   <meta name="twitter:creator" content="{{site.twitter_handle}}">
-  <meta name="twitter:image" content="http://arrow-kt.io/img/poster.png" />
+  <meta name="twitter:image" content="https://arrow-kt.io/img/poster.png" />
 
   <!-- Favicon -->
   <link rel="shortcut icon" type="image/png" href="{{ '/img/favicon.png' | relative_url }}">

--- a/modules/docs/arrow-docs/docs/_includes/_head.html
+++ b/modules/docs/arrow-docs/docs/_includes/_head.html
@@ -5,7 +5,7 @@
   <meta name="description" content="{{site.description}}">
   <meta name="keywords" content="{{site.keywords}}">
 
-  <meta property="og:image" content="http://arrow-kt.io/img/poster.png" />
+  <meta property="og:image" content="https://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.name}}" />
   <meta property="og:site_name" content="{{site.name}}" />
   <meta property="og:url" content="{{site.url}}" />
@@ -17,7 +17,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="{{site.twitter_handle}}">
   <meta name="twitter:creator" content="{{site.twitter_handle}}">
-  <meta name="twitter:image" content="http://arrow-kt.io/img/poster.png" />
+  <meta name="twitter:image" content="https://arrow-kt.io/img/poster.png" />
 
   <script defer src="{{ '/js/main.js' | relative_url }}"></script>
   <script defer src="{{ '/js/main-hovers.js' | relative_url }}"></script>

--- a/modules/docs/arrow-docs/docs/_includes/_head.html
+++ b/modules/docs/arrow-docs/docs/_includes/_head.html
@@ -8,7 +8,7 @@
   <meta property="og:image" content="https://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.name}}" />
   <meta property="og:site_name" content="{{site.name}}" />
-  <meta property="og:url" content="{{site.url}}" />
+  <meta property="og:url" content="https://arrow-kt.io/" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="{{site.description}}" />
   <meta property="og:keywords" content="{{site.keywords}}" />

--- a/modules/docs/arrow-docs/docs/_includes/_head.html
+++ b/modules/docs/arrow-docs/docs/_includes/_head.html
@@ -5,7 +5,7 @@
   <meta name="description" content="{{site.description}}">
   <meta name="keywords" content="{{site.keywords}}">
 
-  <meta property="og:image" content="" />
+  <meta property="og:image" content="http://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.name}}" />
   <meta property="og:site_name" content="{{site.name}}" />
   <meta property="og:url" content="{{site.url}}" />
@@ -17,7 +17,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="{{site.twitter_handle}}">
   <meta name="twitter:creator" content="{{site.twitter_handle}}">
-  <meta name="twitter:image" content="" />
+  <meta name="twitter:image" content="http://arrow-kt.io/img/poster.png" />
 
   <script defer src="{{ '/js/main.js' | relative_url }}"></script>
   <script defer src="{{ '/js/main-hovers.js' | relative_url }}"></script>

--- a/modules/docs/arrow-docs/docs/_layouts/error.html
+++ b/modules/docs/arrow-docs/docs/_layouts/error.html
@@ -8,10 +8,10 @@
   <meta name="description" content="{{site.data.commons.description}}">
   <meta name="keywords" content="{{site.data.commons.keywords}}">
 
-  <meta property="og:image" content="http://arrow-kt.io/img/poster.png" />
+  <meta property="og:image" content="https://arrow-kt.io/img/poster.png" />
   <meta property="og:title" content="{{site.data.commons.name}}" />
   <meta property="og:site_name" content="{{site.data.commons.name}}" />
-  <meta property="og:url" content="http://arrow-kt.io/" />
+  <meta property="og:url" content="https://arrow-kt.io/" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="{{site.data.commons.description}}" />
   <meta property="og:keywords" content="{{site.data.commons.keywords}}" />
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@arrow_kt">
   <meta name="twitter:creator" content="@arrow_kt">
-  <meta name="twitter:image" content="http://arrow-kt.io/img/twitter-card.png" />
+  <meta name="twitter:image" content="https://arrow-kt.io/img/twitter-card.png" />
 
   <link rel="shortcut icon" href="{{ '/img/favicon.png' | relative_url }}">
   <!-- Arrow main css -->


### PR DESCRIPTION
It tries to fix the missing image:

![Screenshot from 2019-12-23 14-51-54](https://user-images.githubusercontent.com/22792183/71362372-21c37080-2596-11ea-83a2-8a34ff0b7ec0.png)

I tried it with [Twitter Card Validator](https://cards-dev.twitter.com/validator) and it works for https://arrow-kt.io/error.html:

![Screenshot from 2019-12-23 15-07-22](https://user-images.githubusercontent.com/22792183/71362419-44558980-2596-11ea-91b9-605b7508b3e6.png)

However, it doesn't work for the rest of the pages:

![Screenshot from 2019-12-23 15-07-39](https://user-images.githubusercontent.com/22792183/71362443-53d4d280-2596-11ea-88ab-ef98e476b646.png)

This pull request tries to fix the missing images.
