### PR TITLE
Fixed some typos in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Add the dependencies that you want to use
 
 #### Enabling kapt
 
-Enable annotaton processing using kotlin plugin 
+Enable annotation processing using kotlin plugin 
 ```
 <plugin>
     <groupId>org.jetbrains.kotlin</groupId>

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/datatypes/sequencek/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/datatypes/sequencek/README.md
@@ -11,7 +11,7 @@ redirect_from:
 
 
 
-SequenceK implements lazy lists representing lazily-evaluated ordered sequence of homogenous values.
+SequenceK implements lazy lists representing lazily-evaluated ordered sequence of homogeneous values.
 
 It can be created from Kotlin Sequence type with a convenient `k()` function.
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/datatypes/setk/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/datatypes/setk/README.md
@@ -14,7 +14,7 @@ video: xtnyCqeLI_4
 
 SetK(Kinded Wrapper) is a higher kinded wrapper around the the Set collection interface.
 
-It can be created from the Kotlin Set type with a convient `k()` function.
+It can be created from the Kotlin Set type with a convenient `k()` function.
 
 ```kotlin:ank
 import arrow.*

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/datatypes/sum/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/datatypes/sum/README.md
@@ -36,12 +36,12 @@ sum.changeSide(Sum.Side.Right).extract(Store.comonad(), Store.comonad())
 As Sum is also a `Comonad`, we have access to `coflatmap` and `map` for changing the `extract` result.
 
 ```kotlin:ank
-val overridenSum = sum.coflatmap(Store.comonad(), Store.comonad()) {
+val overriddenSum = sum.coflatmap(Store.comonad(), Store.comonad()) {
   when (it.side) {
     is Sum.Side.Left -> "Current side is Left"
     is Sum.Side.Right -> "Current side is Right"
   }
 }
 
-overridenSum.extract(Store.comonad(), Store.comonad())
+overriddenSum.extract(Store.comonad(), Store.comonad())
 ```

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/integrations/reactor/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/integrations/reactor/README.md
@@ -111,7 +111,7 @@ FluxK.monadThrow().fx.monadThrow {
 }
 ```
 
-Note that any unexpected exception, like `AritmeticException` when `totalTime` is 0, is automatically caught and wrapped inside the flux.
+Note that any unexpected exception, like `ArithmeticException` when `totalTime` is 0, is automatically caught and wrapped inside the flux.
 
 ### Subscription and cancellation
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/integrations/retrofit/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/integrations/retrofit/README.md
@@ -53,7 +53,7 @@ interface ApiClientTest {
 }
 ```
 
-You can use `CallK` to have [`Async`]({{ '/docs/effects/async' | relative_url }}), [`MonadDefer`]({{ '/docs/effects/monaddefer' | relative_url }}) and [`MonadError`]({{ '/docs/arrow/typeclasses/monaderror/' | relative_url }}) intances as your data wrapper.
+You can use `CallK` to have [`Async`]({{ '/docs/effects/async' | relative_url }}), [`MonadDefer`]({{ '/docs/effects/monaddefer' | relative_url }}) and [`MonadError`]({{ '/docs/arrow/typeclasses/monaderror/' | relative_url }}) instances as your data wrapper.
 
 ### Using `CallK` with `IO`
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/integrations/rx2/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/integrations/rx2/README.md
@@ -173,7 +173,7 @@ ObservableK.fx {
 }
 ```
 
-Note that any unexpected exception, like `AritmeticException` when `totalTime` is 0, is automatically caught and wrapped inside the observable.
+Note that any unexpected exception, like `ArithmeticException` when `totalTime` is 0, is automatically caught and wrapped inside the observable.
 
 ### Subscription and cancellation
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/patterns/glossary/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/patterns/glossary/README.md
@@ -400,7 +400,7 @@ A side-effect is a statement that changes something in the running environment. 
 
 When talking about side-effects, we generally see functions that have the signature `(...) -> Unit`, meaning that, unless the function doesn't do anything, there's at least one side-effect. Side-effects can also happen in the middle of another function, which is an undesirable behavior in Functional Programming.
 
-Side-effects are too general to be unitested for because they depend on the environment. They also have poor composability. Overall, they're considered to be outside the Functional Programming paradigm, and are often referred to as "impure" functions.
+Side-effects are too general to be unit tested for because they depend on the environment. They also have poor composability. Overall, they're considered to be outside the Functional Programming paradigm, and are often referred to as "impure" functions.
 
 Because side-effects are unavoidable in any program, FP provides several datatypes for dealing with them! One way is by abstracting their behavior. The simplest examples of this are the `Writer`datatype, which allows you to write to an information sink like a log or a file buffer; or `State` datatype, which simulates scoped mutable state for the duration of an operation.
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/libraries/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/libraries/README.md
@@ -256,4 +256,4 @@ dependencies {
 }
 ```
 
-It allows anonating data classes with [`@product`]({{ '/docs/generic/product/' | relative_url }}) to enable them to be structurally deconstructed in tuples and heterogeneous lists.
+It allows annotating data classes with [`@product`]({{ '/docs/generic/product/' | relative_url }}) to enable them to be structurally deconstructed in tuples and heterogeneous lists.

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/setup/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/setup/README.md
@@ -169,7 +169,7 @@ Add the dependencies that you want to use:
 
 #### Enabling kapt
 
-Enable annotaton processing using Kotlin plugin:
+Enable annotation processing using Kotlin plugin:
 ```
 <plugin>
     <groupId>org.jetbrains.kotlin</groupId>

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/align/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/align/README.md
@@ -38,7 +38,7 @@ Arrow provides [`AlignLaws`][functor_laws_source]{:target="_blank"} in the form 
 #### Creating your own `Align` instances
 
 Arrow already provides Align instances for common datatypes (e.g. Option, ListK, MapK). See their implementations
-and accomanying testcases for reference.
+and accompanying testcases for reference.
 
 See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | relative_url }})
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/divisible/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/divisible/README.md
@@ -12,7 +12,7 @@ redirect_from:
 
 
 `Divisible` extends upon `Divide` by providing an empty method called `conquer`.
-`conquer` is useful for proving identiy laws when working with `Divisible` instances.
+`conquer` is useful for proving identity laws when working with `Divisible` instances.
 
 Extending the serializer example from `Divide`, `conquer` would simply serialize data to an empty string.
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/order/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/order/README.md
@@ -35,7 +35,7 @@ import arrow.core.extensions.*
 Int.order().run { 1.compare(2) }
 ```
 
-Additionaly, `Order` overloads operators `>`, `<`, `<=`, and `>=`, following the Kotlin `compareTo` convention for every type where an `Order` instance exists.
+Additionally, `Order` overloads operators `>`, `<`, `<=`, and `>=`, following the Kotlin `compareTo` convention for every type where an `Order` instance exists.
 
 ```kotlin:ank
 Int.order().run { 1 > 2 }

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/semialign/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/semialign/README.md
@@ -13,7 +13,7 @@ redirect_from:
 
 The `Semialign` typeclass lets us combine two structures of type `Kind<F, A>` and `Kind<F, B>`
 into a single type `Kind<F, Ior<A,B>>`.
-The type `Ior<A,B>` thats used to hold the elements allows either side to be absent. This allows to combine the two structures
+The type `Ior<A,B>` that's used to hold the elements allows either side to be absent. This allows to combine the two structures
 without truncating to the size of the smaller input.
 
 ### Main Combinators

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/semigroup/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/semigroup/README.md
@@ -66,7 +66,7 @@ Option.semigroup(Int.semigroup()).run {
 
 Many of these types have methods defined directly on them, which allow for this example of combining: `+` on `List`. But the value of having a `Semigroup` typeclass available is that these compose.
 
-Additionaly, `Semigroup` adds `+` syntax to all types for which a Semigroup instance exists:
+Additionally, `Semigroup` adds `+` syntax to all types for which a Semigroup instance exists:
 
 ```kotlin:ank
 Option.semigroup(Int.semigroup()).run {

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/unalign/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/typeclasses/unalign/README.md
@@ -53,7 +53,7 @@ Arrow provides [`UnalignLaws`][functor_laws_source]{:target="_blank"} in the for
 #### Creating your own `Unalign` instances
 
 Arrow already provides Unalign instances for common datatypes (e.g. Option, ListK, MapK). See their implementations
-and accomanying testcases for reference.
+and accompanying testcases for reference.
 
 See [Deriving and creating custom typeclass]({{ '/docs/patterns/glossary' | relative_url }})
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-fx/fx/async/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-fx/fx/async/README.md
@@ -177,7 +177,7 @@ Arrow Fx can be seen as a companion to the KotlinX Coroutines library in the sam
 
 Arrow Fx adds an extra layer of security and effect control where we can easily model side effects and how they interact with pure computations.
 
-In contrast with the couroutines library, where `Deferred` computations are eager by default and fire immediately when instantiated, in Arrow Fx, all bindings and compositions are lazy and suspended, ensuring execution is explicit and always deferred until the last second.
+In contrast with the coroutines library, where `Deferred` computations are eager by default and fire immediately when instantiated, in Arrow Fx, all bindings and compositions are lazy and suspended, ensuring execution is explicit and always deferred until the last second.
 
 Deferring execution and being able to suspend side effects is essential for programs built with Arrow because we can ensure that effects run in a controlled environment and preserve the properties of purity and referential transparency, allowing us to apply equational reasoning over the different parts that conform our programs.
 
@@ -251,7 +251,7 @@ Life goes on.
 
 Arrow Fx offers, in contrast, a different approach that is in line with Arrow's primary concern——helping you, as a user, create well-typed, safe, and pure programs in Kotlin.
 
-On top of complementing the KolinX Coroutines API, Arrow Fx provides interoperability with its runtime, allowing you to run polymorphic programs over the KotlinX Coroutines, Rx2, Reactor, and even custom runtimes.
+On top of complementing the KotlinX Coroutines API, Arrow Fx provides interoperability with its runtime, allowing you to run polymorphic programs over the KotlinX Coroutines, Rx2, Reactor, and even custom runtimes.
 
 ## Integrating with third-party libraries
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-fx/monaddefer/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-fx/monaddefer/README.md
@@ -9,7 +9,7 @@ permalink: /docs/effects/monaddefer/
 
 
 
-`MonadDefer` is a typeclass to abstract over computations that cause side effects. This means that the computations are defered until they're are asked to be performed *synchronously*. Without effect suspension, the effects would otherwise run immediately.
+`MonadDefer` is a typeclass to abstract over computations that cause side effects. This means that the computations are deferred until they're are asked to be performed *synchronously*. Without effect suspension, the effects would otherwise run immediately.
 
 ```kotlin
 val now = IO.applicative().just(println("eager side effect"))

--- a/modules/docs/arrow-docs/docs/docs/arrow-incubator/aql/custom/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-incubator/aql/custom/README.md
@@ -15,7 +15,7 @@ In the example below we will create a minimal data holder data type that can con
 
 ## Creating a __custom data type__
 
-For simplicity the type in the example below is called `Box` and it mirrors the `Option` data type in terms of features. `Box` has two possible states `Empty` and `Full`. The `Empty` state repesents a missing value whereas the `Full<A>` state represents a `Box` that has an `A` value contained within.
+For simplicity the type in the example below is called `Box` and it mirrors the `Option` data type in terms of features. `Box` has two possible states `Empty` and `Full`. The `Empty` state represents a missing value whereas the `Full<A>` state represents a `Box` that has an `A` value contained within.
 
 ```kotlin
 /**

--- a/modules/docs/arrow-docs/docs/docs/arrow-incubator/datatypes/eithert/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-incubator/datatypes/eithert/README.md
@@ -107,7 +107,7 @@ val personDB: Map<Int, Person> = mapOf(
       )
 )
 
-val adressDB: Map<Int, Address> = mapOf(
+val addressDB: Map<Int, Address> = mapOf(
   1 to Address(
     id = 1,
     country = Some(
@@ -131,7 +131,7 @@ fun findPerson(personId: Int): ObservableK<Either<BizError, Person>> =
 
 fun findCountry(addressId: Int): ObservableK<Either<BizError, Country>> =
   ObservableK.just(
-    Option.fromNullable(adressDB.get(addressId))
+    Option.fromNullable(addressDB.get(addressId))
       .flatMap { it.country }
       .toEither { CountryNotFound(addressId) }
   ) //mock impl for simplicity

--- a/modules/docs/arrow-docs/docs/docs/arrow-incubator/datatypes/optiont/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-incubator/datatypes/optiont/README.md
@@ -85,7 +85,7 @@ val personDB: Map<Int, Person> = mapOf(
       )
 )
 
-val adressDB: Map<Int, Address> = mapOf(
+val addressDB: Map<Int, Address> = mapOf(
   1 to Address(
     id = 1,
     country = Some(
@@ -108,7 +108,7 @@ fun findPerson(personId : Int) : ObservableK<Option<Person>> =
 
 fun findCountry(addressId : Int) : ObservableK<Option<Country>> =
   ObservableK.just(
-    Option.fromNullable(adressDB.get(addressId)).flatMap { it.country }
+    Option.fromNullable(addressDB.get(addressId)).flatMap { it.country }
   ) //mock impl for simplicity
 
 ```

--- a/modules/docs/arrow-docs/docs/docs/arrow-incubator/free/recursion/intro/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-incubator/free/recursion/intro/README.md
@@ -239,7 +239,7 @@ fun factorial(i: Int): Int = IntListPattern.functor().hylo(multiply, downFrom, i
 
 Here we use the `IntListPattern` functor to model recursion which resembles a stack; we unfold a list as
 we traverse deeper into the call structure, then fold a list as we evaluate the result. This allows us
-to effectively model any recursive computation with recursion schemes, making them consistant and stack
+to effectively model any recursive computation with recursion schemes, making them consistent and stack
 safe.
 
 #### Typeclasses

--- a/modules/docs/arrow-docs/docs/docs/arrow-optics/iso/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-optics/iso/README.md
@@ -99,7 +99,7 @@ Composing an `Iso` with functions can also be useful for changing the input or o
 
 ```kotlin
 val unknownCode: (String) -> String? = { value ->
-    "unkown $value"
+    "unknown $value"
 }
 
 val nullableOptionIso: Iso<String?, Option<String>> = nullableToOption()

--- a/modules/docs/arrow-docs/docs/docs/arrow-optics/prism/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-optics/prism/README.md
@@ -73,7 +73,7 @@ val liftF = networkSuccessPrism.liftF(Option.applicative()) { None }
 liftF(networkResult)
 ```
 
-`Prisms` can easily be created by using any of the already mentioned constructors, although, for a `sealed class`, a `Prism` could easily be [generated](#generated-prisms). But we can also use a `PartialFuntion` to create a `Prism`.
+`Prisms` can easily be created by using any of the already mentioned constructors, although, for a `sealed class`, a `Prism` could easily be [generated](#generated-prisms). But we can also use a `PartialFunction` to create a `Prism`.
 
 ```kotlin:ank
 val doubleToInt: Prism<Double, Int> = Prism(
@@ -87,7 +87,7 @@ val doubleToInt: Prism<Double, Int> = Prism(
 
 ## Composition
 
-Nesting pattern matching blocks are tedious. We would prefer to define them seperately and compose them together. We can do that by composing mulitple `Prisms`.
+Nesting pattern matching blocks are tedious. We would prefer to define them separately and compose them together. We can do that by composing multiple `Prisms`.
 
 Let's imagine from our previous example that we want to retrieve an `Int` from the network. We get a `Success` OR a `Failure` from the network. In case of a `Success`, we want to safely cast the `String` to an `Int`.
 


### PR DESCRIPTION
I noticed a couple of typos as I was reading through the documentation. So I took a few minutes to find any others.

They are all simple spelling typos, except perhaps my change of `unitested` to `unit tested`. At a minimum, `unitested` is missing a `t` in the middle, and needs to be `unittested`. That said, I have always seen it as two words, and could not find any examples of `unittested` as a single word via an internet search. But I did find numerous examples of it as separate words. So I would argue the convention is for it to be two words.