### PR TITLE
Configuration: fix steps order

### DIFF
--- a/.github/workflows/publish_arrow-stack.yml
+++ b/.github/workflows/publish_arrow-stack.yml
@@ -23,13 +23,13 @@ jobs:
         working-directory: arrow-stack
 
     steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set env
       run: |
         echo "$JAVA_HOME_8_X64/bin" >> $GITHUB_PATH
         echo "JAVA_HOME=$JAVA_HOME_8_X64" >> $GITHUB_ENV
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: "Check versions"
       id: versions
       run: |


### PR DESCRIPTION
All the steps for Arrow Stack are using a working directory so the setup should appear after the checkout.