### PR TITLE
Add missing extension deprecations

### DIFF
--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/MonoidInvariant.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/MonoidInvariant.kt
@@ -1,13 +1,15 @@
 package arrow.core.extensions
 
-import arrow.extension
 import arrow.typeclasses.ForMonoid
 import arrow.typeclasses.Invariant
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.MonoidOf
 import arrow.typeclasses.fix
 
-@extension
+@Deprecated(
+  message = "Invariant typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MonoidInvariant<A> : Invariant<ForMonoid> {
   override fun <A, B> MonoidOf<A>.imap(f: (A) -> B, g: (B) -> A): Monoid<B> =
     object : Monoid<B> {

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/andthen.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/andthen.kt
@@ -9,7 +9,6 @@ import arrow.core.AndThenPartialOf
 import arrow.core.ForAndThen
 import arrow.core.fix
 import arrow.core.invoke
-import arrow.extension
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monoid
@@ -23,7 +22,10 @@ import arrow.typeclasses.counnest
 import arrow.typeclasses.conest
 import arrow.typeclasses.Contravariant
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenSemigroup<A, B> : Semigroup<AndThen<A, B>> {
   fun SB(): Semigroup<B>
 
@@ -32,7 +34,10 @@ interface AndThenSemigroup<A, B> : Semigroup<AndThen<A, B>> {
   }
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenMonoid<A, B> : Monoid<AndThen<A, B>>, AndThenSemigroup<A, B> {
 
   fun MB(): Monoid<B>
@@ -43,13 +48,19 @@ interface AndThenMonoid<A, B> : Monoid<AndThen<A, B>>, AndThenSemigroup<A, B> {
     AndThen { MB().empty() }
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenFunctor<X> : Functor<AndThenPartialOf<X>> {
   override fun <A, B> AndThenOf<X, A>.map(f: (A) -> B): AndThen<X, B> =
     fix().map(f)
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenApply<X> : Apply<AndThenPartialOf<X>>, AndThenFunctor<X> {
   override fun <A, B> AndThenOf<X, A>.ap(ff: AndThenOf<X, (A) -> B>): AndThen<X, B> =
     fix().ap(ff)
@@ -58,7 +69,10 @@ interface AndThenApply<X> : Apply<AndThenPartialOf<X>>, AndThenFunctor<X> {
     fix().map(f)
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenApplicative<X> : Applicative<AndThenPartialOf<X>>, AndThenFunctor<X> {
   override fun <A> just(a: A): AndThenOf<X, A> =
     AndThen.just(a)
@@ -70,7 +84,10 @@ interface AndThenApplicative<X> : Applicative<AndThenPartialOf<X>>, AndThenFunct
     fix().map(f)
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenMonad<X> : Monad<AndThenPartialOf<X>>, AndThenApplicative<X> {
   override fun <A, B> AndThenOf<X, A>.flatMap(f: (A) -> AndThenOf<X, B>): AndThen<X, B> =
     fix().flatMap(f)
@@ -85,7 +102,10 @@ interface AndThenMonad<X> : Monad<AndThenPartialOf<X>>, AndThenApplicative<X> {
     fix().ap(ff)
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenCategory : Category<ForAndThen> {
   override fun <A> id(): AndThen<A, A> =
     AndThen.id()
@@ -94,14 +114,20 @@ interface AndThenCategory : Category<ForAndThen> {
     fix().compose(arr::invoke)
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenContravariant<O> : Contravariant<Conested<ForAndThen, O>> {
 
   override fun <A, B> Kind<Conested<ForAndThen, O>, A>.contramap(f: (B) -> A): Kind<Conested<ForAndThen, O>, B> =
     counnest().fix().contramap(f).conest()
 }
 
-@extension
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 interface AndThenProfunctor : Profunctor<ForAndThen> {
   override fun <A, B, C, D> AndThenOf<A, B>.dimap(fl: (C) -> A, fr: (B) -> D): AndThen<C, D> =
     fix().andThen(fr).compose(fl)

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
@@ -28,11 +28,13 @@ import arrow.typeclasses.Bifoldable
 import arrow.typeclasses.Bifunctor
 import arrow.typeclasses.Bitraverse
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadError
 import arrow.typeclasses.MonadFx
@@ -43,6 +45,7 @@ import arrow.typeclasses.OrderDeprecation
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.hashWithSalt
 import arrow.core.ap as eitherAp
@@ -51,6 +54,13 @@ import arrow.core.extensions.traverse as eitherTraverse
 import arrow.core.flatMap as eitherFlatMap
 import arrow.core.handleErrorWith as eitherHandleErrorWith
 
+@Deprecated(
+  "arrow.core.extensions.combine is deprecated use arrow.core.combine",
+  ReplaceWith(
+    "combine(SGL, SGR, b)",
+    "arrow.core.commbine"
+  )
+)
 fun <L, R> Either<L, R>.combine(SGL: Semigroup<L>, SGR: Semigroup<R>, b: Either<L, R>): Either<L, R> {
   val a = this
 
@@ -66,6 +76,11 @@ fun <L, R> Either<L, R>.combine(SGL: Semigroup<L>, SGR: Semigroup<R>, b: Either<
   }
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Semigroup.either()", "arrow.core.either", "arrow.typeclasses.Semigroup"),
+  DeprecationLevel.WARNING
+)
 interface EitherSemigroup<L, R> : Semigroup<Either<L, R>> {
 
   fun SGL(): Semigroup<L>
@@ -74,6 +89,11 @@ interface EitherSemigroup<L, R> : Semigroup<Either<L, R>> {
   override fun Either<L, R>.combine(b: Either<L, R>): Either<L, R> = fix().combine(SGL(), SGR(), b)
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Monoid.either()", "arrow.core.either", "arrow.typeclasses.Monoid"),
+  DeprecationLevel.WARNING
+)
 interface EitherMonoid<L, R> : Monoid<Either<L, R>>, EitherSemigroup<L, R> {
   fun MOL(): Monoid<L>
   fun MOR(): Monoid<R>
@@ -84,15 +104,27 @@ interface EitherMonoid<L, R> : Monoid<Either<L, R>>, EitherSemigroup<L, R> {
   override fun empty(): Either<L, R> = Right(MOR().empty())
 }
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherFunctor<L> : Functor<EitherPartialOf<L>> {
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
 }
 
+@Deprecated(
+  message = "Bifunctor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherBifunctor : Bifunctor<ForEither> {
   override fun <A, B, C, D> EitherOf<A, B>.bimap(fl: (A) -> C, fr: (B) -> D): Either<C, D> =
     fix().bimap(fl, fr)
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherApply<L> : Apply<EitherPartialOf<L>>, EitherFunctor<L> {
 
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
@@ -104,6 +136,10 @@ interface EitherApply<L> : Apply<EitherPartialOf<L>>, EitherFunctor<L> {
     fix().eitherAp(ff)
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherApplicative<L> : Applicative<EitherPartialOf<L>>, EitherApply<L> {
 
   override fun <A> just(a: A): Either<L, A> = Right(a)
@@ -111,6 +147,10 @@ interface EitherApplicative<L> : Applicative<EitherPartialOf<L>>, EitherApply<L>
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
 }
 
+@Deprecated(
+  message = "Monad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherMonad<L> : Monad<EitherPartialOf<L>>, EitherApplicative<L> {
 
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
@@ -135,6 +175,10 @@ internal object EitherMonadFx : MonadFx<EitherPartialOf<Any?>> {
     super.monad(c).fix()
 }
 
+@Deprecated(
+  message = "ApplicativeError typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherApplicativeError<L> : ApplicativeError<EitherPartialOf<L>, L>, EitherApplicative<L> {
 
   override fun <A> raiseError(e: L): Either<L, A> = Left(e)
@@ -143,8 +187,16 @@ interface EitherApplicativeError<L> : ApplicativeError<EitherPartialOf<L>, L>, E
     fix().eitherHandleErrorWith(f)
 }
 
+@Deprecated(
+  message = "MonadError typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherMonadError<L> : MonadError<EitherPartialOf<L>, L>, EitherApplicativeError<L>, EitherMonad<L>
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherFoldable<L> : Foldable<EitherPartialOf<L>> {
 
   override fun <A, B> EitherOf<L, A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -154,6 +206,10 @@ interface EitherFoldable<L> : Foldable<EitherPartialOf<L>> {
     fix().foldRight(lb, f)
 }
 
+@Deprecated(
+  message = "BiFoldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherBifoldable : Bifoldable<ForEither> {
   override fun <A, B, C> EitherOf<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C = fix().bifoldLeft(c, f, g)
 
@@ -161,26 +217,46 @@ interface EitherBifoldable : Bifoldable<ForEither> {
     fix().bifoldRight(c, f, g)
 }
 
+@Deprecated(
+  message = "traverse with Applicative has been deprecated, use the concretely defined traverse or traverseValidated on Either",
+  level = DeprecationLevel.WARNING
+)
 fun <G, A, B, C> EitherOf<A, B>.traverse(GA: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, Either<A, C>> =
   fix().fold({ GA.just(Either.Left(it)) }, { GA.run { f(it).map { Either.Right(it) } } })
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherTraverse<L> : Traverse<EitherPartialOf<L>>, EitherFoldable<L> {
 
   override fun <G, A, B> EitherOf<L, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, EitherOf<L, B>> =
     fix().eitherTraverse(AP, f)
 }
 
+@Deprecated(
+  message = "BiTraverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherBitraverse : Bitraverse<ForEither>, EitherBifoldable {
   override fun <G, A, B, C, D> EitherOf<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, EitherOf<C, D>> =
     fix().let { AP.run { it.fold({ f(it).map { Either.Left(it) } }, { g(it).map { Either.Right(it) } }) } }
 }
 
+@Deprecated(
+  message = "SemigroupK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherSemigroupK<L> : SemigroupK<EitherPartialOf<L>> {
 
   override fun <A> EitherOf<L, A>.combineK(y: EitherOf<L, A>): Either<L, A> =
     fix().eitherCombineK(y)
 }
 
+@Deprecated(
+  message = EqDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface EitherEq<in L, in R> : Eq<Either<L, R>> {
 
   fun EQL(): Eq<L>
@@ -199,6 +275,10 @@ interface EitherEq<in L, in R> : Eq<Either<L, R>> {
   }
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherEqK<L> : EqK<EitherPartialOf<L>> {
   fun EQL(): Eq<L>
 
@@ -208,6 +288,10 @@ interface EitherEqK<L> : EqK<EitherPartialOf<L>> {
     }
 }
 
+@Deprecated(
+  message = "EqK2 typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherEqK2 : EqK2<ForEither> {
   override fun <A, B> Kind2<ForEither, A, B>.eqK(other: Kind2<ForEither, A, B>, EQA: Eq<A>, EQB: Eq<B>): Boolean =
     (this.fix() to other.fix()).let {
@@ -217,12 +301,20 @@ interface EitherEqK2 : EqK2<ForEither> {
     }
 }
 
+@Deprecated(
+  message = ShowDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface EitherShow<L, R> : Show<Either<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
   override fun Either<L, R>.show(): String = show(SL(), SR())
 }
 
+@Deprecated(
+  message = HashDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface EitherHash<L, R> : Hash<Either<L, R>> {
 
   fun HL(): Hash<L>
@@ -262,6 +354,10 @@ interface EitherOrder<L, R> : Order<Either<L, R>> {
 fun <L, R> Either.Companion.fx(c: suspend MonadSyntax<EitherPartialOf<L>>.() -> R): Either<L, R> =
   Either.monad<L>().fx.monad(c).fix()
 
+@Deprecated(
+  message = "Bicrosswalk typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface EitherBicrosswalk : Bicrosswalk<ForEither>, EitherBifunctor, EitherBifoldable {
   override fun <F, A, B, C, D> bicrosswalk(
     ALIGN: Align<F>,

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/hashed.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/hashed.kt
@@ -6,24 +6,32 @@ import arrow.core.ForHashed
 import arrow.core.Hashed
 import arrow.core.Ordering
 import arrow.core.fix
-import arrow.extension
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Order
 import arrow.typeclasses.OrderDeprecation
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.hashWithSalt
 
-@extension
+@Deprecated(
+  message = EqDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface HashedEq<A> : Eq<Hashed<A>> {
   fun EQA(): Eq<A>
   override fun Hashed<A>.eqv(b: Hashed<A>): Boolean =
     this.hash == b.hash && EQA().run { value.eqv(b.value) }
 }
 
-@extension
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface HashedEqK : EqK<ForHashed> {
   override fun <A> Kind<ForHashed, A>.eqK(other: Kind<ForHashed, A>, EQ: Eq<A>): Boolean =
     fix().let { (h1, v1) ->
@@ -33,7 +41,6 @@ interface HashedEqK : EqK<ForHashed> {
     }
 }
 
-@extension
 @Deprecated(OrderDeprecation)
 interface HashedOrder<A> : Order<Hashed<A>> {
   fun ORD(): Order<A>
@@ -42,13 +49,19 @@ interface HashedOrder<A> : Order<Hashed<A>> {
     this.hash == b.hash && ORD().run { value.eqv(b.value) }
 }
 
-@extension
+@Deprecated(
+  message = ShowDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface HashedShow<A> : Show<Hashed<A>> {
   fun SA(): Show<A>
   override fun Hashed<A>.show(): String = "Hashed(${SA().run { value.show() }})"
 }
 
-@extension
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Either",
+  level = DeprecationLevel.WARNING
+)
 interface HashedFoldable : Foldable<ForHashed> {
   override fun <A, B> Kind<ForHashed, A>.foldLeft(b: B, f: (B, A) -> B): B =
     f(b, fix().value)
@@ -57,7 +70,10 @@ interface HashedFoldable : Foldable<ForHashed> {
     Eval.defer { f(fix().value, lb) }
 }
 
-@extension
+@Deprecated(
+  message = HashDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface HashedHash<A> : Hash<Hashed<A>> {
   override fun Hashed<A>.hash(): Int = hash
   override fun Hashed<A>.hashWithSalt(salt: Int): Int = hash.hashWithSalt(salt)

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -285,7 +285,6 @@ interface ListKFunctorFilter : FunctorFilter<ForListK> {
     fix().map(f)
 }
 
-
 @Deprecated(
   message = "fx bindings for list are no longer supported. Use mapN or flatMap instead.",
   level = DeprecationLevel.WARNING

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -28,11 +28,13 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Crosswalk
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadCombine
 import arrow.typeclasses.MonadFilter
@@ -49,6 +51,7 @@ import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Semigroupal
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.Unalign
 import arrow.typeclasses.Unzip
@@ -58,16 +61,30 @@ import arrow.core.combineK as listCombineK
 import kotlin.collections.plus as listPlus
 import kotlin.collections.zip as listZip
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Semigroup.list()", "arrow.core.list", "arrow.typeclasses.Semigroup"),
+  DeprecationLevel.WARNING
+)
 interface ListKSemigroup<A> : Semigroup<ListK<A>> {
   override fun ListK<A>.combine(b: ListK<A>): ListK<A> =
     (this.listPlus(b)).k()
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Monoid.list()", "arrow.core.list", "arrow.typeclasses.Monoid"),
+  DeprecationLevel.WARNING
+)
 interface ListKMonoid<A> : Monoid<ListK<A>>, ListKSemigroup<A> {
   override fun empty(): ListK<A> =
     emptyList<A>().k()
 }
 
+@Deprecated(
+  message = EqDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface ListKEq<A> : Eq<ListKOf<A>> {
 
   fun EQ(): Eq<A>
@@ -81,16 +98,28 @@ interface ListKEq<A> : Eq<ListKOf<A>> {
     else false
 }
 
+@Deprecated(
+  message = ShowDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface ListKShow<A> : Show<ListKOf<A>> {
   fun SA(): Show<A>
   override fun ListKOf<A>.show(): String = fix().show(SA())
 }
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKFunctor : Functor<ForListK> {
   override fun <A, B> Kind<ForListK, A>.map(f: (A) -> B): ListK<B> =
     fix().map(f)
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKApply : Apply<ForListK> {
   override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
     fix().ap(ff)
@@ -102,6 +131,10 @@ interface ListKApply : Apply<ForListK> {
     fix().map2(fb, f)
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKApplicative : Applicative<ForListK> {
   override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
     fix().ap(ff)
@@ -116,6 +149,10 @@ interface ListKApplicative : Applicative<ForListK> {
     ListK.just(a)
 }
 
+@Deprecated(
+  message = "Monad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonad : Monad<ForListK> {
   override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
     fix().ap(ff)
@@ -142,6 +179,10 @@ interface ListKMonad : Monad<ForListK> {
     ListK.just(a)
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKFoldable : Foldable<ForListK> {
   override fun <A, B> Kind<ForListK, A>.foldLeft(b: B, f: (B, A) -> B): B =
     fix().foldLeft(b, f)
@@ -153,6 +194,10 @@ interface ListKFoldable : Foldable<ForListK> {
     fix().isEmpty()
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKTraverse : Traverse<ForListK> {
   override fun <A, B> Kind<ForListK, A>.map(f: (A) -> B): ListK<B> =
     fix().map(f)
@@ -170,20 +215,36 @@ interface ListKTraverse : Traverse<ForListK> {
     fix().isEmpty()
 }
 
+@Deprecated(
+  message = "SemigroupK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKSemigroupK : SemigroupK<ForListK> {
   override fun <A> Kind<ForListK, A>.combineK(y: Kind<ForListK, A>): ListK<A> =
     fix().listCombineK(y)
 }
 
+@Deprecated(
+  message = "Semigroupal typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKSemigroupal : Semigroupal<ForListK> {
   override fun <A, B> Kind<ForListK, A>.product(fb: Kind<ForListK, B>): Kind<ForListK, Tuple2<A, B>> =
     fb.fix().ap(fix().map { a: A -> { b: B -> Tuple2(a, b) } })
 }
 
+@Deprecated(
+  message = "Monoidal typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonoidal : Monoidal<ForListK>, ListKSemigroupal {
   override fun <A> identity(): Kind<ForListK, A> = ListK.empty()
 }
 
+@Deprecated(
+  message = "MonoidK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonoidK : MonoidK<ForListK> {
   override fun <A> empty(): ListK<A> =
     ListK.empty()
@@ -192,6 +253,10 @@ interface ListKMonoidK : MonoidK<ForListK> {
     fix().listCombineK(y)
 }
 
+@Deprecated(
+  message = HashDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface ListKHash<A> : Hash<ListKOf<A>> {
 
   fun HA(): Hash<A>
@@ -208,6 +273,10 @@ interface ListKOrder<A> : Order<ListKOf<A>> {
       .fold(Ordering.monoid())
 }
 
+@Deprecated(
+  message = "FunctorFilter typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKFunctorFilter : FunctorFilter<ForListK> {
   override fun <A, B> Kind<ForListK, A>.filterMap(f: (A) -> Option<B>): ListK<B> =
     fix().filterMap(f)
@@ -216,9 +285,18 @@ interface ListKFunctorFilter : FunctorFilter<ForListK> {
     fix().map(f)
 }
 
+
+@Deprecated(
+  message = "fx bindings for list are no longer supported. Use mapN or flatMap instead.",
+  level = DeprecationLevel.WARNING
+)
 fun <A> ListK.Companion.fx(c: suspend MonadSyntax<ForListK>.() -> A): ListK<A> =
   ListK.monad().fx.monad(c).fix()
 
+@Deprecated(
+  message = "MonadCombine typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonadCombine : MonadCombine<ForListK>, ListKAlternative {
   override fun <A> empty(): ListK<A> =
     ListK.empty()
@@ -245,6 +323,10 @@ interface ListKMonadCombine : MonadCombine<ForListK>, ListKAlternative {
     ListK.just(a)
 }
 
+@Deprecated(
+  message = "MonadFilter typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonadFilter : MonadFilter<ForListK> {
   override fun <A> empty(): ListK<A> =
     ListK.empty()
@@ -271,12 +353,20 @@ interface ListKMonadFilter : MonadFilter<ForListK> {
     ListK.just(a)
 }
 
+@Deprecated(
+  message = "Alternative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKAlternative : Alternative<ForListK>, ListKApplicative {
   override fun <A> empty(): Kind<ForListK, A> = emptyList<A>().k()
   override fun <A> Kind<ForListK, A>.orElse(b: Kind<ForListK, A>): Kind<ForListK, A> =
     (this.fix() + b.fix()).k()
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKEqK : EqK<ForListK> {
   override fun <A> Kind<ForListK, A>.eqK(other: Kind<ForListK, A>, EQ: Eq<A>) =
     (this.fix() to other.fix()).let {
@@ -286,6 +376,10 @@ interface ListKEqK : EqK<ForListK> {
     }
 }
 
+@Deprecated(
+  message = "Semialign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKSemialign : Semialign<ForListK>, ListKFunctor {
   override fun <A, B> align(
     a: Kind<ForListK, A>,
@@ -293,10 +387,18 @@ interface ListKSemialign : Semialign<ForListK>, ListKFunctor {
   ): Kind<ForListK, Ior<A, B>> = ListK.align(a.fix(), b.fix())
 }
 
+@Deprecated(
+  message = "Align typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKAlign : Align<ForListK>, ListKSemialign {
   override fun <A> empty(): Kind<ForListK, A> = ListK.empty()
 }
 
+@Deprecated(
+  message = "Unalign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKUnalign : Unalign<ForListK>, ListKSemialign {
   override fun <A, B> unalign(ior: Kind<ForListK, Ior<A, B>>): Tuple2<Kind<ForListK, A>, Kind<ForListK, B>> =
     ior.fix().let { list ->
@@ -310,11 +412,19 @@ interface ListKUnalign : Unalign<ForListK>, ListKSemialign {
     }
 }
 
+@Deprecated(
+  message = "Zip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKZip : Zip<ForListK>, ListKSemialign {
   override fun <A, B> Kind<ForListK, A>.zip(other: Kind<ForListK, B>): Kind<ForListK, Tuple2<A, B>> =
     this.fix().listZip(other.fix()).map { it.first toT it.second }.k()
 }
 
+@Deprecated(
+  message = "Unzip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKUnzip : Unzip<ForListK>, ListKZip {
   override fun <A, B> Kind<ForListK, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForListK, A>, Kind<ForListK, B>> =
     this.fix().let { list ->
@@ -324,6 +434,10 @@ interface ListKUnzip : Unzip<ForListK>, ListKZip {
     }.bimap({ it.k() }, { it.k() })
 }
 
+@Deprecated(
+  message = "Crosswalk typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKCrosswalk : Crosswalk<ForListK>, ListKFunctor, ListKFoldable {
   override fun <F, A, B> crosswalk(
     ALIGN: Align<F>,
@@ -343,6 +457,10 @@ interface ListKCrosswalk : Crosswalk<ForListK>, ListKFunctor, ListKFoldable {
     }
 }
 
+@Deprecated(
+  message = "MonadPlus typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonadPlus : MonadPlus<ForListK>, ListKMonad, ListKAlternative {
   override fun <A, B> Kind<ForListK, A>.ap(ff: Kind<ForListK, (A) -> B>): ListK<B> =
     fix().ap(ff)
@@ -357,6 +475,10 @@ interface ListKMonadPlus : MonadPlus<ForListK>, ListKMonad, ListKAlternative {
     ListK.just(a)
 }
 
+@Deprecated(
+  message = "MonadLogic typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on List or Iterable.",
+  level = DeprecationLevel.WARNING
+)
 interface ListKMonadLogic : MonadLogic<ForListK>, ListKMonadPlus {
 
   private fun <E> ListK<E>.tail(): ListK<E> = this.drop(1).k()

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/mapk.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/mapk.kt
@@ -28,24 +28,35 @@ import arrow.typeclasses.Align
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.Zip
 import arrow.typeclasses.Unalign
 import arrow.typeclasses.Unzip
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKFunctor<K> : Functor<MapKPartialOf<K>> {
   override fun <A, B> Kind<MapKPartialOf<K>, A>.map(f: (A) -> B): MapK<K, B> = fix().map(f)
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKFoldable<K> : Foldable<MapKPartialOf<K>> {
 
   override fun <A, B> Kind<MapKPartialOf<K>, A>.foldLeft(b: B, f: (B, A) -> B): B = fix().foldLeft(b, f)
@@ -54,12 +65,19 @@ interface MapKFoldable<K> : Foldable<MapKPartialOf<K>> {
     fix().foldRight(lb, f)
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKTraverse<K> : Traverse<MapKPartialOf<K>>, MapKFoldable<K> {
 
   override fun <G, A, B> MapKOf<K, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, MapKOf<K, B>> =
     fix().traverse(AP, f)
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass."
+)
 interface MapKSemigroup<K, A> : Semigroup<MapK<K, A>> {
 
   fun SG(): Semigroup<A>
@@ -70,6 +88,10 @@ interface MapKSemigroup<K, A> : Semigroup<MapK<K, A>> {
   }
 }
 
+@Deprecated(
+  message = "FunctorFilter typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKFunctorFilter<K> : FunctorFilter<MapKPartialOf<K>> {
   override fun <A, B> Kind<MapKPartialOf<K>, A>.filterMap(f: (A) -> Option<B>): Kind<MapKPartialOf<K>, B> =
     fix().map(f).sequence(Option.applicative()).fix().fold({ emptyMap<K, B>().k() }, ::identity)
@@ -78,6 +100,10 @@ interface MapKFunctorFilter<K> : FunctorFilter<MapKPartialOf<K>> {
     fix().map(f)
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKApply<K> : Apply<MapKPartialOf<K>> {
   override fun <A, B> Kind<MapKPartialOf<K>, A>.ap(ff: Kind<MapKPartialOf<K>, (A) -> B>): Kind<MapKPartialOf<K>, B> =
     fix().ap(ff.fix())
@@ -86,6 +112,9 @@ interface MapKApply<K> : Apply<MapKPartialOf<K>> {
     fix().map(f)
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass."
+)
 interface MapKMonoid<K, A> : Monoid<MapK<K, A>>, MapKSemigroup<K, A> {
 
   override fun SG(): Semigroup<A>
@@ -93,6 +122,10 @@ interface MapKMonoid<K, A> : Monoid<MapK<K, A>>, MapKSemigroup<K, A> {
   override fun empty(): MapK<K, A> = emptyMap<K, A>().k()
 }
 
+@Deprecated(
+  message = EqDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface MapKEq<K, A> : Eq<MapK<K, A>> {
 
   fun EQK(): Eq<K>
@@ -109,12 +142,20 @@ interface MapKEq<K, A> : Eq<MapK<K, A>> {
     } else false
 }
 
+@Deprecated(
+  message = ShowDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface MapKShow<K, A> : Show<MapK<K, A>> {
   fun SK(): Show<K>
   fun SA(): Show<A>
   override fun MapK<K, A>.show(): String = show(SK(), SA())
 }
 
+@Deprecated(
+  message = HashDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface MapKHash<K, A> : Hash<MapK<K, A>> {
   fun HK(): Hash<K>
   fun HA(): Hash<A>
@@ -129,6 +170,10 @@ interface MapKHash<K, A> : Hash<MapK<K, A>> {
     }
 }
 
+@Deprecated(
+  message = "Semialign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKSemialign<K> : Semialign<MapKPartialOf<K>>, MapKFunctor<K> {
   override fun <A, B> align(
     a: Kind<MapKPartialOf<K>, A>,
@@ -144,10 +189,18 @@ interface MapKSemialign<K> : Semialign<MapKPartialOf<K>>, MapKFunctor<K> {
   }
 }
 
+@Deprecated(
+  message = "Align typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKAlign<K> : Align<MapKPartialOf<K>>, MapKSemialign<K> {
   override fun <A> empty(): Kind<MapKPartialOf<K>, A> = emptyMap<K, A>().k()
 }
 
+@Deprecated(
+  message = "Unalign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKUnalign<K> : Unalign<MapKPartialOf<K>>, MapKSemialign<K> {
   override fun <A, B> unalign(ior: Kind<MapKPartialOf<K>, Ior<A, B>>): Tuple2<Kind<MapKPartialOf<K>, A>, Kind<MapKPartialOf<K>, B>> =
     ior.fix().let { map ->
@@ -161,6 +214,10 @@ interface MapKUnalign<K> : Unalign<MapKPartialOf<K>>, MapKSemialign<K> {
     }
 }
 
+@Deprecated(
+  message = "Zip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKZip<K> : Zip<MapKPartialOf<K>>, MapKSemialign<K> {
   override fun <A, B> Kind<MapKPartialOf<K>, A>.zip(other: Kind<MapKPartialOf<K>, B>): Kind<MapKPartialOf<K>, Tuple2<A, B>> =
     (this.fix() to other.fix()).let { (ls, rs) ->
@@ -172,6 +229,10 @@ interface MapKZip<K> : Zip<MapKPartialOf<K>>, MapKSemialign<K> {
     }
 }
 
+@Deprecated(
+  message = "Unzip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKUnzip<K> : Unzip<MapKPartialOf<K>>, MapKZip<K> {
   override fun <A, B> Kind<MapKPartialOf<K>, Tuple2<A, B>>.unzip(): Tuple2<Kind<MapKPartialOf<K>, A>, Kind<MapKPartialOf<K>, B>> =
     this.fix().let { map ->
@@ -181,6 +242,10 @@ interface MapKUnzip<K> : Unzip<MapKPartialOf<K>>, MapKZip<K> {
     }.bimap({ it.k() }, { it.k() })
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Map.",
+  level = DeprecationLevel.WARNING
+)
 interface MapKEqK<K> : EqK<MapKPartialOf<K>> {
 
   fun EQK(): Eq<K>

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
@@ -25,10 +25,12 @@ import arrow.typeclasses.Apply
 import arrow.typeclasses.Bimonad
 import arrow.typeclasses.Comonad
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Order
@@ -38,15 +40,22 @@ import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.Unzip
 import arrow.typeclasses.Zip
 import arrow.core.combineK as nelCombineK
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass."
+)
 interface NonEmptyListSemigroup<A> : Semigroup<NonEmptyList<A>> {
   override fun NonEmptyList<A>.combine(b: NonEmptyList<A>): NonEmptyList<A> = this + b
 }
 
+@Deprecated(
+  EqDeprecation
+)
 interface NonEmptyListEq<A> : Eq<NonEmptyList<A>> {
 
   fun EQ(): Eq<A>
@@ -57,16 +66,27 @@ interface NonEmptyListEq<A> : Eq<NonEmptyList<A>> {
     }
 }
 
+@Deprecated(
+  ShowDeprecation
+)
 interface NonEmptyListShow<A> : Show<NonEmptyList<A>> {
   fun SA(): Show<A>
   override fun NonEmptyList<A>.show(): String = show(SA())
 }
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListFunctor : Functor<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.map(f: (A) -> B): NonEmptyList<B> =
     fix().map(f)
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListApply : Apply<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -75,6 +95,10 @@ interface NonEmptyListApply : Apply<ForNonEmptyList> {
     fix().map(f)
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListApplicative : Applicative<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -86,6 +110,10 @@ interface NonEmptyListApplicative : Applicative<ForNonEmptyList> {
     NonEmptyList.just(a)
 }
 
+@Deprecated(
+  message = "Monad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListMonad : Monad<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -103,6 +131,10 @@ interface NonEmptyListMonad : Monad<ForNonEmptyList> {
     NonEmptyList.just(a)
 }
 
+@Deprecated(
+  message = "Comonad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListComonad : Comonad<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.coflatMap(f: (NonEmptyListOf<A>) -> B): NonEmptyList<B> =
     fix().coflatMap(f)
@@ -114,6 +146,10 @@ interface NonEmptyListComonad : Comonad<ForNonEmptyList> {
     fix().map(f)
 }
 
+@Deprecated(
+  message = "Bimonad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListBimonad : Bimonad<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -137,6 +173,10 @@ interface NonEmptyListBimonad : Bimonad<ForNonEmptyList> {
     fix().extract()
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListFoldable : Foldable<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.foldLeft(b: B, f: (B, A) -> B): B =
     fix().foldLeft(b, f)
@@ -148,6 +188,10 @@ interface NonEmptyListFoldable : Foldable<ForNonEmptyList> {
     fix().isEmpty()
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListTraverse : Traverse<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.map(f: (A) -> B): NonEmptyList<B> =
     fix().map(f)
@@ -165,11 +209,19 @@ interface NonEmptyListTraverse : Traverse<ForNonEmptyList> {
     fix().isEmpty()
 }
 
+@Deprecated(
+  message = "SemigroupK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListSemigroupK : SemigroupK<ForNonEmptyList> {
   override fun <A> NonEmptyListOf<A>.combineK(y: NonEmptyListOf<A>): NonEmptyList<A> =
     fix().nelCombineK(y)
 }
 
+@Deprecated(
+  message = HashDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListHash<A> : Hash<NonEmptyList<A>> {
   fun HA(): Hash<A>
 
@@ -184,6 +236,10 @@ interface NonEmptyListOrder<A> : Order<NonEmptyList<A>> {
     ListK.order(OA()).run { all.k().compare(b.all.k()) }
 }
 
+@Deprecated(
+  message = "Reducible typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 fun <F, A> Reducible<F>.toNonEmptyList(fa: Kind<F, A>): NonEmptyList<A> =
   fa.reduceRightTo(
     { a -> NonEmptyList.of(a) },
@@ -192,9 +248,17 @@ fun <F, A> Reducible<F>.toNonEmptyList(fa: Kind<F, A>): NonEmptyList<A> =
     }
   ).value()
 
+@Deprecated(
+  message = "fx bindings are no longer supported for NonEmptyList. Use mapN or flatMap instead.",
+  level = DeprecationLevel.WARNING
+)
 fun <A> NonEmptyList.Companion.fx(c: suspend MonadSyntax<ForNonEmptyList>.() -> A): NonEmptyList<A> =
   NonEmptyList.monad().fx.monad(c).fix()
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListEqK : EqK<ForNonEmptyList> {
   override fun <A> Kind<ForNonEmptyList, A>.eqK(other: Kind<ForNonEmptyList, A>, EQ: Eq<A>) =
     (this.fix() to other.fix()).let {
@@ -202,6 +266,10 @@ interface NonEmptyListEqK : EqK<ForNonEmptyList> {
     }
 }
 
+@Deprecated(
+  message = "Semialign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListSemialign : Semialign<ForNonEmptyList>, NonEmptyListFunctor {
   override fun <A, B> align(
     a: Kind<ForNonEmptyList, A>,
@@ -216,6 +284,10 @@ interface NonEmptyListSemialign : Semialign<ForNonEmptyList>, NonEmptyListFuncto
   }
 }
 
+@Deprecated(
+  message = "Zip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListZip : Zip<ForNonEmptyList>, NonEmptyListSemialign {
   override fun <A, B> Kind<ForNonEmptyList, A>.zip(other: Kind<ForNonEmptyList, B>): Kind<ForNonEmptyList, Tuple2<A, B>> =
     (this.fix() to other.fix()).let { nel ->
@@ -223,6 +295,10 @@ interface NonEmptyListZip : Zip<ForNonEmptyList>, NonEmptyListSemialign {
     }
 }
 
+@Deprecated(
+  message = "Unzip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on NonEmptyList.",
+  level = DeprecationLevel.WARNING
+)
 interface NonEmptyListUnzip : Unzip<ForNonEmptyList>, NonEmptyListZip {
   override fun <A, B> Kind<ForNonEmptyList, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForNonEmptyList, A>, Kind<ForNonEmptyList, B>> =
     this.fix().all.let { list ->

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/sortedmap.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/sortedmap.kt
@@ -5,6 +5,7 @@ import arrow.core.Eval
 import arrow.core.Ior
 import arrow.core.SetK
 import arrow.core.SortedMapK
+import arrow.core.SortedMapKDeprecation
 import arrow.core.SortedMapKOf
 import arrow.core.SortedMapKPartialOf
 import arrow.core.Tuple2
@@ -19,7 +20,6 @@ import arrow.core.k
 import arrow.core.toOption
 import arrow.core.toT
 import arrow.core.updated
-import arrow.extension
 import arrow.typeclasses.Align
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
@@ -36,14 +36,17 @@ import arrow.typeclasses.Unalign
 import arrow.typeclasses.Unzip
 import arrow.typeclasses.Zip
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKFunctor<A : Comparable<A>> : Functor<SortedMapKPartialOf<A>> {
   override fun <B, C> SortedMapKOf<A, B>.map(f: (B) -> C): SortedMapK<A, C> =
     fix().map(f)
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <A : Comparable<A>> SortedMapK.Companion.functor(): SortedMapKFunctor<A> =
   object : SortedMapKFunctor<A> {}
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKFoldable<A : Comparable<A>> : Foldable<SortedMapKPartialOf<A>> {
   override fun <B, C> SortedMapKOf<A, B>.foldLeft(b: C, f: (C, B) -> C): C =
     fix().foldLeft(b, f)
@@ -52,17 +55,21 @@ interface SortedMapKFoldable<A : Comparable<A>> : Foldable<SortedMapKPartialOf<A
     fix().foldRight(lb, f)
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <A : Comparable<A>> SortedMapK.Companion.foldable(): SortedMapKFoldable<A> =
   object : SortedMapKFoldable<A> {}
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKTraverse<A : Comparable<A>> : Traverse<SortedMapKPartialOf<A>>, SortedMapKFoldable<A> {
   override fun <G, B, C> SortedMapKOf<A, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, Kind<SortedMapKPartialOf<A>, C>> =
     fix().traverse(AP, f)
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <A : Comparable<A>> SortedMapK.Companion.traverse(): SortedMapKTraverse<A> =
   object : SortedMapKTraverse<A> {}
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKSemigroup<A : Comparable<A>, B> : Semigroup<SortedMapK<A, B>> {
   fun SG(): Semigroup<B>
 
@@ -73,33 +80,38 @@ interface SortedMapKSemigroup<A : Comparable<A>, B> : Semigroup<SortedMapK<A, B>
     else b.fix().foldLeft<B>(this.fix()) { my: SortedMapK<A, B>, (k, a) -> my.updated(k, SG().run { a.maybeCombine(my[k]) }) }
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <A : Comparable<A>, B> SortedMapK.Companion.semigroup(SB: Semigroup<B>): SortedMapKSemigroup<A, B> =
   object : SortedMapKSemigroup<A, B> {
     override fun SG(): Semigroup<B> = SB
   }
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKMonoid<A : Comparable<A>, B> : Monoid<SortedMapK<A, B>>, SortedMapKSemigroup<A, B> {
   override fun empty(): SortedMapK<A, B> = sortedMapOf<A, B>().k()
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <A : Comparable<A>, B> SortedMapK.Companion.monoid(SB: Semigroup<B>): SortedMapKMonoid<A, B> =
   object : SortedMapKMonoid<A, B> {
     override fun SG(): Semigroup<B> = SB
   }
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKShow<A : Comparable<A>, B> : Show<SortedMapKOf<A, B>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
   override fun SortedMapKOf<A, B>.show(): String = fix().show(SA(), SB())
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <A : Comparable<A>, B> SortedMapK.Companion.show(SA: Show<A>, SB: Show<B>): SortedMapKShow<A, B> =
   object : SortedMapKShow<A, B> {
     override fun SA(): Show<A> = SA
     override fun SB(): Show<B> = SB
   }
 
-@extension
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKEq<K : Comparable<K>, A> : Eq<SortedMapK<K, A>> {
   fun EQK(): Eq<K>
 
@@ -115,7 +127,7 @@ interface SortedMapKEq<K : Comparable<K>, A> : Eq<SortedMapK<K, A>> {
     } else false
 }
 
-@extension
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKHash<K : Comparable<K>, A> : Hash<SortedMapK<K, A>> {
   fun HK(): Hash<K>
   fun HA(): Hash<A>
@@ -130,6 +142,7 @@ interface SortedMapKHash<K : Comparable<K>, A> : Hash<SortedMapK<K, A>> {
     }
 }
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKSemialign<K : Comparable<K>> : Semialign<SortedMapKPartialOf<K>>, SortedMapKFunctor<K> {
   override fun <A, B> align(
     a: Kind<SortedMapKPartialOf<K>, A>,
@@ -145,17 +158,20 @@ interface SortedMapKSemialign<K : Comparable<K>> : Semialign<SortedMapKPartialOf
   }
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <K : Comparable<K>> SortedMapK.Companion.semialign(): SortedMapKSemialign<K> =
   object : SortedMapKSemialign<K> {}
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKAlign<K : Comparable<K>> : Align<SortedMapKPartialOf<K>>, SortedMapKSemialign<K> {
   override fun <A> empty(): Kind<SortedMapKPartialOf<K>, A> = emptyMap<K, A>().toSortedMap().k()
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <K : Comparable<K>> SortedMapK.Companion.align(): SortedMapKAlign<K> =
   object : SortedMapKAlign<K> {}
 
-@extension
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKEqK<K : Comparable<K>> : EqK<SortedMapKPartialOf<K>> {
   fun EQK(): Eq<K>
 
@@ -163,6 +179,7 @@ interface SortedMapKEqK<K : Comparable<K>> : EqK<SortedMapKPartialOf<K>> {
     SortedMapK.eq(EQK(), EQ).run { this@eqK.fix().eqv(other.fix()) }
 }
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKUnalign<K : Comparable<K>> : Unalign<SortedMapKPartialOf<K>>, SortedMapKSemialign<K> {
   override fun <A, B> unalign(ior: Kind<SortedMapKPartialOf<K>, Ior<A, B>>): Tuple2<Kind<SortedMapKPartialOf<K>, A>, Kind<SortedMapKPartialOf<K>, B>> =
     ior.fix().let { map ->
@@ -176,8 +193,10 @@ interface SortedMapKUnalign<K : Comparable<K>> : Unalign<SortedMapKPartialOf<K>>
     }
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <K : Comparable<K>> SortedMapK.Companion.unalign() = object : SortedMapKUnalign<K> {}
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKZip<K : Comparable<K>> : Zip<SortedMapKPartialOf<K>>, SortedMapKSemialign<K> {
   override fun <A, B> Kind<SortedMapKPartialOf<K>, A>.zip(other: Kind<SortedMapKPartialOf<K>, B>): Kind<SortedMapKPartialOf<K>, Tuple2<A, B>> =
     (this.fix() to other.fix()).let { (ls, rs) ->
@@ -189,8 +208,10 @@ interface SortedMapKZip<K : Comparable<K>> : Zip<SortedMapKPartialOf<K>>, Sorted
     }
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <K : Comparable<K>> SortedMapK.Companion.zip() = object : SortedMapKZip<K> {}
 
+@Deprecated(SortedMapKDeprecation)
 interface SortedMapKUnzip<K : Comparable<K>> : Unzip<SortedMapKPartialOf<K>>, SortedMapKZip<K> {
   override fun <A, B> Kind<SortedMapKPartialOf<K>, Tuple2<A, B>>.unzip(): Tuple2<Kind<SortedMapKPartialOf<K>, A>, Kind<SortedMapKPartialOf<K>, B>> =
     this.fix().let { map ->
@@ -200,4 +221,5 @@ interface SortedMapKUnzip<K : Comparable<K>> : Unzip<SortedMapKPartialOf<K>>, So
     }.bimap({ it.toSortedMap().k() }, { it.toSortedMap().k() })
 }
 
+@Deprecated(SortedMapKDeprecation)
 fun <K : Comparable<K>> SortedMapK.Companion.unzip() = object : SortedMapKUnzip<K> {}

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/tuple.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/tuple.kt
@@ -32,26 +32,30 @@ import arrow.typeclasses.Bifunctor
 import arrow.typeclasses.Bitraverse
 import arrow.typeclasses.Comonad
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.OrderDeprecation
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.Traverse
 import arrow.core.extensions.traverse as tuple2Traverse
 
 // TODO this should be user driven allowing consumers to generate the tuple arities on demand to avoid cluttering arrow dependents with unused code
 // TODO @arities(fromTupleN = 2, toTupleN = 22 | fromHListN = 1, toHListN = 22)
-
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Functor<F> : Functor<Tuple2PartialOf<F>> {
   override fun <A, B> Tuple2Of<F, A>.map(f: (A) -> B) =
     fix().map(f)
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Apply<F> : Apply<Tuple2PartialOf<F>>, Tuple2Functor<F> {
 
   override fun <A, B> Tuple2Of<F, A>.map(f: (A) -> B) =
@@ -61,6 +65,7 @@ interface Tuple2Apply<F> : Apply<Tuple2PartialOf<F>>, Tuple2Functor<F> {
     fix().ap(ff.fix())
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Applicative<F> : Applicative<Tuple2PartialOf<F>>, Tuple2Functor<F> {
   fun MF(): Monoid<F>
 
@@ -74,6 +79,7 @@ interface Tuple2Applicative<F> : Applicative<Tuple2PartialOf<F>>, Tuple2Functor<
     MF().empty() toT a
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Monad<F> : Monad<Tuple2PartialOf<F>>, Tuple2Applicative<F> {
 
   override fun MF(): Monoid<F>
@@ -96,6 +102,7 @@ interface Tuple2Monad<F> : Monad<Tuple2PartialOf<F>>, Tuple2Applicative<F> {
   }
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Bifunctor : Bifunctor<ForTuple2> {
   override fun <A, B, C, D> Tuple2Of<A, B>.bimap(
     fl: (A) -> C,
@@ -103,6 +110,7 @@ interface Tuple2Bifunctor : Bifunctor<ForTuple2> {
   ) = fix().bimap(fl, fr)
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Comonad<F> : Comonad<Tuple2PartialOf<F>>, Tuple2Functor<F> {
   override fun <A, B> Tuple2Of<F, A>.coflatMap(f: (Tuple2Of<F, A>) -> B) =
     fix().coflatMap(f)
@@ -111,6 +119,7 @@ interface Tuple2Comonad<F> : Comonad<Tuple2PartialOf<F>>, Tuple2Functor<F> {
     fix().extract()
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Foldable<F> : Foldable<Tuple2PartialOf<F>> {
   override fun <A, B> Tuple2Of<F, A>.foldLeft(b: B, f: (B, A) -> B) =
     fix().foldL(b, f)
@@ -119,6 +128,7 @@ interface Tuple2Foldable<F> : Foldable<Tuple2PartialOf<F>> {
     fix().foldR(lb, f)
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Bifoldable : Bifoldable<ForTuple2> {
   override fun <A, B, C> Tuple2Of<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C = fix().let { g(f(c, it.a), it.b) }
 
@@ -126,19 +136,23 @@ interface Tuple2Bifoldable : Bifoldable<ForTuple2> {
     fix().let { f(it.a, g(it.b, c)) }
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 fun <F, G, A, B> Tuple2Of<F, A>.traverse(GA: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Tuple2<F, B>> = GA.run {
   fix().let { f(it.b).map(it.a::toT) }
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 fun <F, G, A> Tuple2Of<F, Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, Tuple2<F, A>> =
   fix().tuple2Traverse(GA, ::identity)
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Traverse<F> : Traverse<Tuple2PartialOf<F>>, Tuple2Foldable<F> {
 
   override fun <G, A, B> Tuple2Of<F, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Tuple2<F, B>> =
     tuple2Traverse(AP, f)
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Bitraverse : Bitraverse<ForTuple2>, Tuple2Bifoldable {
   override fun <G, A, B, C, D> Tuple2Of<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, Tuple2Of<C, D>> =
     AP.run {
@@ -146,6 +160,7 @@ interface Tuple2Bitraverse : Bitraverse<ForTuple2>, Tuple2Bifoldable {
     }
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Semigroup<A, B> : Semigroup<Tuple2<A, B>> {
 
   fun SA(): Semigroup<A>
@@ -159,6 +174,7 @@ interface Tuple2Semigroup<A, B> : Semigroup<Tuple2<A, B>> {
   }
 }
 
+@Deprecated("Tuple2 is deprecated in favor of Kotlin's Pair")
 interface Tuple2Monoid<A, B> : Monoid<Tuple2<A, B>>, Tuple2Semigroup<A, B> {
 
   fun MA(): Monoid<A>
@@ -172,6 +188,7 @@ interface Tuple2Monoid<A, B> : Monoid<Tuple2<A, B>>, Tuple2Semigroup<A, B> {
   override fun empty(): Tuple2<A, B> = Tuple2(MA().empty(), MB().empty())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple2Eq<A, B> : Eq<Tuple2<A, B>> {
 
   fun EQA(): Eq<A>
@@ -182,6 +199,7 @@ interface Tuple2Eq<A, B> : Eq<Tuple2<A, B>> {
     EQA().run { a.eqv(b.a) && EQB().run { this@eqv.b.eqv(b.b) } }
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple2Show<A, B> : Show<Tuple2<A, B>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -189,6 +207,7 @@ interface Tuple2Show<A, B> : Show<Tuple2<A, B>> {
     show(SA(), SB())
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple2Hash<A, B> : Hash<Tuple2<A, B>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -208,6 +227,7 @@ interface Tuple2Order<A, B> : Order<Tuple2<A, B>> {
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple3Eq<A, B, C> : Eq<Tuple3<A, B, C>> {
 
   fun EQA(): Eq<A>
@@ -222,6 +242,7 @@ interface Tuple3Eq<A, B, C> : Eq<Tuple3<A, B, C>> {
       EQC().run { c.eqv(b.c) }
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple3Show<A, B, C> : Show<Tuple3<A, B, C>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -230,6 +251,7 @@ interface Tuple3Show<A, B, C> : Show<Tuple3<A, B, C>> {
     show(SA(), SB(), SC())
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple3Hash<A, B, C> : Hash<Tuple3<A, B, C>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -252,6 +274,7 @@ interface Tuple3Order<A, B, C> : Order<Tuple3<A, B, C>> {
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple4Eq<A, B, C, D> : Eq<Tuple4<A, B, C, D>> {
 
   fun EQA(): Eq<A>
@@ -269,6 +292,7 @@ interface Tuple4Eq<A, B, C, D> : Eq<Tuple4<A, B, C, D>> {
       EQD().run { d.eqv(b.d) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple4Hash<A, B, C, D> : Hash<Tuple4<A, B, C, D>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -302,6 +326,7 @@ interface Tuple4Order<A, B, C, D> : Order<Tuple4<A, B, C, D>> {
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple4Show<A, B, C, D> : Show<Tuple4<A, B, C, D>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -311,6 +336,7 @@ interface Tuple4Show<A, B, C, D> : Show<Tuple4<A, B, C, D>> {
     show(SA(), SB(), SC(), SD())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple5Eq<A, B, C, D, E> : Eq<Tuple5<A, B, C, D, E>> {
 
   fun EQA(): Eq<A>
@@ -331,6 +357,7 @@ interface Tuple5Eq<A, B, C, D, E> : Eq<Tuple5<A, B, C, D, E>> {
       EQE().run { e.eqv(b.e) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple5Hash<A, B, C, D, E> : Hash<Tuple5<A, B, C, D, E>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -369,6 +396,7 @@ interface Tuple5Order<A, B, C, D, E> : Order<Tuple5<A, B, C, D, E>> {
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple5Show<A, B, C, D, E> : Show<Tuple5<A, B, C, D, E>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -379,6 +407,7 @@ interface Tuple5Show<A, B, C, D, E> : Show<Tuple5<A, B, C, D, E>> {
     show(SA(), SB(), SC(), SD(), SE())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple6Eq<A, B, C, D, E, F> : Eq<Tuple6<A, B, C, D, E, F>> {
 
   fun EQA(): Eq<A>
@@ -402,6 +431,7 @@ interface Tuple6Eq<A, B, C, D, E, F> : Eq<Tuple6<A, B, C, D, E, F>> {
       EQF().run { f.eqv(b.f) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple6Hash<A, B, C, D, E, F> : Hash<Tuple6<A, B, C, D, E, F>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -445,6 +475,7 @@ interface Tuple6Order<A, B, C, D, E, F> : Order<Tuple6<A, B, C, D, E, F>> {
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple6Show<A, B, C, D, E, F> : Show<Tuple6<A, B, C, D, E, F>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -456,6 +487,7 @@ interface Tuple6Show<A, B, C, D, E, F> : Show<Tuple6<A, B, C, D, E, F>> {
     show(SA(), SB(), SC(), SD(), SE(), SF())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple7Eq<A, B, C, D, E, F, G> : Eq<Tuple7<A, B, C, D, E, F, G>> {
 
   fun EQA(): Eq<A>
@@ -482,6 +514,7 @@ interface Tuple7Eq<A, B, C, D, E, F, G> : Eq<Tuple7<A, B, C, D, E, F, G>> {
       EQG().run { g.eqv(b.g) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple7Hash<A, B, C, D, E, F, G> : Hash<Tuple7<A, B, C, D, E, F, G>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -542,6 +575,7 @@ interface Tuple7Order<A, B, C, D, E, F, G> : Order<Tuple7<A, B, C, D, E, F, G>> 
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple7Show<A, B, C, D, E, F, G> : Show<Tuple7<A, B, C, D, E, F, G>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -554,6 +588,7 @@ interface Tuple7Show<A, B, C, D, E, F, G> : Show<Tuple7<A, B, C, D, E, F, G>> {
     show(SA(), SB(), SC(), SD(), SE(), SF(), SG())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple8Eq<A, B, C, D, E, F, G, H> : Eq<Tuple8<A, B, C, D, E, F, G, H>> {
 
   fun EQA(): Eq<A>
@@ -583,6 +618,7 @@ interface Tuple8Eq<A, B, C, D, E, F, G, H> : Eq<Tuple8<A, B, C, D, E, F, G, H>> 
       EQH().run { h.eqv(b.h) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple8Hash<A, B, C, D, E, F, G, H> : Hash<Tuple8<A, B, C, D, E, F, G, H>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -650,6 +686,7 @@ interface Tuple8Order<A, B, C, D, E, F, G, H> : Order<Tuple8<A, B, C, D, E, F, G
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple8Show<A, B, C, D, E, F, G, H> : Show<Tuple8<A, B, C, D, E, F, G, H>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -663,6 +700,7 @@ interface Tuple8Show<A, B, C, D, E, F, G, H> : Show<Tuple8<A, B, C, D, E, F, G, 
     show(SA(), SB(), SC(), SD(), SE(), SF(), SG(), SH())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple9Eq<A, B, C, D, E, F, G, H, I> : Eq<Tuple9<A, B, C, D, E, F, G, H, I>> {
 
   fun EQA(): Eq<A>
@@ -695,6 +733,7 @@ interface Tuple9Eq<A, B, C, D, E, F, G, H, I> : Eq<Tuple9<A, B, C, D, E, F, G, H
       EQI().run { i.eqv(b.i) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple9Hash<A, B, C, D, E, F, G, H, I> : Hash<Tuple9<A, B, C, D, E, F, G, H, I>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -769,6 +808,7 @@ interface Tuple9Order<A, B, C, D, E, F, G, H, I> : Order<Tuple9<A, B, C, D, E, F
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple9Show<A, B, C, D, E, F, G, H, I> : Show<Tuple9<A, B, C, D, E, F, G, H, I>> {
   fun SA(): Show<A>
   fun SB(): Show<B>
@@ -783,6 +823,7 @@ interface Tuple9Show<A, B, C, D, E, F, G, H, I> : Show<Tuple9<A, B, C, D, E, F, 
     show(SA(), SB(), SC(), SD(), SE(), SF(), SG(), SH(), SI())
 }
 
+@Deprecated(EqDeprecation)
 interface Tuple10Eq<A, B, C, D, E, F, G, H, I, J> : Eq<Tuple10<A, B, C, D, E, F, G, H, I, J>> {
 
   fun EQA(): Eq<A>
@@ -809,6 +850,7 @@ interface Tuple10Eq<A, B, C, D, E, F, G, H, I, J> : Eq<Tuple10<A, B, C, D, E, F,
       EQJ().run { j.eqv(b.j) }
 }
 
+@Deprecated(HashDeprecation)
 interface Tuple10Hash<A, B, C, D, E, F, G, H, I, J> : Hash<Tuple10<A, B, C, D, E, F, G, H, I, J>> {
   fun HA(): Hash<A>
   fun HB(): Hash<B>
@@ -890,6 +932,7 @@ interface Tuple10Order<A, B, C, D, E, F, G, H, I, J> : Order<Tuple10<A, B, C, D,
   ).fold(Ordering.monoid())
 }
 
+@Deprecated(ShowDeprecation)
 interface Tuple10Show<A, B, C, D, E, F, G, H, I, J> : Show<Tuple10<A, B, C, D, E, F, G, H, I, J>> {
   fun SA(): Show<A>
   fun SB(): Show<B>

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
@@ -26,31 +26,46 @@ import arrow.typeclasses.Bifoldable
 import arrow.typeclasses.Bifunctor
 import arrow.typeclasses.Bitraverse
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
+import arrow.typeclasses.HashDeprecation
 import arrow.typeclasses.Order
 import arrow.typeclasses.OrderDeprecation
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.hashWithSalt
 import arrow.core.handleErrorWith as validatedHandleErrorWith
 import arrow.core.traverse as validatedTraverse
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedFunctor<E> : Functor<ValidatedPartialOf<E>> {
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.map(f: (A) -> B): Validated<E, B> = fix().map(f)
 }
 
+@Deprecated(
+  message = "BiFunctor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedBifunctor : Bifunctor<ForValidated> {
   override fun <A, B, C, D> ValidatedOf<A, B>.bimap(fl: (A) -> C, fr: (B) -> D): Validated<C, D> =
     fix().bimap(fl, fr)
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedApplicative<E> : Applicative<ValidatedPartialOf<E>>, ValidatedFunctor<E> {
 
   fun SE(): Semigroup<E>
@@ -62,6 +77,10 @@ interface ValidatedApplicative<E> : Applicative<ValidatedPartialOf<E>>, Validate
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.ap(ff: Kind<ValidatedPartialOf<E>, (A) -> B>): Validated<E, B> = fix().ap(SE(), ff.fix())
 }
 
+@Deprecated(
+  message = "Selective typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedSelective<E> : Selective<ValidatedPartialOf<E>>, ValidatedApplicative<E> {
 
   override fun SE(): Semigroup<E>
@@ -70,6 +89,10 @@ interface ValidatedSelective<E> : Selective<ValidatedPartialOf<E>>, ValidatedApp
     fix().fold({ Invalid(it) }, { it.fold({ l -> f.map { ff -> ff(l) } }, { r -> just(r) }) })
 }
 
+@Deprecated(
+  message = "ApplicativeError typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedApplicativeError<E> : ApplicativeError<ValidatedPartialOf<E>, E>, ValidatedApplicative<E> {
 
   override fun SE(): Semigroup<E>
@@ -80,6 +103,10 @@ interface ValidatedApplicativeError<E> : ApplicativeError<ValidatedPartialOf<E>,
     fix().validatedHandleErrorWith(f)
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedFoldable<E> : Foldable<ValidatedPartialOf<E>> {
 
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -89,12 +116,20 @@ interface ValidatedFoldable<E> : Foldable<ValidatedPartialOf<E>> {
     fix().foldRight(lb, f)
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedTraverse<E> : Traverse<ValidatedPartialOf<E>>, ValidatedFoldable<E> {
 
   override fun <G, A, B> Kind<ValidatedPartialOf<E>, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Validated<E, B>> =
     fix().validatedTraverse(AP, f)
 }
 
+@Deprecated(
+  message = "BiFoldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedBifoldable : Bifoldable<ForValidated> {
   override fun <A, B, C> ValidatedOf<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fix().fold({ f(c, it) }, { g(c, it) })
@@ -103,6 +138,10 @@ interface ValidatedBifoldable : Bifoldable<ForValidated> {
     fix().fold({ f(it, c) }, { g(it, c) })
 }
 
+@Deprecated(
+  message = "BiTraverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedBitraverse : Bitraverse<ForValidated>, ValidatedBifoldable {
   override fun <G, A, B, C, D> ValidatedOf<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, ValidatedOf<C, D>> =
     fix().let {
@@ -115,6 +154,10 @@ interface ValidatedBitraverse : Bitraverse<ForValidated>, ValidatedBifoldable {
     }
 }
 
+@Deprecated(
+  message = "SemigroupK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedSemigroupK<E> : SemigroupK<ValidatedPartialOf<E>> {
 
   fun SE(): Semigroup<E>
@@ -123,6 +166,10 @@ interface ValidatedSemigroupK<E> : SemigroupK<ValidatedPartialOf<E>> {
     fix().combineK(SE(), y)
 }
 
+@Deprecated(
+  message = EqDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedEq<L, R> : Eq<Validated<L, R>> {
 
   fun EQL(): Eq<L>
@@ -141,6 +188,10 @@ interface ValidatedEq<L, R> : Eq<Validated<L, R>> {
   }
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedEqK<L> : EqK<ValidatedPartialOf<L>> {
   fun EQL(): Eq<L>
 
@@ -150,6 +201,10 @@ interface ValidatedEqK<L> : EqK<ValidatedPartialOf<L>> {
     }
 }
 
+@Deprecated(
+  message = "EqK2 typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Validated.",
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedEqK2 : EqK2<ForValidated> {
   override fun <A, B> Kind2<ForValidated, A, B>.eqK(other: Kind2<ForValidated, A, B>, EQA: Eq<A>, EQB: Eq<B>): Boolean =
     (this.fix() to other.fix()).let {
@@ -159,12 +214,20 @@ interface ValidatedEqK2 : EqK2<ForValidated> {
     }
 }
 
+@Deprecated(
+  message = ShowDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedShow<L, R> : Show<Validated<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
   override fun Validated<L, R>.show(): String = show(SL(), SR())
 }
 
+@Deprecated(
+  message = HashDeprecation,
+  level = DeprecationLevel.WARNING
+)
 interface ValidatedHash<L, R> : Hash<Validated<L, R>> {
   fun HL(): Hash<L>
   fun HR(): Hash<R>


### PR DESCRIPTION
Some of the old `@extensions` interfaces were still missing `@Deprecated` notice.