### PR TITLE
Add onCancel to Bracket

### DIFF
--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -982,6 +982,19 @@ sealed class IO<out A> : IOOf<A> {
   fun guaranteeCase(finalizer: (ExitCase<Throwable>) -> IOOf<Unit>): IO<A> =
     IOBracket.guaranteeCase(this, finalizer)
 
+  /**
+   * Executes the given [finalizer] when the source is canceled, allowing registering a cancellation token.
+   *
+   * Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+   */
+  fun onCancel(finalizer: IOOf<Unit>): IO<A> =
+    guaranteeCase { case ->
+      when (case) {
+        ExitCase.Canceled -> finalizer
+        else -> unit
+      }
+    }
+
   internal data class Pure<out A>(val a: A) : IO<A>() {
     // Pure can be replaced by its value
     override fun <B> map(f: (A) -> B): IO<B> = Suspend { Pure(f(a)) }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
@@ -146,4 +146,17 @@ interface Bracket<F, E> : MonadError<F, E> {
    */
   fun <A> Kind<F, A>.guaranteeCase(finalizer: (ExitCase<E>) -> Kind<F, Unit>): Kind<F, A> =
     just<Unit>(Unit).bracketCase({ _, e -> finalizer(e) }, { this })
+
+  /**
+   * Executes the given [finalizer] when the source is canceled, allowing registering a cancellation token.
+   *
+   * Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+   */
+  fun <A> Kind<F, A>.onCancel(finalizer: Kind<F, Unit>): Kind<F, A> =
+    guaranteeCase { case ->
+      when (case) {
+        ExitCase.Canceled -> finalizer
+        else -> just<Unit>(Unit)
+      }
+    }
 }


### PR DESCRIPTION
This PR adds onCancel to `Bracket` which is a specialization over `guaranteeCase`.

It's used frequently in tests, and it can be useful for testing and building inter-op with other effect libraries. See #1939 
