### PR TITLE
add traverseIndexed

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -19,6 +19,9 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
   @Suppress("UNUSED_PARAMETER")
   fun <G, U> traverseFilter(GA: Applicative<G>, f: (T) -> Kind<G, Option<U>>): Kind<G, Const<A, U>> = GA.just(retag())
 
+  @Suppress("UNUSED_PARAMETER")
+  fun <G, U> traverseIndexed(GA: Applicative<G>, f: (Int, T) -> Kind<G, U>): Kind<G, Const<A, U>> = GA.just(retag())
+
   companion object {
     fun <A, T> just(a: A): Const<A, T> = Const(a)
   }

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -357,3 +357,9 @@ fun <A, B> Iterator<A>.iterateRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Ev
     Eval.defer { if (this.hasNext()) f(this.next(), loop()) else lb }
   return loop()
 }
+
+fun <A, B> Iterator<A>.iterateRightIndexed(lb: Eval<B>, f: (Int, A, Eval<B>) -> Eval<B>): Eval<B> {
+  fun loop(acc: Int): Eval<B> =
+    Eval.defer { if (this.hasNext()) f(acc, this.next(), loop(acc.inc())) else lb }
+  return loop(0)
+}

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -230,8 +230,14 @@ class NonEmptyList<out A> private constructor(
   fun <B> foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
     all.k().foldRight(lb, f)
 
+  fun <B> foldRightIndexed(lb: Eval<B>, f: (Int, A, Eval<B>) -> Eval<B>): Eval<B> =
+    all.k().foldRightIndexed(lb, f)
+
   fun <G, B> traverse(AG: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, NonEmptyList<B>> =
     AG.run { all.k().traverse(AG, f).map { Nel.fromListUnsafe(it) } }
+
+  fun <G, B> traverseIndexed(AG: Applicative<G>, f: (Int, A) -> Kind<G, B>): Kind<G, NonEmptyList<B>> =
+    AG.run { all.k().traverseIndexed(AG, f).map { Nel.fromListUnsafe(it) } }
 
   fun <B> coflatMap(f: (NonEmptyListOf<A>) -> B): NonEmptyList<B> {
     val buf = mutableListOf<B>()

--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/core/SortedMapK.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/core/SortedMapK.kt
@@ -48,6 +48,12 @@ data class SortedMapK<A : Comparable<A>, B>(private val map: SortedMap<A, B>) : 
     }.value()
   }
 
+  fun <G, C> traverseIndexed(GA: Applicative<G>, f: (Int, B) -> Kind<G, C>): Kind<G, SortedMapK<A, C>> = GA.run {
+    map.iterator().iterateRightIndexed(Eval.always { just(sortedMapOf<A, C>().k()) }) { index, kv, lbuf ->
+      Eval.later { f(index, kv.value).lazyAp { lbuf.value().map { xs -> { b: C -> (mapOf(kv.key to b).k() + xs).toSortedMap().k() } } } }
+    }.value()
+  }
+
   override fun equals(other: Any?): Boolean =
     when (other) {
       is SortedMapK<*, *> -> this.map == other.map

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -108,6 +108,9 @@ interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
 
   override fun <G, A, B> ConstOf<X, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, ConstOf<X, B>> =
     fix().traverse(AP, f)
+
+  fun <G, A, B> Kind<ConstPartialOf<X>, A>.traverseIndexed(AP: Applicative<G>, f: (Int, A) -> Kind<G, B>): Kind<G, Kind<ConstPartialOf<X>, B>> =
+    fix().traverseIndexed(AP, f)
 }
 
 @extension

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -162,6 +162,9 @@ interface ListKTraverse : Traverse<ForListK> {
 
   override fun <A> Kind<ForListK, A>.isEmpty(): Boolean =
     fix().isEmpty()
+
+  fun <G, A, B> Kind<ForListK, A>.traverseIndexed(AP: Applicative<G>, f: (Int, A) -> Kind<G, B>): Kind<G, ListK<B>> =
+    fix().traverseIndexed(AP, f)
 }
 
 @extension

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/mapk.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/mapk.kt
@@ -66,6 +66,9 @@ interface MapKTraverse<K> : Traverse<MapKPartialOf<K>>, MapKFoldable<K> {
 
   override fun <G, A, B> MapKOf<K, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, MapKOf<K, B>> =
     fix().traverse(AP, f)
+
+  fun <G, A, B> MapKOf<K, A>.traverseIndexed(AP: Applicative<G>, f: (Int, A) -> Kind<G, B>): Kind<G, MapKOf<K, B>> =
+    fix().traverseIndexed(AP, f)
 }
 
 @extension

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -184,6 +184,9 @@ interface SequenceKFoldable : Foldable<ForSequenceK> {
 interface SequenceKTraverse : Traverse<ForSequenceK>, SequenceKFoldable {
   override fun <G, A, B> Kind<ForSequenceK, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, SequenceK<B>> =
     fix().traverse(AP, f)
+
+  fun <G, A, B> Kind<ForSequenceK, A>.traverse(AP: Applicative<G>, f: (Int, A) -> Kind<G, B>): Kind<G, SequenceK<B>> =
+    fix().traverseIndexed(AP, f)
 }
 
 @extension

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sortedmap.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/sortedmap.kt
@@ -58,6 +58,9 @@ fun <A : Comparable<A>> SortedMapK.Companion.foldable(): SortedMapKFoldable<A> =
 interface SortedMapKTraverse<A : Comparable<A>> : Traverse<SortedMapKPartialOf<A>>, SortedMapKFoldable<A> {
   override fun <G, B, C> SortedMapKOf<A, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, Kind<SortedMapKPartialOf<A>, C>> =
     fix().traverse(AP, f)
+
+  fun <G, B, C> SortedMapKOf<A, B>.traverseIndexed(AP: Applicative<G>, f: (Int, B) -> Kind<G, C>): Kind<G, Kind<SortedMapKPartialOf<A>, C>> =
+    fix().traverseIndexed(AP, f)
 }
 
 fun <A : Comparable<A>> SortedMapK.Companion.traverse(): SortedMapKTraverse<A> =

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -114,6 +114,9 @@ interface ObservableKTraverse : Traverse<ForObservableK> {
 
   override fun <A, B> ObservableKOf<A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
     fix().foldRight(lb, f)
+
+  fun <G, A, B> ObservableKOf<A>.traverseIndexed(AP: Applicative<G>, f: (Int, A) -> Kind<G, B>): Kind<G, ObservableK<B>> =
+    fix().traverseIndexed(AP, f)
 }
 
 @extension

--- a/modules/recursion/arrow-recursion-data/src/main/kotlin/arrow/recursion/pattern/ListF.kt
+++ b/modules/recursion/arrow-recursion-data/src/main/kotlin/arrow/recursion/pattern/ListF.kt
@@ -1,7 +1,9 @@
 package arrow.recursion.pattern
 
+import arrow.Kind
 import arrow.higherkind
 import arrow.recursion.data.Fix
+import arrow.typeclasses.Applicative
 
 @higherkind
 sealed class ListF<A, B> : ListFOf<A, B> {
@@ -12,6 +14,12 @@ sealed class ListF<A, B> : ListFOf<A, B> {
     is NilF -> NilF()
     is ConsF -> ConsF(a, f(tail))
   }
+
+  fun <C, G> traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, ListF<A, C>> =
+    when (this) {
+      is ConsF -> AP.run { f(tail).map { ConsF(a, it) } }
+      is NilF -> AP.just(NilF())
+    }
 
   companion object
 }

--- a/modules/recursion/arrow-recursion-data/src/main/kotlin/arrow/recursion/pattern/NonemptyListF.kt
+++ b/modules/recursion/arrow-recursion-data/src/main/kotlin/arrow/recursion/pattern/NonemptyListF.kt
@@ -1,13 +1,22 @@
 package arrow.recursion.pattern
 
+import arrow.Kind
 import arrow.core.Option
+import arrow.core.none
+import arrow.core.some
 import arrow.higherkind
 import arrow.recursion.data.Fix
+import arrow.typeclasses.Applicative
 
 @higherkind
 data class NonEmptyListF<A, B>(val head: A, val tail: Option<B>) : NonEmptyListFOf<A, B> {
 
   fun <C> map(f: (B) -> C): NonEmptyListF<A, C> = NonEmptyListF(head, tail.map(f))
+
+  fun <C, G> traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, NonEmptyListF<A, C>> =
+    tail.fold({ AP.just(NonEmptyListF(fix().head, none())) }, {
+      AP.run { f(it).map { NonEmptyListF(fix().head, it.some()) } }
+    })
 
   companion object
 }

--- a/modules/recursion/arrow-recursion/src/main/kotlin/arrow/recursion/extensions/ListK.kt
+++ b/modules/recursion/arrow-recursion/src/main/kotlin/arrow/recursion/extensions/ListK.kt
@@ -44,10 +44,8 @@ interface ListFFoldable<I> : Foldable<ListFPartialOf<I>> {
 
 @extension
 interface ListFTraverse<I> : Traverse<ListFPartialOf<I>>, ListFFoldable<I> {
-  override fun <G, A, B> Kind<ListFPartialOf<I>, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Kind<ListFPartialOf<I>, B>> = when (val l = fix()) {
-    is ListF.NilF -> AP.just(ListF.NilF())
-    is ListF.ConsF -> AP.run { f(l.tail).map { ListF.ConsF(l.a, it) } }
-  }
+  override fun <G, A, B> Kind<ListFPartialOf<I>, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Kind<ListFPartialOf<I>, B>> =
+    fix().traverse(AP, f)
 }
 
 @extension

--- a/modules/recursion/arrow-recursion/src/main/kotlin/arrow/recursion/extensions/NonEmptyList.kt
+++ b/modules/recursion/arrow-recursion/src/main/kotlin/arrow/recursion/extensions/NonEmptyList.kt
@@ -45,11 +45,9 @@ interface NonEmptyListFFoldable<I> : Foldable<NonEmptyListFPartialOf<I>> {
 }
 
 @extension
-interface NonEmptyListFTraverse<I> : Traverse<NonEmptyListFPartialOf<I>>, NonEmptyListFFoldable<I> {
-  override fun <G, C, B> Kind<NonEmptyListFPartialOf<I>, C>.traverse(AP: Applicative<G>, f: (C) -> Kind<G, B>): Kind<G, Kind<NonEmptyListFPartialOf<I>, B>> =
-    fix().tail.fold({ AP.just(NonEmptyListF(fix().head, none())) }, {
-      AP.run { f(it).map { NonEmptyListF(fix().head, it.some()) } }
-    })
+interface NonEmptyListFTraverse<A1> : Traverse<NonEmptyListFPartialOf<A1>>, NonEmptyListFFoldable<A1> {
+  override fun <G, A2, B> Kind<NonEmptyListFPartialOf<A1>, A2>.traverse(AP: Applicative<G>, f: (A2) -> Kind<G, B>): Kind<G, Kind<NonEmptyListFPartialOf<A1>, B>> =
+    fix().traverse(AP, f)
 }
 
 @extension


### PR DESCRIPTION
Targeted data types:
- Const
- Eval
- ListK
- MapK
- NonEmptyList
- SequenceK
- SortedMapK
- ObservableK
- FlowableK

And moved ListF and NonEmptyListF implementation of `traverse` to their DT