### PR TITLE
Fix: change token to sync branches

### DIFF
--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Merge master on release branch
       id: merge
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
       run: |
         git remote set-url origin https://arrow-kt:$GITHUB_TOKEN@github.com/arrow-kt/arrow.git
         git config --global user.email "raulraja@users.noreply.github.com"
@@ -42,7 +42,7 @@ jobs:
     - name: Push changes
       if: steps.merge.outputs.changes != ''
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
       run: |
         git push origin HEAD:release/0.11.0
     - name: Prepare environment to create the issue (new package)


### PR DESCRIPTION
GitHub App cannot be added in **Restrict who can push to matching branches** so its provided token cannot be used to sync protected branches.

This PR changes that token by another one who has grants to do that sync.