### PR TITLE
Add race 3 to guarantee order of scheduling

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
@@ -366,7 +366,7 @@ interface IORace {
 
       IORunLoop.startCancelable(IOForkedStart(ioC, ctx), connC) { result ->
         result.fold({
-          onError(active, cb, conn, connA, connC, it)
+          onError(active, cb, conn, connA, connB, it)
         }, {
           onSuccess(active, conn, connA, connB, cb, Race3.Third(it))
         })

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
@@ -3,9 +3,7 @@ package arrow.fx
 import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
-import arrow.core.extensions.set.monoidal.identity
 import arrow.core.internal.AtomicBooleanW
-import arrow.fx.extensions.io.apply.tupled
 import arrow.fx.internal.IOFiber
 import arrow.fx.internal.IOForkedStart
 import arrow.fx.internal.Platform

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
@@ -3,7 +3,9 @@ package arrow.fx
 import arrow.core.Either
 import arrow.core.Left
 import arrow.core.Right
+import arrow.core.extensions.set.monoidal.identity
 import arrow.core.internal.AtomicBooleanW
+import arrow.fx.extensions.io.apply.tupled
 import arrow.fx.internal.IOFiber
 import arrow.fx.internal.IOForkedStart
 import arrow.fx.internal.Platform
@@ -81,7 +83,7 @@ interface IORace {
     ioA: IOOf<A>,
     ioB: IOOf<B>
   ): IO<Race2<A, B>> =
-    racePairCancellable(ctx, ioA, ioB)
+    race2(ctx, ioA, ioB)
 
   /**
    * @see raceN
@@ -92,15 +94,7 @@ interface IORace {
     ioB: IOOf<B>,
     ioC: IOOf<C>
   ): IO<Race3<out A, out B, out C>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB),
-      ioC
-    ).map {
-      it.fold(
-        { it.fold({ a -> Race3.First(a) }, { b -> Race3.Second(b) }) },
-        { c -> Race3.Third(c) }
-      )
-    }
+    race3(ctx, ioA, ioB, ioC)
 
   /**
    * @see raceN
@@ -112,9 +106,9 @@ interface IORace {
     ioC: IOOf<C>,
     ioD: IOOf<D>
   ): IO<Race4<out A, out B, out C, out D>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB),
-      raceN(ctx, ioC, ioD)
+    race2(ctx,
+      race2(ctx, ioA, ioB),
+      race2(ctx, ioC, ioD)
     ).map { res ->
       res.fold(
         { it.fold({ a -> Race4.First(a) }, { b -> Race4.Second(b) }) },
@@ -133,9 +127,9 @@ interface IORace {
     ioD: IOOf<D>,
     ioE: IOOf<E>
   ): IO<Race5<out A, out B, out C, out D, out E>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB, ioC),
-      raceN(ctx, ioD, ioE)
+    race2(ctx,
+      race3(ctx, ioA, ioB, ioC),
+      race2(ctx, ioD, ioE)
     ).map { res ->
       res.fold(
         { race3 -> race3.fold({ a -> Race5.First(a) }, { b -> Race5.Second(b) }, { c -> Race5.Third(c) }) },
@@ -155,9 +149,9 @@ interface IORace {
     ioE: IOOf<E>,
     ioF: IOOf<F>
   ): IO<Race6<out A, out B, out C, out D, out E, out F>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB, ioC),
-      raceN(ctx, ioD, ioE, ioF)
+    race2(ctx,
+      race3(ctx, ioA, ioB, ioC),
+      race3(ctx, ioD, ioE, ioF)
     ).map { res ->
       res.fold(
         { race3 -> race3.fold({ a -> Race6.First(a) }, { b -> Race6.Second(b) }, { c -> Race6.Third(c) }) },
@@ -178,10 +172,10 @@ interface IORace {
     ioF: IOOf<F>,
     ioG: IOOf<G>
   ): IO<Race7<out A, out B, out C, out D, out E, out F, out G>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB, ioC),
-      raceN(ctx, ioD, ioE),
-      raceN(ctx, ioF, ioG)
+    race3(ctx,
+      race3(ctx, ioA, ioB, ioC),
+      race2(ctx, ioD, ioE),
+      race2(ctx, ioF, ioG)
     ).map { res ->
       res.fold(
         { race3 -> race3.fold({ a -> Race7.First(a) }, { b -> Race7.Second(b) }, { c -> Race7.Third(c) }) },
@@ -204,10 +198,10 @@ interface IORace {
     ioG: IOOf<G>,
     ioH: IOOf<H>
   ): IO<Race8<out A, out B, out C, out D, out E, out F, out G, out H>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB, ioC),
-      raceN(ctx, ioD, ioE, ioF),
-      raceN(ctx, ioG, ioH)
+    race3(ctx,
+      race3(ctx, ioA, ioB, ioC),
+      race3(ctx, ioD, ioE, ioF),
+      race2(ctx, ioG, ioH)
     ).map { res ->
       res.fold(
         { race3 -> race3.fold({ a -> Race8.First(a) }, { b -> Race8.Second(b) }, { c -> Race8.Third(c) }) },
@@ -231,10 +225,10 @@ interface IORace {
     ioH: IOOf<H>,
     ioI: IOOf<I>
   ): IO<Race9<out A, out B, out C, out D, out E, out F, out G, out H, out I>> =
-    raceN(ctx,
-      raceN(ctx, ioA, ioB, ioC),
-      raceN(ctx, ioD, ioE, ioF),
-      raceN(ctx, ioG, ioH, ioI)
+    race3(ctx,
+      race3(ctx, ioA, ioB, ioC),
+      race3(ctx, ioD, ioE, ioF),
+      race3(ctx, ioG, ioH, ioI)
     ).map { res ->
       res.fold(
         { race3 -> race3.fold({ a -> Race9.First(a) }, { b -> Race9.Second(b) }, { c -> Race9.Third(c) }) },
@@ -243,11 +237,8 @@ interface IORace {
       )
     }
 
-  /**
-   * Implementation for `IO.racePair`, but this way it is more efficient,
-   * as we no longer have to keep internal promises.
-   */
-  private fun <A, B> racePairCancellable(ctx: CoroutineContext, ioA: IOOf<A>, ioB: IOOf<B>): IO<Either<A, B>> {
+  /** Implementation for `IO.raceN` arity 2, this way it is more efficient than racePair, as we no longer have to keep internal promises. */
+  private fun <A, B> race2(ctx: CoroutineContext, ioA: IOOf<A>, ioB: IOOf<B>): IO<Either<A, B>> {
     fun <T, U> onSuccess(
       isActive: AtomicBooleanW,
       main: IOConnection,
@@ -262,9 +253,9 @@ interface IORace {
         }
       } else Unit
 
-    fun <T> onError(
+    fun onError(
       active: AtomicBooleanW,
-      cb: (Either<Throwable, T>) -> Unit,
+      cb: (Either<Throwable, Nothing>) -> Unit,
       main: IOConnection,
       other: IOConnection,
       err: Throwable
@@ -295,6 +286,89 @@ interface IORace {
           onError(active, cb, conn, connA, it)
         }, {
           onSuccess(active, conn, connA, cb, Right(it))
+        })
+      }
+    }
+
+    return IO.Async(true, start)
+  }
+
+  /** Implementation for `IO.raceN` arity 3, this way it is more efficient than racePair, as we no longer have to keep internal promises. */
+  private fun <A, B, C> race3(ctx: CoroutineContext, ioA: IOOf<A>, ioB: IOOf<B>, ioC: IOOf<C>): IO<Race3<A, B, C>> {
+    fun onSuccess(
+      isActive: AtomicBooleanW,
+      main: IOConnection,
+      other2: IOConnection,
+      other3: IOConnection,
+      cb: (Either<Throwable, Race3<A, B, C>>) -> Unit,
+      r: Race3<A, B, C>
+    ): Unit = if (isActive.getAndSet(false)) {
+      other2.cancel().fix().unsafeRunAsync { r2 ->
+        other3.cancel().fix().unsafeRunAsync { r3 ->
+          main.pop()
+          cb(Right(r))
+        }
+      }
+    } else Unit
+
+    fun onError(
+      active: AtomicBooleanW,
+      cb: (Either<Throwable, Nothing>) -> Unit,
+      main: IOConnection,
+      other2: IOConnection,
+      other3: IOConnection,
+      err: Throwable
+    ): Unit = if (active.getAndSet(false)) {
+      other2.cancel().fix().unsafeRunAsync { r2 ->
+        other3.cancel().fix().unsafeRunAsync { r3 ->
+          main.pop()
+          cb(Left(
+            r2.fold({ err2 ->
+              r3.fold({ err3 ->
+                Platform.composeErrors(err, err2, err3)
+              }, {
+                Platform.composeErrors(err, err2)
+              })
+            }, {
+              r3.fold({ err3 ->
+                Platform.composeErrors(err, err3)
+              }, {
+                err
+              })
+            })
+          ))
+        }
+      }
+    } else Unit
+
+    val start = { conn: IOConnection, cb: (Either<Throwable, Race3<A, B, C>>) -> Unit ->
+      val active = AtomicBooleanW(true)
+      val connA = IOConnection()
+      val connB = IOConnection()
+      val connC = IOConnection()
+      conn.push(connA.cancel(), connB.cancel(), connC.cancel())
+
+      IORunLoop.startCancelable(IOForkedStart(ioA, ctx), connA) { result ->
+        result.fold({
+          onError(active, cb, conn, connB, connC, it)
+        }, {
+          onSuccess(active, conn, connB, connC, cb, Race3.First(it))
+        })
+      }
+
+      IORunLoop.startCancelable(IOForkedStart(ioB, ctx), connB) { result ->
+        result.fold({
+          onError(active, cb, conn, connA, connC, it)
+        }, {
+          onSuccess(active, conn, connA, connC, cb, Race3.Second(it))
+        })
+      }
+
+      IORunLoop.startCancelable(IOForkedStart(ioC, ctx), connC) { result ->
+        result.fold({
+          onError(active, cb, conn, connA, connC, it)
+        }, {
+          onSuccess(active, conn, connA, connB, cb, Race3.Third(it))
         })
       }
     }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/RaceModels.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/RaceModels.kt
@@ -36,7 +36,7 @@ sealed class RaceTriple<F, A, B, C> {
 /** Alias for `Either` structure to provide consistent signature for race methods. */
 typealias Race2<A, B> = Either<A, B>
 
-sealed class Race3 <A, B, C> {
+sealed class Race3 <out A, out B, out C> {
   data class First<A>(val winner: A) : Race3<A, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race3<Nothing, B, Nothing>()
   data class Third<C>(val winner: C) : Race3<Nothing, Nothing, C>()
@@ -52,7 +52,7 @@ sealed class Race3 <A, B, C> {
   }
 }
 
-sealed class Race4 <A, B, C, D> {
+sealed class Race4 <out A, out B, out C, out D> {
   data class First<A>(val winner: A) : Race4<A, Nothing, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race4<Nothing, B, Nothing, Nothing>()
   data class Third<C>(val winner: C) : Race4<Nothing, Nothing, C, Nothing>()
@@ -71,7 +71,7 @@ sealed class Race4 <A, B, C, D> {
   }
 }
 
-sealed class Race5 <A, B, C, D, E> {
+sealed class Race5 <out A, out B, out C, out D, out E> {
   data class First<A>(val winner: A) : Race5<A, Nothing, Nothing, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race5<Nothing, B, Nothing, Nothing, Nothing>()
   data class Third<C>(val winner: C) : Race5<Nothing, Nothing, C, Nothing, Nothing>()
@@ -93,7 +93,7 @@ sealed class Race5 <A, B, C, D, E> {
   }
 }
 
-sealed class Race6 <A, B, C, D, E, F> {
+sealed class Race6 <out A, out B, out C, out D, out E, out F> {
   data class First<A>(val winner: A) : Race6<A, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race6<Nothing, B, Nothing, Nothing, Nothing, Nothing>()
   data class Third<C>(val winner: C) : Race6<Nothing, Nothing, C, Nothing, Nothing, Nothing>()
@@ -118,7 +118,7 @@ sealed class Race6 <A, B, C, D, E, F> {
   }
 }
 
-sealed class Race7 <A, B, C, D, E, F, G> {
+sealed class Race7 <out A, out B, out C, out D, out E, out F, out G> {
   data class First<A>(val winner: A) : Race7<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race7<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Third<C>(val winner: C) : Race7<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing>()
@@ -146,7 +146,7 @@ sealed class Race7 <A, B, C, D, E, F, G> {
   }
 }
 
-sealed class Race8 <A, B, C, D, E, F, G, H> {
+sealed class Race8 <out A, out B, out C, out D, out E, out F, out G, out H> {
   data class First<A>(val winner: A) : Race8<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race8<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Third<C>(val winner: C) : Race8<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing>()
@@ -177,7 +177,7 @@ sealed class Race8 <A, B, C, D, E, F, G, H> {
   }
 }
 
-sealed class Race9 <A, B, C, D, E, F, G, H, I> {
+sealed class Race9 <out A, out B, out C, out D, out E, out F, out G, out H, out I> {
   data class First<A>(val winner: A) : Race9<A, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Second<B>(val winner: B) : Race9<Nothing, B, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()
   data class Third<C>(val winner: C) : Race9<Nothing, Nothing, C, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing>()

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -377,6 +377,32 @@ class IOTest : UnitSpec() {
       order.toList() shouldBe listOf(1L, 2, 3, 4, 5, 6)
     }
 
+    "Races are scheduled in the correct order" {
+      val order = mutableListOf<Int>()
+
+      fun makePar(num: Int): IO<Int> =
+        IO.effect {
+          order.add(num)
+        }.followedBy(IO.sleep((num * 200L).milliseconds))
+          .map { num }
+
+      val result = IO.raceN(
+        all,
+        makePar(9),
+        makePar(8),
+        makePar(7),
+        makePar(6),
+        makePar(5),
+        makePar(4),
+        makePar(3),
+        makePar(2),
+        makePar(1)
+      ).unsafeRunSync()
+
+      result shouldBe Race9.Ninth(1)
+      order shouldBe listOf(9, 8, 7, 6, 5, 4, 3, 2, 1)
+    }
+
     "parallel mapping is done in the expected CoroutineContext" {
       fun makePar(num: Long) =
         IO(newSingleThreadContext("$num")) {


### PR DESCRIPTION
Parallel operations should be scheduled in the order they appear in the parameter list.

Without having an arity-2 & arity-3 operator you cannot create N-arty operators that schedule the tasks in the same order as the parameter list.