### PR TITLE
Clean-up new code & breaking changes since 0.12.0

### DIFF
--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1401,17 +1401,6 @@ fun <A, B> EitherOf<A, B>.contains(elem: B): Boolean =
 fun <A, B, C> EitherOf<A, B>.ap(ff: EitherOf<A, (B) -> C>): Either<A, C> =
   fix().zip(ff.fix()) { a, f -> f(a) }
 
-@Deprecated(
-  "apEval is deprecated alongside the Apply typeclass, since it's a low-level operator specific for generically deriving Apply combinators.",
-  ReplaceWith(
-    "fold({ l -> Eval.now(l.left()) }, { r -> ff.map { it.map { f -> f(r) } } })",
-    "arrow.core.Eval",
-    "arrow.core.left"
-  )
-)
-fun <A, B, C> Either<A, B>.apEval(ff: Eval<Either<A, (B) -> C>>): Eval<Either<A, C>> =
-  fold({ l -> Eval.now(l.left()) }, { r -> ff.map { it.map { f -> f(r) } } })
-
 fun <A, B> EitherOf<A, B>.combineK(y: EitherOf<A, B>): Either<A, B> =
   when (this) {
     is Left -> y.fix()

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -692,16 +692,6 @@ inline fun <A, B, D> Ior<A, B>.flatMap(SG: Semigroup<A>, f: (B) -> Ior<A, D>): I
 fun <A, B, D> Ior<A, B>.ap(SG: Semigroup<A>, ff: IorOf<A, (B) -> D>): Ior<A, D> =
   zip(SG, ff.fix()) { a, f -> f(a) }
 
-@Deprecated(
-  "apEval is deprecated alongside the Apply typeclass, since it's a low-level operator specific for generically deriving Apply combinators.",
-  ReplaceWith(
-    "ff.map { fff -> zip(SG, fff) { a, f -> f(a) } }",
-    "arrow.core.zip"
-  )
-)
-fun <A, B, D> Ior<A, B>.apEval(SG: Semigroup<A>, ff: Eval<Ior<A, (B) -> D>>): Eval<Ior<A, D>> =
-  ff.map { fff -> zip(SG, fff) { a, f -> f(a) } }
-
 inline fun <A, B> Ior<A, B>.getOrElse(default: () -> B): B =
   fold({ default() }, ::identity, { _, b -> b })
 

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -509,9 +509,6 @@ operator fun <A : Comparable<A>> NonEmptyList<A>.compareTo(other: NonEmptyList<A
 fun <A> NonEmptyList<NonEmptyList<A>>.flatten(): NonEmptyList<A> =
   this.flatMap(::identity)
 
-fun <A, B> NonEmptyList<Either<A, B>>.selectM(f: NonEmptyList<(A) -> B>): NonEmptyList<B> =
-  this.flatMap { it.fold({ a -> f.map { ff -> ff(a) } }, { b -> NonEmptyList.just(b) }) }
-
 fun <A, B> NonEmptyList<Pair<A, B>>.unzip(): Pair<NonEmptyList<A>, NonEmptyList<B>> =
   this.unzip(::identity)
 

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -658,7 +658,7 @@ fun <E, A, B> Sequence<A>.traverseValidated(
   f: (A) -> Validated<E, B>
 ): Validated<E, Sequence<B>> =
   foldRight<A, Validated<E, Sequence<B>>>(Eval.now(emptySequence<B>().valid())) { a, acc ->
-    f(a).apEval(semigroup, acc.map { it.map { bs -> { b: B -> sequenceOf(b) + bs } } })
+    acc.map { f(a).zip(semigroup, it) { b, bs -> sequenceOf(b) + bs } }
   }.value()
 
 /**

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Tuple3.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Tuple3.kt
@@ -37,6 +37,8 @@ inline fun <A, B, C> Tuple3Of<A, B, C>.fix(): Tuple3<A, B, C> =
 
 @Deprecated("Deprecated in favor of Kotlin's Triple", ReplaceWith("Triple(a, b, c)"))
 data class Tuple3<out A, out B, out C>(val a: A, val b: B, val c: C) : Tuple3Of<A, B, C> {
+  fun reverse(): Tuple3<C, B, A> = Tuple3(c, b, a)
+
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }).joinToString(", ") + ")"

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1159,17 +1159,6 @@ inline fun <E, A, B> ValidatedOf<E, A>.ap(SE: Semigroup<E>, f: Validated<E, (A) 
   fix().zip(SE, f) { a, ff -> ff(a) }
 
 @Deprecated(
-  "apEval is deprecated alongside the Apply typeclass, since it's a low-level operator specific for generically deriving Apply combinators.",
-  ReplaceWith(
-    "fold({ l -> Eval.now(l.left()) }, { r -> ff.map { it.map { f -> f(r) } } })",
-    "arrow.core.Eval",
-    "arrow.core.left"
-  )
-)
-fun <E, A, B> Validated<E, A>.apEval(SE: Semigroup<E>, ff: Eval<Validated<E, (A) -> B>>): Eval<Validated<E, B>> =
-  ff.map { f -> zip(SE, f) { a, ff -> ff(a) } }
-
-@Deprecated(
   "To keep API consistent with Either and Option please use `handleErrorWith` instead",
   ReplaceWith("handleErrorWith(f)")
 )

--- a/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
+++ b/arrow-libs/core/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
@@ -26,9 +26,3 @@ interface Applicative<F> : Apply<F> {
     if (n <= 0) just(MA.empty())
     else mapN(this@replicate, replicate(n - 1, MA)) { (a: A, xs: A) -> MA.run { a + xs } }
 }
-
-@Deprecated("Applicative typeclass is deprecated")
-fun <F, A> Monoid<A>.lift(ap: Applicative<F>): Monoid<Kind<F, A>> = object : Monoid<Kind<F, A>> {
-  override fun empty(): Kind<F, A> = ap.just(this@lift.empty())
-  override fun Kind<F, A>.combine(b: Kind<F, A>): Kind<F, A> = with(ap) { map2(b) { it.a.combine(it.b) } }
-}

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
@@ -354,7 +354,7 @@ fun <B> Kind<ForNonEmptyList, Boolean>.ifM(
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith("flatMap { it.fold({ a -> arg1.map { ff -> ff(a) } }, { b -> NonEmptyList.just(b) }) }"),
+  ReplaceWith("flatMap { it.fold({ a -> arg1.map { ff -> ff(a) } }, { b -> nonEmptyListOf(b) }) }", "arrow.core.nonEmptyListOf"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<ForNonEmptyList, Either<A, B>>.selectM(


### PR DESCRIPTION
This PR fixes breaking changes between 0.11.0 & 0.12.0 in `Tuple3#reverse` which was abruptly removed.

It also removes some newly added code that is not desired and got deprecated immediately, the reason these were added along the way was that they were used in some APIs like `traverseXXX`.
 - Either#apEval
 - Ior#apEval
 - Validated#apEval
 - NonEmptyList#selectM
 - Monoid<A>#lift
 
 
This was observed on the API review repo: https://github.com/nomisRev/arrow-api-review/pull/2
After updating it with merged PRs:
 - https://github.com/arrow-kt/arrow/pull/2330
 - https://github.com/arrow-kt/arrow/pull/2329
 - https://github.com/arrow-kt/arrow/pull/2328