### PR TITLE
use GenK to generate testdata (ProfuctorLaws/CategoryLaws)

### DIFF
--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
@@ -47,11 +47,11 @@ class AndThenTest : UnitSpec() {
   init {
 
     testLaws(
-      MonadLaws.laws(AndThen.monad(), AndThen.functor(), AndThen.applicative(), AndThen.monad(), AndThen.genK<Int>(), AndThen.eqK<Int>()),
+      MonadLaws.laws(AndThen.monad(), AndThen.functor(), AndThen.applicative(), AndThen.monad(), AndThen.genK(), AndThen.eqK<Int>()),
       MonoidLaws.laws(AndThen.monoid<Int, Int>(Int.monoid()), Gen.int().map { i -> AndThen<Int, Int> { i } }, EQ),
-      ContravariantLaws.laws(AndThen.contravariant<Int>(), conestedGENK(), conestedEQK),
-      ProfunctorLaws.laws(AndThen.profunctor(), AndThen.genK<Int>(), AndThen.eqK()),
-      CategoryLaws.laws<ForAndThen>(AndThen.category(), AndThen.genK<Int>(), AndThen.eqK<Int>())
+      ContravariantLaws.laws(AndThen.contravariant(), conestedGENK(), conestedEQK),
+      ProfunctorLaws.laws(AndThen.profunctor(), AndThen.genK(), AndThen.eqK()),
+      CategoryLaws.laws(AndThen.category(), AndThen.genK(), AndThen.eqK())
     )
 
     "compose a chain of functions with andThen should be same with AndThen" {

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
@@ -51,7 +51,7 @@ class AndThenTest : UnitSpec() {
       MonoidLaws.laws(AndThen.monoid<Int, Int>(Int.monoid()), Gen.int().map { i -> AndThen<Int, Int> { i } }, EQ),
       ContravariantLaws.laws(AndThen.contravariant<Int>(), conestedGENK(), conestedEQK),
       ProfunctorLaws.laws(AndThen.profunctor(), AndThen.genK<Int>(), AndThen.eqK()),
-      CategoryLaws.laws(AndThen.category(), { AndThen.just(it) }, EQ)
+      CategoryLaws.laws<ForAndThen>(AndThen.category(), AndThen.genK<Int>(), AndThen.eqK<Int>())
     )
 
     "compose a chain of functions with andThen should be same with AndThen" {

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
@@ -50,7 +50,7 @@ class AndThenTest : UnitSpec() {
       MonadLaws.laws(AndThen.monad(), AndThen.functor(), AndThen.applicative(), AndThen.monad(), AndThen.genK<Int>(), AndThen.eqK<Int>()),
       MonoidLaws.laws(AndThen.monoid<Int, Int>(Int.monoid()), Gen.int().map { i -> AndThen<Int, Int> { i } }, EQ),
       ContravariantLaws.laws(AndThen.contravariant<Int>(), conestedGENK(), conestedEQK),
-      ProfunctorLaws.laws(AndThen.profunctor(), { AndThen.just(it) }, EQ),
+      ProfunctorLaws.laws(AndThen.profunctor(), AndThen.genK<Int>(), AndThen.eqK()),
       CategoryLaws.laws(AndThen.category(), { AndThen.just(it) }, EQ)
     )
 

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function1Test.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function1Test.kt
@@ -66,7 +66,7 @@ class Function1Test : UnitSpec() {
       DivisibleLaws.laws(Function1.divisible(Int.monoid()), conestedGENK(), conestedEQK),
       ProfunctorLaws.laws(Function1.profunctor(), genk(), EQK(123)),
       MonadLaws.laws(Function1.monad(), Function1.functor(), Function1.applicative(), Function1.monad(), genk(), EQK(5150)),
-      CategoryLaws.laws(Function1.category(), { Function1.just(it) }, EQ)
+      CategoryLaws.laws(Function1.category(), genk(), EQK(123))
     )
 
     "Semigroup of Function1<A> is Function1<Semigroup<A>>" {

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function1Test.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/Function1Test.kt
@@ -64,7 +64,7 @@ class Function1Test : UnitSpec() {
     testLaws(
       MonoidLaws.laws(Function1.monoid<Int, Int>(Int.monoid()), Gen.constant({ a: Int -> a + 1 }.k()), EQ),
       DivisibleLaws.laws(Function1.divisible(Int.monoid()), conestedGENK(), conestedEQK),
-      ProfunctorLaws.laws(Function1.profunctor(), { Function1.just(it) }, EQ),
+      ProfunctorLaws.laws(Function1.profunctor(), genk(), EQK(123)),
       MonadLaws.laws(Function1.monad(), Function1.functor(), Function1.applicative(), Function1.monad(), genk(), EQK(5150)),
       CategoryLaws.laws(Function1.category(), { Function1.just(it) }, EQ)
     )

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/CategoryLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/CategoryLaws.kt
@@ -1,32 +1,50 @@
 package arrow.test.laws
 
+import arrow.Kind
 import arrow.Kind2
+import arrow.core.extensions.eq
+import arrow.test.generators.GenK
 import arrow.typeclasses.Category
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 
 object CategoryLaws {
 
-  fun <F> laws(C: Category<F>, f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): List<Law> =
+  fun <F> laws(C: Category<F>, GENK: GenK<Kind<F, Int>>, EQK: EqK<Kind<F, Int>>): List<Law> {
+    val G = GENK.genK(Gen.int())
+    val EQ = EQK.liftEq(Int.eq())
+
+    return categoryLaws<F>(C, G, EQ)
+  }
+
+  fun <F> laws(C: Category<F>, f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): List<Law> {
+
+    val G = Gen.int().map(f)
+
+    return categoryLaws<F>(C, G, EQ)
+  }
+
+  private fun <F> categoryLaws(C: Category<F>, G: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): List<Law> =
     listOf(
-      Law("Category Laws: right identity") { C.rightIdentity(f, EQ) },
-      Law("Category Laws: left identity") { C.leftIdentity(f, EQ) },
-      Law("Category Laws: associativity") { C.associativity(f, EQ) }
+      Law("Category Laws: right identity") { C.rightIdentity(G, EQ) },
+      Law("Category Laws: left identity") { C.leftIdentity(G, EQ) },
+      Law("Category Laws: associativity") { C.associativity(G, EQ) }
     )
 
-  fun <F> Category<F>.rightIdentity(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-    forAll(Gen.int().map(f)) { fa: Kind2<F, Int, Int> ->
+  fun <F> Category<F>.rightIdentity(G: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(G) { fa: Kind2<F, Int, Int> ->
       fa.compose(id()).equalUnderTheLaw(fa, EQ)
     }
 
-  fun <F> Category<F>.leftIdentity(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-    forAll(Gen.int().map(f)) { fa: Kind2<F, Int, Int> ->
+  fun <F> Category<F>.leftIdentity(G: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(G) { fa: Kind2<F, Int, Int> ->
       id<Int>().compose(fa).equalUnderTheLaw(fa, EQ)
     }
 
-  fun <F> Category<F>.associativity(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-    forAll(Gen.int().map(f), Gen.int().map(f), Gen.int().map(f)) { a, b, c ->
+  fun <F> Category<F>.associativity(G: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(G, G, G) { a, b, c ->
       a.compose(b).compose(c).equalUnderTheLaw(a.compose(b.compose(c)), EQ)
     }
 }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ProfunctorLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ProfunctorLaws.kt
@@ -1,66 +1,75 @@
 package arrow.test.laws
 
+import arrow.Kind
 import arrow.Kind2
 import arrow.core.andThen
+import arrow.core.extensions.eq
+import arrow.test.generators.GenK
 import arrow.test.generators.functionAToB
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqK
 import arrow.typeclasses.Profunctor
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 
 object ProfunctorLaws {
 
-    fun <F> laws(PF: Profunctor<F>, f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): List<Law> =
-        listOf(
-            Law("Profunctor Laws: Identity") { PF.identity(f, EQ) },
-            Law("Profunctor Laws: Composition") { PF.composition(f, EQ) },
-            Law("Profunctor Laws: Lmap Identity") { PF.lMapIdentity(f, EQ) },
-            Law("Profunctor Laws: Rmap Identity") { PF.rMapIdentity(f, EQ) },
-            Law("Profunctor Laws: Lmap Composition") { PF.lMapComposition(f, EQ) },
-            Law("Profunctor Laws: Rmap Composition") { PF.rMapComposition(f, EQ) }
-        )
+  fun <F> laws(PF: Profunctor<F>, GENK: GenK<Kind<F, Int>>, EQK: EqK<Kind<F, Int>>): List<Law> {
 
-    fun <F> Profunctor<F>.identity(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-        forAll(Gen.int().map(f)) { fa: Kind2<F, Int, Int> ->
-            fa.dimap<Int, Int, Int, Int>({ it }, { it }).equalUnderTheLaw(fa, EQ)
-        }
+    val G = GENK.genK(Gen.int())
+    val EQ = EQK.liftEq(Int.eq())
 
-    fun <F> Profunctor<F>.composition(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-        forAll(
-          Gen.int().map(f),
-          Gen.functionAToB<Int, Int>(Gen.int()),
-          Gen.functionAToB<Int, Int>(Gen.int()),
-          Gen.functionAToB<Int, Int>(Gen.int()),
-          Gen.functionAToB<Int, Int>(Gen.int())
-        ) { fa: Kind2<F, Int, Int>, ff, g, x, y ->
-            fa.dimap(ff, g).dimap(x, y).equalUnderTheLaw(fa.dimap(x andThen ff, g andThen y), EQ)
-        }
+    return listOf(
+      Law("Profunctor Laws: Identity") { PF.identity(G, EQ) },
+      Law("Profunctor Laws: Composition") { PF.composition(G, EQ) },
+      Law("Profunctor Laws: Lmap Identity") { PF.lMapIdentity(G, EQ) },
+      Law("Profunctor Laws: Rmap Identity") { PF.rMapIdentity(G, EQ) },
+      Law("Profunctor Laws: Lmap Composition") { PF.lMapComposition(G, EQ) },
+      Law("Profunctor Laws: Rmap Composition") { PF.rMapComposition(G, EQ) }
+      )
+  }
 
-    fun <F> Profunctor<F>.lMapIdentity(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-        forAll(Gen.int().map(f)) { fa: Kind2<F, Int, Int> ->
-            fa.lmap<Int, Int, Int> { it }.equalUnderTheLaw(fa, EQ)
-        }
+  fun <F> Profunctor<F>.identity(f: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(f) { fa: Kind2<F, Int, Int> ->
+      fa.dimap<Int, Int, Int, Int>({ it }, { it }).equalUnderTheLaw(fa, EQ)
+    }
 
-    fun <F> Profunctor<F>.rMapIdentity(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-        forAll(Gen.int().map(f)) { fa: Kind2<F, Int, Int> ->
-            fa.rmap { it }.equalUnderTheLaw(fa, EQ)
-        }
+  fun <F> Profunctor<F>.composition(f: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(
+      f,
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int())
+    ) { fa: Kind2<F, Int, Int>, ff, g, x, y ->
+      fa.dimap(ff, g).dimap(x, y).equalUnderTheLaw(fa.dimap(x andThen ff, g andThen y), EQ)
+    }
 
-    fun <F> Profunctor<F>.lMapComposition(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-        forAll(
-          Gen.int().map(f),
-          Gen.functionAToB<Int, Int>(Gen.int()),
-          Gen.functionAToB<Int, Int>(Gen.int())
-        ) { fa: Kind2<F, Int, Int>, ff, g ->
-            fa.lmap(g).lmap(ff).equalUnderTheLaw(fa.lmap(ff andThen g), EQ)
-        }
+  fun <F> Profunctor<F>.lMapIdentity(f: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(f) { fa: Kind2<F, Int, Int> ->
+      fa.lmap<Int, Int, Int> { it }.equalUnderTheLaw(fa, EQ)
+    }
 
-    fun <F> Profunctor<F>.rMapComposition(f: (Int) -> Kind2<F, Int, Int>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
-        forAll(
-          Gen.int().map(f),
-          Gen.functionAToB<Int, Int>(Gen.int()),
-          Gen.functionAToB<Int, Int>(Gen.int())
-        ) { fa: Kind2<F, Int, Int>, ff, g ->
-            fa.lmap(ff).lmap(g).equalUnderTheLaw(fa.lmap(ff andThen g), EQ)
-        }
+  fun <F> Profunctor<F>.rMapIdentity(f: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(f) { fa: Kind2<F, Int, Int> ->
+      fa.rmap { it }.equalUnderTheLaw(fa, EQ)
+    }
+
+  fun <F> Profunctor<F>.lMapComposition(f: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(
+      f,
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int())
+    ) { fa: Kind2<F, Int, Int>, ff, g ->
+      fa.lmap(g).lmap(ff).equalUnderTheLaw(fa.lmap(ff andThen g), EQ)
+    }
+
+  fun <F> Profunctor<F>.rMapComposition(f: Gen<Kind2<F, Int, Int>>, EQ: Eq<Kind2<F, Int, Int>>): Unit =
+    forAll(
+      f,
+      Gen.functionAToB<Int, Int>(Gen.int()),
+      Gen.functionAToB<Int, Int>(Gen.int())
+    ) { fa: Kind2<F, Int, Int>, ff, g ->
+      fa.lmap(ff).lmap(g).equalUnderTheLaw(fa.lmap(ff andThen g), EQ)
+    }
 }

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -132,8 +132,8 @@ class ScheduleTest : UnitSpec() {
       ),
       CategoryLaws.laws(
         Schedule.category(Id.monad()),
-        { i: Int -> Schedule.applicative<ForId, Int>(Id.monad()).just(i) },
-        EQK(Id.eqK(), Id.monad(), 0).liftEq(Int.eq())
+        Schedule.genK<ForId, Int>(Id.monad()),
+        EQK(Id.eqK(), Id.monad(), 0)
       )
     )
 

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -127,8 +127,8 @@ class ScheduleTest : UnitSpec() {
       ),
       ProfunctorLaws.laws(
         Schedule.profunctor(),
-        { i: Int -> Schedule.applicative<ForId, Int>(Id.monad()).just(i) },
-        EQK(Id.eqK(), Id.monad(), 0).liftEq(Int.eq())
+        Schedule.genK<ForId, Int>(Id.monad()),
+        EQK(Id.eqK(), Id.monad(), 0)
       ),
       CategoryLaws.laws(
         Schedule.category(Id.monad()),


### PR DESCRIPTION
use GenK to generate testdata. this is a part of (#1858)

modified laws are:
* ProfunctorLaws
* CategoryLaws