### PR TITLE
Arrow Fx: Clean-up new code & breaking changes since 0.12.0

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines-test/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines-test/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
@@ -4,6 +4,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.string
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.completeWith
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
@@ -14,17 +16,17 @@ class PredefTest : ArrowFxSpec(
 
     "suspended always suspends" {
       checkAll(Arb.int()) { i ->
-        val promise = UnsafePromise<Int>()
+        val promise = CompletableDeferred<Int>()
 
         val x = i.suspended()
           .startCoroutineUninterceptedOrReturn(
             Continuation(EmptyCoroutineContext) {
-              promise.complete(it)
+              promise.completeWith(it)
             }
           )
 
         x shouldBe COROUTINE_SUSPENDED
-        promise.join() shouldBe i
+        promise.await() shouldBe i
       }
     }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/UnsafePromise.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/UnsafePromise.kt
@@ -8,7 +8,7 @@ import kotlinx.atomicfu.atomic
  * @see ForkAndForget
  */
 @Deprecated("UnsafePromise is deprecated. Same use-cases covered by KotlinX CompletableDeferred.")
-class UnsafePromise<A> {
+internal class UnsafePromise<A> {
 
   private sealed class State<out A> {
     object Empty : State<Nothing>()

--- a/arrow-libs/fx/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ConcurrentVarTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ConcurrentVarTest.kt
@@ -1,8 +1,6 @@
 package arrow.fx.coroutines
 
 import arrow.core.Either
-import arrow.core.toT
-import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlin.time.ExperimentalTime
@@ -229,67 +227,6 @@ class ConcurrentVarTest : ArrowFxSpec(
       mVar.put(10)
       val fallback = suspend { delay(200.milliseconds); 0 }
       raceN(finished::get, fallback) shouldBe Either.Right(0)
-    }
-
-    "withConcurrentVar applies the correct value" {
-      val mVar = ConcurrentVar(10)
-      mVar.withConcurrentVar { it } shouldBe 10
-      mVar.take() shouldBe 10
-    }
-
-    "withConcurrentVar is exception safe" {
-      val mVar = ConcurrentVar(10)
-      Either.catch { mVar.withConcurrentVar { throw Throwable("Hello") } }
-        .fold({}, { fail("The impossible happened") })
-      mVar.take() shouldBe 10
-    }
-    "withConcurrentVar is cancellation safe" {
-      val mVar = ConcurrentVar(10)
-      val started = Promise<Int>()
-      val finished = Promise<Unit>()
-      val fiber = ForkAndForget {
-        mVar.withConcurrentVar {
-          started.complete(it)
-          never<Unit>()
-          finished.complete(Unit)
-        }
-      }
-      delay(100.milliseconds)
-      fiber.cancel()
-      started.tryGet() shouldBe 10
-      finished.tryGet() shouldBe null
-      mVar.tryTake() shouldBe 10
-    }
-
-    "modify applies the correct value, returns the second parameter and sets the first" {
-      val mVar = ConcurrentVar(10)
-      mVar.modify { it + 1 toT "Hello" } shouldBe "Hello"
-      mVar.take() shouldBe 11
-    }
-
-    "modify is exception safe" {
-      val mVar = ConcurrentVar(10)
-      Either.catch { mVar.modify_ { throw Throwable("Hello") } }
-        .fold({}, { fail("The impossible happened") })
-      mVar.take() shouldBe 10
-    }
-    "modify is cancellation safe" {
-      val mVar = ConcurrentVar(10)
-      val started = Promise<Int>()
-      val finished = Promise<Unit>()
-      val fiber = ForkAndForget {
-        mVar.modify_ {
-          started.complete(it)
-          never<Unit>()
-          finished.complete(Unit)
-          it + 1
-        }
-      }
-      delay(10.milliseconds)
-      fiber.cancel()
-      started.get() shouldBe 10
-      finished.tryGet() shouldBe null
-      mVar.take() shouldBe 10
     }
   }
 )

--- a/arrow-libs/fx/arrow-fx-stm/src/main/kotlin/arrow/fx/stm/STM.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/main/kotlin/arrow/fx/stm/STM.kt
@@ -1,6 +1,5 @@
 package arrow.fx.stm
 
-import arrow.core.Tuple2
 import arrow.fx.stm.internal.STMTransaction
 import arrow.fx.stm.internal.alterHamtWithHash
 import arrow.fx.stm.internal.lookupHamtWithHash
@@ -1314,30 +1313,6 @@ interface STM {
    * ```
    */
   operator fun <K, V> TMap<K, V>.set(k: K, v: V): Unit = insert(k, v)
-
-  /**
-   * Add a key value pair to the map
-   *
-   * ```kotlin:ank:playground
-   * import arrow.core.toT
-   * import arrow.fx.stm.TMap
-   * import arrow.fx.stm.atomically
-   *
-   * suspend fun main() {
-   *   //sampleStart
-   *   val tmap = TMap.new<Int, String>()
-   *   atomically {
-   *     tmap += (1 toT "Hello")
-   *   }
-   *   //sampleEnd
-   * }
-   * ```
-   */
-  @Deprecated(
-    "Deprecated in favor of Kotlin's Pair",
-    ReplaceWith("this.plusAssign(Pair(kv.a, kv.b))")
-  )
-  operator fun <K, V> TMap<K, V>.plusAssign(kv: Tuple2<K, V>): Unit = insert(kv.a, kv.b)
 
   /**
    * Add a key value pair to the map

--- a/arrow-libs/fx/arrow-fx-stm/src/main/kotlin/arrow/fx/stm/TMap.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/main/kotlin/arrow/fx/stm/TMap.kt
@@ -70,7 +70,6 @@ fun <K, V> STM.newTMap(hash: Hash<K>): TMap<K, V> = newTMap { hash.run { it.hash
  *
  * ```kotlin:ank:playground
  * import arrow.fx.stm.TMap
- * import arrow.core.toT
  * import arrow.fx.stm.atomically
  *
  * suspend fun main() {
@@ -78,7 +77,7 @@ fun <K, V> STM.newTMap(hash: Hash<K>): TMap<K, V> = newTMap { hash.run { it.hash
  *   val tmap = TMap.new<Int, String>()
  *   atomically {
  *     tmap += (1 to "Hello")
- *     tmap += (2 toT "World")
+ *     tmap += (2 to "World")
  *   }
  *   //sampleEnd
  * }


### PR DESCRIPTION
It also removes some newly added code that is not desired and got deprecated immediately.
 - ConcurrentVar#modify
 - ConcurrentVar#modify_
 - ConcurrentVar#withConcurrentVar
 - TMap<K, V>#plusAssign
 
Also, this PR reverts making `UnsafePromise` public in `0.12.0`