### PR TITLE
Remove buildtimetracker configuration

### DIFF
--- a/generic-conf.gradle
+++ b/generic-conf.gradle
@@ -45,16 +45,6 @@ subprojects { project ->
 
     sourceCompatibility = JAVA_VERSION
     targetCompatibility = JAVA_VERSION
-
-    buildtimetracker {
-        reporters {
-            csv {
-                output "build/times.csv"
-                append true
-                header false
-            }
-        }
-    }
 }
 
 configurations {


### PR DESCRIPTION
It's necessary to remove the plugin from the Arrow libraries.