### PR TITLE
CU-ev2g8f Fix Sequence#travserse, Option#apEval & Either#apEval

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1588,7 +1588,7 @@ fun <A, B, C> EitherOf<A, B>.ap(ff: EitherOf<A, (B) -> C>): Either<A, C> =
   flatMap { a -> ff.fix().map { f -> f(a) } }
 
 fun <A, B, C> Either<A, B>.apEval(ff: Eval<Either<A, (B) -> C>>): Eval<Either<A, C>> =
-  ff.map { this.ap(it) }
+  fold({ l -> Eval.now(l.left()) }, { r -> ff.map { it.map { f -> f(r) } } })
 
 fun <A, B> EitherOf<A, B>.combineK(y: EitherOf<A, B>): Either<A, B> =
   when (this) {

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -652,7 +652,7 @@ sealed class Option<out A> : OptionOf<A> {
     ff.fix().flatMap { this.fix().map(it) }
 
   fun <B> apEval(ff: Eval<Option<(A) -> B>>): Eval<Option<B>> =
-    ff.map { ap(it) }
+    fold({ Eval.now(none()) }, { r -> ff.map { it.map { f -> f(r) } } })
 
   inline fun <B> crosswalk(f: (A) -> Option<B>): Option<Option<B>> =
     when (this) {

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -115,7 +115,7 @@ fun <E, A, B> Sequence<A>.flatTraverseEither(f: (A) -> Either<E, Sequence<B>>): 
 
 fun <E, A, B> Sequence<A>.flatTraverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, Sequence<B>>): Validated<E, Sequence<B>> =
   foldRight<A, Validated<E, Sequence<B>>>(Eval.now(emptySequence<B>().valid())) { a, acc ->
-    f(a).apEval(semigroup, acc.map { it.map { bs -> { b: Sequence<B> -> b + bs }  } })
+    f(a).apEval(semigroup, acc.map { it.map { bs -> { b: Sequence<B> -> b + bs } } })
   }.value()
 
 fun <A> Sequence<Sequence<A>>.flatten(): Sequence<A> =
@@ -466,7 +466,7 @@ fun <A> Sequence<A>.tail(): Sequence<A> =
   drop(1)
 
 fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequence<B>> =
-  foldRight<A, Either<E, Sequence<B>>>(Eval.now(emptySequence<B>().right())) { a, acc ->
+  foldRight<A, Either<E, Sequence<B>>>(Eval.now(sequenceOf<B>().right())) { a, acc ->
     f(a).apEval(acc.map { it.map { bs -> { b: B -> sequenceOf(b) + bs } } })
   }.value()
 

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -109,14 +109,14 @@ fun <E, A> Sequence<Validated<E, Sequence<A>>>.flatSequenceValidated(semigroup: 
   flatTraverseValidated(semigroup, ::identity)
 
 fun <E, A, B> Sequence<A>.flatTraverseEither(f: (A) -> Either<E, Sequence<B>>): Either<E, Sequence<B>> =
-  foldRight<A, Either<E, Sequence<B>>>(emptySequence<B>().right()) { a, acc ->
-    f(a).ap(acc.map { bs -> { b: Sequence<B> -> b + bs } })
-  }
+  foldRight<A, Either<E, Sequence<B>>>(Eval.now(emptySequence<B>().right())) { a, acc ->
+    f(a).apEval(acc.map { it.map { bs -> { b: Sequence<B> -> b + bs } } })
+  }.value()
 
 fun <E, A, B> Sequence<A>.flatTraverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, Sequence<B>>): Validated<E, Sequence<B>> =
-  foldRight<A, Validated<E, Sequence<B>>>(emptySequence<B>().valid()) { a, acc ->
-    f(a).ap(semigroup, acc.map { bs -> { b: Sequence<B> -> b + bs } })
-  }
+  foldRight<A, Validated<E, Sequence<B>>>(Eval.now(emptySequence<B>().valid())) { a, acc ->
+    f(a).apEval(semigroup, acc.map { it.map { bs -> { b: Sequence<B> -> b + bs }  } })
+  }.value()
 
 fun <A> Sequence<Sequence<A>>.flatten(): Sequence<A> =
   flatMap(::identity)
@@ -132,9 +132,6 @@ fun <A, B> Sequence<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
     acc.combine(f(a))
   }
 }
-
-inline fun <A, B> Sequence<A>.foldRight(initial: B, operation: (A, B) -> B): B =
-  toList().foldRight(initial, operation)
 
 fun <A, B> Sequence<A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> {
   fun Iterator<A>.loop(): Eval<B> =
@@ -469,26 +466,26 @@ fun <A> Sequence<A>.tail(): Sequence<A> =
   drop(1)
 
 fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequence<B>> =
-  foldRight<A, Either<E, Sequence<B>>>(emptySequence<B>().right()) { a, acc ->
-    f(a).ap(acc.map { bs -> { b: B -> sequenceOf(b) + bs } })
-  }
+  foldRight<A, Either<E, Sequence<B>>>(Eval.now(emptySequence<B>().right())) { a, acc ->
+    f(a).apEval(acc.map { it.map { bs -> { b: B -> sequenceOf(b) + bs } } })
+  }.value()
 
 fun <E, A> Sequence<A>.traverseEither_(f: (A) -> Either<E, *>): Either<E, Unit> {
-  val void = { _: Unit -> { _: Any? -> Unit } }
-  return foldRight<A, Either<E, Unit>>(Unit.right()) { a, acc ->
-    f(a).ap(acc.map(void))
-  }
+  val void: (Either<E, Unit>) -> Either<E, (Any?) -> Unit> = { it.map { { Unit } } }
+  return foldRight<A, Either<E, Unit>>(Eval.now(Unit.right())) { a, acc ->
+    f(a).apEval(acc.map(void))
+  }.value()
 }
 
 fun <E, A, B> Sequence<A>.traverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, B>): Validated<E, Sequence<B>> =
-  foldRight<A, Validated<E, Sequence<B>>>(emptySequence<B>().valid()) { a, acc ->
-    f(a).ap(semigroup, acc.map { bs -> { b: B -> sequenceOf(b) + bs } })
-  }
+  foldRight<A, Validated<E, Sequence<B>>>(Eval.now(emptySequence<B>().valid())) { a, acc ->
+    f(a).apEval(semigroup, acc.map { it.map { bs -> { b: B -> sequenceOf(b) + bs } } })
+  }.value()
 
 fun <E, A> Sequence<A>.traverseValidated_(semigroup: Semigroup<E>, f: (A) -> Validated<E, *>): Validated<E, Unit> =
-  foldRight<A, Validated<E, Unit>>(Unit.valid()) { a, acc ->
-    f(a).ap(semigroup, acc.map { { Unit } })
-  }
+  foldRight<A, Validated<E, Unit>>(Eval.now(Unit.valid())) { a, acc ->
+    f(a).apEval(semigroup, acc.map { it.map { { Unit } } })
+  }.value()
 
 /**
  *  Pairs [B] with [A] returning a Sequence<Pair<B, A>>

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
@@ -1108,14 +1108,12 @@ internal fun <K, V> MutableMap<in K, in V>.putAll(tuples: Sequence<Tuple2<K, V>>
 operator fun <K, V> Map<out K, V>.plus(tuple: Tuple2<K, V>): Map<K, V> =
   if (this.isEmpty()) mapOf(tuple) else LinkedHashMap(this).apply { put(tuple.a, tuple.b) }
 
-
 @Deprecated(
   "Tuple2 is deprecated in favor of Kotlin's Pair",
   ReplaceWith("this.plus(tuples.map { (a, b) -> Pair(a, b) })")
 )
 operator fun <K, V> Map<out K, V>.plus(tuples: Iterable<Tuple2<K, V>>): Map<K, V> =
   if (this.isEmpty()) tuples.toMap() else LinkedHashMap(this).apply { putAll(tuples) }
-
 
 @Deprecated(
   "Tuple2 is deprecated in favor of Kotlin's Pair",

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1112,6 +1112,9 @@ inline fun <E, A, B> ValidatedOf<E, A>.ap(SE: Semigroup<E>, f: Validated<E, (A) 
     }
   }
 
+fun <E, A, B> Validated<E, A>.apEval(SE: Semigroup<E>, ff: Eval<Validated<E, (A) -> B>>): Eval<Validated<E, B>> =
+  ff.map { this.ap(SE, it) }
+
 @Deprecated(
   "To keep API consistent with Either and Option please use `handleErrorWith` instead",
   ReplaceWith("handleErrorWith(f)")

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/typeclasses/TraverseTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/typeclasses/TraverseTest.kt
@@ -1,17 +1,20 @@
 package arrow.typeclasses
 
+import arrow.core.Left
 import arrow.core.None
 import arrow.core.Option
+import arrow.core.Right
 import arrow.core.Some
 import arrow.core.extensions.option.applicative.applicative
 import arrow.core.extensions.sequence.traverse.sequence
+import arrow.core.sequenceEither
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
 class TraverseTest : StringSpec({
   "traverse is stacksafe over very long collections and short circuits properly" {
     // This has to traverse 50k elements till it reaches None and terminates
-    generateSequence(0) { it + 1 }.map { if (it < 50_000) Some(it) else None }
-      .sequence(Option.applicative()) shouldBe None
+    generateSequence(0) { it + 1 }.map { if (it < 50_000) Right(it) else Left(Unit) }
+      .sequenceEither() shouldBe Left(Unit)
   }
 })

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/typeclasses/TraverseTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/typeclasses/TraverseTest.kt
@@ -1,12 +1,7 @@
 package arrow.typeclasses
 
 import arrow.core.Left
-import arrow.core.None
-import arrow.core.Option
 import arrow.core.Right
-import arrow.core.Some
-import arrow.core.extensions.option.applicative.applicative
-import arrow.core.extensions.sequence.traverse.sequence
 import arrow.core.sequenceEither
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec


### PR DESCRIPTION
This PR fixes two issues for traversing an `Sequence`.

- Sequence#traverse was implemented using `foldRight` without `Eval` which first materialises the whole list in memory. This _always_ results in an `OOM` even if the transformation of `traverse` results in a _short-circuit_.
- 
- Fix `apEval` for `Either` and `Option` to properly _short-circuit_.
