### PR TITLE
Setup contracts for Sumtypes to improve compiler autocasts.

### DIFF
--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Nullable.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Nullable.kt
@@ -2,39 +2,75 @@
 
 package arrow.core
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
 object Nullable {
 
   @JvmStatic
-  inline fun <A, R> zip(a: A?, fn: (A) -> R): R? =
-    zip(a, Unit) { a, _ -> fn(a) }
+  inline fun <A, R> zip(a: A?, fn: (A) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null)
+    }
+    return zip(a, Unit) { a, _ -> fn(a) }
+  }
 
   @JvmStatic
-  inline fun <A, B, R> zip(a: A?, b: B?, fn: (A, B) -> R): R? =
-    zip(a, b, Unit) { a, b, _ -> fn(a, b) }
+  inline fun <A, B, R> zip(a: A?, b: B?, fn: (A, B) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null)
+    }
+    return zip(a, b, Unit) { a, b, _ -> fn(a, b) }
+  }
 
   @JvmStatic
-  inline fun <A, B, C, R> zip(a: A?, b: B?, c: C?, fn: (A, B, C) -> R): R? =
-    zip(a, b, c, Unit) { a, b, c, _ -> fn(a, b, c) }
+  inline fun <A, B, C, R> zip(a: A?, b: B?, c: C?, fn: (A, B, C) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null)
+    }
+    return zip(a, b, c, Unit) { a, b, c, _ -> fn(a, b, c) }
+  }
 
   @JvmStatic
-  inline fun <A, B, C, D, R> zip(a: A?, b: B?, c: C?, d: D?, fn: (A, B, C, D) -> R): R? =
-    zip(a, b, c, d, Unit) { a, b, c, d, _ -> fn(a, b, c, d) }
+  inline fun <A, B, C, D, R> zip(a: A?, b: B?, c: C?, d: D?, fn: (A, B, C, D) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null)
+    }
+    return zip(a, b, c, d, Unit) { a, b, c, d, _ -> fn(a, b, c, d) }
+  }
 
   @JvmStatic
-  inline fun <A, B, C, D, E, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, fn: (A, B, C, D, E) -> R): R? =
-    zip(a, b, c, d, e, Unit) { a, b, c, d, e, _ -> fn(a, b, c, d, e) }
+  inline fun <A, B, C, D, E, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, fn: (A, B, C, D, E) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null && e != null)
+    }
+    return zip(a, b, c, d, e, Unit) { a, b, c, d, e, _ -> fn(a, b, c, d, e) }
+  }
 
   @JvmStatic
-  inline fun <A, B, C, D, E, F, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, fn: (A, B, C, D, E, F) -> R): R? =
-    zip(a, b, c, d, e, f, Unit) { a, b, c, d, e, f, _ -> fn(a, b, c, d, e, f) }
+  inline fun <A, B, C, D, E, F, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, fn: (A, B, C, D, E, F) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null && e != null && f != null)
+    }
+    return zip(a, b, c, d, e, f, Unit) { a, b, c, d, e, f, _ -> fn(a, b, c, d, e, f) }
+  }
 
   @JvmStatic
-  inline fun <A, B, C, D, E, F, G, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, fn: (A, B, C, D, E, F, G) -> R): R? =
-    zip(a, b, c, d, e, f, g, Unit) { a, b, c, d, e, f, g, _ -> fn(a, b, c, d, e, f, g) }
+  inline fun <A, B, C, D, E, F, G, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, fn: (A, B, C, D, E, F, G) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null && e != null && f != null && g != null)
+    }
+    return zip(a, b, c, d, e, f, g, Unit) { a, b, c, d, e, f, g, _ -> fn(a, b, c, d, e, f, g) }
+  }
 
   @JvmStatic
-  inline fun <A, B, C, D, E, F, G, H, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, fn: (A, B, C, D, E, F, G, H) -> R): R? =
-    zip(a, b, c, d, e, f, g, h, Unit) { a, b, c, d, e, f, g, h, _ -> fn(a, b, c, d, e, f, g, h) }
+  inline fun <A, B, C, D, E, F, G, H, R> zip(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, fn: (A, B, C, D, E, F, G, H) -> R): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null && e != null && f != null && g != null && h != null)
+    }
+    return zip(a, b, c, d, e, f, g, h, Unit) { a, b, c, d, e, f, g, h, _ -> fn(a, b, c, d, e, f, g, h) }
+  }
 
   @JvmStatic
   inline fun <A, B, C, D, E, F, G, H, I, R> zip(
@@ -48,8 +84,12 @@ object Nullable {
     h: H?,
     i: I?,
     fn: (A, B, C, D, E, F, G, H, I) -> R
-  ): R? =
-    zip(a, b, c, d, e, f, g, h, i, Unit) { a, b, c, d, e, f, g, h, i, _ -> fn(a, b, c, d, e, f, g, h, i) }
+  ): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null && e != null && f != null && g != null && h != null && i != null)
+    }
+    return zip(a, b, c, d, e, f, g, h, i, Unit) { a, b, c, d, e, f, g, h, i, _ -> fn(a, b, c, d, e, f, g, h, i) }
+  }
 
   @JvmStatic
   inline fun <A, B, C, D, E, F, G, H, I, J, R> zip(
@@ -64,8 +104,11 @@ object Nullable {
     i: I?,
     j: J?,
     fn: (A, B, C, D, E, F, G, H, I, J) -> R
-  ): R? =
-    a?.let { a ->
+  ): R? {
+    contract {
+      returnsNotNull() implies (a != null && b != null && c != null && d != null && e != null && f != null && g != null && h != null && i != null && j != null)
+    }
+    return a?.let { a ->
       b?.let { b ->
         c?.let { c ->
           d?.let { d ->
@@ -86,4 +129,5 @@ object Nullable {
         }
       }
     }
+  }
 }


### PR DESCRIPTION
Not sure this is wanted, but this may help the compiler provide a few obvious invariants to the user:
- `zip(nullableA, nullableB, f)?.let { // now nullableA and nullableB should be proven not null }`
- `if (either.exists(f)) /** { either should be proven Right here } */ else /** { either is either left or right here } */`
- `if (ior.isEmpty()) /** { ior is Left } */ else /** { ior is either Right or Both } */`

All of this is annoying to do manually, by using contracts we can prove it automatically. This can be extended quite a bit more by adding `callsInPlace(f, InvocationKind)` in modules, which allows more flexible non-local returns (a return from a function with `InvocationKind` `EXACTLY_ONCE` or `AT_LEAST_ONCE` tells the compiler no other branch outside the lambda needs to be checked for returns. Also some var assignment stuff becomes possible with those contracts, but imo the most important bits are non-local returns in inline functions and sumtype assertions/autocasts.

This does require the flag `ExperimentalContractApi` tho, so not sure what to do about that. Should it be `OptIn` or per method? Or can we enable this globally somehow?