### PR TITLE
Documentation: fix versions menu

### DIFF
--- a/arrow-site/docs/_data/doc-versions.yml
+++ b/arrow-site/docs/_data/doc-versions.yml
@@ -1,9 +1,5 @@
 docVersions:
 
-    - title: "v0.9.0"
-      url: https://arrow-kt.io/docs/0.9/
-      previous: https://arrow-kt.io/docs/0.8/
-
     - title: "v0.10.5"
       url: https://arrow-kt.io/docs/0.10/
       previous: https://arrow-kt.io/docs/0.9/

--- a/arrow-site/docs/_includes/_sidebar-doc-versions.html
+++ b/arrow-site/docs/_includes/_sidebar-doc-versions.html
@@ -38,12 +38,18 @@
         </a>
       </li>
 
+      <li>
+        <a href="https://arrow-kt.io/docs/0.9/">
+          <span>v0.9.0</span>
+        </a>
+      </li>
+
       {% for item in site.data.doc-versions.docVersions %}
       {% if item.url != stable_version.url
             and item.url != next_version.url
             and item.url != previous_version.url %}
       <li>
-        <a href="{{ item.url }}">
+        <a href="{{ item.url | append: doc-link }}">
           <span>{{ item.title }}</span>
         </a>
       </li>


### PR DESCRIPTION
Remove 0.9.0 from the list and add its entry explicitly because it doesn't follow the same URLs from 0.10.x