### PR TITLE
Add a stacksafe variant of Join to AndThen

### DIFF
--- a/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
+++ b/modules/core/arrow-core-data/src/test/kotlin/arrow/core/AndThenTest.kt
@@ -110,6 +110,17 @@ class AndThenTest : UnitSpec() {
         acc.compose { it + 1 }
       }.toString() shouldBe "AndThen.Concat(...)"
     }
+
+    "flatMap is stacksafe" {
+      val res = AndThen<Int, Int>(::identity).flatMap { i -> AndThen<Int, Int> { j -> i + j } }
+        .invoke(3)
+
+      val result = (0 until count).toList().foldLeft(AndThen<Int, Int>(::identity)) { acc, _ ->
+        acc.flatMap { i -> AndThen<Int, Int> { i + it } }
+      }.invoke(1)
+
+      result shouldBe (count + 1)
+    }
   }
 }
 


### PR DESCRIPTION
This allows fully a stacksafe version of `Kleisli.flatMap` and similar datatypes.
Currently even using a stacksafe monad for `Kleisli.flatMap` will cause a stackoverflow because it first builds up lots of `Kleisli { d -> run(d)... } ` functions which all collapse once evaluated (and overflow). Note that `Kleisli` will still be stackunsafe if used with a stackunsafe monad, that cannot ever be prevented.

Using `AndThen.flatMap` instead builds up a tower of `Join`'s which will all be collapsed later in the loop.