### PR TITLE
Remove creation of intermediate lists in mapN

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
@@ -591,18 +591,19 @@ data class ListK<out A>(private val list: List<A>) : ListKOf<A>, List<A> by list
       j: Iterable<J>,
       k: Iterable<K>,
       map: (B, C, D, E, F, G, H, I, J, K) -> L
-    ): List<L> =
-      b.flatMap { bb ->
-        c.flatMap { cc ->
-          d.flatMap { dd ->
-            e.flatMap { ee ->
-              f.flatMap { ff ->
-                g.flatMap { gg ->
-                  h.flatMap { hh ->
-                    i.flatMap { ii ->
-                      j.flatMap { jj ->
-                        k.map { kk ->
-                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+    ): List<L> {
+      val buffer = ArrayList<L>()
+      for (bb in b) {
+        for (cc in c) {
+          for (dd in d) {
+            for (ee in e) {
+              for (ff in f) {
+                for (gg in g) {
+                  for (hh in h) {
+                    for (ii in i) {
+                      for (jj in j) {
+                        for (kk in k) {
+                          buffer.add(map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk))
                         }
                       }
                     }
@@ -613,6 +614,8 @@ data class ListK<out A>(private val list: List<A>) : ListKOf<A>, List<A> by list
           }
         }
       }
+      return buffer
+    }
   }
 }
 

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
@@ -112,12 +112,16 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
     @Deprecated(SequenceKDeprecation, ReplaceWith("sequenceOf<A>(a)"))
     fun <A> just(a: A): SequenceK<A> = sequenceOf(a).k()
 
+    @PublishedApi
+    internal val unit: Sequence<Unit> =
+      sequenceOf(Unit)
+
     fun <B, C, D> mapN(
       b: Sequence<B>,
       c: Sequence<C>,
       map: (B, C) -> D
     ): Sequence<D> =
-      mapN(b, c, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+      mapN(b, c, unit, unit, unit, unit, unit, unit, unit, unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
     fun <B, C, D, E> mapN(
       b: Sequence<B>,
@@ -125,7 +129,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       d: Sequence<D>,
       map: (B, C, D) -> E
     ): Sequence<E> =
-      mapN(b, c, d, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+      mapN(b, c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
     fun <B, C, D, E, F> mapN(
       b: Sequence<B>,
@@ -134,7 +138,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       e: Sequence<E>,
       map: (B, C, D, E) -> F
     ): Sequence<F> =
-      mapN(b, c, d, e, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+      mapN(b, c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
 
     fun <B, C, D, E, F, G> mapN(
       b: Sequence<B>,
@@ -144,7 +148,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       f: Sequence<F>,
       map: (B, C, D, E, F) -> G
     ): Sequence<G> =
-      mapN(b, c, d, e, f, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+      mapN(b, c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
 
     fun <B, C, D, E, F, G, H> mapN(
       b: Sequence<B>,
@@ -155,7 +159,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       g: Sequence<G>,
       map: (B, C, D, E, F, G) -> H
     ): Sequence<H> =
-      mapN(b, c, d, e, f, g, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+      mapN(b, c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
 
     fun <B, C, D, E, F, G, H, I> mapN(
       b: Sequence<B>,
@@ -167,7 +171,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       h: Sequence<H>,
       map: (B, C, D, E, F, G, H) -> I
     ): Sequence<I> =
-      mapN(b, c, d, e, f, g, h, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+      mapN(b, c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
 
     fun <B, C, D, E, F, G, H, I, J> mapN(
       b: Sequence<B>,
@@ -180,7 +184,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       i: Sequence<I>,
       map: (B, C, D, E, F, G, H, I) -> J
     ): Sequence<J> =
-      mapN(b, c, d, e, f, g, h, i, sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+      mapN(b, c, d, e, f, g, h, i, unit, unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
 
     fun <B, C, D, E, F, G, H, I, J, K> mapN(
       b: Sequence<B>,
@@ -194,7 +198,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       j: Sequence<J>,
       map: (B, C, D, E, F, G, H, I, J) -> K
     ): Sequence<K> =
-      mapN(b, c, d, e, f, g, h, i, j, sequenceOf(Unit)) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+      mapN(b, c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
 
     fun <B, C, D, E, F, G, H, I, J, K, L> mapN(
       b: Sequence<B>,


### PR DESCRIPTION
Review in https://github.com/arrow-kt/arrow/pull/2292 revealed a perf issue in mapN for `Iterable`. This PR fixes it for `0.12.0` so it can be merged into `0.13.0` as well.

The issue being that `flatMap` creates intermediate `ArrayList`, and we're thus creating a lot of `ArrayList` whilst we can get away with creating a single `ArrayList`.