### PR TITLE
Cu-f31ena Remove map2

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -512,18 +512,7 @@ sealed class Option<out A> {
    */
   fun <B> mapConst(b: B): Option<B> =
     map { b }
-
-  @Deprecated(
-    "map2 will be renamed to zip to be consistent with Kotlin Std's naming, please use zip instead of map2",
-    ReplaceWith(
-      "zip(fb) { b, c -> f(Tuple2(b, c)) }",
-      "arrow.core.Tuple2",
-      "arrow.core.zip"
-    )
-  )
-  fun <B, R> map2(fb: Option<B>, f: (Tuple2<A, B>) -> R): Option<R> =
-    flatMap { a: A -> fb.map { b -> f(a toT b) } }
-
+  
   @Deprecated(
     "filterMap will be renamed to mapNotNull to be consistent with Kotlin Std's naming, please use mapNotNull instead of filterMap",
     ReplaceWith(

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -72,11 +72,12 @@ class OptionTest : UnitSpec() {
       none.map(String::toUpperCase) shouldBe None
     }
 
-    "map2" {
+    "zip" {
       forAll { a: Int ->
         val op: Option<Int> = a.some()
-        some.map2(op) { (a, b): Tuple2<String, Int> -> a + b } == Some("kotlin$a")
-        none.map2(op) { (a, b): Tuple2<String, Int> -> a + b } == None
+        some.zip(op) { a, b -> a + b } == Some("kotlin$a") &&
+        none.zip(op) { a, b -> a + b } == None &&
+          some.zip(op) == Some(Pair("kotling", a))
       }
     }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Resource.kt
@@ -151,13 +151,15 @@ sealed class Resource<out A> {
   fun <B> flatMap(f: (A) -> Resource<B>): Resource<B> =
     Bind(this, f)
 
-  fun <B, C> map2(other: Resource<B>, combine: (A, B) -> C): Resource<C> =
+  fun <B, C> zip(other: Resource<B>, combine: (A, B) -> C): Resource<C> =
     flatMap { r ->
       other.map { r2 -> combine(r, r2) }
     }
 
   fun <B> zip(other: Resource<B>): Resource<Pair<A, B>> =
-    map2(other, ::Pair)
+    flatMap { r ->
+      other.map { r2 -> Pair(r, r2) }
+    }
 
   class Bind<A, B>(val source: Resource<A>, val f: (A) -> Resource<B>) : Resource<B>()
 


### PR DESCRIPTION
`map2` has been deprecated in favor of `zip` and is thus removed for 0.13.0