### PR TITLE
CU-fh2vcf - Deprecate mapN and fix zip for collections

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Iterable.kt
@@ -9,26 +9,72 @@ import kotlin.collections.foldRight as _foldRight
 inline fun <B, C, D, E> Iterable<B>.zip(
   c: Iterable<C>,
   d: Iterable<D>,
-  map: (B, C, D) -> E
-): List<E> =
-  zip(c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+  transform: (B, C, D) -> E
+): List<E> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<E>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F> Iterable<B>.zip(
   c: Iterable<C>,
   d: Iterable<D>,
   e: Iterable<E>,
-  map: (B, C, D, E) -> F
-): List<F> =
-  zip(c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+  transform: (B, C, D, E) -> F
+): List<F> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<F>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F, G> Iterable<B>.zip(
   c: Iterable<C>,
   d: Iterable<D>,
   e: Iterable<E>,
   f: Iterable<F>,
-  map: (B, C, D, E, F) -> G
-): List<G> =
-  zip(c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+  transform: (B, C, D, E, F) -> G
+): List<G> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val ff = f.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10),
+    f.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<G>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext() && ff.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next(), ff.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F, G, H> Iterable<B>.zip(
   c: Iterable<C>,
@@ -36,9 +82,28 @@ inline fun <B, C, D, E, F, G, H> Iterable<B>.zip(
   e: Iterable<E>,
   f: Iterable<F>,
   g: Iterable<G>,
-  map: (B, C, D, E, F, G) -> H
-): List<H> =
-  zip(c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+  transform: (B, C, D, E, F, G) -> H
+): List<H> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val ff = f.iterator()
+  val gg = g.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10),
+    f.collectionSizeOrDefault(10),
+    g.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<H>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext() && ff.hasNext() && gg.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next(), ff.next(), gg.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F, G, H, I> Iterable<B>.zip(
   c: Iterable<C>,
@@ -47,9 +112,30 @@ inline fun <B, C, D, E, F, G, H, I> Iterable<B>.zip(
   f: Iterable<F>,
   g: Iterable<G>,
   h: Iterable<H>,
-  map: (B, C, D, E, F, G, H) -> I
-): List<I> =
-  zip(c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+  transform: (B, C, D, E, F, G, H) -> I
+): List<I> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val ff = f.iterator()
+  val gg = g.iterator()
+  val hh = h.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10),
+    f.collectionSizeOrDefault(10),
+    g.collectionSizeOrDefault(10),
+    h.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<I>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext() && ff.hasNext() && gg.hasNext() && hh.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next(), ff.next(), gg.next(), hh.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F, G, H, I, J> Iterable<B>.zip(
   c: Iterable<C>,
@@ -59,9 +145,32 @@ inline fun <B, C, D, E, F, G, H, I, J> Iterable<B>.zip(
   g: Iterable<G>,
   h: Iterable<H>,
   i: Iterable<I>,
-  map: (B, C, D, E, F, G, H, I) -> J
-): List<J> =
-  zip(c, d, e, f, g, h, i, unit, unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+  transform: (B, C, D, E, F, G, H, I) -> J
+): List<J> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val ff = f.iterator()
+  val gg = g.iterator()
+  val hh = h.iterator()
+  val ii = i.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10),
+    f.collectionSizeOrDefault(10),
+    g.collectionSizeOrDefault(10),
+    h.collectionSizeOrDefault(10),
+    i.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<J>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext() && ff.hasNext() && gg.hasNext() && hh.hasNext() && ii.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next(), ff.next(), gg.next(), hh.next(), ii.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F, G, H, I, J, K> Iterable<B>.zip(
   c: Iterable<C>,
@@ -72,9 +181,34 @@ inline fun <B, C, D, E, F, G, H, I, J, K> Iterable<B>.zip(
   h: Iterable<H>,
   i: Iterable<I>,
   j: Iterable<J>,
-  map: (B, C, D, E, F, G, H, I, J) -> K
-): List<K> =
-  zip(c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+  transform: (B, C, D, E, F, G, H, I, J) -> K
+): List<K> {
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val ff = f.iterator()
+  val gg = g.iterator()
+  val hh = h.iterator()
+  val ii = i.iterator()
+  val jj = j.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10),
+    f.collectionSizeOrDefault(10),
+    g.collectionSizeOrDefault(10),
+    h.collectionSizeOrDefault(10),
+    i.collectionSizeOrDefault(10),
+    j.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<K>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext() && ff.hasNext() && gg.hasNext() && hh.hasNext() && ii.hasNext() && jj.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next(), ff.next(), gg.next(), hh.next(), ii.next(), jj.next()))
+  }
+  return list
+}
 
 inline fun <B, C, D, E, F, G, H, I, J, K, L> Iterable<B>.zip(
   c: Iterable<C>,
@@ -86,32 +220,40 @@ inline fun <B, C, D, E, F, G, H, I, J, K, L> Iterable<B>.zip(
   i: Iterable<I>,
   j: Iterable<J>,
   k: Iterable<K>,
-  map: (B, C, D, E, F, G, H, I, J, K) -> L
+  transform: (B, C, D, E, F, G, H, I, J, K) -> L
 ): List<L> {
-  val buffer = ArrayList<L>()
-  for (bb in this) {
-    for (cc in c) {
-      for (dd in d) {
-        for (ee in e) {
-          for (ff in f) {
-            for (gg in g) {
-              for (hh in h) {
-                for (ii in i) {
-                  for (jj in j) {
-                    for (kk in k) {
-                      buffer.add(map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk))
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+  val bb = iterator()
+  val cc = c.iterator()
+  val dd = d.iterator()
+  val ee = e.iterator()
+  val ff = f.iterator()
+  val gg = g.iterator()
+  val hh = h.iterator()
+  val ii = i.iterator()
+  val jj = j.iterator()
+  val kk = k.iterator()
+  val size = minOf(
+    collectionSizeOrDefault(10),
+    c.collectionSizeOrDefault(10),
+    d.collectionSizeOrDefault(10),
+    e.collectionSizeOrDefault(10),
+    f.collectionSizeOrDefault(10),
+    g.collectionSizeOrDefault(10),
+    h.collectionSizeOrDefault(10),
+    i.collectionSizeOrDefault(10),
+    j.collectionSizeOrDefault(10),
+    k.collectionSizeOrDefault(10)
+  )
+  val list = ArrayList<L>(size)
+  while (bb.hasNext() && cc.hasNext() && dd.hasNext() && ee.hasNext() && ff.hasNext() && gg.hasNext() && hh.hasNext() && ii.hasNext() && jj.hasNext() && kk.hasNext()) {
+    list.add(transform(bb.next(), cc.next(), dd.next(), ee.next(), ff.next(), gg.next(), hh.next(), ii.next(), jj.next(), kk.next()))
   }
-  return buffer
+  return list
 }
+
+@PublishedApi
+internal fun <T> Iterable<T>.collectionSizeOrDefault(default: Int): Int =
+  if (this is Collection<*>) this.size else default
 
 inline fun <A, B> Iterable<A>.foldRight(initial: B, operation: (A, acc: B) -> B): B =
   when (this) {

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -586,31 +586,8 @@ inline fun <A, B, C, D, E, F, G, H, I, J, Z> NonEmptyList<A>.zip(
   i: NonEmptyList<I>,
   j: NonEmptyList<J>,
   map: (A, B, C, D, E, F, G, H, I, J) -> Z
-): NonEmptyList<Z> {
-  val buffer = ArrayList<Z>()
-  for (aa in tail) {
-    for (bb in b.tail) {
-      for (cc in c.tail) {
-        for (dd in d.tail) {
-          for (ee in e.tail) {
-            for (ff in f.tail) {
-              for (gg in g.tail) {
-                for (hh in h.tail) {
-                  for (ii in i.tail) {
-                    for (jj in j.tail) {
-                      buffer.add(map(aa, bb, cc, dd, ee, ff, gg, hh, ii, jj))
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return NonEmptyList(
+): NonEmptyList<Z> =
+  NonEmptyList(
     map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head),
-    buffer
+    tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, g.tail, h.tail, i.tail, j.tail, map)
   )
-}

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -136,6 +136,7 @@ typealias Nel<A> = NonEmptyList<A>
  * ```kotlin:ank:playground
  * import arrow.core.NonEmptyList
  * import arrow.core.nonEmptyListOf
+ * import arrow.core.zip
  * import java.util.UUID
  *
  * //sampleStart

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -586,21 +586,19 @@ inline fun <A, B, C, D, E, F, G, H, I, J, Z> NonEmptyList<A>.zip(
   i: NonEmptyList<I>,
   j: NonEmptyList<J>,
   map: (A, B, C, D, E, F, G, H, I, J) -> Z
-): NonEmptyList<Z> =
-  NonEmptyList(
-    map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head),
-    tail.flatMap { aa ->
-      b.tail.flatMap { bb ->
-        c.tail.flatMap { cc ->
-          d.tail.flatMap { dd ->
-            e.tail.flatMap { ee ->
-              f.tail.flatMap { ff ->
-                g.tail.flatMap { gg ->
-                  h.tail.flatMap { hh ->
-                    i.tail.flatMap { ii ->
-                      j.tail.map { jj ->
-                        map(aa, bb, cc, dd, ee, ff, gg, hh, ii, jj)
-                      }
+): NonEmptyList<Z> {
+  val buffer = ArrayList<Z>()
+  for (aa in tail) {
+    for (bb in b.tail) {
+      for (cc in c.tail) {
+        for (dd in d.tail) {
+          for (ee in e.tail) {
+            for (ff in f.tail) {
+              for (gg in g.tail) {
+                for (hh in h.tail) {
+                  for (ii in i.tail) {
+                    for (jj in j.tail) {
+                      buffer.add(map(aa, bb, cc, dd, ee, ff, gg, hh, ii, jj))
                     }
                   }
                 }
@@ -610,4 +608,9 @@ inline fun <A, B, C, D, E, F, G, H, I, J, Z> NonEmptyList<A>.zip(
         }
       }
     }
+  }
+  return NonEmptyList(
+    map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head),
+    buffer
   )
+}

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -358,6 +358,126 @@ class NonEmptyList<out A>(
       return fromListUnsafe(buf)
     }
   }
+
+  fun <B> zip(fb: NonEmptyList<B>): NonEmptyList<Pair<A, B>> =
+    zip(fb, ::Pair)
+
+  inline fun <B, Z> zip(
+    b: NonEmptyList<B>,
+    map: (A, B) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head),
+      tail.zip(b.tail, map)
+    )
+
+  inline fun <B, C, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    map: (A, B, C) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head),
+      tail.zip(b.tail, c.tail, map)
+    )
+
+  inline fun <B, C, D, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    map: (A, B, C, D) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head),
+      tail.zip(b.tail, c.tail, d.tail, map)
+    )
+
+  inline fun <B, C, D, E, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    e: NonEmptyList<E>,
+    map: (A, B, C, D, E) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head, e.head),
+      tail.zip(b.tail, c.tail, d.tail, e.tail, map)
+    )
+
+  inline fun <B, C, D, E, F, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    e: NonEmptyList<E>,
+    f: NonEmptyList<F>,
+    map: (A, B, C, D, E, F) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head, e.head, f.head),
+      tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, map)
+    )
+
+  inline fun <B, C, D, E, F, G, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    e: NonEmptyList<E>,
+    f: NonEmptyList<F>,
+    g: NonEmptyList<G>,
+    map: (A, B, C, D, E, F, G) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head, e.head, f.head, g.head),
+      tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, g.tail, map)
+    )
+
+  inline fun <B, C, D, E, F, G, H, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    e: NonEmptyList<E>,
+    f: NonEmptyList<F>,
+    g: NonEmptyList<G>,
+    h: NonEmptyList<H>,
+    map: (A, B, C, D, E, F, G, H) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head),
+      tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, g.tail, h.tail, map)
+    )
+
+  inline fun <B, C, D, E, F, G, H, I, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    e: NonEmptyList<E>,
+    f: NonEmptyList<F>,
+    g: NonEmptyList<G>,
+    h: NonEmptyList<H>,
+    i: NonEmptyList<I>,
+    map: (A, B, C, D, E, F, G, H, I) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head),
+      tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, g.tail, h.tail, i.tail, map)
+    )
+
+  inline fun <B, C, D, E, F, G, H, I, J, Z> zip(
+    b: NonEmptyList<B>,
+    c: NonEmptyList<C>,
+    d: NonEmptyList<D>,
+    e: NonEmptyList<E>,
+    f: NonEmptyList<F>,
+    g: NonEmptyList<G>,
+    h: NonEmptyList<H>,
+    i: NonEmptyList<I>,
+    j: NonEmptyList<J>,
+    map: (A, B, C, D, E, F, G, H, I, J) -> Z
+  ): NonEmptyList<Z> =
+    NonEmptyList(
+      map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head),
+      tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, g.tail, h.tail, i.tail, j.tail, map)
+    )
 }
 
 fun <A> nonEmptyListOf(head: A, vararg t: A): NonEmptyList<A> =
@@ -428,166 +548,3 @@ object NonEmptyListSemigroup : Semigroup<NonEmptyList<Any?>> {
   override fun NonEmptyList<Any?>.combine(b: NonEmptyList<Any?>): NonEmptyList<Any?> =
     NonEmptyList(this.head, this.tail.plus(b))
 }
-
-fun <A, B> NonEmptyList<A>.zip(fb: NonEmptyList<B>): NonEmptyList<Pair<A, B>> =
-  zip(fb, ::Pair)
-
-inline fun <A, B, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  map: (A, B) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit
-  ) { aa, bb, _, _, _, _, _, _, _, _ ->
-    map(aa, bb)
-  }
-
-inline fun <A, B, C, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  map: (A, B, C) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit
-  ) { aa, bb, cc, _, _, _, _, _, _, _ ->
-    map(aa, bb, cc)
-  }
-
-inline fun <A, B, C, D, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  map: (A, B, C, D) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c, d,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit
-  ) { aa, bb, cc, dd, _, _, _, _, _, _ ->
-    map(aa, bb, cc, dd)
-  }
-
-inline fun <A, B, C, D, E, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  e: NonEmptyList<E>,
-  map: (A, B, C, D, E) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c, d, e,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit
-  ) { aa, bb, cc, dd, ee, _, _, _, _, _ ->
-    map(aa, bb, cc, dd, ee)
-  }
-
-inline fun <A, B, C, D, E, F, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  e: NonEmptyList<E>,
-  f: NonEmptyList<F>,
-  map: (A, B, C, D, E, F) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c, d, e, f,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit
-  ) { aa, bb, cc, dd, ee, ff, _, _, _, _ ->
-    map(aa, bb, cc, dd, ee, ff)
-  }
-
-inline fun <A, B, C, D, E, F, G, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  e: NonEmptyList<E>,
-  f: NonEmptyList<F>,
-  g: NonEmptyList<G>,
-  map: (A, B, C, D, E, F, G) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c, d, e, f, g,
-    NonEmptyList.unit,
-    NonEmptyList.unit,
-    NonEmptyList.unit
-  ) { aa, bb, cc, dd, ee, ff, gg, _, _, _ ->
-    map(aa, bb, cc, dd, ee, ff, gg)
-  }
-
-inline fun <A, B, C, D, E, F, G, H, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  e: NonEmptyList<E>,
-  f: NonEmptyList<F>,
-  g: NonEmptyList<G>,
-  h: NonEmptyList<H>,
-  map: (A, B, C, D, E, F, G, H) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c, d, e, f, g, h,
-    NonEmptyList.unit, NonEmptyList.unit
-  ) { aa, bb, cc, dd, ee, ff, gg, hh, _, _ ->
-    map(aa, bb, cc, dd, ee, ff, gg, hh)
-  }
-
-inline fun <A, B, C, D, E, F, G, H, I, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  e: NonEmptyList<E>,
-  f: NonEmptyList<F>,
-  g: NonEmptyList<G>,
-  h: NonEmptyList<H>,
-  i: NonEmptyList<I>,
-  map: (A, B, C, D, E, F, G, H, I) -> Z
-): NonEmptyList<Z> =
-  zip(
-    b, c, d, e, f, g, h, i,
-    NonEmptyList.unit
-  ) { aa, bb, cc, dd, ee, ff, gg, hh, ii, _ ->
-    map(aa, bb, cc, dd, ee, ff, gg, hh, ii)
-  }
-
-inline fun <A, B, C, D, E, F, G, H, I, J, Z> NonEmptyList<A>.zip(
-  b: NonEmptyList<B>,
-  c: NonEmptyList<C>,
-  d: NonEmptyList<D>,
-  e: NonEmptyList<E>,
-  f: NonEmptyList<F>,
-  g: NonEmptyList<G>,
-  h: NonEmptyList<H>,
-  i: NonEmptyList<I>,
-  j: NonEmptyList<J>,
-  map: (A, B, C, D, E, F, G, H, I, J) -> Z
-): NonEmptyList<Z> =
-  NonEmptyList(
-    map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head),
-    tail.zip(b.tail, c.tail, d.tail, e.tail, f.tail, g.tail, h.tail, i.tail, j.tail, map)
-  )

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -10,7 +10,8 @@ import arrow.typeclasses.ShowDeprecation
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-) class ForNonEmptyList private constructor() {
+)
+class ForNonEmptyList private constructor() {
   companion object
 }
 
@@ -128,7 +129,7 @@ typealias Nel<A> = NonEmptyList<A>
  * }
  * ```
  *
- * ### mapN
+ * ### zip
  *
  * Λrrow contains methods that allow you to preserve type information when computing over different `NonEmptyList` typed values.
  *
@@ -145,7 +146,7 @@ typealias Nel<A> = NonEmptyList<A>
  * val nelName: NonEmptyList<String> = nonEmptyListOf("William Alvin Howard", "Haskell Curry")
  * val nelYear: NonEmptyList<Int> = nonEmptyListOf(1926, 1900)
  *
- * val value = NonEmptyList.mapN(nelId, nelName, nelYear) { id, name, year ->
+ * val value = nelId.zip(nelName, nelYear) { id, name, year ->
  *  Person(id, name, year)
  * }
  * //sampleEnd
@@ -159,7 +160,7 @@ typealias Nel<A> = NonEmptyList<A>
  * - `NonEmptyList` is __used to model lists that guarantee at least one element__
  * - We can easily construct values of `NonEmptyList` with `nonEmptyListOf`
  * - `foldLeft`, `map`, `flatMap` and others are used to compute over the internal contents of a `NonEmptyList` value.
- * - `NonEmptyList.mapM(a, b, c) { ... }` can be used to compute over multiple `NonEmptyList` values preserving type information and __abstracting over arity__ with `mapN`
+ * - `a.zip(b, c) { ... }` can be used to compute over multiple `NonEmptyList` values preserving type information and __abstracting over arity__ with `zip`
  *
  */
 class NonEmptyList<out A>(
@@ -330,128 +331,6 @@ class NonEmptyList<out A>(
     internal val unit: NonEmptyList<Unit> =
       of(Unit)
 
-    inline fun <B, C, D> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      map: (B, C) -> D
-    ): NonEmptyList<D> =
-      mapN(b, c, unit, unit, unit, unit, unit, unit, unit, unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
-
-    inline fun <B, C, D, E> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      map: (B, C, D) -> E
-    ): NonEmptyList<E> =
-      mapN(b, c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
-
-    inline fun <B, C, D, E, F> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      map: (B, C, D, E) -> F
-    ): NonEmptyList<F> =
-      mapN(b, c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
-
-    inline fun <B, C, D, E, F, G> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      map: (B, C, D, E, F) -> G
-    ): NonEmptyList<G> =
-      mapN(b, c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
-
-    inline fun <B, C, D, E, F, G, H> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      map: (B, C, D, E, F, G) -> H
-    ): NonEmptyList<H> =
-      mapN(b, c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
-
-    inline fun <B, C, D, E, F, G, H, I> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      map: (B, C, D, E, F, G, H) -> I
-    ): NonEmptyList<I> =
-      mapN(b, c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
-
-    inline fun <B, C, D, E, F, G, H, I, J> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      i: NonEmptyList<I>,
-      crossinline map: (B, C, D, E, F, G, H, I) -> J
-    ): NonEmptyList<J> =
-      mapN(b, c, d, e, f, g, h, i, unit, unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
-
-    inline fun <B, C, D, E, F, G, H, I, J, K> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      i: NonEmptyList<I>,
-      j: NonEmptyList<J>,
-      map: (B, C, D, E, F, G, H, I, J) -> K
-    ): NonEmptyList<K> =
-      mapN(b, c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
-
-    inline fun <B, C, D, E, F, G, H, I, J, K, L> mapN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      i: NonEmptyList<I>,
-      j: NonEmptyList<J>,
-      k: NonEmptyList<K>,
-      map: (B, C, D, E, F, G, H, I, J, K) -> L
-    ): NonEmptyList<L> =
-      NonEmptyList(
-        map(b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head, k.head),
-        b.tail.flatMap { bb ->
-          c.tail.flatMap { cc ->
-            d.tail.flatMap { dd ->
-              e.tail.flatMap { ee ->
-                f.tail.flatMap { ff ->
-                  g.tail.flatMap { gg ->
-                    h.tail.flatMap { hh ->
-                      i.tail.flatMap { ii ->
-                        j.tail.flatMap { jj ->
-                          k.tail.map { kk ->
-                            map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      )
-
     @Suppress("UNCHECKED_CAST")
     private tailrec fun <A, B> go(
       buf: ArrayList<B>,
@@ -580,8 +459,185 @@ object NonEmptyListSemigroup : Semigroup<NonEmptyList<Any?>> {
     NonEmptyList(this.head, this.tail.plus(b))
 }
 
-fun <A, B, Z> NonEmptyList<A>.zip(fb: NonEmptyList<B>, f: (A, B) -> Z): NonEmptyList<Z> =
-  NonEmptyList(f(head, fb.head), tail.zip(fb.tail, f))
-
 fun <A, B> NonEmptyList<A>.zip(fb: NonEmptyList<B>): NonEmptyList<Pair<A, B>> =
   zip(fb, ::Pair)
+
+inline fun <A, B, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  map: (A, B) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit
+  ) { aa, bb, _, _, _, _, _, _, _, _ ->
+    map(aa, bb)
+  }
+
+inline fun <A, B, C, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  map: (A, B, C) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit
+  ) { aa, bb, cc, _, _, _, _, _, _, _ ->
+    map(aa, bb, cc)
+  }
+
+inline fun <A, B, C, D, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  map: (A, B, C, D) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c, d,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit
+  ) { aa, bb, cc, dd, _, _, _, _, _, _ ->
+    map(aa, bb, cc, dd)
+  }
+
+inline fun <A, B, C, D, E, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  e: NonEmptyList<E>,
+  map: (A, B, C, D, E) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c, d, e,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit
+  ) { aa, bb, cc, dd, ee, _, _, _, _, _ ->
+    map(aa, bb, cc, dd, ee)
+  }
+
+inline fun <A, B, C, D, E, F, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  e: NonEmptyList<E>,
+  f: NonEmptyList<F>,
+  map: (A, B, C, D, E, F) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c, d, e, f,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit
+  ) { aa, bb, cc, dd, ee, ff, _, _, _, _ ->
+    map(aa, bb, cc, dd, ee, ff)
+  }
+
+inline fun <A, B, C, D, E, F, G, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  e: NonEmptyList<E>,
+  f: NonEmptyList<F>,
+  g: NonEmptyList<G>,
+  map: (A, B, C, D, E, F, G) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c, d, e, f, g,
+    NonEmptyList.unit,
+    NonEmptyList.unit,
+    NonEmptyList.unit
+  ) { aa, bb, cc, dd, ee, ff, gg, _, _, _ ->
+    map(aa, bb, cc, dd, ee, ff, gg)
+  }
+
+inline fun <A, B, C, D, E, F, G, H, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  e: NonEmptyList<E>,
+  f: NonEmptyList<F>,
+  g: NonEmptyList<G>,
+  h: NonEmptyList<H>,
+  map: (A, B, C, D, E, F, G, H) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c, d, e, f, g, h,
+    NonEmptyList.unit, NonEmptyList.unit
+  ) { aa, bb, cc, dd, ee, ff, gg, hh, _, _ ->
+    map(aa, bb, cc, dd, ee, ff, gg, hh)
+  }
+
+inline fun <A, B, C, D, E, F, G, H, I, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  e: NonEmptyList<E>,
+  f: NonEmptyList<F>,
+  g: NonEmptyList<G>,
+  h: NonEmptyList<H>,
+  i: NonEmptyList<I>,
+  map: (A, B, C, D, E, F, G, H, I) -> Z
+): NonEmptyList<Z> =
+  zip(
+    b, c, d, e, f, g, h, i,
+    NonEmptyList.unit
+  ) { aa, bb, cc, dd, ee, ff, gg, hh, ii, _ ->
+    map(aa, bb, cc, dd, ee, ff, gg, hh, ii)
+  }
+
+inline fun <A, B, C, D, E, F, G, H, I, J, Z> NonEmptyList<A>.zip(
+  b: NonEmptyList<B>,
+  c: NonEmptyList<C>,
+  d: NonEmptyList<D>,
+  e: NonEmptyList<E>,
+  f: NonEmptyList<F>,
+  g: NonEmptyList<G>,
+  h: NonEmptyList<H>,
+  i: NonEmptyList<I>,
+  j: NonEmptyList<J>,
+  map: (A, B, C, D, E, F, G, H, I, J) -> Z
+): NonEmptyList<Z> =
+  NonEmptyList(
+    map(head, b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head),
+    tail.flatMap { aa ->
+      b.tail.flatMap { bb ->
+        c.tail.flatMap { cc ->
+          d.tail.flatMap { dd ->
+            e.tail.flatMap { ee ->
+              f.tail.flatMap { ff ->
+                g.tail.flatMap { gg ->
+                  h.tail.flatMap { hh ->
+                    i.tail.flatMap { ii ->
+                      j.tail.map { jj ->
+                        map(aa, bb, cc, dd, ee, ff, gg, hh, ii, jj)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  )

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -7,16 +7,39 @@ fun <B, C, D, E> Sequence<B>.zip(
   c: Sequence<C>,
   d: Sequence<D>,
   map: (B, C, D) -> E
-): Sequence<E> =
-  zip(c, d, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+): Sequence<E> = Sequence {
+  object : Iterator<E> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+
+    override fun next(): E =
+      map(iterator1.next(), iterator2.next(), iterator3.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext()
+  }
+}
 
 fun <B, C, D, E, F> Sequence<B>.zip(
   c: Sequence<C>,
   d: Sequence<D>,
   e: Sequence<E>,
   map: (B, C, D, E) -> F
-): Sequence<F> =
-  zip(c, d, e, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+): Sequence<F> = Sequence {
+  object : Iterator<F> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+
+    override fun next(): F =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext()
+  }
+}
 
 fun <B, C, D, E, F, G> Sequence<B>.zip(
   c: Sequence<C>,
@@ -24,8 +47,21 @@ fun <B, C, D, E, F, G> Sequence<B>.zip(
   e: Sequence<E>,
   f: Sequence<F>,
   map: (B, C, D, E, F) -> G
-): Sequence<G> =
-  zip(c, d, e, f, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+): Sequence<G> = Sequence {
+  object : Iterator<G> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+    val iterator5 = f.iterator()
+
+    override fun next(): G =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext() && iterator5.hasNext()
+  }
+}
 
 fun <B, C, D, E, F, G, H> Sequence<B>.zip(
   c: Sequence<C>,
@@ -34,8 +70,22 @@ fun <B, C, D, E, F, G, H> Sequence<B>.zip(
   f: Sequence<F>,
   g: Sequence<G>,
   map: (B, C, D, E, F, G) -> H
-): Sequence<H> =
-  zip(c, d, e, f, g, SequenceK.unit, SequenceK.unit, SequenceK.unit, SequenceK.unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+): Sequence<H> = Sequence {
+  object : Iterator<H> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+    val iterator5 = f.iterator()
+    val iterator6 = g.iterator()
+
+    override fun next(): H =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next(), iterator6.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext() && iterator5.hasNext() && iterator6.hasNext()
+  }
+}
 
 fun <B, C, D, E, F, G, H, I> Sequence<B>.zip(
   c: Sequence<C>,
@@ -45,8 +95,22 @@ fun <B, C, D, E, F, G, H, I> Sequence<B>.zip(
   g: Sequence<G>,
   h: Sequence<H>,
   map: (B, C, D, E, F, G, H) -> I
-): Sequence<I> =
-  zip(c, d, e, f, g, h, SequenceK.unit, SequenceK.unit, SequenceK.unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+): Sequence<I> = Sequence {
+  object : Iterator<I> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+    val iterator5 = f.iterator()
+    val iterator6 = g.iterator()
+    val iterator7 = h.iterator()
+    override fun next(): I =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next(), iterator6.next(), iterator7.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext() && iterator5.hasNext() && iterator6.hasNext() && iterator7.hasNext()
+  }
+}
 
 fun <B, C, D, E, F, G, H, I, J> Sequence<B>.zip(
   c: Sequence<C>,
@@ -57,8 +121,23 @@ fun <B, C, D, E, F, G, H, I, J> Sequence<B>.zip(
   h: Sequence<H>,
   i: Sequence<I>,
   map: (B, C, D, E, F, G, H, I) -> J
-): Sequence<J> =
-  zip(c, d, e, f, g, h, i, SequenceK.unit, SequenceK.unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+): Sequence<J> = Sequence {
+  object : Iterator<J> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+    val iterator5 = f.iterator()
+    val iterator6 = g.iterator()
+    val iterator7 = h.iterator()
+    val iterator8 = i.iterator()
+    override fun next(): J =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next(), iterator6.next(), iterator7.next(), iterator8.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext() && iterator5.hasNext() && iterator6.hasNext() && iterator7.hasNext() && iterator8.hasNext()
+  }
+}
 
 fun <B, C, D, E, F, G, H, I, J, K> Sequence<B>.zip(
   c: Sequence<C>,
@@ -70,8 +149,24 @@ fun <B, C, D, E, F, G, H, I, J, K> Sequence<B>.zip(
   i: Sequence<I>,
   j: Sequence<J>,
   map: (B, C, D, E, F, G, H, I, J) -> K
-): Sequence<K> =
-  zip(c, d, e, f, g, h, i, j, SequenceK.unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+): Sequence<K> = Sequence {
+  object : Iterator<K> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+    val iterator5 = f.iterator()
+    val iterator6 = g.iterator()
+    val iterator7 = h.iterator()
+    val iterator8 = i.iterator()
+    val iterator9 = j.iterator()
+    override fun next(): K =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next(), iterator6.next(), iterator7.next(), iterator8.next(), iterator9.next())
+
+    override fun hasNext(): Boolean =
+      iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext() && iterator5.hasNext() && iterator6.hasNext() && iterator7.hasNext() && iterator8.hasNext() && iterator9.hasNext()
+  }
+}
 
 fun <B, C, D, E, F, G, H, I, J, K, L> Sequence<B>.zip(
   c: Sequence<C>,
@@ -84,36 +179,20 @@ fun <B, C, D, E, F, G, H, I, J, K, L> Sequence<B>.zip(
   j: Sequence<J>,
   k: Sequence<K>,
   map: (B, C, D, E, F, G, H, I, J, K) -> L
-): Sequence<L> =
-  MergingSequence(this, c, d, e, f, g, h, i, j, k, map)
-
-// Ported from Kotlin Std for arity 10
-internal class MergingSequence<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, V> constructor(
-  private val sequence1: Sequence<T1>,
-  private val sequence2: Sequence<T2>,
-  private val sequence3: Sequence<T3>,
-  private val sequence4: Sequence<T4>,
-  private val sequence5: Sequence<T5>,
-  private val sequence6: Sequence<T6>,
-  private val sequence7: Sequence<T7>,
-  private val sequence8: Sequence<T8>,
-  private val sequence9: Sequence<T9>,
-  private val sequence10: Sequence<T10>,
-  private val transform: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> V
-) : Sequence<V> {
-  override fun iterator(): Iterator<V> = object : Iterator<V> {
-    val iterator1 = sequence1.iterator()
-    val iterator2 = sequence2.iterator()
-    val iterator3 = sequence3.iterator()
-    val iterator4 = sequence4.iterator()
-    val iterator5 = sequence5.iterator()
-    val iterator6 = sequence6.iterator()
-    val iterator7 = sequence7.iterator()
-    val iterator8 = sequence8.iterator()
-    val iterator9 = sequence9.iterator()
-    val iterator10 = sequence10.iterator()
-    override fun next(): V =
-      transform(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next(), iterator6.next(), iterator7.next(), iterator8.next(), iterator9.next(), iterator10.next())
+): Sequence<L> = Sequence {
+  object : Iterator<L> {
+    val iterator1 = this@zip.iterator()
+    val iterator2 = c.iterator()
+    val iterator3 = d.iterator()
+    val iterator4 = e.iterator()
+    val iterator5 = f.iterator()
+    val iterator6 = g.iterator()
+    val iterator7 = h.iterator()
+    val iterator8 = i.iterator()
+    val iterator9 = j.iterator()
+    val iterator10 = k.iterator()
+    override fun next(): L =
+      map(iterator1.next(), iterator2.next(), iterator3.next(), iterator4.next(), iterator5.next(), iterator6.next(), iterator7.next(), iterator8.next(), iterator9.next(), iterator10.next())
 
     override fun hasNext(): Boolean =
       iterator1.hasNext() && iterator2.hasNext() && iterator3.hasNext() && iterator4.hasNext() && iterator5.hasNext() && iterator6.hasNext() && iterator7.hasNext() && iterator8.hasNext() && iterator9.hasNext() && iterator10.hasNext()

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/map.kt
@@ -47,29 +47,41 @@ fun <K, A, B> Map<K, A>.zip(other: Map<K, B>): Map<K, Pair<A, B>> =
  * }
  * ```
  */
-inline fun <Key, A, B, C> Map<Key, A>.zip(other: Map<Key, B>, map: (Key, A, B) -> C): Map<Key, C> =
-  zip(other, emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, _, _, _, _, _, _, _, _ ->
-    map(key, bb, cc)
+inline fun <Key, A, B, C> Map<Key, A>.zip(other: Map<Key, B>, map: (Key, A, B) -> C): Map<Key, C> {
+  val destination = LinkedHashMap<Key, C>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(other[key]) { cc -> map(key, bb, cc) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
   map: (Key, B, C, D) -> E
-): Map<Key, E> =
-  zip(c, d, emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, dd, _, _, _, _, _, _, _ ->
-    map(key, bb, cc, dd)
+): Map<Key, E> {
+  val destination = LinkedHashMap<Key, E>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key]) { cc, dd -> map(key, bb, cc, dd) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
   e: Map<Key, E>,
   map: (Key, B, C, D, E) -> F
-): Map<Key, F> =
-  zip(c, d, e, emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, dd, ee, _, _, _, _, _, _ ->
-    map(key, bb, cc, dd, ee)
+): Map<Key, F> {
+  val destination = LinkedHashMap<Key, F>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key], e[key]) { cc, dd, ee -> map(key, bb, cc, dd, ee) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F, G> Map<Key, B>.zip(
   c: Map<Key, C>,
@@ -77,10 +89,14 @@ inline fun <Key, B, C, D, E, F, G> Map<Key, B>.zip(
   e: Map<Key, E>,
   f: Map<Key, F>,
   map: (Key, B, C, D, E, F) -> G
-): Map<Key, G> =
-  zip(c, d, e, f, emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, dd, ee, ff, _, _, _, _, _ ->
-    map(key, bb, cc, dd, ee, ff)
+): Map<Key, G> {
+  val destination = LinkedHashMap<Key, G>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key], e[key], f[key]) { cc, dd, ee, ff -> map(key, bb, cc, dd, ee, ff) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F, G, H> Map<Key, B>.zip(
   c: Map<Key, C>,
@@ -89,10 +105,14 @@ inline fun <Key, B, C, D, E, F, G, H> Map<Key, B>.zip(
   f: Map<Key, F>,
   g: Map<Key, G>,
   map: (Key, B, C, D, E, F, G) -> H
-): Map<Key, H> =
-  zip(c, d, e, f, g, emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, dd, ee, ff, gg, _, _, _, _ ->
-    map(key, bb, cc, dd, ee, ff, gg)
+): Map<Key, H> {
+  val destination = LinkedHashMap<Key, H>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key], e[key], f[key], g[key]) { cc, dd, ee, ff, gg -> map(key, bb, cc, dd, ee, ff, gg) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F, G, H, I> Map<Key, B>.zip(
   c: Map<Key, C>,
@@ -102,10 +122,14 @@ inline fun <Key, B, C, D, E, F, G, H, I> Map<Key, B>.zip(
   g: Map<Key, G>,
   h: Map<Key, H>,
   map: (Key, B, C, D, E, F, G, H) -> I
-): Map<Key, I> =
-  zip(c, d, e, f, g, h, emptyMap<Key, Unit>(), emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, dd, ee, ff, gg, hh, _, _, _ ->
-    map(key, bb, cc, dd, ee, ff, gg, hh)
+): Map<Key, I> {
+  val destination = LinkedHashMap<Key, I>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key], e[key], f[key], g[key], h[key]) { cc, dd, ee, ff, gg, hh -> map(key, bb, cc, dd, ee, ff, gg, hh) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F, G, H, I, J> Map<Key, B>.zip(
   c: Map<Key, C>,
@@ -116,10 +140,14 @@ inline fun <Key, B, C, D, E, F, G, H, I, J> Map<Key, B>.zip(
   h: Map<Key, H>,
   i: Map<Key, I>,
   map: (Key, B, C, D, E, F, G, H, I) -> J
-): Map<Key, J> =
-  zip(c, d, e, f, g, h, i, emptyMap<Key, Unit>(), emptyMap<Key, Unit>()) { key, bb, cc, dd, ee, ff, gg, hh, ii, _, _ ->
-    map(key, bb, cc, dd, ee, ff, gg, hh, ii)
+): Map<Key, J> {
+  val destination = LinkedHashMap<Key, J>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key], e[key], f[key], g[key], h[key], i[key]) { cc, dd, ee, ff, gg, hh, ii -> map(key, bb, cc, dd, ee, ff, gg, hh, ii) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F, G, H, I, J, K> Map<Key, B>.zip(
   c: Map<Key, C>,
@@ -131,10 +159,14 @@ inline fun <Key, B, C, D, E, F, G, H, I, J, K> Map<Key, B>.zip(
   i: Map<Key, I>,
   j: Map<Key, J>,
   map: (Key, B, C, D, E, F, G, H, I, J) -> K
-): Map<Key, K> =
-  zip(c, d, e, f, g, h, i, j, emptyMap<Key, Unit>()) { key, bb, cc, dd, ee, ff, gg, hh, ii, jj, _ ->
-    map(key, bb, cc, dd, ee, ff, gg, hh, ii, jj)
+): Map<Key, K> {
+  val destination = LinkedHashMap<Key, K>(size)
+  for ((key, bb) in this) {
+    Nullable.zip(c[key], d[key], e[key], f[key], g[key], h[key], i[key], j[key]) { cc, dd, ee, ff, gg, hh, ii, jj -> map(key, bb, cc, dd, ee, ff, gg, hh, ii, jj) }
+      ?.let { l -> destination.put(key, l) }
   }
+  return destination
+}
 
 inline fun <Key, B, C, D, E, F, G, H, I, J, K, L> Map<Key, B>.zip(
   c: Map<Key, C>,

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/IterableTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/IterableTest.kt
@@ -10,6 +10,163 @@ import kotlin.math.min
 
 class IterableTest : UnitSpec() {
   init {
+    "zip3" {
+      forAll(Gen.list(Gen.int()), Gen.list(Gen.int()), Gen.list(Gen.int())) { a, b, c ->
+        val result = a.zip(b, c, ::Triple)
+        val expected = a.zip(b, ::Pair).zip(c) { (a, b), c -> Triple(a, b, c) }
+        result == expected
+      }
+    }
+
+    "zip4" {
+      forAll(Gen.list(Gen.int()), Gen.list(Gen.int()), Gen.list(Gen.int()), Gen.list(Gen.int())) { a, b, c, d ->
+        val result = a.zip(b, c, d, ::Tuple4)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+
+        result == expected
+      }
+    }
+
+    "zip5" {
+      forAll(
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int())
+      ) { a, b, c, d, e ->
+        val result = a.zip(b, c, d, e, ::Tuple5)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+
+        result == expected
+      }
+    }
+
+    "zip6" {
+      forAll(
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int())
+      ) { a, b, c, d, e, f ->
+        val result = a.zip(b, c, d, e, f, ::Tuple6)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+
+        result == expected
+      }
+    }
+
+    "zip7" {
+      forAll(
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int())
+      ) { a, b, c, d, e, f, g ->
+        val result = a.zip(b, c, d, e, f, g, ::Tuple7)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+
+        result == expected
+      }
+    }
+
+    "zip8" {
+      forAll(
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int())
+      ) { a, b, c, d, e, f, g, h ->
+        val result = a.zip(b, c, d, e, f, g, h, ::Tuple8)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+          .zip(h) { (a, b, c, d, e, f, g), h -> Tuple8(a, b, c, d, e, f, g, h) }
+
+        result == expected
+      }
+    }
+
+    "zip9" {
+      forAll(
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int())
+      ) { a, b, c, d, e, f, g, h, i ->
+        val result = a.zip(b, c, d, e, f, g, h, i, ::Tuple9)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+          .zip(h) { (a, b, c, d, e, f, g), h -> Tuple8(a, b, c, d, e, f, g, h) }
+          .zip(i) { (a, b, c, d, e, f, g, h), i -> Tuple9(a, b, c, d, e, f, g, h, i) }
+
+        result == expected
+      }
+    }
+
+    "zip10" {
+      forAll(
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int()),
+        Gen.list(Gen.int())
+      ) { a, b, c, d, e, f, g, h, i, j ->
+        val result = a.zip(b, c, d, e, f, g, h, i, j, ::Tuple10)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+          .zip(h) { (a, b, c, d, e, f, g), h -> Tuple8(a, b, c, d, e, f, g, h) }
+          .zip(i) { (a, b, c, d, e, f, g, h), i -> Tuple9(a, b, c, d, e, f, g, h, i) }
+          .zip(j) { (a, b, c, d, e, f, g, h, i), j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }
+
+        result == expected
+      }
+    }
+
     "can align lists with different lengths" {
       forAll(Gen.list(Gen.bool()), Gen.list(Gen.bool())) { a, b ->
         a.align(b).size == max(a.size, b.size)

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -115,15 +115,136 @@ class MapKTest : UnitSpec() {
       }
     }
 
-    "map2" {
+    "zip2" {
       forAll(
-        Gen.mapK(Gen.intSmall(), Gen.intSmall()),
-        Gen.mapK(Gen.intSmall(), Gen.intSmall())
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall())
       ) { a, b ->
-        val result = a.map2(b) { left, right -> left + right }
-        val expected: MapK<Int, Int> = a.filter { (k, v) -> b.containsKey(k) }
-          .map { (k, v) -> Tuple2(k, v + b[k]!!) }
-          .let { mapOf(*it.toTypedArray()) }
+        val result = a.zip(b) { _, aa, bb -> Pair(aa, bb) }
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Pair(v, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip3" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.zip(b, b) { _, aa, bb, cc -> Triple(aa, bb, cc) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Triple(v, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip4" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+      ) { a, b ->
+        val result = a.zip(b, b, b) { _, aa, bb, cc, dd -> Tuple4(aa, bb, cc, dd) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple4(v, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip5" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+      ) { a, b ->
+        val result = a.zip(b, b, b, b) { _, aa, bb, cc, dd, ee -> Tuple5(aa, bb, cc, dd, ee) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple5(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip6" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+      ) { a, b ->
+        val result = a.zip(b, b, b, b, b) { _, aa, bb, cc, dd, ee, ff -> Tuple6(aa, bb, cc, dd, ee, ff) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple6(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip7" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.zip(b, b, b, b, b, b) { _, aa, bb, cc, dd, ee, ff, gg -> Tuple7(aa, bb, cc, dd, ee, ff, gg) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple7(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip8" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.zip(b, b, b, b, b, b, b) { _, aa, bb, cc, dd, ee, ff, gg, hh -> Tuple8(aa, bb, cc, dd, ee, ff, gg, hh) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple8(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip9" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.zip(b, b, b, b, b, b, b, b) { _, aa, bb, cc, dd, ee, ff, gg, hh, ii -> Tuple9(aa, bb, cc, dd, ee, ff, gg, hh, ii) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple9(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result == expected
+      }
+    }
+
+    "zip10" {
+      forAll(
+        Gen.map(Gen.intSmall(), Gen.intSmall()),
+        Gen.map(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.zip(b, b, b, b, b, b, b, b, b) { _, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj -> Tuple10(aa, bb, cc, dd, ee, ff, gg, hh, ii, jj) }
+
+        val expected = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple10(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
         result == expected
       }
     }
@@ -134,7 +255,7 @@ class MapKTest : UnitSpec() {
         Gen.mapK(Gen.intSmall(), Gen.intSmall())
       ) { a, b ->
         val result = a.ap2(
-          a.map { {x: Int, y: Int -> x + y } },
+          a.map { { x: Int, y: Int -> x + y } },
           b
         )
         val expected: MapK<Int, Int> = a.filter { (k, v) -> b.containsKey(k) }

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/NonEmptyListTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/NonEmptyListTest.kt
@@ -90,5 +90,137 @@ class NonEmptyListTest : UnitSpec() {
         }
       }
     }
+
+    "zip2" {
+      forAll(Gen.nonEmptyList(Gen.int()), Gen.nonEmptyList(Gen.int())) { a, b ->
+        val result = a.zip(b)
+        val expected = a.all.zip(b.all).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip3" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c ->
+        val result = a.zip(b, c, ::Triple)
+        val expected = a.all.zip(b.all, c.all, ::Triple).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip4" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d ->
+        val result = a.zip(b, c, d, ::Tuple4)
+        val expected = a.all.zip(b.all, c.all, d.all, ::Tuple4).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip5" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d, e ->
+        val result = a.zip(b, c, d, e, ::Tuple5)
+        val expected = a.all.zip(b.all, c.all, d.all, e.all, ::Tuple5).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip6" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d, e, f ->
+        val result = a.zip(b, c, d, e, f, ::Tuple6)
+        val expected = a.all.zip(b.all, c.all, d.all, e.all, f.all, ::Tuple6).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip7" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d, e, f, g ->
+        val result = a.zip(b, c, d, e, f, g, ::Tuple7)
+        val expected = a.all.zip(b.all, c.all, d.all, e.all, f.all, g.all, ::Tuple7).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip8" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d, e, f, g, h ->
+        val result = a.zip(b, c, d, e, f, g, h, ::Tuple8)
+        val expected = a.all.zip(b.all, c.all, d.all, e.all, f.all, g.all, h.all, ::Tuple8).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip9" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d, e, f, g, h, i ->
+        val result = a.zip(b, c, d, e, f, g, h, i, ::Tuple9)
+        val expected = a.all.zip(b.all, c.all, d.all, e.all, f.all, g.all, h.all, i.all, ::Tuple9).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
+
+    "zip10" {
+      forAll(
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int()),
+        Gen.nonEmptyList(Gen.int())
+      ) { a, b, c, d, e, f, g, h, i, j ->
+        val result = a.zip(b, c, d, e, f, g, h, i, j, ::Tuple10)
+        val expected = a.all.zip(b.all, c.all, d.all, e.all, f.all, g.all, h.all, i.all, j.all, ::Tuple10).let(NonEmptyList.Companion::fromListUnsafe)
+        result == expected
+      }
+    }
   }
 }

--- a/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-libs/core/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -113,6 +113,163 @@ class SequenceKTest : UnitSpec() {
       )
     )
 
+    "zip3" {
+      forAll(Gen.sequence(Gen.int()), Gen.sequence(Gen.int()), Gen.sequence(Gen.int())) { a, b, c ->
+        val result = a.zip(b, c, ::Triple)
+        val expected = a.zip(b, ::Pair).zip(c) { (a, b), c -> Triple(a, b, c) }
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip4" {
+      forAll(Gen.sequence(Gen.int()), Gen.sequence(Gen.int()), Gen.sequence(Gen.int()), Gen.sequence(Gen.int())) { a, b, c, d ->
+        val result = a.zip(b, c, d, ::Tuple4)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip5" {
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d, e ->
+        val result = a.zip(b, c, d, e, ::Tuple5)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip6" {
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d, e, f ->
+        val result = a.zip(b, c, d, e, f, ::Tuple6)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip7" {
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d, e, f, g ->
+        val result = a.zip(b, c, d, e, f, g, ::Tuple7)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip8" {
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d, e, f, g, h ->
+        val result = a.zip(b, c, d, e, f, g, h, ::Tuple8)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+          .zip(h) { (a, b, c, d, e, f, g), h -> Tuple8(a, b, c, d, e, f, g, h) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip9" {
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d, e, f, g, h, i ->
+        val result = a.zip(b, c, d, e, f, g, h, i, ::Tuple9)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+          .zip(h) { (a, b, c, d, e, f, g), h -> Tuple8(a, b, c, d, e, f, g, h) }
+          .zip(i) { (a, b, c, d, e, f, g, h), i -> Tuple9(a, b, c, d, e, f, g, h, i) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
+    "zip10" {
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d, e, f, g, h, i, j ->
+        val result = a.zip(b, c, d, e, f, g, h, i, j, ::Tuple10)
+        val expected = a.zip(b, ::Pair)
+          .zip(c) { (a, b), c -> Triple(a, b, c) }
+          .zip(d) { (a, b, c), d -> Tuple4(a, b, c, d) }
+          .zip(e) { (a, b, c, d), e -> Tuple5(a, b, c, d, e) }
+          .zip(f) { (a, b, c, d, e), f -> Tuple6(a, b, c, d, e, f) }
+          .zip(g) { (a, b, c, d, e, f), g -> Tuple7(a, b, c, d, e, f, g) }
+          .zip(h) { (a, b, c, d, e, f, g), h -> Tuple8(a, b, c, d, e, f, g, h) }
+          .zip(i) { (a, b, c, d, e, f, g, h), i -> Tuple9(a, b, c, d, e, f, g, h, i) }
+          .zip(j) { (a, b, c, d, e, f, g, h, i), j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }
+
+        result.toList() == expected.toList()
+      }
+    }
+
     "can align sequences" {
       forAll(Gen.sequenceK(Gen.int()), Gen.sequenceK(Gen.string())) { a, b ->
         SequenceK.semialign().run {

--- a/arrow-libs/core/arrow-core-test/src/main/kotlin/arrow/core/test/UnitSpec.kt
+++ b/arrow-libs/core/arrow-core-test/src/main/kotlin/arrow/core/test/UnitSpec.kt
@@ -1,8 +1,14 @@
 package arrow.core.test
 
+import arrow.core.Tuple4
+import arrow.core.Tuple5
 import arrow.core.test.laws.Law
 import io.kotlintest.TestCase
 import io.kotlintest.TestType
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.PropertyContext
+import io.kotlintest.properties.assertAll
+import io.kotlintest.shouldBe
 import io.kotlintest.specs.AbstractStringSpec
 
 /**
@@ -22,4 +28,70 @@ abstract class UnitSpec : AbstractStringSpec() {
     }
 
   override fun testCases(): List<TestCase> = super.testCases() + lawTestCases
+
+  fun <A, B, C, D, E, F, G> forAll(
+    gena: Gen<A>,
+    genb: Gen<B>,
+    genc: Gen<C>,
+    gend: Gen<D>,
+    gene: Gen<E>,
+    genf: Gen<F>,
+    geng: Gen<G>,
+    fn: PropertyContext.(a: A, b: B, c: C, d: D, e: E, f: F, g: G) -> Boolean
+  ) {
+    assertAll(gena, genb, genc, gend, gene, Gen.bind(genf, geng, ::Pair)) { a, b, c, d, e, (f, g) ->
+      fn(a, b, c, d, e, f, g) shouldBe true
+    }
+  }
+
+  fun <A, B, C, D, E, F, G, H> forAll(
+    gena: Gen<A>,
+    genb: Gen<B>,
+    genc: Gen<C>,
+    gend: Gen<D>,
+    gene: Gen<E>,
+    genf: Gen<F>,
+    geng: Gen<G>,
+    genh: Gen<H>,
+    fn: PropertyContext.(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) -> Boolean
+  ) {
+    assertAll(gena, genb, genc, gend, gene, Gen.bind(genf, geng, genh, ::Triple)) { a, b, c, d, e, (f, g, h) ->
+      fn(a, b, c, d, e, f, g, h) shouldBe true
+    }
+  }
+
+  fun <A, B, C, D, E, F, G, H, I> forAll(
+    gena: Gen<A>,
+    genb: Gen<B>,
+    genc: Gen<C>,
+    gend: Gen<D>,
+    gene: Gen<E>,
+    genf: Gen<F>,
+    geng: Gen<G>,
+    genh: Gen<H>,
+    geni: Gen<I>,
+    fn: PropertyContext.(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) -> Boolean
+  ) {
+    assertAll(gena, genb, genc, gend, gene, Gen.bind(genf, geng, genh, geni, ::Tuple4)) { a, b, c, d, e, (f, g, h, i) ->
+      fn(a, b, c, d, e, f, g, h, i) shouldBe true
+    }
+  }
+
+  fun <A, B, C, D, E, F, G, H, I, J> forAll(
+    gena: Gen<A>,
+    genb: Gen<B>,
+    genc: Gen<C>,
+    gend: Gen<D>,
+    gene: Gen<E>,
+    genf: Gen<F>,
+    geng: Gen<G>,
+    genh: Gen<H>,
+    geni: Gen<I>,
+    genj: Gen<J>,
+    fn: PropertyContext.(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) -> Boolean
+  ) {
+    assertAll(gena, genb, genc, gend, gene, Gen.bind(genf, geng, genh, geni, genj, ::Tuple5)) { a, b, c, d, e, (f, g, h, i, j) ->
+      fn(a, b, c, d, e, f, g, h, i, j) shouldBe true
+    }
+  }
 }

--- a/arrow-libs/core/arrow-core-test/src/main/kotlin/arrow/core/test/generators/Generators.kt
+++ b/arrow-libs/core/arrow-core-test/src/main/kotlin/arrow/core/test/generators/Generators.kt
@@ -11,6 +11,7 @@ import arrow.core.Left
 import arrow.core.ListK
 import arrow.core.MapK
 import arrow.core.NonEmptyList
+import arrow.core.NonEmptyList.Companion.fromListUnsafe
 import arrow.core.Option
 import arrow.core.Right
 import arrow.core.SequenceK
@@ -151,7 +152,7 @@ fun <E, A> Gen.Companion.validated(genE: Gen<E>, genA: Gen<A>): Gen<Validated<E,
   Gen.either(genE, genA).map { Validated.fromEither(it) }
 
 fun <A> Gen.Companion.nonEmptyList(gen: Gen<A>): Gen<NonEmptyList<A>> =
-  gen.flatMap { head -> Gen.list(gen).map { NonEmptyList(head, it) } }
+  Gen.list(gen).filter(List<A>::isNotEmpty).map(::fromListUnsafe)
 
 fun <K : Comparable<K>, V> Gen.Companion.sortedMapK(genK: Gen<K>, genV: Gen<V>): Gen<SortedMapK<K, V>> =
   Gen.bind(genK, genV) { k: K, v: V -> sortedMapOf(k to v) }.map { it.k() }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/list/apply/ListKApply.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/list/apply/ListKApply.kt
@@ -5,7 +5,6 @@ import arrow.core.Eval
 import arrow.core.ap as _ap
 import kotlin.collections.flatMap as _flatMap
 import arrow.core.ForListK
-import arrow.core.zip
 import arrow.core.Tuple10
 import arrow.core.Tuple2
 import arrow.core.Tuple3
@@ -16,6 +15,7 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.ListKApply
+import arrow.core.extensions.listk.apply.apply
 import arrow.core.fix
 import arrow.core.k
 import kotlin.Function1
@@ -24,6 +24,9 @@ import kotlin.Suppress
 import kotlin.collections.List
 import kotlin.jvm.JvmName
 
+const val ListMapNDeprecated =
+  "mapN is no longer supported for List. This operation easily results in extremely big lists, prefer flatMap chains instead."
+
 @JvmName("ap")
 @Suppress(
   "UNCHECKED_CAST",
@@ -31,7 +34,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("_ap(arg1)", "arrow.core.ap"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ap(arg1)", "arrow.core.ap"))
 fun <A, B> List<A>.ap(arg1: List<Function1<A, B>>): List<B> =
   _ap(arg1)
 
@@ -65,13 +68,15 @@ fun <A, B, Z> List<A>.map2Eval(arg1: Eval<Kind<ForListK, B>>, arg2: Function1<Tu
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(, arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> map(
   arg0: List<A>,
   arg1: List<B>,
   arg2: Function1<Tuple2<A, B>, Z>
 ): List<Z> =
-  arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -80,13 +85,15 @@ fun <A, B, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
   arg2: Function1<Tuple2<A, B>, Z>
 ): List<Z> =
-  arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -95,14 +102,16 @@ fun <A, B, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, Z> map(
   arg0: List<A>,
   arg1: List<B>,
   arg2: List<C>,
   arg3: Function1<Tuple3<A, B, C>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -111,14 +120,16 @@ fun <A, B, C, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
   arg2: List<C>,
   arg3: Function1<Tuple3<A, B, C>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -127,7 +138,7 @@ fun <A, B, C, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -135,7 +146,9 @@ fun <A, B, C, D, Z> map(
   arg3: List<D>,
   arg4: Function1<Tuple4<A, B, C, D>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -144,7 +157,7 @@ fun <A, B, C, D, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -152,7 +165,9 @@ fun <A, B, C, D, Z> mapN(
   arg3: List<D>,
   arg4: Function1<Tuple4<A, B, C, D>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -161,7 +176,7 @@ fun <A, B, C, D, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -170,7 +185,9 @@ fun <A, B, C, D, E, Z> map(
   arg4: List<E>,
   arg5: Function1<Tuple5<A, B, C, D, E>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -179,7 +196,7 @@ fun <A, B, C, D, E, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -188,7 +205,9 @@ fun <A, B, C, D, E, Z> mapN(
   arg4: List<E>,
   arg5: Function1<Tuple5<A, B, C, D, E>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -197,7 +216,7 @@ fun <A, B, C, D, E, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> arg6(Tuple6(a, b, c, d, e, ff)) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -207,7 +226,9 @@ fun <A, B, C, D, E, FF, Z> map(
   arg5: List<FF>,
   arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> arg6(Tuple6(a, b, c, d, e, ff)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -216,7 +237,7 @@ fun <A, B, C, D, E, FF, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> arg6(Tuple6(a, b, c, d, e, ff)) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -226,7 +247,9 @@ fun <A, B, C, D, E, FF, Z> mapN(
   arg5: List<FF>,
   arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> arg6(Tuple6(a, b, c, d, e, ff)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -235,7 +258,7 @@ fun <A, B, C, D, E, FF, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> arg7(Tuple7(a, b, c, d, e, ff, g)) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -246,7 +269,9 @@ fun <A, B, C, D, E, FF, G, Z> map(
   arg6: List<G>,
   arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> arg7(Tuple7(a, b, c, d, e, ff, g)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -255,7 +280,7 @@ fun <A, B, C, D, E, FF, G, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> arg7(Tuple7(a, b, c, d, e, ff, g)) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -266,7 +291,9 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   arg6: List<G>,
   arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> arg7(Tuple7(a, b, c, d, e, ff, g)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -275,7 +302,7 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -287,7 +314,9 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   arg7: List<H>,
   arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7.k(), arg8) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -296,7 +325,7 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -308,7 +337,9 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg7: List<H>,
   arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7.k(), arg8) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -317,7 +348,7 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -330,7 +361,9 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg8: List<I>,
   arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> arg9(Tuple9(a, b, c, d, e, ff, g, h, i)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7.k(), arg8.k(), arg9) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -339,7 +372,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> arg9(Tuple9(a, b, c, d, e, ff, g, h, i)) }", "arrow.core.zip", "arrow.core.Tuple9"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -352,7 +385,9 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg8: List<I>,
   arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> arg9(Tuple9(a, b, c, d, e, ff, g, h, i)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7.k(), arg8.k(), arg9) as List<Z>
 
 @JvmName("map")
 @Suppress(
@@ -361,7 +396,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, ff, g, h, i, j)) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg0: List<A>,
   arg1: List<B>,
@@ -375,7 +410,9 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg9: List<J>,
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, ff, g, h, i, j)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7.k(), arg8.k(), arg9.k(), arg10) as List<Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -384,7 +421,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, ff, g, h, i, j)) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg0: List<A>,
   arg1: List<B>,
@@ -398,7 +435,9 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg9: List<J>,
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
 ): List<Z> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, ff, g, h, i, j)) }
+  arrow.core.ListK
+    .apply()
+    .mapN(arg0.k(), arg1.k(), arg2.k(), arg3.k(), arg4.k(), arg5.k(), arg6.k(), arg7.k(), arg8.k(), arg9.k(), arg10) as List<Z>
 
 @JvmName("map2")
 @Suppress(
@@ -407,9 +446,11 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> List<A>.map2(arg1: List<B>, arg2: Function1<Tuple2<A, B>, Z>): List<Z> =
-  zip(arg1) { a, b -> arg2(Tuple2(a, b)) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@map2.k().map2(arg1.k(), arg2) as List<Z>
+  }
 
 @JvmName("product")
 @Suppress(
@@ -418,9 +459,12 @@ fun <A, B, Z> List<A>.map2(arg1: List<B>, arg2: Function1<Tuple2<A, B>, Z>): Lis
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { a, b -> Tuple2(a, b) }", "arrow.core.Tuple2", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B> List<A>.product(arg1: List<B>): List<Tuple2<A, B>> =
-  zip(arg1) { a, b -> Tuple2(a, b) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B>(arg1) as
+      List<arrow.core.Tuple2<A, B>>
+  }
 
 @JvmName("product1")
 @Suppress(
@@ -429,9 +473,12 @@ fun <A, B> List<A>.product(arg1: List<B>): List<Tuple2<A, B>> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b), z -> Tuple3(a, b, z)", "arrow.core.Tuple3", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> List<Tuple2<A, B>>.product(arg1: List<Z>): List<Tuple3<A, B, Z>> =
-  zip(arg1) { (a, b), z -> Tuple3(a, b, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, Z>(arg1) as
+      List<arrow.core.Tuple3<A, B, Z>>
+  }
 
 @JvmName("product2")
 @Suppress(
@@ -440,9 +487,12 @@ fun <A, B, Z> List<Tuple2<A, B>>.product(arg1: List<Z>): List<Tuple3<A, B, Z>> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }", "arrow.core.Tuple4", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, Z> List<Tuple3<A, B, C>>.product(arg1: List<Z>): List<Tuple4<A, B, C, Z>> =
-  zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, Z>(arg1) as
+      List<arrow.core.Tuple4<A, B, C, Z>>
+  }
 
 @JvmName("product3")
 @Suppress(
@@ -451,9 +501,12 @@ fun <A, B, C, Z> List<Tuple3<A, B, C>>.product(arg1: List<Z>): List<Tuple4<A, B,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }", "arrow.core.Tuple5", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, Z> List<Tuple4<A, B, C, D>>.product(arg1: List<Z>): List<Tuple5<A, B, C, D, Z>> =
-  zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, D, Z>(arg1) as
+      List<arrow.core.Tuple5<A, B, C, D, Z>>
+  }
 
 @JvmName("product4")
 @Suppress(
@@ -462,9 +515,12 @@ fun <A, B, C, D, Z> List<Tuple4<A, B, C, D>>.product(arg1: List<Z>): List<Tuple5
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }", "arrow.core.Tuple6", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, Z> List<Tuple5<A, B, C, D, E>>.product(arg1: List<Z>): List<Tuple6<A, B, C, D, E, Z>> =
-  zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, D, E, Z>(arg1) as
+      List<arrow.core.Tuple6<A, B, C, D, E, Z>>
+  }
 
 @JvmName("product5")
 @Suppress(
@@ -473,10 +529,13 @@ fun <A, B, C, D, E, Z> List<Tuple5<A, B, C, D, E>>.product(arg1: List<Z>): List<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff), z -> Tuple7(a, b, c, d, e, ff, z) }", "arrow.core.Tuple7", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> List<Tuple6<A, B, C, D, E, FF>>.product(arg1: List<Z>): List<Tuple7<A, B,
     C, D, E, FF, Z>> =
-  zip(arg1) { (a, b, c, d, e, ff), z -> Tuple7(a, b, c, d, e, ff, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, D, E, FF, Z>(arg1) as
+      List<arrow.core.Tuple7<A, B, C, D, E, FF, Z>>
+  }
 
 @JvmName("product6")
 @Suppress(
@@ -485,10 +544,13 @@ fun <A, B, C, D, E, FF, Z> List<Tuple6<A, B, C, D, E, FF>>.product(arg1: List<Z>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff, g), z -> Tuple8(a, b, c, d, e, ff, g, z) }", "arrow.core.Tuple8", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> List<Tuple7<A, B, C, D, E, FF, G>>.product(arg1: List<Z>):
   List<Tuple8<A, B, C, D, E, FF, G, Z>> =
-    zip(arg1) { (a, b, c, d, e, ff, g), z -> Tuple8(a, b, c, d, e, ff, g, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as
+      List<arrow.core.Tuple8<A, B, C, D, E, FF, G, Z>>
+  }
 
 @JvmName("product7")
 @Suppress(
@@ -497,10 +559,13 @@ fun <A, B, C, D, E, FF, G, Z> List<Tuple7<A, B, C, D, E, FF, G>>.product(arg1: L
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff, g, h), z -> Tuple9(a, b, c, d, e, ff, g, h, z) }", "arrow.core.Tuple9", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> List<Tuple8<A, B, C, D, E, FF, G, H>>.product(arg1: List<Z>):
   List<Tuple9<A, B, C, D, E, FF, G, H, Z>> =
-    zip(arg1) { (a, b, c, d, e, ff, g, h), z -> Tuple9(a, b, c, d, e, ff, g, h, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as
+      List<arrow.core.Tuple9<A, B, C, D, E, FF, G, H, Z>>
+  }
 
 @JvmName("product8")
 @Suppress(
@@ -509,10 +574,13 @@ fun <A, B, C, D, E, FF, G, H, Z> List<Tuple8<A, B, C, D, E, FF, G, H>>.product(a
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff, g, h, i), z -> Tuple10(a, b, c, d, e, ff, g, h, i, z) }", "arrow.core.Tuple10", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> List<Tuple9<A, B, C, D, E, FF, G, H, I>>.product(arg1: List<Z>):
   List<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
-    zip(arg1) { (a, b, c, d, e, ff, g, h, i), z -> Tuple10(a, b, c, d, e, ff, g, h, i, z) }
+  arrow.core.extensions.list.apply.List.apply().run {
+    this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as
+      List<arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
+  }
 
 @JvmName("tupled")
 @Suppress(
@@ -521,9 +589,12 @@ fun <A, B, C, D, E, FF, G, H, I, Z> List<Tuple9<A, B, C, D, E, FF, G, H, I>>.pro
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> Tuple2(a, b) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B> tupled(arg0: List<A>, arg1: List<B>): List<Tuple2<A, B>> =
-  arg0.zip(arg1) { a, b -> Tuple2(a, b) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1))
+    as List<Tuple2<A, B>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -532,9 +603,12 @@ fun <A, B> tupled(arg0: List<A>, arg1: List<B>): List<Tuple2<A, B>> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> Tuple2(a, b) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B> tupledN(arg0: List<A>, arg1: List<B>): List<Tuple2<A, B>> =
-  arg0.zip(arg1) { a, b -> Tuple2(a, b) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1))
+    as List<Tuple2<A, B>>
 
 @JvmName("tupled")
 @Suppress(
@@ -543,13 +617,16 @@ fun <A, B> tupledN(arg0: List<A>, arg1: List<B>): List<Tuple2<A, B>> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C> tupled(
   arg0: List<A>,
   arg1: List<B>,
   arg2: List<C>
 ): List<Tuple3<A, B, C>> =
-  arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2))
+    as List<Tuple3<A, B, C>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -558,13 +635,16 @@ fun <A, B, C> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C> tupledN(
   arg0: List<A>,
   arg1: List<B>,
   arg2: List<C>
 ): List<Tuple3<A, B, C>> =
-  arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2))
+    as List<Tuple3<A, B, C>>
 
 @JvmName("tupled")
 @Suppress(
@@ -573,14 +653,17 @@ fun <A, B, C> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D> tupled(
   arg0: List<A>,
   arg1: List<B>,
   arg2: List<C>,
   arg3: List<D>
 ): List<Tuple4<A, B, C, D>> =
-  arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3))
+    as List<Tuple4<A, B, C, D>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -589,14 +672,17 @@ fun <A, B, C, D> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D> tupledN(
   arg0: List<A>,
   arg1: List<B>,
   arg2: List<C>,
   arg3: List<D>
 ): List<Tuple4<A, B, C, D>> =
-  arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3))
+    as List<Tuple4<A, B, C, D>>
 
 @JvmName("tupled")
 @Suppress(
@@ -605,7 +691,7 @@ fun <A, B, C, D> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E> tupled(
   arg0: List<A>,
   arg1: List<B>,
@@ -613,7 +699,10 @@ fun <A, B, C, D, E> tupled(
   arg3: List<D>,
   arg4: List<E>
 ): List<Tuple5<A, B, C, D, E>> =
-  arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4))
+    as List<Tuple5<A, B, C, D, E>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -622,7 +711,7 @@ fun <A, B, C, D, E> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E> tupledN(
   arg0: List<A>,
   arg1: List<B>,
@@ -630,7 +719,10 @@ fun <A, B, C, D, E> tupledN(
   arg3: List<D>,
   arg4: List<E>
 ): List<Tuple5<A, B, C, D, E>> =
-  arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4))
+    as List<Tuple5<A, B, C, D, E>>
 
 @JvmName("tupled")
 @Suppress(
@@ -639,7 +731,7 @@ fun <A, B, C, D, E> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF> tupled(
   arg0: List<A>,
   arg1: List<B>,
@@ -648,7 +740,10 @@ fun <A, B, C, D, E, FF> tupled(
   arg4: List<E>,
   arg5: List<FF>
 ): List<Tuple6<A, B, C, D, E, FF>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5))
+    as List<Tuple6<A, B, C, D, E, FF>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -657,7 +752,7 @@ fun <A, B, C, D, E, FF> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF> tupledN(
   arg0: List<A>,
   arg1: List<B>,
@@ -666,7 +761,10 @@ fun <A, B, C, D, E, FF> tupledN(
   arg4: List<E>,
   arg5: List<FF>
 ): List<Tuple6<A, B, C, D, E, FF>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5))
+    as List<Tuple6<A, B, C, D, E, FF>>
 
 @JvmName("tupled")
 @Suppress(
@@ -675,7 +773,7 @@ fun <A, B, C, D, E, FF> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupled(
   arg0: List<A>,
   arg1: List<B>,
@@ -685,7 +783,10 @@ fun <A, B, C, D, E, FF, G> tupled(
   arg5: List<FF>,
   arg6: List<G>
 ): List<Tuple7<A, B, C, D, E, FF, G>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6))
+    as List<Tuple7<A, B, C, D, E, FF, G>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -694,7 +795,7 @@ fun <A, B, C, D, E, FF, G> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupledN(
   arg0: List<A>,
   arg1: List<B>,
@@ -704,7 +805,10 @@ fun <A, B, C, D, E, FF, G> tupledN(
   arg5: List<FF>,
   arg6: List<G>
 ): List<Tuple7<A, B, C, D, E, FF, G>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6))
+    as List<Tuple7<A, B, C, D, E, FF, G>>
 
 @JvmName("tupled")
 @Suppress(
@@ -713,7 +817,7 @@ fun <A, B, C, D, E, FF, G> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupled(
   arg0: List<A>,
   arg1: List<B>,
@@ -724,7 +828,10 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   arg6: List<G>,
   arg7: List<H>
 ): List<Tuple8<A, B, C, D, E, FF, G, H>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6), arrow.core.ListK(arg7))
+    as List<Tuple8<A, B, C, D, E, FF, G, H>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -733,7 +840,7 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupledN(
   arg0: List<A>,
   arg1: List<B>,
@@ -744,7 +851,10 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   arg6: List<G>,
   arg7: List<H>
 ): List<Tuple8<A, B, C, D, E, FF, G, H>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6), arrow.core.ListK(arg7))
+    as List<Tuple8<A, B, C, D, E, FF, G, H>>
 
 @JvmName("tupled")
 @Suppress(
@@ -753,7 +863,7 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> Tuple9(a, b, c, d, e, ff, g, h, i) }", "arrow.core.zip", "arrow.core.Tuple9"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg0: List<A>,
   arg1: List<B>,
@@ -765,7 +875,10 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg7: List<H>,
   arg8: List<I>
 ): List<Tuple9<A, B, C, D, E, FF, G, H, I>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> Tuple9(a, b, c, d, e, ff, g, h, i) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6), arrow.core.ListK(arg7), arrow.core.ListK(arg8))
+    as List<Tuple9<A, B, C, D, E, FF, G, H, I>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -774,7 +887,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> Tuple9(a, b, c, d, e, ff, g, h, i) }", "arrow.core.zip", "arrow.core.Tuple9"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg0: List<A>,
   arg1: List<B>,
@@ -786,7 +899,10 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg7: List<H>,
   arg8: List<I>
 ): List<Tuple9<A, B, C, D, E, FF, G, H, I>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> Tuple9(a, b, c, d, e, ff, g, h, i) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6), arrow.core.ListK(arg7), arrow.core.ListK(arg8))
+    as List<Tuple9<A, B, C, D, E, FF, G, H, I>>
 
 @JvmName("tupled")
 @Suppress(
@@ -795,7 +911,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> Tuple10(a, b, c, d, e, ff, g, h, i, j) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg0: List<A>,
   arg1: List<B>,
@@ -808,7 +924,10 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg8: List<I>,
   arg9: List<J>
 ): List<Tuple10<A, B, C, D, E, FF, G, H, I, J>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> Tuple10(a, b, c, d, e, ff, g, h, i, j) }
+  arrow.core.extensions.list.apply.List
+    .apply()
+    .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6), arrow.core.ListK(arg7), arrow.core.ListK(arg8), arrow.core.ListK(arg9))
+    as List<Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -817,7 +936,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> Tuple10(a, b, c, d, e, ff, g, h, i, j) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg0: List<A>,
   arg1: List<B>,
@@ -829,8 +948,10 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg7: List<H>,
   arg8: List<I>,
   arg9: List<J>
-): List<Tuple10<A, B, C, D, E, FF, G, H, I, J>> =
-  arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> Tuple10(a, b, c, d, e, ff, g, h, i, j) }
+): List<Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.extensions.list.apply.List
+  .apply()
+  .tupledN(arrow.core.ListK(arg0), arrow.core.ListK(arg1), arrow.core.ListK(arg2), arrow.core.ListK(arg3), arrow.core.ListK(arg4), arrow.core.ListK(arg5), arrow.core.ListK(arg6), arrow.core.ListK(arg7), arrow.core.ListK(arg8), arrow.core.ListK(arg9))
+  as List<Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 
 @JvmName("followedBy")
 @Suppress(
@@ -850,9 +971,9 @@ fun <A, B> List<A>.followedBy(arg1: List<B>): List<B> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("this.zip(arg1) { left, _ -> left }"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1.map { a } }"))
 fun <A, B> List<A>.apTap(arg1: List<B>): List<A> =
-  this.zip(arg1) { left, _ -> left }
+  _flatMap { a -> arg1.map { a } }
 
 /**
  * cached extension

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk/apply/ListKApply.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/listk/apply/ListKApply.kt
@@ -15,6 +15,7 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.ListKApply
+import arrow.core.extensions.list.apply.ListMapNDeprecated
 import kotlin.Function1
 import kotlin.PublishedApi
 import kotlin.Suppress
@@ -33,7 +34,7 @@ internal val apply_singleton: ListKApply = object : arrow.core.extensions.ListKA
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("_ap(arg1)", "arrow.core.ap"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ap(arg1)", "arrow.core.ap"))
 fun <A, B> Kind<ForListK, A>.ap(arg1: Kind<ForListK, Function1<A, B>>): ListK<B> =
   arrow.core.ListK.apply().run {
     this@ap.ap<A, B>(arg1) as arrow.core.ListK<B>
@@ -75,7 +76,7 @@ fun <A, B, Z> Kind<ForListK, A>.map2Eval(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -91,7 +92,7 @@ fun <A, B, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -107,7 +108,7 @@ fun <A, B, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -124,7 +125,7 @@ fun <A, B, C, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -141,7 +142,7 @@ fun <A, B, C, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -159,7 +160,7 @@ fun <A, B, C, D, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }", "arrow.core.ListK", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -177,7 +178,7 @@ fun <A, B, C, D, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -196,7 +197,7 @@ fun <A, B, C, D, E, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -215,7 +216,7 @@ fun <A, B, C, D, E, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> arg6(Tuple6(a, b, c, d, e, ff)) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -235,7 +236,7 @@ fun <A, B, C, D, E, FF, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> arg6(Tuple6(a, b, c, d, e, ff)) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -255,7 +256,7 @@ fun <A, B, C, D, E, FF, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> arg7(Tuple7(a, b, c, d, e, ff, g)) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -277,7 +278,7 @@ fun <A, B, C, D, E, FF, G, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> arg7(Tuple7(a, b, c, d, e, ff, g)) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -299,7 +300,7 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -322,7 +323,7 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -345,7 +346,7 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -369,7 +370,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> arg8(Tuple8(a, b, c, d, e, ff, g, h)) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -393,7 +394,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, ff, g, h, i, j)) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -418,7 +419,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, ff, g, h, i, j)) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -443,7 +444,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> Kind<ForListK, A>.map2(arg1: Kind<ForListK, B>, arg2: Function1<Tuple2<A, B>, Z>):
   ListK<Z> = arrow.core.ListK.apply().run {
     this@map2.map2<A, B, Z>(arg1, arg2) as arrow.core.ListK<Z>
@@ -456,7 +457,7 @@ fun <A, B, Z> Kind<ForListK, A>.map2(arg1: Kind<ForListK, B>, arg2: Function1<Tu
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.Tuple2", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B> Kind<ForListK, A>.product(arg1: Kind<ForListK, B>): ListK<Tuple2<A, B>> =
   arrow.core.ListK.apply().run {
     this@product.product<A, B>(arg1) as arrow.core.ListK<arrow.core.Tuple2<A, B>>
@@ -469,7 +470,7 @@ fun <A, B> Kind<ForListK, A>.product(arg1: Kind<ForListK, B>): ListK<Tuple2<A, B
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b), z -> Tuple3(a, b, z)", "arrow.core.Tuple3", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, Z> Kind<ForListK, Tuple2<A, B>>.product(arg1: Kind<ForListK, Z>): ListK<Tuple3<A, B, Z>> =
   arrow.core.ListK.apply().run {
     this@product.product<A, B, Z>(arg1) as arrow.core.ListK<arrow.core.Tuple3<A, B, Z>>
@@ -482,7 +483,7 @@ fun <A, B, Z> Kind<ForListK, Tuple2<A, B>>.product(arg1: Kind<ForListK, Z>): Lis
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }", "arrow.core.Tuple4", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, Z> Kind<ForListK, Tuple3<A, B, C>>.product(arg1: Kind<ForListK, Z>): ListK<Tuple4<A,
     B, C, Z>> = arrow.core.ListK.apply().run {
   this@product.product<A, B, C, Z>(arg1) as arrow.core.ListK<arrow.core.Tuple4<A, B, C, Z>>
@@ -495,7 +496,7 @@ fun <A, B, C, Z> Kind<ForListK, Tuple3<A, B, C>>.product(arg1: Kind<ForListK, Z>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }", "arrow.core.Tuple5", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, Z> Kind<ForListK, Tuple4<A, B, C, D>>.product(arg1: Kind<ForListK, Z>):
   ListK<Tuple5<A, B, C, D, Z>> = arrow.core.ListK.apply().run {
     this@product.product<A, B, C, D, Z>(arg1) as arrow.core.ListK<arrow.core.Tuple5<A, B, C, D, Z>>
@@ -508,7 +509,7 @@ fun <A, B, C, D, Z> Kind<ForListK, Tuple4<A, B, C, D>>.product(arg1: Kind<ForLis
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }", "arrow.core.Tuple6", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, Z> Kind<ForListK, Tuple5<A, B, C, D, E>>.product(arg1: Kind<ForListK, Z>):
   ListK<Tuple6<A, B, C, D, E, Z>> = arrow.core.ListK.apply().run {
     this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.ListK<arrow.core.Tuple6<A, B, C, D, E,
@@ -522,7 +523,7 @@ fun <A, B, C, D, E, Z> Kind<ForListK, Tuple5<A, B, C, D, E>>.product(arg1: Kind<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff), z -> Tuple7(a, b, c, d, e, ff, z) }", "arrow.core.Tuple7", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> Kind<ForListK, Tuple6<A, B, C, D, E, FF>>.product(
   arg1: Kind<ForListK,
     Z>
@@ -538,7 +539,7 @@ fun <A, B, C, D, E, FF, Z> Kind<ForListK, Tuple6<A, B, C, D, E, FF>>.product(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff, g), z -> Tuple8(a, b, c, d, e, ff, g, z) }", "arrow.core.Tuple8", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> Kind<ForListK, Tuple7<A, B, C, D, E, FF,
     G>>.product(arg1: Kind<ForListK, Z>): ListK<Tuple8<A, B, C, D, E, FF, G, Z>> =
   arrow.core.ListK.apply().run {
@@ -553,7 +554,7 @@ fun <A, B, C, D, E, FF, G, Z> Kind<ForListK, Tuple7<A, B, C, D, E, FF,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff, g, h), z -> Tuple9(a, b, c, d, e, ff, g, h, z) }", "arrow.core.Tuple9", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> Kind<ForListK, Tuple8<A, B, C, D, E, FF, G,
     H>>.product(arg1: Kind<ForListK, Z>): ListK<Tuple9<A, B, C, D, E, FF, G, H, Z>> =
   arrow.core.ListK.apply().run {
@@ -568,7 +569,7 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<ForListK, Tuple8<A, B, C, D, E, FF, G,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("zip(arg1) { (a, b, c, d, e, ff, g, h, i), z -> Tuple10(a, b, c, d, e, ff, g, h, i, z) }", "arrow.core.Tuple10", "kotlin.collections.zip"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForListK, Tuple9<A, B, C, D, E, FF, G, H,
     I>>.product(arg1: Kind<ForListK, Z>): ListK<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
   arrow.core.ListK.apply().run {
@@ -583,7 +584,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForListK, Tuple9<A, B, C, D, E, FF, G, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> Tuple2(a, b) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B> tupled(arg0: Kind<ForListK, A>, arg1: Kind<ForListK, B>): ListK<Tuple2<A, B>> =
   arrow.core.ListK
     .apply()
@@ -596,7 +597,7 @@ fun <A, B> tupled(arg0: Kind<ForListK, A>, arg1: Kind<ForListK, B>): ListK<Tuple
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1) { a, b -> Tuple2(a, b) }", "arrow.core.Tuple2"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B> tupledN(arg0: Kind<ForListK, A>, arg1: Kind<ForListK, B>): ListK<Tuple2<A, B>> =
   arrow.core.ListK
     .apply()
@@ -609,7 +610,7 @@ fun <A, B> tupledN(arg0: Kind<ForListK, A>, arg1: Kind<ForListK, B>): ListK<Tupl
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -625,7 +626,7 @@ fun <A, B, C> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }", "arrow.core.zip", "arrow.core.Tuple3"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -641,7 +642,7 @@ fun <A, B, C> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -658,7 +659,7 @@ fun <A, B, C, D> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }", "arrow.core.zip", "arrow.core.Tuple4"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -675,7 +676,7 @@ fun <A, B, C, D> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -694,7 +695,7 @@ fun <A, B, C, D, E> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }", "arrow.core.zip", "arrow.core.Tuple5"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -713,7 +714,7 @@ fun <A, B, C, D, E> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -733,7 +734,7 @@ fun <A, B, C, D, E, FF> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }", "arrow.core.zip", "arrow.core.Tuple6"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -753,7 +754,7 @@ fun <A, B, C, D, E, FF> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -774,7 +775,7 @@ fun <A, B, C, D, E, FF, G> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }", "arrow.core.zip", "arrow.core.Tuple7"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -795,7 +796,7 @@ fun <A, B, C, D, E, FF, G> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -817,7 +818,7 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }", "arrow.core.zip", "arrow.core.Tuple8"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -839,7 +840,7 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> Tuple9(a, b, c, d, e, ff, g, h, i) }", "arrow.core.zip", "arrow.core.Tuple9"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -862,7 +863,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> Tuple9(a, b, c, d, e, ff, g, h, i) }", "arrow.core.zip", "arrow.core.Tuple9"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -885,7 +886,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> Tuple10(a, b, c, d, e, ff, g, h, i, j) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -910,7 +911,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> Tuple10(a, b, c, d, e, ff, g, h, i, j) }", "arrow.core.zip", "arrow.core.Tuple10"))
+@Deprecated(ListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg0: Kind<ForListK, A>,
   arg1: Kind<ForListK, B>,
@@ -948,7 +949,7 @@ fun <A, B> Kind<ForListK, A>.followedBy(arg1: Kind<ForListK, B>): ListK<B> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("this.zip(arg1) { left, _ -> left }", "arrow.core.zip"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1.map { a } }"))
 fun <A, B> Kind<ForListK, A>.apTap(arg1: Kind<ForListK, B>): ListK<A> =
   arrow.core.ListK.apply().run {
     this@apTap.apTap<A, B>(arg1) as arrow.core.ListK<A>

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
@@ -20,6 +20,9 @@ import kotlin.PublishedApi
 import kotlin.Suppress
 import kotlin.jvm.JvmName
 
+const val NonEmptyListMapNDeprecated =
+  "mapN is no longer supported for NonEmptyList. This operation easily results in extremely big lists, prefer flatMap chains instead."
+
 /**
  * cached extension
  */
@@ -99,15 +102,7 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2Eval(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -123,15 +118,7 @@ fun <A, B, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -147,15 +134,7 @@ fun <A, B, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -172,15 +151,7 @@ fun <A, B, C, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -197,15 +168,7 @@ fun <A, B, C, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -223,15 +186,7 @@ fun <A, B, C, D, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -249,15 +204,7 @@ fun <A, B, C, D, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -276,15 +223,7 @@ fun <A, B, C, D, E, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -303,15 +242,7 @@ fun <A, B, C, D, E, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -332,15 +263,7 @@ fun <A, B, C, D, E, FF, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -361,15 +284,7 @@ fun <A, B, C, D, E, FF, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -391,15 +306,7 @@ fun <A, B, C, D, E, FF, G, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -421,15 +328,7 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -452,15 +351,7 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -483,15 +374,7 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -515,15 +398,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -547,15 +422,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -581,15 +448,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.zip",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -637,14 +496,7 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "ap(arg1.map<(A) -> Tuple2<A, B>> { b -> { a -> Tuple2<A, B>(a, b) } })",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B> Kind<ForNonEmptyList, A>.product(arg1: Kind<ForNonEmptyList, B>): NonEmptyList<Tuple2<A,
     B>> = arrow.core.NonEmptyList.apply().run {
   this@product.product<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<A, B>>
@@ -657,14 +509,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.product(arg1: Kind<ForNonEmptyList, B>): Non
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple3<A, B, Z>> { a -> arg1.map<Tuple3<A, B, Z>> { z -> Tuple3<A, B, Z>(a.a, a.b, z) }}",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, Z> Kind<ForNonEmptyList, Tuple2<A, B>>.product(arg1: Kind<ForNonEmptyList, Z>):
   NonEmptyList<Tuple3<A, B, Z>> = arrow.core.NonEmptyList.apply().run {
     this@product.product<A, B, Z>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple3<A, B, Z>>
@@ -677,14 +522,7 @@ fun <A, B, Z> Kind<ForNonEmptyList, Tuple2<A, B>>.product(arg1: Kind<ForNonEmpty
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple4<A, B, C, Z>> { a -> arg1.map<Tuple4<A, B, C, Z>> { z -> Tuple4<A, B, C, Z>(a.a, a.b, a.c, z) }}",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, Z> Kind<ForNonEmptyList, Tuple3<A, B, C>>.product(arg1: Kind<ForNonEmptyList, Z>):
   NonEmptyList<Tuple4<A, B, C, Z>> = arrow.core.NonEmptyList.apply().run {
     this@product.product<A, B, C, Z>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple4<A, B, C, Z>>
@@ -697,14 +535,7 @@ fun <A, B, C, Z> Kind<ForNonEmptyList, Tuple3<A, B, C>>.product(arg1: Kind<ForNo
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple5<A, B, C, D, Z>> { a -> arg1.map<Tuple5<A, B, C, D, Z>> { z -> Tuple5<A, B, C, D, Z>(a.a, a.b, a.c, a.d, z) }}",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, Z> Kind<ForNonEmptyList, Tuple4<A, B, C, D>>.product(
   arg1: Kind<ForNonEmptyList, Z>
 ): NonEmptyList<Tuple5<A, B, C, D, Z>> = arrow.core.NonEmptyList.apply().run {
@@ -719,14 +550,7 @@ fun <A, B, C, D, Z> Kind<ForNonEmptyList, Tuple4<A, B, C, D>>.product(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple6<A, B, C, D, E, Z>> { a -> arg1.map<Tuple6<A, B, C, D, E, Z>> { z -> Tuple6<A, B, C, D, E, Z>(a.a, a.b, a.c, a.d, a.e, z) }}",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, Z> Kind<ForNonEmptyList, Tuple5<A, B, C, D,
     E>>.product(arg1: Kind<ForNonEmptyList, Z>): NonEmptyList<Tuple6<A, B, C, D, E, Z>> =
   arrow.core.NonEmptyList.apply().run {
@@ -741,14 +565,7 @@ fun <A, B, C, D, E, Z> Kind<ForNonEmptyList, Tuple5<A, B, C, D,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple7<A, B, C, D, E, FF, Z>> { a -> arg1.map<Tuple7<A, B, C, D, E, FF, Z>> { z -> Tuple7<A, B, C, D, E, FF, Z>(a.a, a.b, a.c, a.d, a.e, a.f, z) }}",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> Kind<ForNonEmptyList, Tuple6<A, B, C, D, E,
     FF>>.product(arg1: Kind<ForNonEmptyList, Z>): NonEmptyList<Tuple7<A, B, C, D, E, FF, Z>> =
   arrow.core.NonEmptyList.apply().run {
@@ -763,14 +580,7 @@ fun <A, B, C, D, E, FF, Z> Kind<ForNonEmptyList, Tuple6<A, B, C, D, E,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple8<A, B, C, D, E, FF, G, Z>> { a -> arg1.map<Tuple8<A, B, C, D, E, FF, G, Z>> { z -> Tuple8<A, B, C, D, E, FF, G, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, z) }}",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> Kind<ForNonEmptyList, Tuple7<A, B, C, D, E, FF,
     G>>.product(arg1: Kind<ForNonEmptyList, Z>): NonEmptyList<Tuple8<A, B, C, D, E, FF, G, Z>> =
   arrow.core.NonEmptyList.apply().run {
@@ -785,14 +595,7 @@ fun <A, B, C, D, E, FF, G, Z> Kind<ForNonEmptyList, Tuple7<A, B, C, D, E, FF,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple9<A, B, C, D, E, FF, G, H, Z>> { a -> arg1.map<Tuple9<A, B, C, D, E, FF, G, H, Z>> { z -> Tuple9<A, B, C, D, E, FF, G, H, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, z) }}",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> Kind<ForNonEmptyList, Tuple8<A, B, C, D, E, FF, G,
     H>>.product(arg1: Kind<ForNonEmptyList, Z>): NonEmptyList<Tuple9<A, B, C, D, E, FF, G, H, Z>> =
   arrow.core.NonEmptyList.apply().run {
@@ -807,14 +610,7 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<ForNonEmptyList, Tuple8<A, B, C, D, E, FF,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "flatMap<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { a -> arg1.map<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { z -> Tuple10<A, B, C, D, E, FF, G, H, I, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, a.i, z) }}",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForNonEmptyList, Tuple9<A, B, C, D, E, FF, G, H,
     I>>.product(arg1: Kind<ForNonEmptyList, Z>): NonEmptyList<Tuple10<A, B, C, D, E, FF, G, H, I,
     Z>> = arrow.core.NonEmptyList.apply().run {
@@ -829,16 +625,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForNonEmptyList, Tuple9<A, B, C, D, E, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, Tuple2<A, B>>(arg0.fix(), arg1.fix()) { a, b -> Tuple2(a, b) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple2",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B> tupled(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B>):
   NonEmptyList<Tuple2<A, B>> = arrow.core.NonEmptyList
     .apply()
@@ -851,16 +638,7 @@ fun <A, B> tupled(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, Tuple2<A, B>>(arg0.fix(), arg1.fix()) { a, b -> Tuple2(a, b) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple2",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B> tupledN(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B>):
   NonEmptyList<Tuple2<A, B>> = arrow.core.NonEmptyList
     .apply()
@@ -873,16 +651,7 @@ fun <A, B> tupledN(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, Tuple3<A, B, C>>(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple3",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -898,16 +667,7 @@ fun <A, B, C> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, Tuple3<A, B, C>>(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple3",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -923,16 +683,7 @@ fun <A, B, C> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, Tuple4<A, B, C, D>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple4",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -950,16 +701,7 @@ fun <A, B, C, D> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, Tuple4<A, B, C, D>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple4",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -977,16 +719,7 @@ fun <A, B, C, D> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, Tuple5<A, B, C, D, E>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple5",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1005,16 +738,7 @@ fun <A, B, C, D, E> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, Tuple5<A, B, C, D, E>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple5",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1033,16 +757,7 @@ fun <A, B, C, D, E> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, Tuple6<A, B, C, D, E, FF>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple6",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1062,16 +777,7 @@ fun <A, B, C, D, E, FF> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, Tuple6<A, B, C, D, E, FF>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple6",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1091,16 +797,7 @@ fun <A, B, C, D, E, FF> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, Tuple7<A, B, C, D, E, FF, G>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple7",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1121,16 +818,7 @@ fun <A, B, C, D, E, FF, G> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, Tuple7<A, B, C, D, E, FF, G>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple7",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1151,16 +839,7 @@ fun <A, B, C, D, E, FF, G> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, Tuple8<A, B, C, D, E, FF, G, H>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple8",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1182,16 +861,7 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, Tuple8<A, B, C, D, E, FF, G, H>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple8",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1213,16 +883,7 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, Tuple9<A, B, C, D, E, FF, G, H, I>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple9",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1245,16 +906,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, Tuple9<A, B, C, D, E, FF, G, H, I>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple9",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1277,16 +929,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, J, Tuple10<A, B, C, D, E, FF, G, H, I, J>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple10",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1311,16 +954,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, J, Tuple10<A, B, C, D, E, FF, G, H, I, J>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
-    "arrow.core.NonEmptyList",
-    "arrow.core.Tuple10",
-    "arrow.core.fix"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(NonEmptyListMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg0: Kind<ForNonEmptyList, A>,
   arg1: Kind<ForNonEmptyList, B>,
@@ -1368,9 +1002,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.followedBy(arg1: Kind<ForNonEmptyList, B>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(this.fix(), arg1.fix()) { left, _ -> left }",
-    "arrow.core.fix",
-    "arrow.core.mapN"
+    "this.flatMap { a -> arg1.map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
@@ -102,8 +102,8 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -126,8 +126,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -150,8 +150,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -175,8 +175,8 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -200,8 +200,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -226,8 +226,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -252,8 +252,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -279,8 +279,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -306,8 +306,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -335,8 +335,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -364,8 +364,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -394,8 +394,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -424,8 +424,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -455,8 +455,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -486,8 +486,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -518,8 +518,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -550,8 +550,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -584,8 +584,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.NonEmptyList",
+    "arg0.fix().zip(arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.zip",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/apply/SequenceKApply.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/apply/SequenceKApply.kt
@@ -15,6 +15,9 @@ import arrow.core.Tuple9
 import arrow.core.extensions.SequenceKApply
 import kotlin.sequences.Sequence
 
+const val SequenceMapNDeprecated =
+  "mapN is no longer supported for Sequence. This operation easily results in extremely big lists, prefer flatMap chains instead."
+
 @JvmName("ap")
 @Suppress(
   "UNCHECKED_CAST",
@@ -86,15 +89,7 @@ fun <A, B, Z> Sequence<A>.map2Eval(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -111,15 +106,7 @@ fun <A, B, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -136,15 +123,7 @@ fun <A, B, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -163,15 +142,7 @@ fun <A, B, C, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -190,15 +161,7 @@ fun <A, B, C, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -218,15 +181,7 @@ fun <A, B, C, D, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -246,15 +201,7 @@ fun <A, B, C, D, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -275,15 +222,7 @@ fun <A, B, C, D, E, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -304,15 +243,7 @@ fun <A, B, C, D, E, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -334,15 +265,7 @@ fun <A, B, C, D, E, FF, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -364,15 +287,7 @@ fun <A, B, C, D, E, FF, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -395,15 +310,7 @@ fun <A, B, C, D, E, FF, G, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -426,15 +333,7 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -458,15 +357,7 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -490,15 +381,7 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -523,15 +406,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -556,15 +431,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -590,15 +457,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -626,9 +485,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }"
-  ),
+  ReplaceWith("this.flatMap { aa -> b.map { bb -> Tuple2(aa, bb) } }"),
   DeprecationLevel.WARNING
 )
 fun <A, B, Z> Sequence<A>.map2(arg1: Sequence<B>, arg2: Function1<Tuple2<A, B>, Z>): Sequence<Z> =
@@ -644,14 +501,7 @@ fun <A, B, Z> Sequence<A>.map2(arg1: Sequence<B>, arg2: Function1<Tuple2<A, B>, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B> Sequence<A>.product(arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
   arrow.core.extensions.sequence.apply.Sequence.apply().run {
     arrow.core.SequenceK(this@product).product<A, B>(arrow.core.SequenceK(arg1)) as
@@ -665,14 +515,7 @@ fun <A, B> Sequence<A>.product(arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b), z -> Tuple3(a, b, z) }",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, Z> Sequence<Tuple2<A, B>>.product(arg1: Sequence<Z>): Sequence<Tuple3<A, B, Z>> =
   arrow.core.extensions.sequence.apply.Sequence.apply().run {
     arrow.core.SequenceK(this@product).product<A, B, Z>(arrow.core.SequenceK(arg1)) as
@@ -686,14 +529,7 @@ fun <A, B, Z> Sequence<Tuple2<A, B>>.product(arg1: Sequence<Z>): Sequence<Tuple3
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, Z> Sequence<Tuple3<A, B, C>>.product(arg1: Sequence<Z>): Sequence<Tuple4<A, B, C, Z>> =
   arrow.core.extensions.sequence.apply.Sequence.apply().run {
     arrow.core.SequenceK(this@product).product<A, B, C, Z>(arrow.core.SequenceK(arg1)) as
@@ -707,14 +543,7 @@ fun <A, B, C, Z> Sequence<Tuple3<A, B, C>>.product(arg1: Sequence<Z>): Sequence<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, Z> Sequence<Tuple4<A, B, C, D>>.product(arg1: Sequence<Z>): Sequence<Tuple5<A, B,
     C, D, Z>> = arrow.core.extensions.sequence.apply.Sequence.apply().run {
   arrow.core.SequenceK(this@product).product<A, B, C, D, Z>(arrow.core.SequenceK(arg1)) as
@@ -728,14 +557,7 @@ fun <A, B, C, D, Z> Sequence<Tuple4<A, B, C, D>>.product(arg1: Sequence<Z>): Seq
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, Z> Sequence<Tuple5<A, B, C, D, E>>.product(arg1: Sequence<Z>):
   Sequence<Tuple6<A, B, C, D, E, Z>> = arrow.core.extensions.sequence.apply.Sequence.apply().run {
     arrow.core.SequenceK(this@product).product<A, B, C, D, E, Z>(arrow.core.SequenceK(arg1)) as
@@ -749,14 +571,7 @@ fun <A, B, C, D, E, Z> Sequence<Tuple5<A, B, C, D, E>>.product(arg1: Sequence<Z>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f), z -> Tuple7(a, b, c, d, e, f, z) }",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> Sequence<Tuple6<A, B, C, D, E, FF>>.product(arg1: Sequence<Z>):
   Sequence<Tuple7<A, B, C, D, E, FF, Z>> =
     arrow.core.extensions.sequence.apply.Sequence.apply().run {
@@ -771,14 +586,7 @@ fun <A, B, C, D, E, FF, Z> Sequence<Tuple6<A, B, C, D, E, FF>>.product(arg1: Seq
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f, g), z -> Tuple8(a, b, c, d, e, f, g, z) }",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> Sequence<Tuple7<A, B, C, D, E, FF, G>>.product(arg1: Sequence<Z>):
   Sequence<Tuple8<A, B, C, D, E, FF, G, Z>> =
     arrow.core.extensions.sequence.apply.Sequence.apply().run {
@@ -793,14 +601,7 @@ fun <A, B, C, D, E, FF, G, Z> Sequence<Tuple7<A, B, C, D, E, FF, G>>.product(arg
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f, g, h), z -> Tuple9(a, b, c, d, e, f, g, h, z) }",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> Sequence<Tuple8<A, B, C, D, E, FF, G,
     H>>.product(arg1: Sequence<Z>): Sequence<Tuple9<A, B, C, D, E, FF, G, H, Z>> =
   arrow.core.extensions.sequence.apply.Sequence.apply().run {
@@ -815,14 +616,7 @@ fun <A, B, C, D, E, FF, G, H, Z> Sequence<Tuple8<A, B, C, D, E, FF, G,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f, g, h, i), z -> Tuple10(a, b, c, d, e, f, g, h, i, z) }",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> Sequence<Tuple9<A, B, C, D, E, FF, G, H,
     I>>.product(arg1: Sequence<Z>): Sequence<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
   arrow.core.extensions.sequence.apply.Sequence.apply().run {
@@ -838,15 +632,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Sequence<Tuple9<A, B, C, D, E, FF, G, H,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B> tupled(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
   arrow.core.extensions.sequence.apply.Sequence
     .apply()
@@ -860,15 +646,7 @@ fun <A, B> tupled(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Tuple2<A, B>> 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B> tupledN(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
   arrow.core.extensions.sequence.apply.Sequence
     .apply()
@@ -882,15 +660,7 @@ fun <A, B> tupledN(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Tuple2<A, B>>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -908,15 +678,7 @@ fun <A, B, C> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -934,15 +696,7 @@ fun <A, B, C> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -961,15 +715,7 @@ fun <A, B, C, D> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -988,15 +734,7 @@ fun <A, B, C, D> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1016,15 +754,7 @@ fun <A, B, C, D, E> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1044,15 +774,7 @@ fun <A, B, C, D, E> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1073,15 +795,7 @@ fun <A, B, C, D, E, FF> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1102,15 +816,7 @@ fun <A, B, C, D, E, FF> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1132,15 +838,7 @@ fun <A, B, C, D, E, FF, G> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1162,15 +860,7 @@ fun <A, B, C, D, E, FF, G> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1193,15 +883,7 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1224,15 +906,7 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1256,15 +930,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1288,15 +954,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1321,15 +979,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg0: Sequence<A>,
   arg1: Sequence<B>,
@@ -1376,10 +1026,7 @@ fun <A, B> Sequence<A>.followedBy(arg1: Sequence<B>): Sequence<B> =
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { left, _ -> left }",
-    "arrow.core.zip"
-  ),
+  ReplaceWith("this.flatMap { a -> arg1.map { a } }"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Sequence<A>.apTap(arg1: Sequence<B>): Sequence<A> =

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/apply/SequenceKApply.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/apply/SequenceKApply.kt
@@ -15,6 +15,7 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.SequenceKApply
+import arrow.core.extensions.sequence.apply.SequenceMapNDeprecated
 
 /**
  * cached extension
@@ -93,15 +94,7 @@ fun <A, B, Z> Kind<ForSequenceK, A>.map2Eval(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -117,15 +110,7 @@ fun <A, B, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -141,15 +126,7 @@ fun <A, B, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -166,15 +143,7 @@ fun <A, B, C, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -191,15 +160,7 @@ fun <A, B, C, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -217,15 +178,7 @@ fun <A, B, C, D, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -243,15 +196,7 @@ fun <A, B, C, D, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -270,15 +215,7 @@ fun <A, B, C, D, E, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -297,15 +234,7 @@ fun <A, B, C, D, E, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -325,15 +254,7 @@ fun <A, B, C, D, E, FF, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -353,15 +274,7 @@ fun <A, B, C, D, E, FF, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -383,15 +296,7 @@ fun <A, B, C, D, E, FF, G, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -413,15 +318,7 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -444,15 +341,7 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -475,15 +364,7 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -507,15 +388,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -539,15 +412,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -572,15 +437,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -607,9 +464,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }"
-  ),
+  ReplaceWith("this.flatMap { aa -> arg1.map { bb -> Tuple2(aa, bb) } }"),
   DeprecationLevel.WARNING
 )
 fun <A, B, Z> Kind<ForSequenceK, A>.map2(
@@ -626,14 +481,7 @@ fun <A, B, Z> Kind<ForSequenceK, A>.map2(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B> Kind<ForSequenceK, A>.product(arg1: Kind<ForSequenceK, B>): SequenceK<Tuple2<A, B>> =
   arrow.core.SequenceK.apply().run {
     this@product.product<A, B>(arg1) as arrow.core.SequenceK<arrow.core.Tuple2<A, B>>
@@ -646,14 +494,7 @@ fun <A, B> Kind<ForSequenceK, A>.product(arg1: Kind<ForSequenceK, B>): SequenceK
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b), z -> Tuple3(a, b, z) }",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, Z> Kind<ForSequenceK, Tuple2<A, B>>.product(arg1: Kind<ForSequenceK, Z>):
   SequenceK<Tuple3<A, B, Z>> = arrow.core.SequenceK.apply().run {
     this@product.product<A, B, Z>(arg1) as arrow.core.SequenceK<arrow.core.Tuple3<A, B, Z>>
@@ -666,14 +507,7 @@ fun <A, B, Z> Kind<ForSequenceK, Tuple2<A, B>>.product(arg1: Kind<ForSequenceK, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, Z> Kind<ForSequenceK, Tuple3<A, B, C>>.product(arg1: Kind<ForSequenceK, Z>):
   SequenceK<Tuple4<A, B, C, Z>> = arrow.core.SequenceK.apply().run {
     this@product.product<A, B, C, Z>(arg1) as arrow.core.SequenceK<arrow.core.Tuple4<A, B, C, Z>>
@@ -686,14 +520,7 @@ fun <A, B, C, Z> Kind<ForSequenceK, Tuple3<A, B, C>>.product(arg1: Kind<ForSeque
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, Z> Kind<ForSequenceK, Tuple4<A, B, C, D>>.product(arg1: Kind<ForSequenceK, Z>):
   SequenceK<Tuple5<A, B, C, D, Z>> = arrow.core.SequenceK.apply().run {
     this@product.product<A, B, C, D, Z>(arg1) as arrow.core.SequenceK<arrow.core.Tuple5<A, B, C, D,
@@ -707,14 +534,7 @@ fun <A, B, C, D, Z> Kind<ForSequenceK, Tuple4<A, B, C, D>>.product(arg1: Kind<Fo
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, Z> Kind<ForSequenceK, Tuple5<A, B, C, D, E>>.product(
   arg1: Kind<ForSequenceK, Z>
 ): SequenceK<Tuple6<A, B, C, D, E, Z>> = arrow.core.SequenceK.apply().run {
@@ -729,14 +549,7 @@ fun <A, B, C, D, E, Z> Kind<ForSequenceK, Tuple5<A, B, C, D, E>>.product(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f), z -> Tuple7(a, b, c, d, e, f, z) }",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, Z> Kind<ForSequenceK, Tuple6<A, B, C, D, E,
     FF>>.product(arg1: Kind<ForSequenceK, Z>): SequenceK<Tuple7<A, B, C, D, E, FF, Z>> =
   arrow.core.SequenceK.apply().run {
@@ -751,14 +564,7 @@ fun <A, B, C, D, E, FF, Z> Kind<ForSequenceK, Tuple6<A, B, C, D, E,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f, g), z -> Tuple8(a, b, c, d, e, f, g, z) }",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, Z> Kind<ForSequenceK, Tuple7<A, B, C, D, E, FF,
     G>>.product(arg1: Kind<ForSequenceK, Z>): SequenceK<Tuple8<A, B, C, D, E, FF, G, Z>> =
   arrow.core.SequenceK.apply().run {
@@ -773,14 +579,7 @@ fun <A, B, C, D, E, FF, G, Z> Kind<ForSequenceK, Tuple7<A, B, C, D, E, FF,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f, g, h), z -> Tuple9(a, b, c, d, e, f, g, h, z) }",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, Z> Kind<ForSequenceK, Tuple8<A, B, C, D, E, FF, G,
     H>>.product(arg1: Kind<ForSequenceK, Z>): SequenceK<Tuple9<A, B, C, D, E, FF, G, H, Z>> =
   arrow.core.SequenceK.apply().run {
@@ -795,14 +594,7 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<ForSequenceK, Tuple8<A, B, C, D, E, FF, G,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { (a, b, c, d, e, f, g, h, i), z -> Tuple10(a, b, c, d, e, f, g, h, i, z) }",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForSequenceK, Tuple9<A, B, C, D, E, FF, G, H,
     I>>.product(arg1: Kind<ForSequenceK, Z>): SequenceK<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
   arrow.core.SequenceK.apply().run {
@@ -817,15 +609,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForSequenceK, Tuple9<A, B, C, D, E, FF,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B> tupled(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): SequenceK<Tuple2<A, B>> =
   arrow.core.SequenceK
     .apply()
@@ -838,15 +622,7 @@ fun <A, B> tupled(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): Seq
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple2"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B> tupledN(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): SequenceK<Tuple2<A,
     B>> = arrow.core.SequenceK
   .apply()
@@ -859,15 +635,7 @@ fun <A, B> tupledN(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): Se
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -883,15 +651,7 @@ fun <A, B, C> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple3"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -907,15 +667,7 @@ fun <A, B, C> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -933,15 +685,7 @@ fun <A, B, C, D> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -959,15 +703,7 @@ fun <A, B, C, D> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -986,15 +722,7 @@ fun <A, B, C, D, E> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1013,15 +741,7 @@ fun <A, B, C, D, E> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1041,15 +761,7 @@ fun <A, B, C, D, E, FF> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1069,15 +781,7 @@ fun <A, B, C, D, E, FF> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1098,15 +802,7 @@ fun <A, B, C, D, E, FF, G> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1127,15 +823,7 @@ fun <A, B, C, D, E, FF, G> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1157,15 +845,7 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1187,15 +867,7 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1218,15 +890,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1249,15 +913,7 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1282,15 +938,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "arg0.zip(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
-    "arrow.core.zip",
-    "arrow.core.Tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(SequenceMapNDeprecated)
 fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg0: Kind<ForSequenceK, A>,
   arg1: Kind<ForSequenceK, B>,
@@ -1336,10 +984,7 @@ fun <A, B> Kind<ForSequenceK, A>.followedBy(arg1: Kind<ForSequenceK, B>): Sequen
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.zip(arg1) { left, _ -> left }",
-    "arrow.core.zip"
-  ),
+  ReplaceWith("this.flatMap { aa -> arg1.map { a } }"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<ForSequenceK, A>.apTap(arg1: Kind<ForSequenceK, B>): SequenceK<A> =

--- a/arrow-site/docs/docs/datatypes/nonemptylist/README.md
+++ b/arrow-site/docs/docs/datatypes/nonemptylist/README.md
@@ -122,7 +122,7 @@ val nelId: NonEmptyList<UUID> = NonEmptyList.of(UUID.randomUUID(), UUID.randomUU
 val nelName: NonEmptyList<String> = NonEmptyList.of("William Alvin Howard", "Haskell Curry")
 val nelYear: NonEmptyList<Int> = NonEmptyList.of(1926, 1900)
 
-NonEmptyList.mapN(nelId, nelName, nelYear) { id, name, year ->
+nelId.zip(nelName, nelYear) { id, name, year ->
   Person(id, name, year)
 }
 ```


### PR DESCRIPTION
This PR updates/fixes some `zip` implementations and adds tests for it.
It also deprecates `mapN` for collections, which were cartesian builders. For collections, this easily results in really big lists that make the JVM OOM.

Example of dangerous usage:

```kotlin
val x: List<Int> = listOf(1, 2, 3, 4, 5, 6)

// OOMs
val result = mapN(x, x, x, x, x, x, x, x, x, x, ::Tuple10)
```

This tries to create a list with 6^10 (60466176) elements and as a result OOMs. As you can see this easily results in bad code since here we're only using a list with 6 elements and it already results in problematic code.

Since this pattern isn't so common and is only safe with low arities we will recommend to simply use `flatMap/map` chains instead.