### PR TITLE
Fix archive classifier deprecation

### DIFF
--- a/gradle/android-module.gradle
+++ b/gradle/android-module.gradle
@@ -93,11 +93,13 @@ task androidJavadocs(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: androidJavadocs) {
-    classifier = 'javadoc'
+    //noinspection GroovyAccessibility //alternatively replace this with archiveClassifier.set('...')
+    archiveClassifier = 'javadoc'
     from androidJavadocs.destinationDir
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    //noinspection GroovyAccessibility //alternatively replace this with archiveClassifier.set('...')
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }

--- a/gradle/publication.gradle
+++ b/gradle/publication.gradle
@@ -69,11 +69,13 @@ afterEvaluate {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    //noinspection GroovyAccessibility //alternatively replace this with archiveClassifier.set('...')
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource, 'build/generated/source/kapt/main', 'build/generated/source/kaptKotlin/main'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    //noinspection GroovyAccessibility //alternatively replace this with archiveClassifier.set('...')
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }


### PR DESCRIPTION
Something I came across: `classifier` seems to have been deprecated since Gradle 5.0 and has been replaced with `archiveClassifier` which ironically also produces a warning because the member is private (unless you use `set` o_O). 

See https://github.com/gradle/gradle/issues/8257

@rachelcarmena 