### PR TITLE
Undeprecate Option data type

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -348,12 +348,6 @@ inline fun <A> OptionOf<A>.fix(): Option<A> = this as Option<A>
  * Contents partially adapted from [Scala Exercises Option Tutorial](https://www.scala-exercises.org/std_lib/options)
  * Originally based on the Scala Koans.
  */
-@Deprecated(
-  "Option will be deleted soon as it promotes the wrong message of using a slower and memory unfriendly " +
-    "abstraction when the lang provides a better one. Alternatively, if you can't support nulls, consider aliasing Either<Unit, A> " +
-    "as described here https://github.com/arrow-kt/arrow-core/issues/114#issuecomment-641211639",
-  ReplaceWith("A?")
-)
 sealed class Option<out A> : OptionOf<A> {
 
   companion object {


### PR DESCRIPTION
The `Option` datatype was deprecated in favor of `Nullable` types because the latter is faster than boxed types like `Option`. However,  it will be supported by Arrow again to interop with Java-based libraries that use `null` as signal or interruption value like [ReactiveX RxJava](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#nulls).