### PR TITLE
Fix recently added doc links

### DIFF
--- a/modules/docs/arrow-docs/docs/_data/sidebar-fx.yml
+++ b/modules/docs/arrow-docs/docs/_data/sidebar-fx.yml
@@ -42,7 +42,7 @@ options:
         url: /docs/apidocs/arrow-fx/arrow.fx/-resource/
 
       - title: Schedule
-        url: docs/apidocs/arrow-fx/arrow.fx/-schedule/
+        url: /docs/apidocs/arrow-fx/arrow.fx/-schedule/
 
       - title: Queue
         url: /docs/effects/queue/
@@ -55,7 +55,7 @@ options:
         url: /docs/fx/typeclasses/bracket/
 
       - title: MonadIO
-        url: /docs/apidocs/arrow-fx/arrow.fx.typeclasses/-monadio/
+        url: /docs/apidocs/arrow-fx/arrow.fx.typeclasses/-monad-i-o/
 
   - title: API Docs
 


### PR DESCRIPTION
I totally did not mess them up the first time :see_no_evil: 

@calvellido are the links correct now?

Also is there a tool to check broken links at build time for docs? I've been using Hugo for the docs on my prettyprinter and it complains when I add broken links ^^