### PR TITLE
Re-enabled MVar test

### DIFF
--- a/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/MVarTest.kt
+++ b/modules/fx/arrow-fx/src/test/kotlin/arrow/fx/MVarTest.kt
@@ -276,20 +276,20 @@ class MVarTest : UnitSpec() {
         }.equalUnderTheLaw(IO.unit, EQ())
       }
 
-      // "$label - concurrent take and put" {
-      //   val count = 10000
-      //   IO.fx {
-      //     val mvar = !mvar.empty<Int>()
-      //     val ref = !Ref(0)
-      //     val takes = (0 until count).map { mvar.read().map2(mvar.take()) { (a, b) -> a + b }.flatMap { x -> ref.update { it + x } } }.parSequence()
-      //     val puts = (0 until count).map { mvar.put(1) }.parSequence()
-      //     val f1 = !takes.fork()
-      //     val f2 = !puts.fork()
-      //     !f1.join()
-      //     !f2.join()
-      //     !ref.get()
-      //   }.equalUnderTheLaw(IO.just(count), EQ())
-      // }
+      "$label - concurrent take and put" {
+        val count = 5000
+        IO.fx {
+          val mVar = !mvar.empty<Int>()
+          val ref = !Ref(0)
+          val takes = (0 until count).map { mVar.read().map2(mVar.take()) { (a, b) -> a + b }.flatMap { x -> ref.update { it + x } } }.parSequence()
+          val puts = (0 until count).map { mVar.put(1) }.parSequence()
+          val f1 = !takes.fork()
+          val f2 = !puts.fork()
+          !f1.join()
+          !f2.join()
+          !ref.get()
+        }.equalUnderTheLaw(IO.just(count), EQ())
+      }
     }
 
     fun concurrentTests(label: String, mvar: MVarFactory<ForIO>) {


### PR DESCRIPTION
Re-enabled MVar test _concurrent take and put_

This test was timing out because the number of iterations. Since it's not a stackoverflow test, 5K iterations for a stress test seems sufficient.