### PR TITLE
CU-f540fg Deprecate remaining tuple2 APIs

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
@@ -1027,6 +1027,10 @@ fun <A, B> Tuple2<A, B>.toPair(): Pair<A, B> = Pair(this.a, this.b)
 )
 fun <A, B> Pair<A, B>.toTuple2(): Tuple2<A, B> = Tuple2(this.first, this.second)
 
+@Deprecated(
+  "Tuple3 is deprecated in favor of Kotlin's Triple. Please use Triple values instead.",
+  level = DeprecationLevel.WARNING
+)
 fun <A, B, C> Tuple3<A, B, C>.toTriple(): Triple<A, B, C> = Triple(this.a, this.b, this.c)
 
 @Deprecated(

--- a/arrow-libs/fx/arrow-fx-stm/src/main/kotlin/arrow/fx/stm/STM.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/main/kotlin/arrow/fx/stm/STM.kt
@@ -1333,6 +1333,10 @@ interface STM {
    * }
    * ```
    */
+  @Deprecated(
+    "Deprecated in favor of Kotlin's Pair",
+    ReplaceWith("this.plusAssign(Pair(kv.a, kv.b))")
+  )
   operator fun <K, V> TMap<K, V>.plusAssign(kv: Tuple2<K, V>): Unit = insert(kv.a, kv.b)
 
   /**


### PR DESCRIPTION
2 APIs were not deprecated when I removed them in https://github.com/arrow-kt/arrow/pull/2293.
This PR deprecates these two APIs for 0.12.0 before removal in 0.13.0