### PR TITLE
More meaningful mapping Either to 0.11.0 IO #2002

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
@@ -4,7 +4,6 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
-import arrow.core.identity
 import arrow.extension
 import arrow.fx.IO
 import arrow.fx.IOPartialOf
@@ -423,15 +422,15 @@ fun <A> IO.Companion.fx(c: suspend ConcurrentSyntax<IOPartialOf<Nothing>>.() -> 
  * converts this Either to an IO. The resulting IO will evaluate to this Eithers
  * Right value or alternatively to the result of applying the specified function to this Left value.
  */
-fun <E, A> Either<E, A>.toIO(f: (E) -> Throwable): IO<Nothing, A> =
-  fold({ IO.raiseException(f(it)) }, { IO.just(it) })
+fun <A> Either<Throwable, A>.toIOException(): IO<Nothing, A> =
+  fold({ IO.raiseException(it) }, { IO.just(it) })
 
 /**
  * converts this Either to an IO. The resulting IO will evaluate to this Eithers
- * Right value or Left exception.
+ * Right value or Left error value
  */
-fun <A> Either<Throwable, A>.toIO(): IO<Nothing, A> =
-  toIO(::identity)
+fun <E, A> Either<E, A>.toIO(): IO<E, A> =
+  fold({ IO.raiseError(it) }, { IO.just(it) })
 
 interface IOSyntax<E> : BindSyntax<IOPartialOf<E>> {
   suspend fun continueOn(ctx: CoroutineContext): Unit =


### PR DESCRIPTION
1) do we want to leave `toIO(f: (E) -> Throwable)` and deprecate it in favour of `toIOException`
2) will this be whole? Or add / change any other method?