### PR TITLE
Fix OptionT applicative to short-circuit properly

### DIFF
--- a/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/OptionT.kt
+++ b/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/OptionT.kt
@@ -62,12 +62,8 @@ data class OptionT<F, A>(private val value: Kind<F, Option<A>>) : OptionTOf<F, A
 
   fun <B> cata(FF: Functor<F>, default: () -> B, f: (A) -> B): Kind<F, B> = fold(FF, default, f)
 
-  fun <B> ap(AF: Applicative<F>, ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
-    OptionT(AF.map(ff.value(), value) { (a, b) ->
-      b.flatMap { bb ->
-        a.map { f -> f(bb) }
-      }
-    })
+  fun <B> ap(MF: Monad<F>, ff: OptionTOf<F, (A) -> B>): OptionT<F, B> =
+    flatMap(MF) { a -> ff.fix().map(MF) { it(a) } }
 
   fun <B> flatMap(MF: Monad<F>, f: (A) -> OptionTOf<F, B>): OptionT<F, B> = flatMapF(MF) { f(it).value() }
 

--- a/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/OptionTTest.kt
+++ b/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/OptionTTest.kt
@@ -67,7 +67,7 @@ class OptionTTest : UnitSpec() {
       ConcurrentLaws.laws(
         OptionT.concurrent(IO.concurrent()),
         OptionT.functor(IO.functor()),
-        OptionT.applicative(IO.applicative()),
+        OptionT.applicative(IO.monad()),
         OptionT.monad(IO.monad()),
         OptionT.genK(IO.genK()),
         ioEQK


### PR DESCRIPTION
Currently `OptionT.ap` always evaluated both arguments before checking the `Option` in the first one. This leads to fun things like `listOf(1,2,3,4).traverse(OptionT.monad(IO.monad())) { OptionT(IO { println(it); None }) }` printing 1,2,3,4 instead of just 1.