### PR TITLE
CU-fv6x6d Clean up Arrow Fx based on API Review

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/UnsafePromise.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/UnsafePromise.kt
@@ -7,6 +7,7 @@ import kotlinx.atomicfu.atomic
  * An eager Promise implementation to bridge results across processes internally.
  * @see ForkAndForget
  */
+@Deprecated("UnsafePromise is deprecated. Same use-cases covered by KotlinX CompletableDeferred.")
 class UnsafePromise<A> {
 
   private sealed class State<out A> {

--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/startCoroutineCancellable.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/startCoroutineCancellable.kt
@@ -11,7 +11,7 @@ import kotlin.coroutines.resume
  * Type to constraint [startCoroutineCancellable] to the [CancellableContinuation] constructor.
  */
 @Deprecated("Use KotlinX structured concurrency as unsafe Environment to launch side-effects from non-suspending code")
-abstract class CancellableContinuation<A> internal constructor() : Continuation<A>
+interface CancellableContinuation<A> : Continuation<A>
 
 /** Constructor for [CancellableContinuation] */
 @Suppress("FunctionName")
@@ -47,7 +47,7 @@ internal fun <A> CancellableContinuation(
   ctx: CoroutineContext = Dispatchers.Default,
   conn: SuspendConnection,
   resumeWith: (Result<A>) -> Unit
-): CancellableContinuation<A> = object : CancellableContinuation<A>() {
+): CancellableContinuation<A> = object : CancellableContinuation<A> {
   override val context: CoroutineContext = conn + ctx // Faster in case ctx is EmptyCoroutineContext
   override fun resumeWith(result: Result<A>) {
     if (conn.isNotCancelled()) resumeWith(result)

--- a/arrow-libs/fx/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -62,26 +62,6 @@ class ResourceTest : ArrowFxSpec(
       }
     }
 
-    "traverseFilterResource: identity" {
-      checkAll(
-        Arb.list(Arb.int()),
-        Arb.functionAToB<Int, String?>(Arb.nullable(Arb.string()))
-      ) { list, f ->
-        list.traverseFilterResource { Resource.just(f(it)) } resourceShouldBe Resource.just(list.mapNotNull(f))
-      }
-    }
-
-    "flatTraverseFilterResource: identity" {
-      checkAll(
-        Arb.list(Arb.int()),
-        Arb.functionAToB<Int, List<String?>>(Arb.list(Arb.nullable(Arb.string())))
-      ) { list, f ->
-        list.flatTraverseFilterResource { Resource.just(f(it)) } resourceShouldBe Resource.just(
-          list.flatMap(f).filterNotNull()
-        )
-      }
-    }
-
     "traverseResource: identity" {
       checkAll(
         Arb.list(Arb.int()),
@@ -99,16 +79,6 @@ class ResourceTest : ArrowFxSpec(
         list.traverseResource(f) resourceShouldBe list.map(f).sequence()
       }
     }
-
-    "flatTraverseResource: map + flatSequence == flatTraverse" {
-      checkAll(
-        Arb.list(Arb.int()),
-        Arb.list(Arb.string()).map { { _: Int -> Resource.just(it) } }
-      ) { list, f ->
-        list.flatTraverseResource(f) resourceShouldBe list.map(f).flatSequence()
-      }
-    }
-
     "traverseResource: parallelComposition" {
       checkAll(
         Arb.list(Arb.int()),
@@ -124,17 +94,6 @@ class ResourceTest : ArrowFxSpec(
         }
 
         list.traverseResource { Resource.just(f(it) to g(it)) } resourceShouldBe result
-      }
-    }
-
-    "traverseResource: sequentialComposition" {
-      checkAll(
-        Arb.list(Arb.int()),
-        Arb.functionAToB<Int, String>(Arb.string()),
-        Arb.functionAToB<String, Long>(Arb.long())
-      ) { list, f, g ->
-        list.traverseResource { Resource.just(f(it)) }
-          .map { it.map(g) } resourceShouldBe list.traverseFilterResource { Resource.just(g(f(it))) }
       }
     }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
-import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.string
 


### PR DESCRIPTION
This PR cleans up the API for Arrow Syntax for Arrow 0.13.0 (1.0.0). The API review can be found [here](https://github.com/nomisRev/arrow-api-review/pull/2/files?file-filters%5B%5D=.api)

- Revert CancellableContinuation changes
- Remove Resource.unit
- Clean-up Resource traverse API
- Add deprecation UnsafePromise