### PR TITLE
Fix Async and Concurrent fx block's lazyness

### DIFF
--- a/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/MonadError.kt
+++ b/modules/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/MonadError.kt
@@ -135,7 +135,7 @@ interface MonadThrow<F> : MonadError<F, Throwable> {
    */
   override val fx: MonadThrowFx<F>
     get() = object : MonadThrowFx<F> {
-      override val ME: MonadThrow<F> = this@MonadThrow
+      override val M: MonadThrow<F> = this@MonadThrow
     }
 
   fun <A> Throwable.raiseNonFatal(): Kind<F, A> =
@@ -143,10 +143,9 @@ interface MonadThrow<F> : MonadError<F, Throwable> {
 }
 
 interface MonadThrowFx<F> : MonadFx<F> {
-  val ME: MonadThrow<F>
-  override val M: Monad<F> get() = ME
+  override val M: MonadThrow<F>
   fun <A> monadThrow(c: suspend MonadThrowSyntax<F>.() -> A): Kind<F, A> {
-    val continuation = MonadThrowContinuation<F, A>(ME)
+    val continuation = MonadThrowContinuation<F, A>(M)
     val wrapReturn: suspend MonadThrowSyntax<F>.() -> Kind<F, A> = { just(c()) }
     wrapReturn.startCoroutine(continuation, continuation)
     return continuation.returnedMonad()

--- a/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/try.kt
+++ b/modules/core/arrow-core/src/main/kotlin/arrow/core/extensions/try.kt
@@ -213,7 +213,7 @@ interface TryHash<A> : Hash<Try<A>>, TryEq<A> {
 }
 
 internal object TryFxMonadThrow : MonadThrowFx<ForTry> {
-  override val ME: MonadThrow<ForTry> = Try.monadThrow()
+  override val M: MonadThrow<ForTry> = Try.monadThrow()
 }
 
 fun <A> Try.Companion.fx(c: suspend MonadThrowSyntax<ForTry>.() -> A): Try<A> =

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/AsyncLaws.kt
@@ -5,6 +5,7 @@ import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
 import arrow.core.extensions.eq
+import arrow.core.internal.AtomicBooleanW
 import arrow.fx.Promise
 import arrow.fx.typeclasses.Async
 import arrow.fx.typeclasses.ExitCase
@@ -14,7 +15,6 @@ import arrow.test.generators.either
 import arrow.test.generators.functionAToB
 import arrow.test.generators.intSmall
 import arrow.test.generators.throwable
-import arrow.test.laws.AsyncLaws.bracketReleaseIscalledOnCompletedOrError
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
@@ -31,6 +31,7 @@ object AsyncLaws {
 
   private fun <F> asyncLaws(AC: Async<F>, EQK: EqK<F>): List<Law> {
     val EQ = EQK.liftEq(Int.eq())
+    val EQB = EQK.liftEq(Boolean.eq())
 
     return listOf(
       Law("Async Laws: success equivalence") { AC.asyncSuccess(EQ) },
@@ -41,7 +42,8 @@ object AsyncLaws {
       Law("Async Laws: bracket release is called on completed or error") { AC.bracketReleaseIscalledOnCompletedOrError(EQ) },
       Law("Async Laws: continueOn on comprehensions") { AC.continueOnComprehension(EQ) },
       Law("Async Laws: effect calls suspend functions in the right dispatcher") { AC.effectCanCallSuspend(EQ) },
-      Law("Async Laws: effect is equivalent to later") { AC.effectEquivalence(EQ) }
+      Law("Async Laws: effect is equivalent to later") { AC.effectEquivalence(EQ) },
+      Law("Async Laws: fx block runs lazily") { AC.fxLazyEvaluation(Boolean.eq(), EQB) }
     )
   }
 
@@ -147,6 +149,18 @@ object AsyncLaws {
       val continueOn = effect(two) { f(Unit) }
 
       effect.equalUnderTheLaw(continueOn, EQ)
+    }
+
+  fun <F> Async<F>.fxLazyEvaluation(EQ: Eq<Boolean>, EQK: Eq<Kind<F, Boolean>>): Unit =
+    forAll(Gen.functionAToB<Unit, Int>(Gen.constant(0))) { f ->
+      val run = AtomicBooleanW(false)
+      val p = fx.async {
+        run.getAndSet(true)
+        run.value
+      }
+
+      run.value.equalUnderTheLaw(false, EQ) &&
+        p.equalUnderTheLaw(just(true), EQK)
     }
 
   // Turns out that kotlinx.coroutines decides to rewrite thread names

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
@@ -199,7 +199,7 @@ fun FluxK.Companion.monadErrorSwitch(): FluxKMonadError = object : FluxKMonadErr
 
 // TODO FluxK does not yet have a Concurrent instance
 fun <A> FluxK.Companion.fx(c: suspend AsyncSyntax<ForFluxK>.() -> A): FluxK<A> =
-  defer { FluxK.async().fx.async(c).fix() }
+  FluxK.async().fx.async(c).fix()
 
 @extension
 interface FluxKTimer : Timer<ForFluxK> {

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
@@ -138,4 +138,4 @@ interface MonoKTimer : Timer<ForMonoK> {
 
 // TODO FluxK does not yet have a Concurrent instance
 fun <A> MonoK.Companion.fx(c: suspend AsyncSyntax<ForMonoK>.() -> A): MonoK<A> =
-  defer { MonoK.async().fx.async(c).fix() }
+  MonoK.async().fx.async(c).fix()

--- a/modules/fx/arrow-fx-reactor/src/test/kotlin/arrow/fx/FluxKTest.kt
+++ b/modules/fx/arrow-fx-reactor/src/test/kotlin/arrow/fx/FluxKTest.kt
@@ -73,17 +73,6 @@ class FluxKTest : UnitSpec() {
        */
     )
 
-    "fx should defer evaluation until subscribed" {
-      var run = false
-      val value = FluxK.fx {
-        run = true
-      }.value()
-
-      run shouldBe false
-      value.subscribe()
-      run shouldBe true
-    }
-
     "Multi-thread Fluxes finish correctly" {
       val value: Flux<Int> = FluxK.fx {
         val a = Flux.just(0).delayElements(Duration.ofSeconds(2)).k().bind()

--- a/modules/fx/arrow-fx-reactor/src/test/kotlin/arrow/fx/MonoKTest.kt
+++ b/modules/fx/arrow-fx-reactor/src/test/kotlin/arrow/fx/MonoKTest.kt
@@ -77,17 +77,6 @@ class MonoKTest : UnitSpec() {
       TimerLaws.laws(MonoK.async(), MonoK.timer(), EQ())
     )
 
-    "fx should defer evaluation until subscribed" {
-      var run = false
-      val value = MonoK.fx {
-        run = true
-      }.value()
-
-      run shouldBe false
-      value.subscribe()
-      run shouldBe true
-    }
-
     "Multi-thread Monos finish correctly" {
       val value: Mono<Long> = MonoK.fx {
         val a = Mono.just(0L).delayElement(Duration.ofSeconds(2)).k().bind()

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -375,4 +375,4 @@ interface FlowableKMonadFilter : MonadFilter<ForFlowableK>, FlowableKMonad {
     fix().filterMap(f)
 }
 fun <A> FlowableK.Companion.fx(c: suspend ConcurrentSyntax<ForFlowableK>.() -> A): FlowableK<A> =
-  defer { FlowableK.concurrent().fx.concurrent(c).fix() }
+  FlowableK.concurrent().fx.concurrent(c).fix()

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -288,4 +288,4 @@ interface MaybeKMonadFilter : MonadFilter<ForMaybeK>, MaybeKMonad {
 }
 
 fun <A> MaybeK.Companion.fx(c: suspend ConcurrentSyntax<ForMaybeK>.() -> A): MaybeK<A> =
-  defer { MaybeK.concurrent().fx.concurrent(c).fix() }
+  MaybeK.concurrent().fx.concurrent(c).fix()

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -271,7 +271,7 @@ fun ObservableK.Companion.monadErrorSwitch(): ObservableKMonadError = object : O
 }
 
 fun <A> ObservableK.Companion.fx(c: suspend ConcurrentSyntax<ForObservableK>.() -> A): ObservableK<A> =
-  defer { ObservableK.concurrent().fx.concurrent(c).fix() }
+  ObservableK.concurrent().fx.concurrent(c).fix()
 
 @extension
 interface ObservableKTimer : Timer<ForObservableK> {

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
@@ -258,4 +258,4 @@ interface SingleKUnsafeRun : UnsafeRun<ForSingleK> {
 }
 
 fun <A> SingleK.Companion.fx(c: suspend ConcurrentSyntax<ForSingleK>.() -> A): SingleK<A> =
-  defer { SingleK.concurrent().fx.concurrent(c).fix() }
+  SingleK.concurrent().fx.concurrent(c).fix()

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/FlowableKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/FlowableKTests.kt
@@ -104,17 +104,6 @@ class FlowableKTests : RxJavaSpec() {
 
     testLaws(MonadFilterLaws.laws(FlowableK.monadFilter(), FlowableK.functor(), FlowableK.applicative(), FlowableK.monad(), GENK(), EQK()))
 
-    "fx should defer evaluation until subscribed" {
-      var run = false
-      val value = FlowableK.fx {
-        run = true
-      }.value()
-
-      run shouldBe false
-      value.subscribe()
-      run shouldBe true
-    }
-
     "Multi-thread Flowables finish correctly" {
       val value: Flowable<Long> = FlowableK.fx {
         val a = Flowable.timer(2, TimeUnit.SECONDS).k().bind()

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/MaybeKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/MaybeKTests.kt
@@ -64,17 +64,6 @@ class MaybeKTests : RxJavaSpec() {
        */
     )
 
-    "fx should defer evaluation until subscribed" {
-      var run = false
-      val value = MaybeK.fx {
-        run = true
-      }.value()
-
-      run shouldBe false
-      value.subscribe()
-      run shouldBe true
-    }
-
     "Multi-thread Maybes finish correctly" {
       val value: Maybe<Long> = MaybeK.fx {
         val a = Maybe.timer(2, TimeUnit.SECONDS).k().bind()

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/ObservableKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/ObservableKTests.kt
@@ -47,17 +47,6 @@ class ObservableKTests : RxJavaSpec() {
       TimerLaws.laws(ObservableK.async(), ObservableK.timer(), ObservableK.eq())
     )
 
-    "fx should defer evaluation until subscribed" {
-      var run = false
-      val value = ObservableK.fx {
-        run = true
-      }.value()
-
-      run shouldBe false
-      value.subscribe()
-      run shouldBe true
-    }
-
     "Multi-thread Observables finish correctly" {
       val value: Observable<Long> = ObservableK.fx {
         val a = Observable.timer(2, SECONDS).k().bind()

--- a/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
+++ b/modules/fx/arrow-fx-rx2/src/test/kotlin/arrow/fx/SingleKTests.kt
@@ -52,17 +52,6 @@ class SingleKTests : RxJavaSpec() {
       TimerLaws.laws(SingleK.async(), SingleK.timer(), SingleK.eq())
     )
 
-    "fx should defer evaluation until subscribed" {
-      var run = false
-      val value = SingleK.fx {
-        run = true
-      }.value()
-
-      run shouldBe false
-      value.subscribe()
-      run shouldBe true
-    }
-
     "Multi-thread Singles finish correctly" {
       forFew(10, Gen.choose(10L, 50)) { delay ->
         SingleK.fx {

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
@@ -311,7 +311,7 @@ fun IO.Companion.timer(): Timer<ForIO> = Timer(IO.concurrent())
 interface IODefaultConcurrentEffect : ConcurrentEffect<ForIO>, IOConcurrentEffect, IODefaultConcurrent
 
 fun <A> IO.Companion.fx(c: suspend ConcurrentSyntax<ForIO>.() -> A): IO<A> =
-  defer { IO.concurrent().fx.concurrent(c).fix() }
+  IO.concurrent().fx.concurrent(c).fix()
 
 /**
  * converts this Either to an IO. The resulting IO will evaluate to this Eithers

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Async.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Async.kt
@@ -6,7 +6,6 @@ import arrow.core.Right
 import arrow.documented
 import arrow.fx.internal.asyncContinuation
 import arrow.typeclasses.MonadError
-import arrow.typeclasses.MonadThrow
 import arrow.typeclasses.MonadThrowFx
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Async.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Async.kt
@@ -40,7 +40,7 @@ interface Async<F> : MonadDefer<F> {
    */
   override val fx: AsyncFx<F>
     get() = object : AsyncFx<F> {
-      override val async: Async<F> get() = this@Async
+      override val M: Async<F> get() = this@Async
     }
 
   /**
@@ -350,11 +350,10 @@ internal val rightUnit = Right(Unit)
 internal val unitCallback = { cb: (Either<Throwable, Unit>) -> Unit -> cb(rightUnit) }
 
 interface AsyncFx<F> : MonadThrowFx<F> {
-  val async: Async<F>
-  override val ME: MonadDefer<F> get() = async
+  override val M: Async<F>
   // Deferring in order to lazily launch the coroutine so it doesn't eagerly run on declaring context
-  fun <A> async(c: suspend AsyncSyntax<F>.() -> A): Kind<F, A> = ME.defer {
-    val continuation = AsyncContinuation<F, A>(async)
+  fun <A> async(c: suspend AsyncSyntax<F>.() -> A): Kind<F, A> = M.defer {
+    val continuation = AsyncContinuation<F, A>(M)
     val wrapReturn: suspend AsyncSyntax<F>.() -> Kind<F, A> = { just(c()) }
     wrapReturn.startCoroutine(continuation, continuation)
     continuation.returnedMonad()

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
@@ -974,14 +974,12 @@ interface Concurrent<F> : Async<F> {
 
 interface ConcurrentFx<F> : AsyncFx<F> {
   val concurrent: Concurrent<F>
-
-  override val async: Async<F>
-    get() = concurrent
-
-  fun <A> concurrent(c: suspend ConcurrentSyntax<F>.() -> A): Kind<F, A> {
+  override val async: Async<F> get() = concurrent
+  // Deferring in order to lazily launch the coroutine so it doesn't eagerly run on declaring context
+  fun <A> concurrent(c: suspend ConcurrentSyntax<F>.() -> A): Kind<F, A> = async.defer {
     val continuation = ConcurrentContinuation<F, A>(concurrent)
     val wrapReturn: suspend ConcurrentSyntax<F>.() -> Kind<F, A> = { just(c()) }
     wrapReturn.startCoroutine(continuation, continuation)
-    return continuation.returnedMonad()
+    continuation.returnedMonad()
   }
 }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
@@ -63,7 +63,7 @@ interface Concurrent<F> : Async<F> {
    */
   override val fx: ConcurrentFx<F>
     get() = object : ConcurrentFx<F> {
-      override val concurrent: Concurrent<F> = this@Concurrent
+      override val M: Concurrent<F> = this@Concurrent
     }
 
   /**
@@ -973,11 +973,10 @@ interface Concurrent<F> : Async<F> {
 }
 
 interface ConcurrentFx<F> : AsyncFx<F> {
-  val concurrent: Concurrent<F>
-  override val async: Async<F> get() = concurrent
+  override val M: Concurrent<F>
   // Deferring in order to lazily launch the coroutine so it doesn't eagerly run on declaring context
-  fun <A> concurrent(c: suspend ConcurrentSyntax<F>.() -> A): Kind<F, A> = async.defer {
-    val continuation = ConcurrentContinuation<F, A>(concurrent)
+  fun <A> concurrent(c: suspend ConcurrentSyntax<F>.() -> A): Kind<F, A> = M.defer {
+    val continuation = ConcurrentContinuation<F, A>(M)
     val wrapReturn: suspend ConcurrentSyntax<F>.() -> Kind<F, A> = { just(c()) }
     wrapReturn.startCoroutine(continuation, continuation)
     continuation.returnedMonad()

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -287,17 +287,6 @@ class IOTest : UnitSpec() {
         .unsafeRunSync()
     }
 
-    "fx should defer evaluation until run" {
-      var run = false
-      val program = IO.fx {
-        run = true
-      }
-
-      run shouldBe false
-      program.unsafeRunSync()
-      run shouldBe true
-    }
-
     "fx can switch execution context state across not/bind" {
       val program = IO.fx {
         val ctx = !effect { kotlin.coroutines.coroutineContext }


### PR DESCRIPTION
- [x] Add Async law to check for fx lazyness
- [x] Remove defer from each Fx instance
- [x] Make tests fail
- [x] Fix fx eagerness globally
- [x] Remove old tests replaced by law

Fixes #1977 