### PR TITLE
CU-et6c7a Deprecates racePair and raceTriple

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RacePair.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RacePair.kt
@@ -12,11 +12,14 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 
+@Deprecated("Will be removed since it leaks Fiber, and breaks structured concurrency. Replace with select")
 typealias RacePair<A, B> = Either<Pair<A, Fiber<B>>, Pair<Fiber<A>, B>>
 
+@Deprecated("Will be removed since it leaks Fiber, and breaks structured concurrency. Replace with select")
 fun <A, B, C> Either<Pair<A, Fiber<B>>, Pair<Fiber<A>, B>>.fold(ifLeft: (A, Fiber<B>) -> C, ifRight: (Fiber<A>, B) -> C): C =
   fold({ (a, b) -> ifLeft(a, b) }, { (a, b) -> ifRight(a, b) })
 
+@Deprecated("Will be removed since it leaks Fiber, and breaks structured concurrency. Replace with select")
 suspend fun <A, B> racePair(fa: suspend () -> A, fb: suspend () -> B): RacePair<A, B> =
   racePair(Dispatchers.Default, fa, fb)
 
@@ -63,7 +66,7 @@ suspend fun <A, B> racePair(
     }
   }
 
-suspend fun <A, B> oldRacePair(
+private suspend fun <A, B> oldRacePair(
   ctx: CoroutineContext,
   fa: suspend () -> A,
   fb: suspend () -> B

--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RaceTriple.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RaceTriple.kt
@@ -11,6 +11,7 @@ import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.intercepted
 
+@Deprecated("Will be removed since it leaks Fiber, and breaks structured concurrency. Replace with select")
 sealed class RaceTriple<A, B, C> {
   data class First<A, B, C>(val winner: A, val fiberB: Fiber<B>, val fiberC: Fiber<C>) : RaceTriple<A, B, C>()
   data class Second<A, B, C>(val fiberA: Fiber<A>, val winner: B, val fiberC: Fiber<C>) : RaceTriple<A, B, C>()
@@ -27,6 +28,7 @@ sealed class RaceTriple<A, B, C> {
   }
 }
 
+@Deprecated("Will be removed since it leaks Fiber, and breaks structured concurrency. Replace with select")
 suspend fun <A, B, C> raceTriple(fa: suspend () -> A, fb: suspend () -> B, fc: suspend () -> C): RaceTriple<A, B, C> =
   raceTriple(Dispatchers.Default, fa, fb, fc)
 
@@ -76,7 +78,7 @@ suspend fun <A, B, C> raceTriple(
     }
   }
 
-suspend fun <A, B, C> oldRaceTriple(
+private suspend fun <A, B, C> oldRaceTriple(
   ctx: CoroutineContext,
   fa: suspend () -> A,
   fb: suspend () -> B,


### PR DESCRIPTION
This PR deprecates all code in `RacePair.kt` and `RaceTriple.kt` since they break guarantees provided with KotlinX Coroutines structured coroutines and KotlinX offers other/safer mechanisms to cover this use-case.