### PR TITLE
EitherTest#contains - check that arbitrary values aren't the same

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -214,9 +214,12 @@ class EitherTest : UnitSpec() {
 
     "contains should check value" {
       forAll(Gen.intSmall(), Gen.intSmall()) { a: Int, b: Int ->
-        Right(a).contains(a) &&
-          !Right(a).contains(b) &&
-          !Left(a).contains(a)
+        val rightContains = Right(a).contains(a)
+        // We need to check that a != b or this test will result in a false negative
+        val rightDoesntContains = if (a != b) !Right(a).contains(b) else true
+        val leftNeverContains = !Left(a).contains(a)
+
+        rightContains && rightDoesntContains && leftNeverContains
       }
     }
 


### PR DESCRIPTION
I ran in an unlikely scenario where `a == b` which made this test fail with a false negative, and as a result it also failed the build.

This small PR removes the assumption that both generated values are never the same/