### PR TITLE
Nits oncancel onerror

### DIFF
--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
@@ -51,7 +51,6 @@ object ConcurrentLaws {
       Law("Concurrent Laws: release is not cancelable") { CF.releaseBracketIsNotCancelable(EQ, ctx) },
       Law("Concurrent Laws: cancel on guarantee runs finalizer") { CF.guaranteeFinalizerOnCancel(EQ, ctx) },
       Law("Concurrent Laws: release is not cancelable") { CF.guaranteeFinalizerIsNotCancelable(EQ, ctx) },
-      Law("Concurrent Laws: cancel on onCancel runs finalizer") { CF.onCancelFinalizerOnCancel(EQ, ctx) },
       Law("Concurrent Laws: async cancelable coherence") { CF.asyncCancelableCoherence(EQ) },
       Law("Concurrent Laws: cancelable cancelableF coherence") { CF.cancelableCancelableFCoherence(EQ) },
       Law("Concurrent Laws: cancelable should run CancelToken on cancel") { CF.cancelableReceivesCancelSignal(EQ, ctx) },
@@ -85,7 +84,8 @@ object ConcurrentLaws {
       Law("Concurrent Laws: parTraverse results in the correct error") { CF.parTraverseResultsInTheCorrectError(EQ_UNIT) },
       Law("Concurrent Laws: parTraverse forks the effects") { CF.parTraverseForksTheEffects(EQ_UNIT) },
       Law("Concurrent Laws: parSequence forks the effects") { CF.parSequenceForksTheEffects(EQ_UNIT) },
-      Law("Concurrent Laws: onError is run when error is raised") { CF.onErrorIsRunWhenErrorIsRaised(EQ, ctx) },
+      Law("Concurrent Laws: onCancel runs finalizer when cancelled") { CF.onCancelFinalizerOnCancel(EQ, ctx) },
+      Law("Concurrent Laws: onError is run when error is raised") { CF.onErrorIsRunWhenErrorIsRaised(EQ_UNIT, ctx) },
       Law("Concurrent Laws: onError is not run when completes normally") { CF.onErrorIsNotRunByDefault(EQK.liftEq(Tuple2.eq(Int.eq(), Boolean.eq())), ctx) },
       Law("Concurrent Laws: onError outer and inner finalizer is run when error is raised") { CF.outerAndInnerOnErrorIsRun(EQK.liftEq(Int.eq()), ctx) }
     )
@@ -184,23 +184,6 @@ object ConcurrentLaws {
               else -> unit()
             }
           }.fork(ctx).bind() // Fork execution, allowing us to cancel it later
-
-        startLatch.get().bind() // Waits on promise of `use`
-        cancel.fork(ctx).bind() // Cancel bracketCase
-        val waitExit = exitLatch.get().bind() // Observes cancellation via bracket's `release`
-        waitExit
-      }.equalUnderTheLaw(just(i), EQ)
-    }
-
-  fun <F> Concurrent<F>.onCancelFinalizerOnCancel(EQ: Eq<Kind<F, Int>>, ctx: CoroutineContext) =
-    forAll(Gen.int()) { i ->
-      fx.concurrent {
-        val startLatch = Promise<F, Unit>(this@onCancelFinalizerOnCancel).bind() // A promise that `use` was executed
-        val exitLatch = Promise<F, Int>(this@onCancelFinalizerOnCancel).bind() // A promise that `release` was executed
-
-        val (_, cancel) = startLatch.complete(Unit).flatMap { never<Int>() }
-          .onCancel(exitLatch.complete(i)) // Fulfil promise that `release` was executed with Canceled
-          .fork(ctx).bind() // Fork execution, allowing us to cancel it later
 
         startLatch.get().bind() // Waits on promise of `use`
         cancel.fork(ctx).bind() // Cancel bracketCase
@@ -662,35 +645,50 @@ object ConcurrentLaws {
       }.equalUnderTheLaw(unit(), EQ)
     }
 
-  fun <F> Concurrent<F>.onErrorIsRunWhenErrorIsRaised(EQ: Eq<Kind<F, Int>>, ctx: CoroutineContext) =
-    forAll(Gen.int()) { i ->
-      fx.concurrent {
+    fun <F> Concurrent<F>.onCancelFinalizerOnCancel(EQ: Eq<Kind<F, Int>>, ctx: CoroutineContext) =
+        forAll(Gen.int()) { i ->
+            fx.concurrent {
+                val startLatch = Promise<F, Unit>(this).bind() // A promise that `use` was executed
+                val exitLatch = Promise<F, Int>(this).bind() // A promise that `release` was executed
 
-        val startLatch = Promise<F, Unit>(this@onErrorIsRunWhenErrorIsRaised).bind()
-        val errorLatch = Promise<F, Int>(this@onErrorIsRunWhenErrorIsRaised).bind()
+                val (_, cancel) = startLatch.complete(Unit).flatMap { never<Int>() }
+                    .onCancel(exitLatch.complete(i)) // Fulfil promise that `release` was executed with Canceled
+                    .fork(ctx).bind() // Fork execution, allowing us to cancel it later
 
-        startLatch.complete(Unit).flatMap { raiseError<Exception>(RuntimeException("Boom")) }
-          .onError(errorLatch.complete(i))
-          .fork(ctx).bind()
+                startLatch.get().bind() // Waits on promise of `use`
+                cancel.fork(ctx).bind() // Cancel bracketCase
+                val waitExit = exitLatch.get().bind() // Observes cancellation via bracket's `release`
+                waitExit
+            }.equalUnderTheLaw(just(i), EQ)
+        }
 
-        startLatch.get().bind() // Waits on promise of `use`
+    fun <F> Concurrent<F>.onErrorIsRunWhenErrorIsRaised(EQ: Eq<Kind<F, Throwable>>, ctx: CoroutineContext) =
+        forAll(Gen.throwable()) { e ->
+          fx.concurrent {
 
-        val waitExit = errorLatch.get().bind()
-        waitExit
-      }.equalUnderTheLaw(just(i), EQ)
-    }
+            val startLatch = Promise<F, Unit>(this).bind()
+            val errorLatch = Promise<F, Throwable>(this).bind()
+
+            startLatch.complete(Unit).flatMap { raiseError<Throwable>(e) }
+              .onError { errorLatch.complete(it) }
+              .fork(ctx).bind()
+
+            startLatch.get().bind() // Waits on promise of `use`
+
+            val waitExit = errorLatch.get().bind()
+            waitExit
+          }.equalUnderTheLaw(just(e), EQ)
+        }
 
   fun <F> Concurrent<F>.onErrorIsNotRunByDefault(EQ: Eq<Kind<F, Tuple2<Int, Boolean>>>, ctx: CoroutineContext) =
     forAll(Gen.int()) { i ->
-
-      val CF = this@onErrorIsNotRunByDefault
       fx.concurrent {
 
-        val startLatch = Promise<F, Int>(CF).bind()
+        val startLatch = Promise<F, Int>(this).bind()
         val onErrorRun = Ref(false).bind()
 
         val (completed, _) = startLatch.complete(i)
-          .onError(onErrorRun.set(true))
+          .onError { onErrorRun.set(true) }
           .fork(ctx).bind()
 
         completed.bind()
@@ -701,18 +699,17 @@ object ConcurrentLaws {
 
   fun <F> Concurrent<F>.outerAndInnerOnErrorIsRun(EQ: Eq<Kind<F, Int>>, ctx: CoroutineContext) =
     fx.concurrent {
-      val CF = this@outerAndInnerOnErrorIsRun
-      val latch = Promise<F, Unit>(CF).bind()
+      val latch = Promise<F, Unit>(this).bind()
       val counter = AtomicInteger(0)
-      val incrementCounter = CF.later {
+      val incrementCounter = later {
         counter.getAndIncrement()
         Unit
       }
 
       just(Unit).flatMap {
         raiseError<Unit>(RuntimeException("failed"))
-          .onError(incrementCounter)
-      }.onError(incrementCounter)
+          .onError { incrementCounter }
+      }.onError { incrementCounter }
         .guarantee(latch.complete(Unit))
         .fork(ctx).bind()
 

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
@@ -85,7 +85,7 @@ object ConcurrentLaws {
       Law("Concurrent Laws: parTraverse results in the correct error") { CF.parTraverseResultsInTheCorrectError(EQ_UNIT) },
       Law("Concurrent Laws: parTraverse forks the effects") { CF.parTraverseForksTheEffects(EQ_UNIT) },
       Law("Concurrent Laws: parSequence forks the effects") { CF.parSequenceForksTheEffects(EQ_UNIT) },
-      Law("Concurrent Laws: onError is run when error is raised") { CF.onErrorIsRunWhenErrorIsRaised(EQ, ctx) },
+      Law("Concurrent Laws: onError is run when error is raised") { CF.onErrorIsRunWhenErrorIsRaised(EQ_UNIT, ctx) },
       Law("Concurrent Laws: onError is not run when completes normally") { CF.onErrorIsNotRunByDefault(EQK.liftEq(Tuple2.eq(Int.eq(), Boolean.eq())), ctx) },
       Law("Concurrent Laws: onError outer and inner finalizer is run when error is raised") { CF.outerAndInnerOnErrorIsRun(EQK.liftEq(Int.eq()), ctx) }
     )
@@ -662,22 +662,22 @@ object ConcurrentLaws {
       }.equalUnderTheLaw(unit(), EQ)
     }
 
-  fun <F> Concurrent<F>.onErrorIsRunWhenErrorIsRaised(EQ: Eq<Kind<F, Int>>, ctx: CoroutineContext) =
-    forAll(Gen.int()) { i ->
+  fun <F> Concurrent<F>.onErrorIsRunWhenErrorIsRaised(EQ: Eq<Kind<F, Unit>>, ctx: CoroutineContext) =
+    forAll(Gen.throwable()) { expected ->
       fx.concurrent {
 
         val startLatch = Promise<F, Unit>(this@onErrorIsRunWhenErrorIsRaised).bind()
         val errorLatch = Promise<F, Throwable>(this@onErrorIsRunWhenErrorIsRaised).bind()
 
-        startLatch.complete(Unit).flatMap { raiseError<Exception>(RuntimeException("Boom")) }
+        startLatch.complete(Unit).flatMap { raiseError<Exception>(expected) }
           .onError(errorLatch::complete)
           .fork(ctx).bind()
 
         startLatch.get().bind() // Waits on promise of `use`
 
         val waitExit = errorLatch.get().bind()
-        waitExit
-      }.equalUnderTheLaw(just(i), EQ)
+        !effect { waitExit shouldBe expected }
+      }.equalUnderTheLaw(Unit.just(), EQ)
     }
 
   fun <F> Concurrent<F>.onErrorIsNotRunByDefault(EQ: Eq<Kind<F, Tuple2<Int, Boolean>>>, ctx: CoroutineContext) =

--- a/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
+++ b/modules/core/arrow-test/src/main/kotlin/arrow/test/laws/ConcurrentLaws.kt
@@ -667,10 +667,10 @@ object ConcurrentLaws {
       fx.concurrent {
 
         val startLatch = Promise<F, Unit>(this@onErrorIsRunWhenErrorIsRaised).bind()
-        val errorLatch = Promise<F, Int>(this@onErrorIsRunWhenErrorIsRaised).bind()
+        val errorLatch = Promise<F, Throwable>(this@onErrorIsRunWhenErrorIsRaised).bind()
 
         startLatch.complete(Unit).flatMap { raiseError<Exception>(RuntimeException("Boom")) }
-          .onError { errorLatch.complete(i) }
+          .onError(errorLatch::complete)
           .fork(ctx).bind()
 
         startLatch.get().bind() // Waits on promise of `use`

--- a/modules/fx/arrow-fx-kotlinx-coroutines/src/test/kotlin/arrow/integrations/kotlinx/CoroutinesIntegrationTest.kt
+++ b/modules/fx/arrow-fx-kotlinx-coroutines/src/test/kotlin/arrow/integrations/kotlinx/CoroutinesIntegrationTest.kt
@@ -5,6 +5,7 @@ import arrow.core.right
 import arrow.core.some
 import arrow.fx.IO
 import arrow.fx.extensions.fx
+import arrow.fx.extensions.io.bracket.onCancel
 import arrow.fx.typeclasses.milliseconds
 import arrow.fx.typeclasses.seconds
 import arrow.test.UnitSpec

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -982,30 +982,6 @@ sealed class IO<out A> : IOOf<A> {
   fun guaranteeCase(finalizer: (ExitCase<Throwable>) -> IOOf<Unit>): IO<A> =
     IOBracket.guaranteeCase(this, finalizer)
 
-  /**
-   * Executes the given [finalizer] when the source is canceled, allowing registering a cancellation token.
-   *
-   * Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
-   */
-  fun onCancel(finalizer: IOOf<Unit>): IO<A> =
-    guaranteeCase { case ->
-      when (case) {
-        ExitCase.Canceled -> finalizer
-        else -> unit
-      }
-    }
-
-  /**
-   * Executes the given [finalizer] when the source is finishes with an error.
-   */
-  fun onError(finalizer: IOOf<Unit>): IO<A> =
-    guaranteeCase { case ->
-      when (case) {
-        is ExitCase.Error -> finalizer
-        else -> unit
-      }
-    }
-
   internal data class Pure<out A>(val a: A) : IO<A>() {
     // Pure can be replaced by its value
     override fun <B> map(f: (A) -> B): IO<B> = Suspend { Pure(f(a)) }

--- a/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
+++ b/modules/fx/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
@@ -161,13 +161,13 @@ interface Bracket<F, E> : MonadError<F, E> {
     }
 
   /**
-   * Executes the given `finalizer` when the source is finished in error.
+   * Executes the given `finalizer` with the given error when the source is finished in error.
    */
-  fun <A> Kind<F, A>.onError(finalizer: Kind<F, Unit>): Kind<F, A> =
-    guaranteeCase { case ->
-      when (case) {
-        is Error -> finalizer
-        else -> just<Unit>(Unit)
+  fun <A> Kind<F, A>.onError(finalizer: (E) -> Kind<F, Unit>): Kind<F, A> =
+      guaranteeCase { case ->
+        when (case) {
+          is ExitCase.Error -> finalizer(case.e)
+          else -> just<Unit>(Unit)
+        }
       }
-    }
 }

--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -560,14 +560,6 @@ class IOTest : UnitSpec() {
       }.unsafeRunTimed(1.seconds) shouldBe Unit.some()
     }
 
-    "onError should be called on finish with error" {
-      IO.fx {
-        val p = !Promise<Unit>()
-        effect { throw Exception() }.onError(p.complete(Unit)).attempt().bind()
-        !p.get()
-      }.unsafeRunTimed(1.seconds) shouldBe Unit.some()
-    }
-
     "Bracket should be stack safe" {
       val size = 5000
 


### PR DESCRIPTION
Because "code is worth a thousand words", following [this comment](https://github.com/arrow-kt/arrow/issues/2018#issuecomment-582947509):

* Add the error instance to Bracket's `onError`
* Remove redeclaration of `onCancel` and `onError` in IO