### PR TITLE
Fix recursive flatten for stdlib List

### DIFF
--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -3,7 +3,6 @@ package arrow.core
 import arrow.Kind
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
-import arrow.core.extensions.list.monad.flatten as monadFlatten
 import arrow.core.extensions.listk.align.align
 import arrow.core.extensions.listk.applicative.applicative
 import arrow.core.extensions.listk.crosswalk.crosswalk
@@ -12,7 +11,6 @@ import arrow.core.extensions.listk.eqK.eqK
 import arrow.core.extensions.listk.foldable.foldable
 import arrow.core.extensions.listk.functor.functor
 import arrow.core.extensions.listk.hash.hash
-import arrow.core.extensions.listk.monad.flatten as kMonadFlatten
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.monadCombine.monadCombine
 import arrow.core.extensions.listk.monoid.monoid
@@ -48,6 +46,8 @@ import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe
 import kotlin.math.max
 import kotlin.math.min
+import arrow.core.extensions.list.monad.flatten as monadFlatten
+import arrow.core.extensions.listk.monad.flatten as kMonadFlatten
 
 class ListKTest : UnitSpec() {
 
@@ -101,13 +101,13 @@ class ListKTest : UnitSpec() {
     )
 
     "stdlib list can flatten" {
-     val a: List<List<Int>> = listOf(listOf(0, 1), listOf(2), listOf(3, 4), listOf(5))
+      val a: List<List<Int>> = listOf(listOf(0, 1), listOf(2), listOf(3, 4), listOf(5))
 
       a.monadFlatten() shouldBe listOf(0, 1, 2, 3, 4, 5)
     }
 
     "can flatten" {
-     val a: ListK<ListK<Int>> = listOf(listOf(0, 1).k(), listOf(2).k(), listOf(3, 4).k(), listOf(5).k()).k()
+      val a: ListK<ListK<Int>> = listOf(listOf(0, 1).k(), listOf(2).k(), listOf(3, 4).k(), listOf(5).k()).k()
 
       a.kMonadFlatten() shouldBe listOf(0, 1, 2, 3, 4, 5)
     }

--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -3,6 +3,7 @@ package arrow.core
 import arrow.Kind
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
+import arrow.core.extensions.list.monad.flatten as monadFlatten
 import arrow.core.extensions.listk.align.align
 import arrow.core.extensions.listk.applicative.applicative
 import arrow.core.extensions.listk.crosswalk.crosswalk
@@ -11,6 +12,7 @@ import arrow.core.extensions.listk.eqK.eqK
 import arrow.core.extensions.listk.foldable.foldable
 import arrow.core.extensions.listk.functor.functor
 import arrow.core.extensions.listk.hash.hash
+import arrow.core.extensions.listk.monad.flatten as kMonadFlatten
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.monadCombine.monadCombine
 import arrow.core.extensions.listk.monoid.monoid
@@ -23,7 +25,6 @@ import arrow.core.extensions.listk.traverse.traverse
 import arrow.core.extensions.listk.unalign.unalign
 import arrow.core.extensions.listk.unzip.unzip
 import arrow.core.extensions.show
-import arrow.core.extensions.tuple2.eq.eq
 import arrow.test.UnitSpec
 import arrow.test.generators.genK
 import arrow.test.generators.listK
@@ -44,6 +45,7 @@ import arrow.test.laws.equalUnderTheLaw
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import io.kotlintest.shouldBe
 import kotlin.math.max
 import kotlin.math.min
 
@@ -97,6 +99,18 @@ class ListKTest : UnitSpec() {
         ListK.eqK()
       )
     )
+
+    "stdlib list can flatten" {
+     val a: List<List<Int>> = listOf(listOf(0, 1), listOf(2), listOf(3, 4), listOf(5))
+
+      a.monadFlatten() shouldBe listOf(0, 1, 2, 3, 4, 5)
+    }
+
+    "can flatten" {
+     val a: ListK<ListK<Int>> = listOf(listOf(0, 1).k(), listOf(2).k(), listOf(3, 4).k(), listOf(5).k()).k()
+
+      a.kMonadFlatten() shouldBe listOf(0, 1, 2, 3, 4, 5)
+    }
 
     "can align lists with different lengths" {
       forAll(Gen.listK(Gen.bool()), Gen.listK(Gen.bool())) { a, b ->

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/MonadLaws.kt
@@ -34,25 +34,25 @@ object MonadLaws {
       )
   }
 
-    fun <F> laws(
-      M: Monad<F>,
-      FF: Functor<F>,
-      AP: Apply<F>,
-      SL: Selective<F>,
-      GENK: GenK<F>,
-      EQK: EqK<F>
-    ): List<Law> {
-      val EQ = EQK.liftEq(Int.eq())
-      val G = GENK.genK(Gen.int())
+  fun <F> laws(
+    M: Monad<F>,
+    FF: Functor<F>,
+    AP: Apply<F>,
+    SL: Selective<F>,
+    GENK: GenK<F>,
+    EQK: EqK<F>
+  ): List<Law> {
+    val EQ = EQK.liftEq(Int.eq())
+    val G = GENK.genK(Gen.int())
 
-      return laws(M, GENK, EQK) + listOf(
-        Law("Monad Laws: monad map should be consistent with functor map") { M.derivedMapConsistent(G, FF, EQ) },
-        Law("Monad Laws: monad ap should be consistent with applicative ap") { M.derivedApConsistent(GENK, AP, EQ) },
-        Law("Monad Laws: monad apTap should be consistent with applicative apTap") { M.derivedApTapConsistent(GENK, AP, EQ) },
-        Law("Monad Laws: monad followedBy should be consistent with applicative followedBy") { M.derivedFollowedByConsistent(GENK, AP, EQ) },
-        Law("Monad Laws: monad selective should be consistent with selective selective") { M.derivedSelectiveConsistent(GENK, SL, EQ) }
-      )
-    }
+    return laws(M, GENK, EQK) + listOf(
+      Law("Monad Laws: monad map should be consistent with functor map") { M.derivedMapConsistent(G, FF, EQ) },
+      Law("Monad Laws: monad ap should be consistent with applicative ap") { M.derivedApConsistent(GENK, AP, EQ) },
+      Law("Monad Laws: monad apTap should be consistent with applicative apTap") { M.derivedApTapConsistent(GENK, AP, EQ) },
+      Law("Monad Laws: monad followedBy should be consistent with applicative followedBy") { M.derivedFollowedByConsistent(GENK, AP, EQ) },
+      Law("Monad Laws: monad selective should be consistent with selective selective") { M.derivedSelectiveConsistent(GENK, SL, EQ) }
+    )
+  }
 
   fun <F> Monad<F>.leftIdentity(G: Gen<Kind<F, Int>>, EQ: Eq<Kind<F, Int>>): Unit =
     forAll(Gen.functionAToB<Int, Kind<F, Int>>(G), Gen.int()) { f: (Int) -> Kind<F, Int>, a: Int ->


### PR DESCRIPTION
The problem here was that the autogenerated version of `flatten` for List wraps the outer list in ListK:

```
fun <A> List<List<A>>.flatten(): List<A> = arrow.core.extensions.list.monad.List.monad().run {
  arrow.core.ListK(this@flatten).flatten<A>() as kotlin.collections.List<A>
}
```
which causes resolution to fail since ListK flatten would be defined as `Kind<ForListK, Kind<ForListK, A>>` (note the inner Kind) from Monad and also because ListK extends List, therefore the function resolution enters into a recursive loop.

One option is to create a special flatten function in ListKMonad to work with `Kind<ForListK, List<A>>` specifically, so the type resolution finds that one before the other.

Fixes #1726.