### PR TITLE
Deprecate Duration

### DIFF
--- a/modules/aql/arrow-aql/src/test/kotlin/arrow/aql/tests/IOExample.kt
+++ b/modules/aql/arrow-aql/src/test/kotlin/arrow/aql/tests/IOExample.kt
@@ -5,6 +5,7 @@ import arrow.core.left
 import arrow.core.right
 import arrow.fx.IO
 import arrow.fx.handleErrorWith
+import kotlin.time.ExperimentalTime
 
 data class UserId(val value: String)
 data class User(val userId: UserId)
@@ -69,6 +70,7 @@ class Module {
 }
 
 object test {
+  @ExperimentalTime
   @JvmStatic
   fun main(args: Array<String>) {
     val user1 = User(UserId("user1"))

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Async.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Async.kt
@@ -11,6 +11,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -27,6 +28,7 @@ open class Async {
       if (i > size) IO.just(i) else ioAsyncLoop(i + 1)
     )
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioAsyncLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/AttemptNonRaised.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/AttemptNonRaised.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -28,6 +29,7 @@ open class AttemptNonRaised {
       }
     } else IO.just(1)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioLoopHappy(size, 0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/AttemptRaisedError.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/AttemptRaisedError.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 val dummy = object : RuntimeException("dummy") {
   override fun fillInStackTrace(): Throwable =
@@ -33,6 +34,7 @@ open class AttemptRaisedError {
       }
     } else IO.just(1)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioLoopNotHappy(size, 0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Cancellable.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Cancellable.kt
@@ -13,6 +13,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -34,6 +35,7 @@ open class Cancellable {
     if (i < size) evalCancelable(i + 1).flatMap { cancelableLoop(it) }
     else evalCancelable(i)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     cancelableLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/DeepBind.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/DeepBind.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -27,6 +28,7 @@ open class DeepBind {
       ioFibLazy(n - 2).flatMap { b -> IO { a + b } }
     }
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioFibLazy(depth).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Defer.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Defer.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -26,6 +27,7 @@ open class Defer {
       if (j > size) IO.defer { IO.just(j) } else ioDeferLoop(j + 1)
     }
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioDeferLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Delay.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Delay.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -26,6 +27,7 @@ open class Delay {
       if (j > size) IO { j } else ioDelayLoop(j + 1)
     }
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioDelayLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/ForkFiber.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/ForkFiber.kt
@@ -12,6 +12,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -30,6 +31,7 @@ open class ForkFiber {
       }
     } else IO.just(i)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioStartLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/HandleNonRaised.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/HandleNonRaised.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 import arrow.fx.handleErrorWith as ioHandleErrorWith
 
 @State(Scope.Thread)
@@ -30,6 +31,7 @@ open class HandleNonRaised {
     else
       IO.just(i)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioHappyPathLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/HandleRaisedError.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/HandleRaisedError.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 import arrow.fx.extensions.io.applicativeError.handleErrorWith as ioHandleError
 
 @State(Scope.Thread)
@@ -33,6 +34,7 @@ open class HandleRaisedError {
     else
       IO.just(i)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioErrorRaisedloop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/LeftBind.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/LeftBind.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -29,6 +30,7 @@ open class LeftBind {
     else if (i < size) ioLoop(i + 1).flatMap { IO.just(it) }
     else IO.just(i)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     IO.just(0).flatMap { ioLoop(it) }.unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Map.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Map.kt
@@ -9,6 +9,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(1)
@@ -62,6 +63,7 @@ open class Map {
   fun kioBatch120(): Long =
     arrow.benchmarks.effects.kio.Map.kioMapTest(12000 / 120, 120)
 
+  @ExperimentalTime
   private fun ioTest(iterations: Int, batch: Int): Long {
     val f = { x: Int -> x + 1 }
     var io = IO.just(0)

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/MapStream.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/MapStream.kt
@@ -12,6 +12,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(1)
@@ -20,12 +21,15 @@ import java.util.concurrent.TimeUnit
 @CompilerControl(CompilerControl.Mode.DONT_INLINE)
 open class MapStream {
 
+  @ExperimentalTime
   @Benchmark
   fun ioOne(): Long = IOStream.test(12000, 1).unsafeRunSync()
 
+  @ExperimentalTime
   @Benchmark
   fun io30(): Long = IOStream.test(1000, 30).unsafeRunSync()
 
+  @ExperimentalTime
   @Benchmark
   fun io120(): Long = IOStream.test(100, 120).unsafeRunSync()
 

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/ParMap.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/ParMap.kt
@@ -13,6 +13,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -29,6 +30,7 @@ open class ParMap {
       IODispatchers.CommonPool.parMapN(acc, IO { i }) { a, b -> a + b }
     }
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioHelper().unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Pure.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Pure.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -26,6 +27,7 @@ open class Pure {
       if (j > size) IO.just(j) else ioPureLoop(j + 1)
     }
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int =
     ioPureLoop(0).unsafeRunSync()

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/RacePair.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/RacePair.kt
@@ -13,6 +13,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -34,6 +35,7 @@ open class RacePair {
     }
   }
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int = racePairHelper().unsafeRunSync()
 }

--- a/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Uncancellable.kt
+++ b/modules/benchmarks/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Uncancellable.kt
@@ -10,6 +10,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
 
 @State(Scope.Thread)
 @Fork(2)
@@ -25,6 +26,7 @@ open class Uncancellable {
     if (i < size) IO { i + 1 }.uncancelable().flatMap { ioUncancelableLoop(it) }
     else IO.just(i)
 
+  @ExperimentalTime
   @Benchmark
   fun io(): Int = ioUncancelableLoop(0).unsafeRunSync()
 }

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ApplicativeErrorLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ApplicativeErrorLaws.kt
@@ -18,6 +18,7 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import kotlin.time.ExperimentalTime
 
 object ApplicativeErrorLaws {
 
@@ -79,6 +80,7 @@ object ApplicativeErrorLaws {
       catch { either.fold({ throw it }, ::identity) }.equalUnderTheLaw(either.fold({ raiseError<Int>(it) }, { just(it) }), EQ)
     }
 
+  @ExperimentalTime
   fun <F> ApplicativeError<F, Throwable>.applicativeErrorEffectCatch(EQ: Eq<Kind<F, Int>>): Unit =
     forAll(Gen.either(Gen.throwable(), Gen.int())) { either: Either<Throwable, Int> ->
       IO.effect {

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/TimerLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/TimerLaws.kt
@@ -3,11 +3,12 @@ package arrow.test.laws
 import arrow.Kind
 import arrow.fx.Timer
 import arrow.fx.typeclasses.Async
-import arrow.fx.typeclasses.milliseconds
-import arrow.fx.typeclasses.seconds
 import arrow.test.generators.intSmall
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+import kotlin.time.seconds
 
 object TimerLaws {
 
@@ -27,12 +28,14 @@ object TimerLaws {
     }
   }
 
+  @ExperimentalTime
   fun <F> laws(AS: Async<F>, T: Timer<F>, EQ: Eq<Kind<F, Boolean>>): List<Law> =
     listOf(
       Law("Timer Laws: sleep should last specified time") { AS.sleepShouldLastSpecifiedTime(T, Clock(AS), EQ) },
       Law("Timer Laws: negative sleep should be immediate") { AS.negativeSleepShouldBeImmediate(T, EQ) }
     )
 
+  @ExperimentalTime
   fun <F> Async<F>.sleepShouldLastSpecifiedTime(
     T: Timer<F>,
     C: Clock<F>,
@@ -49,6 +52,7 @@ object TimerLaws {
     lhs.equalUnderTheLaw(just(true), EQ)
   }
 
+  @ExperimentalTime
   fun <F> Async<F>.negativeSleepShouldBeImmediate(
     T: Timer<F>,
     EQ: Eq<Kind<F, Boolean>>

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
@@ -39,6 +39,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.toFlux
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import arrow.fx.reactor.handleErrorWith as fluxHandleErrorWith
 
 @extension
@@ -203,8 +204,13 @@ fun <A> FluxK.Companion.fx(c: suspend AsyncSyntax<ForFluxK>.() -> A): FluxK<A> =
 
 @extension
 interface FluxKTimer : Timer<ForFluxK> {
+  @ExperimentalTime
   override fun sleep(duration: Duration): FluxK<Unit> =
-    FluxK(Mono.delay(java.time.Duration.ofNanos(duration.nanoseconds))
+    sleep(duration.duration)
+
+  @ExperimentalTime
+  override fun sleep(duration: kotlin.time.Duration): FluxK<Unit> =
+    FluxK(Mono.delay(java.time.Duration.ofNanos(duration.toLongNanoseconds()))
       .map { Unit }.toFlux())
 }
 

--- a/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
+++ b/modules/fx/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
@@ -28,6 +28,7 @@ import arrow.typeclasses.MonadError
 import arrow.typeclasses.MonadThrow
 import reactor.core.publisher.Mono
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import arrow.fx.reactor.handleErrorWith as monoHandleErrorWith
 
 @extension
@@ -131,8 +132,13 @@ interface MonoKConcurrentEffect : ConcurrentEffect<ForMonoK>, MonoKEffect {
 
 @extension
 interface MonoKTimer : Timer<ForMonoK> {
+  @ExperimentalTime
   override fun sleep(duration: Duration): MonoK<Unit> =
-    MonoK(Mono.delay(java.time.Duration.ofNanos(duration.nanoseconds))
+    sleep(duration.duration)
+
+  @ExperimentalTime
+  override fun sleep(duration: kotlin.time.Duration): MonoK<Unit> =
+    MonoK(Mono.delay(java.time.Duration.ofNanos(duration.toLongNanoseconds()))
       .map { Unit })
 }
 

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -55,6 +55,7 @@ import arrow.typeclasses.FunctorFilter
 import arrow.typeclasses.MonadFilter
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.ReplaySubject
+import kotlin.time.ExperimentalTime
 import io.reactivex.disposables.Disposable as RxDisposable
 import arrow.fx.rx2.handleErrorWith as flowableHandleErrorWith
 
@@ -355,8 +356,13 @@ fun FlowableK.Companion.effectMissing(): FlowableKEffect = object : FlowableKEff
 
 @extension
 interface FlowableKTimer : Timer<ForFlowableK> {
+  @ExperimentalTime
   override fun sleep(duration: Duration): FlowableK<Unit> =
-    FlowableK(Flowable.timer(duration.nanoseconds, TimeUnit.NANOSECONDS)
+    sleep(duration.duration)
+
+  @ExperimentalTime
+  override fun sleep(duration: kotlin.time.Duration): FlowableK<Unit> =
+    FlowableK(Flowable.timer(duration.toLongNanoseconds(), TimeUnit.NANOSECONDS)
       .map { Unit })
 }
 

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -50,6 +50,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.ReplaySubject
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import arrow.fx.rx2.handleErrorWith as maybeHandleErrorWith
 import io.reactivex.disposables.Disposable as RxDisposable
 
@@ -267,8 +268,13 @@ interface MaybeKDispatchers : Dispatchers<ForMaybeK> {
 
 @extension
 interface MaybeKTimer : Timer<ForMaybeK> {
+  @ExperimentalTime
   override fun sleep(duration: Duration): MaybeK<Unit> =
-    MaybeK(Maybe.timer(duration.nanoseconds, TimeUnit.NANOSECONDS)
+    sleep(duration.duration)
+
+  @ExperimentalTime
+  override fun sleep(duration: kotlin.time.Duration): MaybeK<Unit> =
+    MaybeK(Maybe.timer(duration.toLongNanoseconds(), TimeUnit.NANOSECONDS)
       .map { Unit })
 }
 

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -48,6 +48,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.ReplaySubject
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import arrow.fx.rx2.handleErrorWith as observableHandleErrorWith
 import io.reactivex.disposables.Disposable as RxDisposable
 
@@ -275,8 +276,13 @@ fun <A> ObservableK.Companion.fx(c: suspend ConcurrentSyntax<ForObservableK>.() 
 
 @extension
 interface ObservableKTimer : Timer<ForObservableK> {
+  @ExperimentalTime
   override fun sleep(duration: Duration): ObservableK<Unit> =
-    ObservableK(Observable.timer(duration.nanoseconds, TimeUnit.NANOSECONDS)
+    sleep(duration.duration)
+
+  @ExperimentalTime
+  override fun sleep(duration: kotlin.time.Duration): ObservableK<Unit> =
+    ObservableK(Observable.timer(duration.toLongNanoseconds(), TimeUnit.NANOSECONDS)
       .map { Unit })
 }
 

--- a/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
+++ b/modules/fx/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
@@ -48,6 +48,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.ReplaySubject
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import io.reactivex.disposables.Disposable as RxDisposable
 import arrow.fx.rx2.handleErrorWith as singleHandleErrorWith
 
@@ -243,8 +244,13 @@ interface SingleKConcurrentEffect : ConcurrentEffect<ForSingleK>, SingleKEffect 
 
 @extension
 interface SingleKTimer : Timer<ForSingleK> {
+  @ExperimentalTime
   override fun sleep(duration: Duration): SingleK<Unit> =
-    SingleK(Single.timer(duration.nanoseconds, TimeUnit.NANOSECONDS)
+    sleep(duration.duration)
+
+  @ExperimentalTime
+  override fun sleep(duration: kotlin.time.Duration): SingleK<Unit> =
+    SingleK(Single.timer(duration.toLongNanoseconds(), TimeUnit.NANOSECONDS)
       .map { Unit })
 }
 

--- a/modules/fx/arrow-fx/build.gradle
+++ b/modules/fx/arrow-fx/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
-    compile project(':arrow-annotations')
-    compile project(':arrow-core')
-    kapt project(':arrow-meta')
-    kaptTest project(':arrow-meta')
-    compileOnly project(':arrow-meta')
-    testCompileOnly project(':arrow-meta')
-    testRuntime("org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION")
-    testCompile "io.kotlintest:kotlintest-runner-junit5:$KOTLIN_TEST_VERSION"
-    testCompile project(':arrow-test')
+  compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+  compile project(':arrow-annotations')
+  compile project(':arrow-core')
+  kapt project(':arrow-meta')
+  kaptTest project(':arrow-meta')
+  compileOnly project(':arrow-meta')
+  testCompileOnly project(':arrow-meta')
+  testRuntime("org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION")
+  testCompile "io.kotlintest:kotlintest-runner-junit5:$KOTLIN_TEST_VERSION"
+  testCompile project(':arrow-test')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/modules/fx/arrow-fx/gradle.properties
+++ b/modules/fx/arrow-fx/gradle.properties
@@ -2,3 +2,4 @@
 POM_NAME=Arrow-Fx
 POM_ARTIFACT_ID=arrow-fx
 POM_PACKAGING=jar
+org.gradle.debug=true

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IOConnection.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IOConnection.kt
@@ -8,8 +8,10 @@ import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.MonadDefer
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import arrow.fx.handleErrorWith as handleErrorW
 
+@ExperimentalTime
 fun IOConnection.toDisposable(): Disposable = { cancel().fix().unsafeRunSync() }
 typealias IOConnection = KindConnection<ForIO>
 

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
@@ -28,6 +28,7 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlin.random.Random
+import kotlin.time.ExperimentalTime
 
 class ForSchedule private constructor() {
   companion object
@@ -875,6 +876,7 @@ sealed class Schedule<F, Input, Output> : ScheduleOf<F, Input, Output> {
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Returns the last output from the policy or raises an error if a repeat failed.
  */
+@ExperimentalTime
 fun <F, A, B> Kind<F, A>.repeat(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>
@@ -884,6 +886,7 @@ fun <F, A, B> Kind<F, A>.repeat(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Returns the last output from the policy or raises an error if a repeat failed.
  */
+@ExperimentalTime
 fun <F, E, A, B> Kind<F, A>.repeat(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -894,6 +897,7 @@ fun <F, E, A, B> Kind<F, A>.repeat(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@ExperimentalTime
 fun <F, A, B> Kind<F, A>.repeatOrElse(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>,
@@ -904,6 +908,7 @@ fun <F, A, B> Kind<F, A>.repeatOrElse(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@ExperimentalTime
 fun <F, E, A, B> Kind<F, A>.repeatOrElse(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -915,6 +920,7 @@ fun <F, E, A, B> Kind<F, A>.repeatOrElse(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@ExperimentalTime
 fun <F, A, B, C> Kind<F, A>.repeatOrElseEither(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>,
@@ -925,6 +931,7 @@ fun <F, A, B, C> Kind<F, A>.repeatOrElseEither(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@ExperimentalTime
 fun <F, E, A, B, C> Kind<F, A>.repeatOrElseEither(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -950,6 +957,7 @@ fun <F, E, A, B, C> Kind<F, A>.repeatOrElseEither(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Returns the result of the effect if if it was successful or re-raises the last error encountered when the schedule ends.
  */
+@ExperimentalTime
 fun <F, A, B> Kind<F, A>.retry(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>
@@ -959,6 +967,7 @@ fun <F, A, B> Kind<F, A>.retry(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Returns the result of the effect if if it was successful or re-raises the last error encountered when the schedule ends.
  */
+@ExperimentalTime
 fun <F, E, A, B> Kind<F, A>.retry(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -969,6 +978,7 @@ fun <F, E, A, B> Kind<F, A>.retry(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@ExperimentalTime
 fun <F, A, B> Kind<F, A>.retryOrElse(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>,
@@ -979,6 +989,7 @@ fun <F, A, B> Kind<F, A>.retryOrElse(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@ExperimentalTime
 fun <F, E, A, B> Kind<F, A>.retryOrElse(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -990,6 +1001,7 @@ fun <F, E, A, B> Kind<F, A>.retryOrElse(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@ExperimentalTime
 fun <F, A, B, C> Kind<F, A>.retryOrElseEither(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>,
@@ -1000,6 +1012,7 @@ fun <F, A, B, C> Kind<F, A>.retryOrElseEither(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@ExperimentalTime
 fun <F, E, A, B, C> Kind<F, A>.retryOrElseEither(
   ME: MonadError<F, E>,
   T: Timer<F>,

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Timer.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/Timer.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.fx.internal.ConcurrentSleep
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Duration
+import kotlin.time.ExperimentalTime
 
 /**
  * [Timer] allows to [sleep] for a [Duration] in [F].
@@ -33,11 +34,18 @@ interface Timer<F> {
    * }
    * ```
    **/
-  fun sleep(duration: Duration): Kind<F, Unit>
+  @ExperimentalTime
+  @Deprecated("Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP", ReplaceWith("sleep(duration.duration)"))
+  fun sleep(duration: Duration): Kind<F, Unit> = sleep(duration.duration)
+
+  @ExperimentalTime
+  fun sleep(duration: kotlin.time.Duration): Kind<F, Unit>
 
   companion object {
+    @ExperimentalTime
     operator fun <F> invoke(CF: Concurrent<F>): Timer<F> = object : Timer<F> {
-      override fun sleep(duration: Duration): Kind<F, Unit> = CF.ConcurrentSleep(duration)
+      @ExperimentalTime
+      override fun sleep(duration: kotlin.time.Duration): Kind<F, Unit> = CF.ConcurrentSleep(duration)
     }
   }
 }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
@@ -45,6 +45,7 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import arrow.unsafe
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import arrow.fx.handleError as ioHandleError
 import arrow.fx.handleErrorWith as ioHandleErrorWith
 
@@ -216,6 +217,7 @@ fun IO.Companion.concurrent(dispatchers: Dispatchers<ForIO>): Concurrent<ForIO> 
   override fun dispatchers(): Dispatchers<ForIO> = dispatchers
 }
 
+@ExperimentalTime
 fun IO.Companion.timer(CF: Concurrent<ForIO>): Timer<ForIO> =
   Timer(CF)
 
@@ -228,6 +230,7 @@ interface IOEffect : Effect<ForIO>, IOAsync {
 // FIXME default @extension are temporarily declared in arrow-effects-io-extensions due to multiplatform needs
 interface IOConcurrentEffect : ConcurrentEffect<ForIO>, IOEffect, IOConcurrent {
 
+  @ExperimentalTime
   override fun <A> IOOf<A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> IOOf<Unit>): IO<Disposable> =
     fix().runAsyncCancellable(OnCancel.ThrowCancellationException, cb)
 }
@@ -263,6 +266,7 @@ interface IOMonadIO : MonadIO<ForIO>, IOMonad {
 @extension
 interface IOUnsafeRun : UnsafeRun<ForIO> {
 
+  @ExperimentalTime
   override suspend fun <A> unsafe.runBlocking(fa: () -> Kind<ForIO, A>): A = fa().fix().unsafeRunSync()
 
   override suspend fun <A> unsafe.runNonBlocking(fa: () -> Kind<ForIO, A>, cb: (Either<Throwable, A>) -> Unit): Unit =
@@ -271,11 +275,13 @@ interface IOUnsafeRun : UnsafeRun<ForIO> {
 
 @extension
 interface IOUnsafeCancellableRun : UnsafeCancellableRun<ForIO> {
+  @ExperimentalTime
   override suspend fun <A> unsafe.runBlocking(fa: () -> Kind<ForIO, A>): A = fa().fix().unsafeRunSync()
 
   override suspend fun <A> unsafe.runNonBlocking(fa: () -> Kind<ForIO, A>, cb: (Either<Throwable, A>) -> Unit) =
     fa().fix().unsafeRunAsync(cb)
 
+  @ExperimentalTime
   override suspend fun <A> unsafe.runNonBlockingCancellable(onCancel: OnCancel, fa: () -> Kind<ForIO, A>, cb: (Either<Throwable, A>) -> Unit): Disposable =
     fa().fix().unsafeRunAsyncCancellable(onCancel, cb)
 }
@@ -305,6 +311,7 @@ interface IODefaultConcurrent : Concurrent<ForIO>, IOConcurrent {
     IO.dispatchers()
 }
 
+@ExperimentalTime
 fun IO.Companion.timer(): Timer<ForIO> = Timer(IO.concurrent())
 
 @extension

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ConcurrentSleep.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/internal/ConcurrentSleep.kt
@@ -8,12 +8,20 @@ import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.startCoroutine
+import kotlin.time.ExperimentalTime
 
-internal fun <F> Concurrent<F>.ConcurrentSleep(duration: Duration): Kind<F, Unit> = cancelable { cb ->
-  val cancelRef = scheduler.schedule(ShiftTick(dispatchers().default(), cb), duration.amount, duration.timeUnit)
+@ExperimentalTime
+@Deprecated("Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("ConcurrentSleep(duration.duration)"))
+internal fun <F> Concurrent<F>.ConcurrentSleep(duration: Duration): Kind<F, Unit> = ConcurrentSleep(duration.duration)
+
+@ExperimentalTime
+internal fun <F> Concurrent<F>.ConcurrentSleep(duration: kotlin.time.Duration): Kind<F, Unit> = cancelable { cb ->
+  val cancelRef = scheduler.schedule(ShiftTick(dispatchers().default(), cb), duration.toLongNanoseconds(), TimeUnit.NANOSECONDS)
   later { cancelRef.cancel(false); Unit }
 }
 

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Duration.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Duration.kt
@@ -1,17 +1,38 @@
 package arrow.fx.typeclasses
 
 import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
+import kotlin.time.toDuration
 
+@Deprecated("Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("kotlin.time.Duration")
+)
 data class Duration(val amount: Long, val timeUnit: TimeUnit) {
+
+  @ExperimentalTime
+  val duration: kotlin.time.Duration by lazy { amount.toDuration(timeUnit) }
+
   val nanoseconds: Long by lazy { timeUnit.toNanos(amount) }
 
   companion object {
     // Actually limited to 9223372036854775807 days, so unless you are very patient, it is unlimited ;-)
+    @Deprecated(
+      "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+      ReplaceWith("kotlin.time.Duration.INFINITE")
+    )
     val INFINITE = Duration(amount = Long.MAX_VALUE, timeUnit = TimeUnit.DAYS)
   }
 
+  @Deprecated(
+    "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+    ReplaceWith("this.amount.toDuration(this.timeUnit).times(i)", imports = arrayOf("kotlin.time.toDuration"))
+  )
   operator fun times(i: Int) = Duration(amount * i, timeUnit)
 
+  @Deprecated(
+    "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+    ReplaceWith("plus", imports = arrayOf("kotlin.time.Duration"))
+  )
   operator fun plus(d: Duration): Duration = run {
     val comp = timeUnit.compareTo(d.timeUnit)
     when {
@@ -22,46 +43,106 @@ data class Duration(val amount: Long, val timeUnit: TimeUnit) {
   }
 }
 
-operator fun Int.times(d: Duration) = d * this
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("d.amount.toDuration(d.timeUnit).times(this)")
+)
+operator fun Int.times(d: Duration): Duration = d * this
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("days", imports = arrayOf("kotlin.time.days"))
+)
 val Long.days: Duration
   get() = Duration(this, TimeUnit.DAYS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("days", imports = arrayOf("kotlin.time.days"))
+)
 val Int.days: Duration
   get() = Duration(this.toLong(), TimeUnit.DAYS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("hours", imports = arrayOf("kotlin.time.hours"))
+)
 val Long.hours: Duration
   get() = Duration(this, TimeUnit.HOURS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("hours", imports = arrayOf("kotlin.time.hours"))
+)
 val Int.hours: Duration
   get() = Duration(this.toLong(), TimeUnit.HOURS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("microseconds", imports = arrayOf("kotlin.time.microseconds"))
+)
 val Long.microseconds: Duration
   get() = Duration(this, TimeUnit.MICROSECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("microseconds", imports = arrayOf("kotlin.time.microseconds"))
+)
 val Int.microseconds: Duration
   get() = Duration(this.toLong(), TimeUnit.MICROSECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("minutes", imports = arrayOf("kotlin.time.minutes"))
+)
 val Long.minutes: Duration
   get() = Duration(this, TimeUnit.MINUTES)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("minutes", imports = arrayOf("kotlin.time.minutes"))
+)
 val Int.minutes: Duration
   get() = Duration(this.toLong(), TimeUnit.MINUTES)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("milliseconds", imports = arrayOf("kotlin.time.milliseconds"))
+)
 val Long.milliseconds: Duration
   get() = Duration(this, TimeUnit.MILLISECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("milliseconds", imports = arrayOf("kotlin.time.milliseconds"))
+)
 val Int.milliseconds: Duration
   get() = Duration(this.toLong(), TimeUnit.MILLISECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("nanoseconds", imports = arrayOf("kotlin.time.nanoseconds"))
+)
 val Long.nanoseconds: Duration
   get() = Duration(this, TimeUnit.NANOSECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("nanoseconds", imports = arrayOf("kotlin.time.nanoseconds"))
+)
 val Int.nanoseconds: Duration
   get() = Duration(this.toLong(), TimeUnit.NANOSECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("seconds", imports = arrayOf("kotlin.time.seconds"))
+)
 val Long.seconds: Duration
   get() = Duration(this, TimeUnit.SECONDS)
 
+@Deprecated(
+  "Duration will be removed after 0.10.5 in favor of kotlin.time.Duration to support MPP",
+  ReplaceWith("seconds", imports = arrayOf("kotlin.time.seconds"))
+)
 val Int.seconds: Duration
   get() = Duration(this.toLong(), TimeUnit.SECONDS)

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -27,8 +27,6 @@ import arrow.fx.extensions.toIO
 import arrow.fx.internal.parMap2
 import arrow.fx.internal.parMap3
 import arrow.fx.typeclasses.ExitCase
-import arrow.fx.typeclasses.milliseconds
-import arrow.fx.typeclasses.seconds
 import arrow.test.UnitSpec
 import arrow.test.concurrency.SideEffect
 import arrow.test.generators.GenK
@@ -44,7 +42,11 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.newSingleThreadContext
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+import kotlin.time.seconds
 
+@ExperimentalTime
 @kotlinx.coroutines.ObsoleteCoroutinesApi
 class IOTest : UnitSpec() {
 

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
@@ -23,7 +23,9 @@ import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class QueueTest : UnitSpec() {
 
   init {

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/ResourceTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/ResourceTest.kt
@@ -11,7 +11,6 @@ import arrow.fx.extensions.resource.functor.functor
 import arrow.fx.extensions.resource.monad.monad
 import arrow.fx.extensions.resource.monoid.monoid
 import arrow.fx.extensions.resource.selective.selective
-import arrow.fx.typeclasses.seconds
 import arrow.test.UnitSpec
 import arrow.test.generators.GenK
 import arrow.test.laws.MonadLaws
@@ -20,7 +19,10 @@ import arrow.test.laws.forFew
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 
+@ExperimentalTime
 class ResourceTest : UnitSpec() {
   init {
 
@@ -56,6 +58,7 @@ class ResourceTest : UnitSpec() {
   }
 }
 
+@ExperimentalTime
 private fun Resource.Companion.eqK() = object : EqK<ResourcePartialOf<ForIO, Throwable>> {
   override fun <A> Kind<ResourcePartialOf<ForIO, Throwable>, A>.eqK(other: Kind<ResourcePartialOf<ForIO, Throwable>, A>, EQ: Eq<A>): Boolean =
     (this.fix() to other.fix()).let {

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/SemaphoreTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/SemaphoreTest.kt
@@ -16,7 +16,9 @@ import arrow.test.laws.equalUnderTheLaw
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import kotlinx.coroutines.Dispatchers
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class SemaphoreTest : UnitSpec() {
 
   init {

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/data/DurationTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/data/DurationTest.kt
@@ -1,19 +1,21 @@
 package arrow.fx.data
 
-import arrow.fx.typeclasses.Duration
 import arrow.test.UnitSpec
 import arrow.test.generators.intSmall
 import arrow.test.generators.timeUnit
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import kotlin.time.ExperimentalTime
+import kotlin.time.toDuration
 
+@ExperimentalTime
 class DurationTest : UnitSpec() {
 
   init {
     "plus should be commutative" {
       forAll(Gen.intSmall(), Gen.timeUnit(), Gen.intSmall(), Gen.timeUnit()) { i, u, j, v ->
-        val a = Duration(i.toLong(), u)
-        val b = Duration(j.toLong(), v)
+        val a = i.toDuration(u)
+        val b = j.toDuration(v)
         a + b == b + a
       }
     }

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ProcCallBackTest.kt
@@ -20,7 +20,9 @@ import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class ProcCallBackTest : UnitSpec() {
 
   private fun server(): MockWebServer = MockWebServer().apply {

--- a/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ResponseCallbackTest.kt
+++ b/modules/integrations/arrow-integrations-retrofit-adapter/src/test/kotlin/arrow/integrations/retrofit/adapter/ResponseCallbackTest.kt
@@ -10,7 +10,9 @@ import io.kotlintest.fail
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class ResponseCallbackTest : UnitSpec() {
   private val server = MockWebServer().apply {
     enqueue(MockResponse().setBody("{response:  \"hello, world!\"}").setResponseCode(200))

--- a/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
+++ b/modules/meta/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
@@ -103,7 +103,11 @@ interface JvmMetaApi : MetaApi, TypeElementEncoder, ProcessorUtils, TypeDecoder 
   override fun Func.removeConstrains(keepModifiers: Set<Modifier>): Func =
     copy(
       modifiers = modifiers.filterNot { it !in keepModifiers },
-      annotations = emptyList(),
+      annotations = annotations.also {
+        annotations.forEach {
+          println("annotation: simpleName:${it.type.simpleName}")
+        }
+      },
       receiverType = receiverType?.removeConstrains(),
       returnType = returnType?.removeConstrains(),
       parameters = parameters.map { it.removeConstrains() },

--- a/modules/streams/arrow-streams/src/test/kotlin/arrow/streams/internal/FreeCTest.kt
+++ b/modules/streams/arrow-streams/src/test/kotlin/arrow/streams/internal/FreeCTest.kt
@@ -42,6 +42,7 @@ import arrow.typeclasses.EqK
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe
+import kotlin.time.ExperimentalTime
 
 @higherkind
 sealed class Ops<out A> : OpsOf<A> {
@@ -95,6 +96,7 @@ private fun stackSafeTestProgram(n: Int, stopAt: Int): FreeC<ForOps, Int> = Ops.
   r
 }.fix()
 
+@ExperimentalTime
 class FreeCTest : UnitSpec() {
 
   init {


### PR DESCRIPTION
Goal for this PR is to deprecate `arrow.fx.typeclasses.Duration` and replace it with `kotlin.time.Duration`. 

There are a few initial problems, which I encountered:
- ExtensionProcessor removes `@ExperimentalTime` [here](https://github.com/arrow-kt/arrow/blob/ebe3dac5aff0cd4b26c1c547070f17c61d226ed7/modules/meta/arrow-meta/src/main/java/arrow/core/extensions/ExtensionProcessor.kt#L203). Where is the right place to add that Annotation to generated Members? -- filtering it out from `removeConstrains` seems not to work properly. 
The issue here is that generated Members do not contain `@ExperimentalTime` and resolve in failed builds.
Ideally it generates: 
```
@JvmName("waitFor")
@ExperimentalTime // this is missing
@Suppress(
    "UNCHECKED_CAST",
    "USELESS_CAST",
    "EXTENSION_SHADOWED_BY_MEMBER",
    "UNUSED_PARAMETER"
)
fun <A> Kind<ForIO, A>.waitFor(duration: kotlin.time.Duration): IO<A> = arrow.fx.IO.concurrent().run {
  this@waitFor.waitFor<A>(duration) as arrow.fx.IO<A>
}
```
- Schedule relays on `arrow.fx.typeclasses.Duration` shall I change the type signature in this PR or create a duplicate with `kotlin.time.Duration`. 

Adding everywhere `@ExperimentalTime` seemed the better approach, because adding `-Xuse-experimental=kotlin.time.ExperimentalTime` to the free compiler Arguments breaks the build. One example:
```
@JvmName("sleep-LRDsOJo")
@Suppress(
    "UNCHECKED_CAST",
    "USELESS_CAST",
    "EXTENSION_SHADOWED_BY_MEMBER",
    "UNUSED_PARAMETER"
)
fun `sleep-LRDsOJo`(arg0: Double): FluxK<Unit> = arrow.fx.reactor.FluxK
   .timer()
   .sleep-LRDsOJo(arg0) as arrow.fx.reactor.FluxK<kotlin.Unit> // UnresolvedReference
```