### PR TITLE
Configuration: remove installAllWithLocalDeps task from Arrow group

### DIFF
--- a/docs/move-to-multi-repo/how-to-manage-several-repositories.md
+++ b/docs/move-to-multi-repo/how-to-manage-several-repositories.md
@@ -30,7 +30,6 @@ buildAllWithLocalDeps - Build libs and examples with local Arrow dependencies (t
 buildArrowDoc - Generate API doc and run validation
 buildArrowDocWithLocalDeps - Generate API doc and run validation with local Arrow dependencies
 buildWithLocalDeps - Build with local Arrow dependencies (tests execution included)
-installAllWithLocalDeps - Install all the artifacts using local Arrow dependencies (no tests execution)
 
 Arrow (Git) tasks
 -----------------

--- a/generic-conf.gradle
+++ b/generic-conf.gradle
@@ -78,7 +78,6 @@ task checkoutOrchestrator(type:Exec) {
 }
 
 task installAllWithLocalDeps(type:Exec) {
-    group = ARROW_GROUP
     description = "Install all the artifacts using local Arrow dependencies (no tests execution)"
     commandLine "${rootDir}/../arrow/scripts/libs-install.sh", "${rootProject.name}"
     mustRunAfter 'checkoutOrchestrator'


### PR DESCRIPTION
**Reason**: it's used by other Gradle tasks. However, it's confusing for the users.