### PR TITLE
WriterT inconsistencies

### DIFF
--- a/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/WriterT.kt
+++ b/modules/mtl/arrow-mtl-data/src/main/kotlin/arrow/mtl/WriterT.kt
@@ -117,12 +117,12 @@ data class WriterT<F, W, A>(private val value: Kind<F, Tuple2<W, A>>) : WriterTO
     transform(MF) { it.b toT it.a }
 
   fun <B> ap(AF: Applicative<F>, SG: Semigroup<W>, ff: WriterTOf<F, W, (A) -> B>): WriterT<F, W, B> =
-    WriterT(AF.map(ff.value(), value) { (a, b) ->
-      Tuple2(SG.run { a.a.combine(b.a) }, a.b(b.b))
+    WriterT(AF.map(value, ff.value()) { (a, b) ->
+      Tuple2(SG.run { a.a.combine(b.a) }, b.b(a.b))
     })
 
   fun <B> flatMap(MF: Monad<F>, SG: Semigroup<W>, f: (A) -> WriterTOf<F, W, B>): WriterT<F, W, B> = MF.run {
-    WriterT(value.flatMap { value -> f(value.b).value().map { SG.run { it.a.combine(value.a) } toT it.b } })
+    WriterT(value.flatMap { value -> f(value.b).value().map { SG.run { value.a.combine(it.a) } toT it.b } })
   }
 
   fun <B, U> transform(MF: Monad<F>, f: (Tuple2<W, A>) -> Tuple2<U, B>): WriterT<F, U, B> = MF.run {

--- a/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/WriterTTest.kt
+++ b/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/WriterTTest.kt
@@ -42,7 +42,6 @@ import arrow.mtl.extensions.writert.monoidK.monoidK
 import arrow.test.UnitSpec
 import arrow.test.generators.GenK
 import arrow.test.generators.genK
-import arrow.test.generators.intSmall
 import arrow.test.generators.tuple2
 import arrow.test.laws.AlternativeLaws
 import arrow.test.laws.ConcurrentLaws

--- a/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/WriterTTest.kt
+++ b/modules/mtl/arrow-mtl-data/src/test/kotlin/arrow/mtl/WriterTTest.kt
@@ -10,7 +10,9 @@ import arrow.core.Option
 import arrow.core.extensions.const.divisible.divisible
 import arrow.core.extensions.const.eqK.eqK
 import arrow.core.extensions.eq
+import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.listk.eqK.eqK
+import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.listk.monoidK.monoidK
 import arrow.core.extensions.monoid
 import arrow.core.extensions.option.alternative.alternative
@@ -19,6 +21,7 @@ import arrow.core.extensions.option.eqK.eqK
 import arrow.core.extensions.option.functor.functor
 import arrow.core.extensions.option.monad.monad
 import arrow.core.extensions.option.monadFilter.monadFilter
+import arrow.core.k
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.extensions.io.applicative.applicative
@@ -26,6 +29,7 @@ import arrow.fx.extensions.io.concurrent.concurrent
 import arrow.fx.extensions.io.functor.functor
 import arrow.fx.extensions.io.monad.monad
 import arrow.fx.mtl.concurrent
+import arrow.mtl.extensions.WriterTEqK
 import arrow.mtl.extensions.writert.alternative.alternative
 import arrow.mtl.extensions.writert.applicative.applicative
 import arrow.mtl.extensions.writert.divisible.divisible
@@ -50,60 +54,60 @@ import io.kotlintest.properties.Gen
 
 class WriterTTest : UnitSpec() {
 
-  fun ioEQK() = WriterT.eqK(IO.eqK(), Int.eq())
+  fun ioEQK(): WriterTEqK<ForIO, ListK<Int>> = WriterT.eqK(IO.eqK(), ListK.eq(Int.eq()))
 
-  fun optionEQK() = WriterT.eqK(Option.eqK(), Int.eq())
+  fun optionEQK(): WriterTEqK<ForOption, ListK<Int>> = WriterT.eqK(Option.eqK(), ListK.eq(Int.eq()))
 
-  fun constEQK() = WriterT.eqK(Const.eqK(Int.eq()), Int.eq())
+  fun constEQK(): WriterTEqK<ConstPartialOf<Int>, ListK<Int>> = WriterT.eqK(Const.eqK(Int.eq()), ListK.eq(Int.eq()))
 
-  fun listEQK() = WriterT.eqK(ListK.eqK(), Int.eq())
+  fun listEQK(): WriterTEqK<ForListK, ListK<Int>> = WriterT.eqK(ListK.eqK(), ListK.eq(Int.eq()))
 
   init {
 
     testLaws(
       AlternativeLaws.laws(
-        WriterT.alternative(Int.monoid(), Option.alternative()),
-        WriterT.genK(Option.genK(), Gen.int()),
+        WriterT.alternative(ListK.monoid<Int>(), Option.alternative()),
+        WriterT.genK(Option.genK(), Gen.list(Gen.int()).map { it.k() }),
         optionEQK()
       ),
       DivisibleLaws.laws(
-        WriterT.divisible<ConstPartialOf<Int>, Int>(Const.divisible(Int.monoid())),
-        WriterT.genK(Const.genK(Gen.int()), Gen.int()),
+        WriterT.divisible<ConstPartialOf<Int>, ListK<Int>>(Const.divisible(Int.monoid())),
+        WriterT.genK(Const.genK(Gen.int()), Gen.list(Gen.int()).map { it.k() }),
         constEQK()
       ),
       ConcurrentLaws.laws(
-        WriterT.concurrent(IO.concurrent(), Int.monoid()),
-        WriterT.functor<ForIO, Int>(IO.functor()),
-        WriterT.applicative(IO.applicative(), Int.monoid()),
-        WriterT.monad(IO.monad(), Int.monoid()),
-        WriterT.genK(IO.genK(), Gen.int()),
+        WriterT.concurrent(IO.concurrent(), ListK.monoid<Int>()),
+        WriterT.functor<ForIO, ListK<Int>>(IO.functor()),
+        WriterT.applicative(IO.applicative(), ListK.monoid<Int>()),
+        WriterT.monad(IO.monad(), ListK.monoid<Int>()),
+        WriterT.genK(IO.genK(), Gen.list(Gen.int()).map { it.k() }),
         ioEQK()
       ),
       MonoidKLaws.laws(
-        WriterT.monoidK<ForListK, Int>(ListK.monoidK()),
-        WriterT.genK(ListK.genK(), Gen.int()),
+        WriterT.monoidK<ForListK, ListK<Int>>(ListK.monoidK()),
+        WriterT.genK(ListK.genK(), Gen.list(Gen.int()).map { it.k() }),
         listEQK()
       ),
 
       MonadWriterLaws.laws(
-        WriterT.monad(Option.monad(), Int.monoid()),
-        WriterT.monadWriter(Option.monad(), Int.monoid()),
-        Int.monoid(),
-        WriterT.functor<ForOption, Int>(Option.functor()),
-        WriterT.applicative(Option.applicative(), Int.monoid()),
-        WriterT.monad(Option.monad(), Int.monoid()),
-        Gen.intSmall(),
-        WriterT.genK(Option.genK(), Gen.int()),
+        WriterT.monad(Option.monad(), ListK.monoid<Int>()),
+        WriterT.monadWriter(Option.monad(), ListK.monoid<Int>()),
+        ListK.monoid<Int>(),
+        WriterT.functor<ForOption, ListK<Int>>(Option.functor()),
+        WriterT.applicative(Option.applicative(), ListK.monoid<Int>()),
+        WriterT.monad(Option.monad(), ListK.monoid<Int>()),
+        Gen.list(Gen.int()).map { it.k() },
+        WriterT.genK(Option.genK(), Gen.list(Gen.int()).map { it.k() }),
         optionEQK(),
-        Int.eq()
+        ListK.eq(Int.eq())
       ),
 
       MonadFilterLaws.laws(
-        WriterT.monadFilter(Option.monadFilter(), Int.monoid()),
-        WriterT.functor<ForOption, Int>(Option.functor()),
-        WriterT.applicative(Option.applicative(), Int.monoid()),
-        WriterT.monad(Option.monad(), Int.monoid()),
-        WriterT.genK(Option.genK(), Gen.int()),
+        WriterT.monadFilter(Option.monadFilter(), ListK.monoid<Int>()),
+        WriterT.functor<ForOption, ListK<Int>>(Option.functor()),
+        WriterT.applicative(Option.applicative(), ListK.monoid<Int>()),
+        WriterT.monad(Option.monad(), ListK.monoid<Int>()),
+        WriterT.genK(Option.genK(), Gen.list(Gen.int()).map { it.k() }),
         optionEQK()
       )
     )


### PR DESCRIPTION
WriterT currently produces the accumulated value backwards. This failed a law in `MonadWriterLaws`. 

The reason this was not caught in tests is because we used a commutative monoid (Int addition) which does not care about order. I changed the tests to run with `ListK` to produce the failed tests.

The first problem was in `flatMap` where the writer returned by `f` was the first argument to combine and the original writer was second.
For reference the semantics in this pr now match the ones from haskell mtl: https://hackage.haskell.org/package/transformers-0.5.6.2/docs/src/Control.Monad.Trans.Writer.Strict.html#line-200

The second problem was that this change broke monad-applicative-consistency, which revealed that `WriterT` also applied the underlying effects in reverse order. Changed that too.