### PR TITLE
CU-et6dqh Deprecate CancelToken and Disposable

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/SuspendConnection.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/SuspendConnection.kt
@@ -5,6 +5,7 @@ package arrow.fx.coroutines
  * This allows for clearer APIs in functions that expect a [CancelToken] to be returned.
  */
 @Suppress("EXPERIMENTAL_FEATURE_WARNING")
+@Deprecated("CancelToken is deprecated together with Arrow Fx's old builders in favor of KotlinX's suspendCoroutineCancellable builder")
 inline class CancelToken(val cancel: suspend () -> Unit) {
 
   suspend fun invoke(): Unit = cancel.invoke()
@@ -16,4 +17,5 @@ inline class CancelToken(val cancel: suspend () -> Unit) {
   }
 }
 
+@Deprecated("Disposable alias is deprecated in favor of structured concurrency")
 typealias Disposable = () -> Unit


### PR DESCRIPTION
`CancelToken` will be removed together with `cancelable` and `cancelableF` in favor of KotlinX's `suspendCoroutineCancellable` builder.