### PR TITLE
Disable logging of PASSED tests

### DIFF
--- a/subproject-conf.gradle
+++ b/subproject-conf.gradle
@@ -18,7 +18,7 @@ test {
     useJUnitPlatform()
     testLogging {
         exceptionFormat 'full'
-        events "passed", "skipped", "failed", "standardOut", "standardError"
+        events "skipped", "failed", "standardOut", "standardError"
     }
 }
 


### PR DESCRIPTION
Closes #2150.

Currently we log events "passed", "skipped", "failed", "standardOut", "standardError".

This PR will change it to only log  "skipped", "failed", "standardOut", "standardError", to not flood the logs on CI making them easier to browse.