### PR TITLE
Add deriving option for `@product` annotation

### DIFF
--- a/modules/meta/arrow-annotations/src/main/java/arrow/product.kt
+++ b/modules/meta/arrow-annotations/src/main/java/arrow/product.kt
@@ -5,4 +5,11 @@ import kotlin.annotation.AnnotationTarget.CLASS
 
 @Retention(SOURCE)
 @Target(CLASS)
-annotation class product
+/**
+ * Empty arrays means "Everything that matches annotated class"
+ */
+annotation class product(val deriving: Array<DerivingTarget> = [])
+
+enum class DerivingTarget {
+  SEMIGROUP, MONOID, TUPLED, HLIST, APPLICATIVE, EQ, SHOW
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Applicative.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Applicative.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.APPLICATIVE])
+data class Applicative(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Eq.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Eq.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.EQ])
+data class Eq(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/HList.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/HList.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.HLIST])
+data class HList(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Monoid.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Monoid.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.MONOID])
+data class Monoid(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/ProductWithoutCompanion.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/ProductWithoutCompanion.kt
@@ -1,0 +1,7 @@
+package arrow.ap.objects.generic
+
+import arrow.core.Option
+import arrow.product
+
+@product
+data class ProductWithoutCompanion(val field: String, val option: Option<String>)

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/ProductXXL.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/ProductXXL.kt
@@ -1,0 +1,32 @@
+package arrow.ap.objects.generic
+
+import arrow.product
+
+@product
+data class ProductXXL(
+  val field1: String,
+  val field2: String,
+  val field3: String,
+  val field4: String,
+  val field5: String,
+  val field6: String,
+  val field7: String,
+  val field8: String,
+  val field9: String,
+  val field10: String,
+  val field11: String,
+  val field12: String,
+  val field13: String,
+  val field14: String,
+  val field15: String,
+  val field16: String,
+  val field17: String,
+  val field18: String,
+  val field19: String,
+  val field20: String,
+  val field21: String,
+  val field22: String,
+  val field23: String
+) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Semigroup.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Semigroup.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.SEMIGROUP])
+data class Semigroup(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Show.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Show.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.SHOW])
+data class Show(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Tupled.kt
+++ b/modules/meta/arrow-meta/models/src/main/java/arrow/ap/objects/generic/Tupled.kt
@@ -1,0 +1,10 @@
+package arrow.ap.objects.generic
+
+import arrow.DerivingTarget
+import arrow.core.Option
+import arrow.product
+
+@product([DerivingTarget.TUPLED])
+data class Tupled(val field: String, val option: Option<String>) {
+  companion object
+}

--- a/modules/meta/arrow-meta/src/main/java/arrow/generic/AnnotatedDomain.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/generic/AnnotatedDomain.kt
@@ -1,11 +1,12 @@
 package arrow.generic
 
+import arrow.DerivingTarget
 import arrow.common.utils.ClassOrPackageDataWrapper
 import arrow.common.utils.fullName
 import me.eugeniomarletti.kotlin.metadata.escapedClassName
 import javax.lang.model.element.TypeElement
 
-data class AnnotatedGeneric(val type: TypeElement, val classData: ClassOrPackageDataWrapper.Class, val targets: List<Target>) {
+data class AnnotatedGeneric(val type: TypeElement, val classData: ClassOrPackageDataWrapper.Class, val targets: List<Target>, val deriving: List<DerivingTarget>) {
   val sourceClassName = classData.fullName.escapedClassName
   val sourceSimpleName = type.simpleName.toString()
   val sourceName = type.simpleName.toString().decapitalize()

--- a/modules/meta/arrow-meta/src/test/java/arrow/ap/tests/ProductTest.kt
+++ b/modules/meta/arrow-meta/src/test/java/arrow/ap/tests/ProductTest.kt
@@ -1,0 +1,74 @@
+package arrow.ap.tests
+
+import arrow.generic.ProductProcessor
+
+class ProductTest : APTest("arrow.ap.objects.generic", enforcePackage = false) {
+
+  init {
+
+    testProcessor(AnnotationProcessor(
+      name = "Product instances cannot be generated for huge classes",
+      sourceFiles = listOf("ProductXXL.java"),
+      errorMessage = "arrow.ap.objects.generic.ProductXXL up to 22 constructor parameters is supported",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Product instances generation requires companion object declaration",
+      sourceFiles = listOf("ProductWithoutCompanion.java"),
+      errorMessage = "@product annotated class arrow.ap.objects.generic.ProductWithoutCompanion needs to declare companion object.",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Semigroup instance will be generated for data class annotated with @product([DerivingTarget.SEMIGROUP])",
+      sourceFiles = listOf("Semigroup.java"),
+      destFile = "Semigroup.kt",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Semigroup and Monoid instances will be generated for data class annotated with @product([DerivingTarget.MONOID])",
+      sourceFiles = listOf("Monoid.java"),
+      destFile = "Monoid.kt",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Method `.tupled()` will be generated for data class annotated with @product([DerivingTarget.TUPLED])",
+      sourceFiles = listOf("Tupled.java"),
+      destFile = "Tupled.kt",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Method `.toHList()` will be generated for data class annotated with @product([DerivingTarget.HLIST])",
+      sourceFiles = listOf("HList.java"),
+      destFile = "HList.kt",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Applicative instance and method `.tupled()` will be generated for data class annotated with @product([DerivingTarget.APPLICATIVE])",
+      sourceFiles = listOf("Applicative.java"),
+      destFile = "Applicative.kt",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Eq instance will be generated for data class annotated with @product([DerivingTarget.EQ])",
+      sourceFiles = listOf("Eq.java"),
+      destFile = "Eq.kt",
+      processor = ProductProcessor()
+    ))
+
+    testProcessor(AnnotationProcessor(
+      name = "Show instance will be generated for data class annotated with @product([DerivingTarget.SHOw])",
+      sourceFiles = listOf("Show.java"),
+      destFile = "Show.kt",
+      processor = ProductProcessor()
+    ))
+
+  }
+
+}

--- a/modules/meta/arrow-meta/src/test/java/arrow/ap/tests/ProductTest.kt
+++ b/modules/meta/arrow-meta/src/test/java/arrow/ap/tests/ProductTest.kt
@@ -68,7 +68,5 @@ class ProductTest : APTest("arrow.ap.objects.generic", enforcePackage = false) {
       destFile = "Show.kt",
       processor = ProductProcessor()
     ))
-
   }
-
 }

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Applicative.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Applicative.kt
@@ -1,0 +1,23 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.core.*
+import arrow.core.extensions.*
+import arrow.typeclasses.*
+
+fun `arrow`.`ap`.`objects`.`generic`.`Applicative`.tupled(): arrow.core.Tuple2<`kotlin`.`String`, `arrow`.`core`.`Option`<`kotlin`.`String`>> =
+  arrow.core.Tuple2(this.`field`, this.`option`)
+
+fun `arrow`.`ap`.`objects`.`generic`.`Applicative`.tupledLabeled(): arrow.core.Tuple2<arrow.core.Tuple2<String, `kotlin`.`String`>, arrow.core.Tuple2<String, `arrow`.`core`.`Option`<`kotlin`.`String`>>> =
+  arrow.core.Tuple2(("field" toT field), ("option" toT option))
+
+fun <B> `arrow`.`ap`.`objects`.`generic`.`Applicative`.foldLabeled(f: (arrow.core.Tuple2<kotlin.String, `kotlin`.`String`>, arrow.core.Tuple2<kotlin.String, `arrow`.`core`.`Option`<`kotlin`.`String`>>) -> B): B {
+  val t = tupledLabeled()
+  return f(t.a, t.b)
+}
+
+fun arrow.core.Tuple2<`kotlin`.`String`, `arrow`.`core`.`Option`<`kotlin`.`String`>>.toApplicative(): `arrow`.`ap`.`objects`.`generic`.`Applicative` =
+  `arrow`.`ap`.`objects`.`generic`.`Applicative`(this.a, this.b)
+
+fun <F> arrow.typeclasses.Applicative<F>.mapToApplicative(field: arrow.Kind<F, `kotlin`.`String`>, option: arrow.Kind<F, `arrow`.`core`.`Option`<`kotlin`.`String`>>): arrow.Kind<F, `arrow`.`ap`.`objects`.`generic`.`Applicative`> =
+  this.map(field, option) { it.toApplicative() }
+

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Eq.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Eq.kt
@@ -1,0 +1,17 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.typeclasses.*
+
+interface EqEq : arrow.typeclasses.Eq<`arrow`.`ap`.`objects`.`generic`.`Eq`> {
+  override fun `arrow`.`ap`.`objects`.`generic`.`Eq`.eqv(b: `arrow`.`ap`.`objects`.`generic`.`Eq`): Boolean =
+    this == b
+
+  companion object {
+    val defaultInstance : arrow.typeclasses.Eq<`arrow`.`ap`.`objects`.`generic`.`Eq`> =
+      object : EqEq{}
+  }
+}
+
+fun `arrow`.`ap`.`objects`.`generic`.`Eq`.Companion.eq(): arrow.typeclasses.Eq<`arrow`.`ap`.`objects`.`generic`.`Eq`> =
+  EqEq.defaultInstance
+

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/HList.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/HList.kt
@@ -1,0 +1,14 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.core.*
+import arrow.core.extensions.*
+
+fun `arrow`.`ap`.`objects`.`generic`.`HList`.toHList(): arrow.generic.HList2<`kotlin`.`String`, `arrow`.`core`.`Option`<`kotlin`.`String`>> =
+  arrow.generic.hListOf(this.`field`, this.`option`)
+
+fun arrow.generic.HList2<`kotlin`.`String`, `arrow`.`core`.`Option`<`kotlin`.`String`>>.toHList(): `arrow`.`ap`.`objects`.`generic`.`HList` =
+  `arrow`.`ap`.`objects`.`generic`.`HList`(this.head, this.tail.head)
+
+fun `arrow`.`ap`.`objects`.`generic`.`HList`.toHListLabeled(): arrow.generic.HList2<arrow.core.Tuple2<String, `kotlin`.`String`>, arrow.core.Tuple2<String, `arrow`.`core`.`Option`<`kotlin`.`String`>>> =
+  arrow.generic.hListOf(("field" toT field), ("option" toT option))
+

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Monoid.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Monoid.kt
@@ -1,0 +1,48 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.typeclasses.*
+import arrow.core.extensions.*
+import arrow.core.extensions.option.semigroup.semigroup
+import arrow.core.extensions.option.monoid.monoid
+
+fun `arrow`.`ap`.`objects`.`generic`.`Monoid`.combine(other: `arrow`.`ap`.`objects`.`generic`.`Monoid`): `arrow`.`ap`.`objects`.`generic`.`Monoid` =
+  this + other
+
+fun List<`arrow`.`ap`.`objects`.`generic`.`Monoid`>.combineAll(): `arrow`.`ap`.`objects`.`generic`.`Monoid` =
+  this.reduce { a, b -> a + b }
+
+operator fun `arrow`.`ap`.`objects`.`generic`.`Monoid`.plus(other: `arrow`.`ap`.`objects`.`generic`.`Monoid`): `arrow`.`ap`.`objects`.`generic`.`Monoid` =
+  with(`arrow`.`ap`.`objects`.`generic`.`Monoid`.semigroup()) { this@plus.combine(other) }
+
+fun emptyMonoid(): `arrow`.`ap`.`objects`.`generic`.`Monoid` =
+  `arrow`.`ap`.`objects`.`generic`.`Monoid`.monoid().empty()
+
+interface MonoidSemigroup : arrow.typeclasses.Semigroup<`arrow`.`ap`.`objects`.`generic`.`Monoid`> {
+  override fun `arrow`.`ap`.`objects`.`generic`.`Monoid`.combine(b: `arrow`.`ap`.`objects`.`generic`.`Monoid`): `arrow`.`ap`.`objects`.`generic`.`Monoid` {
+    val (xA, xB) = this
+    val (yA, yB) = b
+    return `arrow`.`ap`.`objects`.`generic`.`Monoid`(with(`kotlin`.`String`.semigroup()){ xA.combine(yA) }, with(`arrow`.`core`.`Option`.semigroup<`kotlin`.`String`>(`kotlin`.`String`.semigroup())){ xB.combine(yB) })
+  }
+
+  companion object {
+    val defaultInstance : arrow.typeclasses.Semigroup<`arrow`.`ap`.`objects`.`generic`.`Monoid`> =
+      object : MonoidSemigroup{}
+  }
+}
+
+fun `arrow`.`ap`.`objects`.`generic`.`Monoid`.Companion.semigroup(): arrow.typeclasses.Semigroup<`arrow`.`ap`.`objects`.`generic`.`Monoid`> =
+  MonoidSemigroup.defaultInstance
+
+interface MonoidMonoid: arrow.typeclasses.Monoid<`arrow`.`ap`.`objects`.`generic`.`Monoid`>, MonoidSemigroup {
+  override fun empty(): `arrow`.`ap`.`objects`.`generic`.`Monoid` =
+    `arrow`.`ap`.`objects`.`generic`.`Monoid`(with(`kotlin`.`String`.monoid()){ empty() }, with(`arrow`.`core`.`Option`.monoid<`kotlin`.`String`>(`kotlin`.`String`.monoid())){ empty() })
+
+  companion object {
+    val defaultInstance : arrow.typeclasses.Monoid<`arrow`.`ap`.`objects`.`generic`.`Monoid`> =
+      object : MonoidMonoid{}
+  }
+}
+
+fun `arrow`.`ap`.`objects`.`generic`.`Monoid`.Companion.monoid(): arrow.typeclasses.Monoid<`arrow`.`ap`.`objects`.`generic`.`Monoid`> =
+  MonoidMonoid.defaultInstance
+

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Semigroup.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Semigroup.kt
@@ -1,0 +1,31 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.typeclasses.*
+import arrow.core.extensions.*
+import arrow.core.extensions.option.semigroup.semigroup
+
+fun `arrow`.`ap`.`objects`.`generic`.`Semigroup`.combine(other: `arrow`.`ap`.`objects`.`generic`.`Semigroup`): `arrow`.`ap`.`objects`.`generic`.`Semigroup` =
+  this + other
+
+fun List<`arrow`.`ap`.`objects`.`generic`.`Semigroup`>.combineAll(): `arrow`.`ap`.`objects`.`generic`.`Semigroup` =
+  this.reduce { a, b -> a + b }
+
+operator fun `arrow`.`ap`.`objects`.`generic`.`Semigroup`.plus(other: `arrow`.`ap`.`objects`.`generic`.`Semigroup`): `arrow`.`ap`.`objects`.`generic`.`Semigroup` =
+  with(`arrow`.`ap`.`objects`.`generic`.`Semigroup`.semigroup()) { this@plus.combine(other) }
+
+interface SemigroupSemigroup : arrow.typeclasses.Semigroup<`arrow`.`ap`.`objects`.`generic`.`Semigroup`> {
+  override fun `arrow`.`ap`.`objects`.`generic`.`Semigroup`.combine(b: `arrow`.`ap`.`objects`.`generic`.`Semigroup`): `arrow`.`ap`.`objects`.`generic`.`Semigroup` {
+    val (xA, xB) = this
+    val (yA, yB) = b
+    return `arrow`.`ap`.`objects`.`generic`.`Semigroup`(with(`kotlin`.`String`.semigroup()){ xA.combine(yA) }, with(`arrow`.`core`.`Option`.semigroup<`kotlin`.`String`>(`kotlin`.`String`.semigroup())){ xB.combine(yB) })
+  }
+
+  companion object {
+    val defaultInstance : arrow.typeclasses.Semigroup<`arrow`.`ap`.`objects`.`generic`.`Semigroup`> =
+      object : SemigroupSemigroup{}
+  }
+}
+
+fun `arrow`.`ap`.`objects`.`generic`.`Semigroup`.Companion.semigroup(): arrow.typeclasses.Semigroup<`arrow`.`ap`.`objects`.`generic`.`Semigroup`> =
+  SemigroupSemigroup.defaultInstance
+

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Show.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Show.kt
@@ -1,0 +1,12 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.typeclasses.*
+
+interface ShowShow : arrow.typeclasses.Show<`arrow`.`ap`.`objects`.`generic`.`Show`> {
+  override fun `arrow`.`ap`.`objects`.`generic`.`Show`.show(): String =
+    this.toString()
+}
+
+fun `arrow`.`ap`.`objects`.`generic`.`Show`.Companion.show(): arrow.typeclasses.Show<`arrow`.`ap`.`objects`.`generic`.`Show`> =
+  object : ShowShow{}
+

--- a/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Tupled.kt
+++ b/modules/meta/arrow-meta/src/test/resources/arrow/ap/objects/generic/Tupled.kt
@@ -1,0 +1,19 @@
+package `arrow`.`ap`.`objects`.`generic`
+
+import arrow.core.*
+import arrow.core.extensions.*
+
+fun `arrow`.`ap`.`objects`.`generic`.`Tupled`.tupled(): arrow.core.Tuple2<`kotlin`.`String`, `arrow`.`core`.`Option`<`kotlin`.`String`>> =
+  arrow.core.Tuple2(this.`field`, this.`option`)
+
+fun `arrow`.`ap`.`objects`.`generic`.`Tupled`.tupledLabeled(): arrow.core.Tuple2<arrow.core.Tuple2<String, `kotlin`.`String`>, arrow.core.Tuple2<String, `arrow`.`core`.`Option`<`kotlin`.`String`>>> =
+  arrow.core.Tuple2(("field" toT field), ("option" toT option))
+
+fun <B> `arrow`.`ap`.`objects`.`generic`.`Tupled`.foldLabeled(f: (arrow.core.Tuple2<kotlin.String, `kotlin`.`String`>, arrow.core.Tuple2<kotlin.String, `arrow`.`core`.`Option`<`kotlin`.`String`>>) -> B): B {
+  val t = tupledLabeled()
+  return f(t.a, t.b)
+}
+
+fun arrow.core.Tuple2<`kotlin`.`String`, `arrow`.`core`.`Option`<`kotlin`.`String`>>.toTupled(): `arrow`.`ap`.`objects`.`generic`.`Tupled` =
+  `arrow`.`ap`.`objects`.`generic`.`Tupled`(this.a, this.b)
+


### PR DESCRIPTION
This PR can be a partial fix for #909. 

For it I've added option for customising of type class deriving with `@product` annotation as suggested by @raulraja [here](https://github.com/arrow-kt/arrow/issues/909#issuecomment-399795215).   

For correct test running PR #1906 need to be merged.