### PR TITLE
Doc: update badges to show both WIP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 <img height="100" src="https://avatars2.githubusercontent.com/u/29458023?v=4&amp;s=200" width="100">
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core-data/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-core?color=%234caf50)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
+<!-- Remove the following on when having just one WIP again -->
+[![Latest snapshot](https://img.shields.io/badge/latest%20snapshot-v0.10.5--SNAPSHOT-blue)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
 [![Release Status](https://github.com/arrow-kt/arrow/workflows/Release/badge.svg)](https://github.com/arrow-kt/arrow/actions?query=workflow%3ARelease+branch%3Amaster)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)]( http://stackoverflow.com/questions/tagged/arrow-kt )
-
+[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/arrow-kt)
 
 Λrrow is a library for Typed Functional Programming in Kotlin.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Latest snapshot](https://img.shields.io/maven-metadata/v?label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
 [![Release Status](https://github.com/arrow-kt/arrow/workflows/Release/badge.svg)](https://github.com/arrow-kt/arrow/actions?query=workflow%3ARelease+branch%3Amaster)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/arrow-kt)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/arrow-kt)
 
 Λrrow is a library for Typed Functional Programming in Kotlin.
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/README.md
@@ -10,8 +10,8 @@ permalink: /docs/core/
 [![Latest snapshot](https://img.shields.io/maven-metadata/v?label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
 [![Release Status](https://github.com/arrow-kt/arrow/workflows/Release/badge.svg)](https://github.com/arrow-kt/arrow/actions?query=workflow%3ARelease+branch%3Amaster)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/arrow-kt)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/arrow-kt)
 
 Λrrow is a library for Typed Functional Programming in Kotlin.
 

--- a/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/README.md
+++ b/modules/docs/arrow-docs/docs/docs/arrow-core/quickstart/README.md
@@ -4,11 +4,14 @@ title: Quick Start
 permalink: /docs/core/
 ---
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core-data/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![Build Status](https://travis-ci.org/arrow-kt/arrow.svg?branch=master)](https://travis-ci.org/arrow-kt/arrow/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-core?color=%234caf50)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
+<!-- Remove the following on when having just one WIP again -->
+[![Latest snapshot](https://img.shields.io/badge/latest%20snapshot-v0.10.5--SNAPSHOT-blue)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
+[![Release Status](https://github.com/arrow-kt/arrow/workflows/Release/badge.svg)](https://github.com/arrow-kt/arrow/actions?query=workflow%3ARelease+branch%3Amaster)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)]( http://stackoverflow.com/questions/tagged/arrow-kt)
+[![StackOverflow](https://img.shields.io/badge/arrow--kt-black.svg?logo=stackoverflow)](http://stackoverflow.com/questions/tagged/arrow-kt)
 
 Λrrow is a library for Typed Functional Programming in Kotlin.
 


### PR DESCRIPTION
## Reason

The badge of latest snapshot version shows `0.11.0-SNAPSHOT` and we have 2 versions in progress right now.

## Changes

- Add a new badge to show that we have 2 WIP versions.
- Fix a badge in documentation because it pointed to Travis.

## Screenshots

From:

![Screenshot from 2020-01-22 14-51-13](https://user-images.githubusercontent.com/22792183/72899619-ac7ac500-3d26-11ea-86e5-132a629534eb.png)


to:

![Screenshot from 2020-01-22 14-55-06](https://user-images.githubusercontent.com/22792183/72899910-3f1b6400-3d27-11ea-873a-93f4ab6cb384.png)


