### PR TITLE
Fix guarantee/guaranteeCase not calling finalizer for error

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/BracketLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/BracketLaws.kt
@@ -35,7 +35,8 @@ object BracketLaws {
       Law("Bracket: guarantee is derived from bracket") { BF.guaranteeIsDerivedFromBracket(BF.just(Unit), EQ) },
       Law("Bracket: guaranteeCase is derived from bracketCase") { BF.guaranteeCaseIsDerivedFromBracketCase({ BF.just(Unit) }, EQ) },
       Law("Bracket: bracket propagates transformer effects") { BF.bracketPropagatesTransformerEffects(EQ) },
-      Law("Bracket: bracket must run release task") { BF.bracketMustRunReleaseTask(EQ) }
+      Law("Bracket: bracket must run release task on use error") { BF.bracketMustRunReleaseTaskOnUseError(EQ) },
+      Law("Bracket: bracket must run release task on adquire error") { BF.bracketMustRunReleaseTaskOnAdquireError(EQ) }
     )
   }
 
@@ -128,12 +129,24 @@ object BracketLaws {
         acquire.flatMap { a -> use(a).flatMap { b -> release(a).map { b } } }, EQ)
     }
 
-  fun <F> Bracket<F, Throwable>.bracketMustRunReleaseTask(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(Gen.int(), Gen.int().applicativeError(this)) { i, fa ->
-      val msg: AtomicIntW = AtomicIntW(0)
+  fun <F> Bracket<F, Throwable>.bracketMustRunReleaseTaskOnUseError(EQ: Eq<Kind<F, Int>>): Unit =
+    forAll(Gen.int()) { i ->
+      val msg = AtomicIntW(0)
       just(i).bracket<Int, Int>(
         release = { ii -> msg.value = ii; unit() },
         use = { throw Throwable("Expected failure!") }
+      )
+        .attempt()
+        .map { msg.value }
+        .equalUnderTheLaw(just(i), EQ)
+    }
+
+  fun <F> Bracket<F, Throwable>.bracketMustRunReleaseTaskOnAdquireError(EQ: Eq<Kind<F, Int>>): Unit =
+    forAll(Gen.int()) { i ->
+      val msg = AtomicIntW(0)
+      raiseError<Int>(Throwable("Expected failure!")).bracket(
+        release = { ii -> msg.value = ii; unit() },
+        use = { just(it) }
       )
         .attempt()
         .map { msg.value }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/IOBracket.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/IOBracket.kt
@@ -83,7 +83,7 @@ internal object IOBracket {
     IO.Async { conn, cb ->
       Platform.trampoline {
         val frame = EnsureReleaseFrame<A>(release)
-        val onNext = source.flatMap(frame)
+        val onNext = IO.Bind(source, frame)
         // Registering our cancelable token ensures that in case
         // cancellation is detected, `release` gets called
         conn.push(frame.cancel)

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
@@ -130,7 +130,7 @@ interface Bracket<F, E> : MonadError<F, E> {
    * @see [bracket] for the more general operation
    */
   fun <A> Kind<F, A>.guarantee(finalizer: Kind<F, Unit>): Kind<F, A> =
-    bracket({ finalizer }, { this })
+    guaranteeCase { finalizer }
 
   /**
    * Executes the given `finalizer` when the source is finished, either in success or in error, or if canceled, allowing
@@ -145,5 +145,5 @@ interface Bracket<F, E> : MonadError<F, E> {
    *
    */
   fun <A> Kind<F, A>.guaranteeCase(finalizer: (ExitCase<E>) -> Kind<F, Unit>): Kind<F, A> =
-    bracketCase({ _, e -> finalizer(e) }, { this })
+    just<Unit>(Unit).bracketCase({ _, e -> finalizer(e) }, { this })
 }

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -9,10 +9,12 @@ import arrow.core.Some
 import arrow.core.Tuple4
 import arrow.core.identity
 import arrow.core.right
+import arrow.core.some
 import arrow.fx.IO.Companion.just
 import arrow.fx.extensions.fx
 import arrow.fx.extensions.io.applicative.applicative
 import arrow.fx.extensions.io.async.async
+import arrow.fx.extensions.io.bracket.guarantee
 import arrow.fx.extensions.io.concurrent.concurrent
 import arrow.fx.extensions.io.concurrent.parMapN
 import arrow.fx.extensions.io.dispatchers.dispatchers
@@ -525,6 +527,14 @@ class IOTest : UnitSpec() {
             .invoke()
         }.flatMap { latch.get() }
       }.unsafeRunSync()
+    }
+
+    "guarantee should be called on finish with error" {
+      IO.fx {
+        val p = !Promise<Unit>()
+        effect { throw Exception() }.guarantee(p.complete(Unit)).attempt().bind()
+        !p.get()
+      }.unsafeRunTimed(1.seconds) shouldBe Unit.some()
     }
 
     "Bracket should be stack safe" {


### PR DESCRIPTION
Fixes two bugs within Bracket implementation:

* `IOBracket.guaranteeCase` was wrongly doing a flatMap between an IO and a recovery frame, which caused the frame not to be called -> Fixed by calling IO.Bind directly
* `Bracket.guaranteeCase` was calling the bracket function over itself and then again on the use function -> Fixed by executing the bracket over a unit IO for the acquire.

TODO:
* Discuss if we should update the Bracket docs and possibly some docs examples explaining the difference between `bracket(Case)` and `guarantee(Case)`.

Attempt to fix #1996