### PR TITLE
Update typeclasses docs

### DIFF
--- a/arrow-docs/docs/arrow/typeclasses/monoid/README.md
+++ b/arrow-docs/docs/arrow/typeclasses/monoid/README.md
@@ -17,7 +17,7 @@ permalink: /arrow/typeclasses/monoid/
 
 For example, if we have a `Monoid<String>` with `combine` defined as string concatenation, then `empty() = ""`.
 
-Having an empty defined allows us to combine all the elements of some potentially empty collection of `T` for which a `Monoid<T>` is defined and return a `T`, rather than an `Option<T>` as we have a sensible default to fall back to.
+Having `empty` defined allows us to combine all the elements of some potentially empty collection of `T` for which a `Monoid<T>` is defined and return a `T`, rather than an `Option<T>` as we have a sensible default to fall back to.
 
 Let's see the instance of Monoid<String> in action:
 

--- a/arrow-docs/docs/arrow/typeclasses/semigroup/README.md
+++ b/arrow-docs/docs/arrow/typeclasses/semigroup/README.md
@@ -58,6 +58,12 @@ Semigroup.option(Semigroup.int()).run {
 ```
 
 ```kotlin:ank
+import arrow.core.Option
+import arrow.core.None
+import arrow.core.int
+import arrow.core.option
+import arrow.typeclasses.Semigroup
+
 Semigroup.option(Semigroup.int()).run {
     Option(1).combine(None)
 }

--- a/arrow-docs/docs/arrow/typeclasses/semigroup/README.md
+++ b/arrow-docs/docs/arrow/typeclasses/semigroup/README.md
@@ -31,34 +31,35 @@ For example, `Int` values are combined using addition by default, but multiplica
 Now that you've learned about the Semigroup instance for Int, try to guess how it works in the following examples:
 
 ```kotlin:ank
-import arrow.*
-import arrow.core.extensions.*
+import arrow.core.int
+import arrow.typeclasses.Semigroup
 
-Int.semigroup().run { 1.combine(2) }
+Semigroup.int().run { 1.combine(2) }
 ```
 
 ```kotlin:ank
-import arrow.core.*
-import arrow.core.extensions.*
-import arrow.core.extensions.listk.semigroup.*
+import arrow.core.list
+import arrow.typeclasses.Semigroup
 
-ListK.semigroup<Int>().run {
-  listOf(1, 2, 3).k().combine(listOf(4, 5, 6).k())
+Semigroup.list<Int>().run {
+    listOf(1, 2, 3).combine(listOf(4, 5, 6))
 }
 ```
 
 ```kotlin:ank
-import arrow.core.*
-import arrow.core.extensions.option.semigroup.semigroup
+import arrow.core.Option
+import arrow.core.int
+import arrow.core.option
+import arrow.typeclasses.Semigroup
 
-Option.semigroup(Int.semigroup()).run {
-  Option(1).combine(Option(2))
+Semigroup.option(Semigroup.int()).run {
+    Option(1).combine(Option(2))
 }
 ```
 
 ```kotlin:ank
-Option.semigroup(Int.semigroup()).run {
-  Option(1).combine(None)
+Semigroup.option(Semigroup.int()).run {
+    Option(1).combine(None)
 }
 ```
 
@@ -67,8 +68,8 @@ Many of these types have methods defined directly on them, which allow for this 
 Additionally, `Semigroup` adds `+` syntax to all types for which a Semigroup instance exists:
 
 ```kotlin:ank
-Option.semigroup(Int.semigroup()).run {
-  Option(1) + Option(2)
+Semigroup.option(Semigroup.int()).run {
+    Option(1) + Option(2)
 }
 ```
 

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Semigroup.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Semigroup.kt
@@ -1,7 +1,5 @@
 package arrow.typeclasses
 
-import arrow.core.Option
-
 interface Semigroup<A> {
   /**
    * Combine two [A] values.
@@ -11,7 +9,8 @@ interface Semigroup<A> {
   operator fun A.plus(b: A): A =
     this.combine(b)
 
-  fun A.maybeCombine(b: A?): A = Option.fromNullable(b).fold({ this }, { combine(it) })
+  fun A.maybeCombine(b: A?): A =
+    b?.let { combine(it) } ?: this
 
   companion object
 }

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Semiring.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Semiring.kt
@@ -11,11 +11,11 @@ import arrow.documented
  * (a.combineMultiplicate(b)).combineMultiplicate(c) == a.combineMultiplicate(b.combineMultiplicate(c))
  * ```
  *
- * The [one] value serves exactly like the [empty] function for an additive [Monoid], just adapted for the multiplicative
+ * The [one] function serves exactly like the [empty] function for an additive [Monoid], just adapted for the multiplicative
  * version. This forms the following law:
  *
  * ```kotlin
- * combineMultiplicate(x, one) == combineMultiplicate(one, x) == x
+ * a.combineMultiplicate(one()) == one().combineMultiplicate(a) == a
  * ```
  *
  * Please note that the empty function has been renamed to [zero] to get a consistent naming style inside the semiring.
@@ -27,24 +27,26 @@ import arrow.documented
  * Here a some examples:
  *
  * ```kotlin:ank:playground
- * import arrow.core.extensions.*
+ * import arrow.core.int
+ * import arrow.typeclasses.Semiring
  *
  * fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- *   Int.semiring().run { 1.combine(2) }
+ *   Semiring.int().run { 1.combine(2) }
  *   //sampleEnd
  *   println(result)
  * }
  * ```
  *
  * ```kotlin:ank:playground
- * import arrow.core.extensions.*
+ * import arrow.core.int
+ * import arrow.typeclasses.Semiring
  *
  * fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- *   Int.semiring().run { 2.combineMultiplicate(3) }
+ *   Semiring.int().run { 2.combineMultiplicate(3) }
  *   //sampleEnd
  *   println(result)
  * }
@@ -53,29 +55,14 @@ import arrow.documented
  * The type class `Semiring` also has support for the `+` `*` syntax:
  *
  * ```kotlin:ank:playground
- * import arrow.core.Option
- * import arrow.core.extensions.*
+ * import arrow.core.int
+ * import arrow.typeclasses.Semiring
  *
  * fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- *   Int.semiring().run {
- *      1 + 2
- *   }
- *   //sampleEnd
- *   println(result)
- * }
- * ```
- *
- * ```kotlin:ank:playground
- * import arrow.core.Option
- * import arrow.core.extensions.*
- *
- * fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- *   Int.semiring().run {
- *      2 * 3
+ *   Semiring.int().run {
+ *      1 + 2 * 3
  *   }
  *   //sampleEnd
  *   println(result)


### PR DESCRIPTION
Adapt Monoid, Semigroup and Semiring docs to the new typeclass syntax