### PR TITLE
CU-ev1jrd Fix Monoid for Sequence and Set

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -673,5 +673,5 @@ fun <A> Monoid.Companion.sequence(): Monoid<Sequence<A>> =
 
 object SequenceMonoid : Monoid<Sequence<Any?>> {
   override fun empty(): Sequence<Any?> = emptySequence()
-  override fun Sequence<Any?>.combine(b: Sequence<Any?>): Sequence<Any?> = this + b
+  override fun Sequence<Any?>.combine(b: Sequence<Any?>): Sequence<Any?> = sequenceOf(this, b).flatten()
 }

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/set.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/set.kt
@@ -2,6 +2,7 @@ package arrow.core
 
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
+import kotlin.collections.plus as _plus
 
 object SetExtensions
 
@@ -9,7 +10,7 @@ object SortedSetInstances
 
 fun <A> Semigroup.Companion.set(): Semigroup<Set<A>> = object : Semigroup<Set<A>> {
   override fun Set<A>.combine(b: Set<A>): Set<A> =
-    this + b
+    this._plus(b)
 }
 
 fun <A> Monoid.Companion.set(): Monoid<Set<A>> = object : Monoid<Set<A>> {
@@ -17,5 +18,5 @@ fun <A> Monoid.Companion.set(): Monoid<Set<A>> = object : Monoid<Set<A>> {
     emptySet<A>()
 
   override fun Set<A>.combine(b: Set<A>): Set<A> =
-    this + b
+    this._plus(b)
 }

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -16,7 +16,6 @@ import arrow.core.extensions.sequencek.hash.hash
 import arrow.core.extensions.sequencek.monad.monad
 import arrow.core.extensions.sequencek.monadCombine.monadCombine
 import arrow.core.extensions.sequencek.monadLogic.monadLogic
-import arrow.core.extensions.sequencek.monoid.monoid
 import arrow.core.extensions.sequencek.monoidK.monoidK
 import arrow.core.extensions.sequencek.monoidal.monoidal
 import arrow.core.extensions.sequencek.order.order

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -29,6 +29,7 @@ import arrow.core.extensions.sequencek.unzip.unzip
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.genK
+import arrow.core.test.generators.sequence
 import arrow.core.test.generators.sequenceK
 import arrow.core.test.laws.AlignLaws
 import arrow.core.test.laws.CrosswalkLaws
@@ -45,6 +46,8 @@ import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseLaws
 import arrow.core.test.laws.UnalignLaws
 import arrow.core.test.laws.UnzipLaws
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Monoid
 import io.kotlintest.matchers.sequences.shouldBeEmpty
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
@@ -69,7 +72,7 @@ class SequenceKTest : UnitSpec() {
       MonadCombineLaws.laws(SequenceK.monadCombine(), SequenceK.genK(), SequenceK.eqK()),
       ShowLaws.laws(SequenceK.show(Int.show()), EQ, Gen.sequenceK(Gen.int())),
       MonoidKLaws.laws(SequenceK.monoidK(), SequenceK.genK(), SequenceK.eqK()),
-      MonoidLaws.laws(SequenceK.monoid(), Gen.sequenceK(Gen.int()), EQ),
+      MonoidLaws.laws(Monoid.sequence(), Gen.sequence(Gen.int()), Eq { a, b -> a.toList() == b.toList() }),
       MonoidalLaws.laws(SequenceK.monoidal(), SequenceK.genK(), SequenceK.eqK(), this::bijection),
       TraverseLaws.laws(SequenceK.traverse(), SequenceK.genK(), SequenceK.eqK()),
       FunctorFilterLaws.laws(SequenceK.functorFilter(), SequenceK.genK(), SequenceK.eqK()),

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
@@ -26,6 +26,7 @@ import arrow.core.test.laws.MonoidalLaws
 import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Monoid
 import io.kotlintest.properties.Gen
 
 class SetKTest : UnitSpec() {
@@ -44,7 +45,7 @@ class SetKTest : UnitSpec() {
 
     testLaws(
       ShowLaws.laws(SetK.show(Int.show()), EQ, Gen.genSetK(Gen.int())),
-      MonoidLaws.laws(SetK.monoid(), Gen.genSetK(Gen.int()), EQ),
+      MonoidLaws.laws(Monoid.set(), Gen.set(Gen.int()), Eq.any()),
       SemigroupKLaws.laws(SetK.semigroupK(), SetK.genK(), SetK.eqK()),
       MonoidalLaws.laws(
         SetK.monoidal(),

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SetKTest.kt
@@ -7,7 +7,6 @@ import arrow.core.extensions.setk.eq.eq
 import arrow.core.extensions.setk.eqK.eqK
 import arrow.core.extensions.setk.foldable.foldable
 import arrow.core.extensions.setk.hash.hash
-import arrow.core.extensions.setk.monoid.monoid
 import arrow.core.extensions.setk.monoidK.monoidK
 import arrow.core.extensions.setk.monoidal.monoidal
 import arrow.core.extensions.setk.semigroupK.semigroupK

--- a/arrow-libs/core/arrow-core-test/src/main/kotlin/arrow/core/test/generators/Generators.kt
+++ b/arrow-libs/core/arrow-core-test/src/main/kotlin/arrow/core/test/generators/Generators.kt
@@ -163,6 +163,8 @@ fun <A> Gen.Companion.listK(genA: Gen<A>): Gen<ListK<A>> = Gen.list(genA).map { 
 
 fun <A> Gen.Companion.sequenceK(genA: Gen<A>): Gen<SequenceK<A>> = Gen.list(genA).map { it.asSequence().k() }
 
+fun <A> Gen.Companion.sequence(genA: Gen<A>): Gen<Sequence<A>> = Gen.list(genA).map { it.asSequence() }
+
 fun <A> Gen.Companion.genSetK(genA: Gen<A>): Gen<SetK<A>> = Gen.set(genA).map { it.k() }
 
 fun Gen.Companion.unit(): Gen<Unit> =


### PR DESCRIPTION
The `Monoid` instance for `Sequence` and `Set` were resulting in `StackOverflow` since they were delegating to their `Monoid#plus` function instead of the `plus` function from the standard library.