### PR TITLE
Configuration: re-locate landscape code snippets

### DIFF
--- a/docs/how-to-release-arrow.md
+++ b/docs/how-to-release-arrow.md
@@ -37,9 +37,10 @@ Every **Λrrow** library publishes the API Doc and some static documentation fro
 
 After creating a new RELEASE version, prepare a pull request for `arrow-site` repository with these changes:
 
-1. Update `gradle.properties` (check `runAnk` task locally because maybe it's necessary to adapt the code snippets in the landing page).
-2. Update `docs/_data/doc-versions.yml`.
-3. (Optional) Add the RELEASE version in `update-other-versions.txt` if it's necessary to create `docs/<major.minor>`.
+1. Update `docs/_data/doc-versions.yml`.
+2. (Optional) Add the RELEASE version in `update-other-versions.txt` if it's necessary to create `docs/<major.minor>`.
+
+After merging that pull request, create and push the corresponding tag.
 
 ### How to fix the documentation for the latest release
 

--- a/docs/libraries/how-to-run-the-website-in-your-local-server.md
+++ b/docs/libraries/how-to-run-the-website-in-your-local-server.md
@@ -1,6 +1,6 @@
 # Arrow library: How to run the website in your local server
 
-## Via Gradle task
+## Via Gradle task (recommended)
 
 Arrow website can be run for any of the Arrow libraries via this Gradle task:
 
@@ -19,13 +19,8 @@ It can be useful to know an alternative in order to avoid running all the steps 
 ```sh
 git clone https://github.com/arrow-kt/arrow-site.git
 cd arrow-site
-perl -pe "s/\/docs//g" -i docs/_data/features.yml
-./gradlew runAnk
+rm docs/index.md
 ```
-
-Then `build/site` directory will be created.
-
-If you need to change any of the files on `arrow-site` (for instance, the sidebar menu), remember to do it before executing `runAnk` task.
 
 ### 2. Copy the documentation from Arrow library
 
@@ -44,10 +39,10 @@ cd <arrow-library>
 ./gradlew buildArrowDoc
 ```
 
-Then copy the result to the previous directory:
+Then copy the result to the `docs` directory:
 
 ```sh
-cp -r <arrow-library>/arrow-docs/build/site/* arrow-site/build/site/
+cp -r <arrow-library>/arrow-docs/build/site/* arrow-site/docs
 ```
 
 ### 3. Run the website in your local server
@@ -55,10 +50,10 @@ cp -r <arrow-library>/arrow-docs/build/site/* arrow-site/build/site/
 ```sh
 cd arrow-site
 bundle install --gemfile Gemfile --path vendor/bundle
-bundle exec jekyll serve -s build/site/
+bundle exec jekyll serve -s docs
 ```
 
-This will install any needed dependencies locally, and will use it to launch the complete website in [127.0.0.1:4000](http://127.0.0.1:4000) so you can open it with a standard browser.
+This will install any needed dependencies locally, and will use it to launch the complete website in [127.0.0.1:4000/docs](http://127.0.0.1:4000/docs) so you can open it with a standard browser.
 
 If you get an error while installing the Ruby gem _http_parser_, check if the path to your Arrow directory contains spaces. According to this [issue](https://github.com/tmm1/http_parser.rb/issues/47), the installation with spaces in the path is currently not working.
 

--- a/scripts/check-doc-integration.sh
+++ b/scripts/check-doc-integration.sh
@@ -9,7 +9,6 @@ if [ $# -eq 1 ]; then BRANCH=$1; fi
 replaceOSSbyLocalRepository "$BASEDIR/arrow/gradle/*.gradle"
 
 $BASEDIR/arrow/scripts/site-download.sh
-runAndSaveResult "Site" "Run Ank" "$BASEDIR/arrow/scripts/site-run-ank.sh"
 
 for repository in $(cat $BASEDIR/arrow/lists/libs.txt); do
     checkAndDownloadBranch $repository $BRANCH

--- a/scripts/project-locate-doc.sh
+++ b/scripts/project-locate-doc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 set -e
-cp -r $BASEDIR/$1/arrow-docs/build/site/* $BASEDIR/arrow-site/build/site/
+cp -r $BASEDIR/$1/arrow-docs/build/site/* $BASEDIR/arrow-site/docs/

--- a/scripts/repository-run-website.sh
+++ b/scripts/repository-run-website.sh
@@ -10,7 +10,6 @@ ARROW_LIB=$(echo $1 | cut -d- -f1-2)
 
 checkAndDownload arrow-site
 perl -pe "s/\/docs//g" -i $BASEDIR/arrow-site/docs/_data/features.yml
-$BASEDIR/arrow/scripts/site-run-ank.sh
 
 addArrowDocs $BASEDIR/${ARROW_LIB}/settings.gradle
 $BASEDIR/arrow/scripts/project-build-doc.sh ${ARROW_LIB}

--- a/scripts/site-build.sh
+++ b/scripts/site-build.sh
@@ -5,4 +5,4 @@ echo "Build site ..."
 export JEKYLL_ENV=production
 cd $BASEDIR/arrow-site
 bundle install --gemfile $BASEDIR/arrow-site/Gemfile --path vendor/bundle
-bundle exec jekyll build -b docs/next -s $BASEDIR/arrow-site/build/site -d $BASEDIR/arrow-site/build/_site
+bundle exec jekyll build -b docs/next -s $BASEDIR/arrow-site/docs -d $BASEDIR/arrow-site/_site

--- a/scripts/site-publish.sh
+++ b/scripts/site-publish.sh
@@ -5,7 +5,7 @@ MAIN_CONTENT=(CNAME  code  css  error.html  fonts  img  index.html  js  redirect
 
 
 echo "Publish in S3 ..."
-cd $BASEDIR/arrow-site/build/_site
+cd $BASEDIR/arrow-site/_site
 
 for file in ${MAIN_CONTENT[*]}; do
     rm -rf $file

--- a/scripts/site-run-ank.sh
+++ b/scripts/site-run-ank.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-set -e
-cd $BASEDIR/arrow-site
-./gradlew runAnk
+echo "-- runAnk is not executed for the site"

--- a/scripts/site-run.sh
+++ b/scripts/site-run.sh
@@ -4,4 +4,4 @@ set -e
 echo "Build site ..."
 cd $BASEDIR/arrow-site
 bundle install --gemfile $BASEDIR/arrow-site/Gemfile --path vendor/bundle
-bundle exec jekyll serve -s $BASEDIR/arrow-site/build/site
+bundle exec jekyll serve -s $BASEDIR/arrow-site/docs


### PR DESCRIPTION
Reason: `arrow-site` repository will be moved to a just Jekyll content repository without documentation validation because landscape code snippets have been located into their corresponding repositories. In this way they will be updated according to Arrow libraries changes without waiting to the release time.

Changes:

* Remove documentation validation for `arrow-site`
* Adapt configuration.
* Remove unnecessary steps.
