### PR TITLE
Deprecate foldRight and all lazy folds

### DIFF
--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Either.kt
@@ -764,6 +764,7 @@ sealed class Either<out A, out B> {
       is Left -> initial
     }
 
+  @Deprecated(FoldRightDeprecation)
   inline fun <C> foldRight(initial: Eval<C>, crossinline rightOperation: (B, Eval<C>) -> Eval<C>): Eval<C> =
     when (this) {
       is Right -> Eval.defer { rightOperation(value, initial) }
@@ -777,6 +778,7 @@ sealed class Either<out A, out B> {
   inline fun <C> bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fold({ f(c, it) }, { g(c, it) })
 
+  @Deprecated(FoldRightDeprecation)
   inline fun <C> bifoldRight(c: Eval<C>, f: (A, Eval<C>) -> Eval<C>, g: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fold({ f(it, c) }, { g(it, c) })
 

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
@@ -151,6 +151,7 @@ sealed class Ior<out A, out B> {
   inline fun <C> foldLeft(c: C, f: (C, B) -> C): C =
     fold({ c }, { f(c, it) }, { _, b -> f(c, b) })
 
+  @Deprecated(FoldRightDeprecation)
   inline fun <C> foldRight(lc: Eval<C>, crossinline f: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fold({ lc }, { Eval.defer { f(it, lc) } }, { _, b -> Eval.defer { f(b, lc) } })
 
@@ -161,6 +162,7 @@ sealed class Ior<out A, out B> {
   inline fun <C> bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fold({ f(c, it) }, { g(c, it) }, { a, b -> g(f(c, a), b) })
 
+  @Deprecated(FoldRightDeprecation)
   inline fun <C> bifoldRight(c: Eval<C>, f: (A, Eval<C>) -> Eval<C>, g: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fold({ f(it, c) }, { g(it, c) }, { a, b -> f(a, g(b, c)) })
 

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
@@ -281,6 +281,7 @@ inline fun <B, C, D, E, F, G, H, I, J, K, L> Iterable<B>.zip(
 internal fun <T> Iterable<T>.collectionSizeOrDefault(default: Int): Int =
   if (this is Collection<*>) this.size else default
 
+@Deprecated("Iterable.foldRight is being deprecated because its functionality differs from other foldRight definitions within arrow. Use the stdlib foldRight instead", replaceWith = ReplaceWith("foldRight(initial) { acc, b -> operation(b, acc) }"))
 inline fun <A, B> Iterable<A>.foldRight(initial: B, operation: (A, acc: B) -> B): B =
   when (this) {
     is List -> _foldRight(initial, operation)
@@ -331,6 +332,7 @@ fun <E, A> Iterable<ValidatedNel<E, A>>.sequenceValidated(): ValidatedNel<E, Lis
 fun <A> Iterable<A>.void(): List<Unit> =
   map { Unit }
 
+@Deprecated(FoldRightDeprecation)
 fun <A, B> List<A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> {
   fun loop(fa_p: List<A>): Eval<B> = when {
     fa_p.isEmpty() -> lb
@@ -350,6 +352,7 @@ fun <A, B> Iterable<A>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A) ->
   return accumulator
 }
 
+@Deprecated(FoldRightDeprecation)
 inline fun <A, B> List<A>.reduceRightEvalOrNull(
   initial: (A) -> B,
   operation: (A, acc: Eval<B>) -> Eval<B>

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -179,6 +179,7 @@ class NonEmptyList<out A>(
   inline fun <B> foldLeft(b: B, f: (B, A) -> B): B =
     this.tail.fold(f(b, this.head), f)
 
+  @Deprecated(FoldRightDeprecation)
   fun <B> foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
     all.foldRight(lb, f)
 

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -626,6 +626,7 @@ sealed class Option<out A> {
       is None -> initial
     }
 
+  @Deprecated(FoldRightDeprecation)
   inline fun <B> foldRight(initial: Eval<B>, crossinline operation: (A, Eval<B>) -> Eval<B>): Eval<B> =
     when (this) {
       is Some -> Eval.defer { operation(value, initial) }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Sequence.kt
@@ -347,6 +347,7 @@ fun <A, B> Sequence<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
   }
 }
 
+@Deprecated(FoldRightDeprecation)
 fun <A, B> Sequence<A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> {
   fun Iterator<A>.loop(): Eval<B> =
     if (hasNext()) f(next(), Eval.defer { loop() }) else lb
@@ -512,6 +513,7 @@ fun <A, B> Sequence<A>.padZip(other: Sequence<B>): Sequence<Pair<A?, B?>> =
 fun <A, B, C> Sequence<A>.padZip(other: Sequence<B>, fa: (A?, B?) -> C): Sequence<C> =
   padZip(other).map { fa(it.first, it.second) }
 
+@Deprecated(FoldRightDeprecation)
 fun <A, B> Sequence<A>.reduceRightEvalOrNull(
   initial: (A) -> B,
   operation: (A, acc: Eval<B>) -> Eval<B>

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/SortedMapK.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/SortedMapK.kt
@@ -8,5 +8,6 @@ fun <A, B, C> SortedMap<A, B>.foldLeft(b: SortedMap<A, C>, f: (SortedMap<A, C>, 
   return result
 }
 
+@Deprecated("SortedMap<K, A>.foldRight is being deprecated because its functionality differs from other definitions of foldRight within arrow.")
 fun <A : Comparable<A>, B, C> SortedMap<A, B>.foldRight(b: SortedMap<A, C>, f: (Map.Entry<A, B>, SortedMap<A, C>) -> SortedMap<A, C>): SortedMap<A, C> =
   this.entries.reversed().fold(b) { x: SortedMap<A, C>, y: Map.Entry<A, B> -> f(y, x) }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Validated.kt
@@ -569,6 +569,7 @@ sealed class Validated<out E, out A> {
   ): B =
     fold({ fe(c, it) }, { fa(c, it) })
 
+  @Deprecated(FoldRightDeprecation)
   inline fun <B> bifoldRight(
     c: Eval<B>,
     fe: (E, Eval<B>) -> Eval<B>,
@@ -693,6 +694,7 @@ sealed class Validated<out E, out A> {
   inline fun <B> foldLeft(b: B, f: (B, A) -> B): B =
     fold({ b }, { f(b, it) })
 
+  @Deprecated(FoldRightDeprecation)
   fun <B> foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
     when (this) {
       is Valid -> Eval.defer { f(this.value, lb) }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/map.kt
@@ -413,6 +413,7 @@ fun <K, A> Map<K, A>.combine(SG: Semigroup<A>, b: Map<K, A>): Map<K, A> = with(S
 fun <K, A> Iterable<Map<K, A>>.combineAll(SG: Semigroup<A>): Map<K, A> =
   fold(emptyMap()) { acc, map -> acc.combine(SG, map) }
 
+@Deprecated("Map<K, A>.foldRight is being deprecated because its functionality differs from other definitions of foldRight within arrow.")
 inline fun <K, A, B> Map<K, A>.foldRight(b: B, f: (Map.Entry<K, A>, B) -> B): B =
   this.entries.reversed().fold(b) { x, y: Map.Entry<K, A> -> f(y, x) }
 

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/predef.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/predef.kt
@@ -15,6 +15,9 @@ internal object ArrowCoreInternalException : RuntimeException(
 const val TailRecMDeprecation: String =
   "tailRecM is deprecated together with the Kind type classes since it's meant for writing kind-based polymorphic stack-safe programs."
 
+const val FoldRightDeprecation: String =
+  "foldRight, and all lazy folds, are being deprecated as a normal fold can sufficiently cover all its use cases as long as it's inline. See https://github.com/arrow-kt/arrow/pull/2370 for more information."
+
 /**
  * This is a work-around for having nested nulls in generic code.
  * This allows for writing faster generic code instead of using `Option`.


### PR DESCRIPTION
FoldRight and similar are useless in most cases in arrow atm.
- No kinds, without kinds we know that all implementations of foldRight atm are on non-lazy types that call the fold in place
- A consequence of the above is that all of these folds are `inline` and can thus short circuit using non-local returns.

A quick overview of all the types of folds present in arrow atm:
- `foldLeft = fold` This iterates over the elements in order left to right and accumulates along the way
- `foldRight` (without `Eval`) This iterates over the elements in order right to left. I'd argue that this is hardly ever what anyone wants or needs and writing `reverse().fold` isn't that annoying or common to warrant a shortcut (especially not one named `foldRight`)
- `foldRight` (with `Eval`): This returns a lazy computation that is right nested. This means it only ever iterates the list as far as necessary to calculate a result. Thus it is also safe for infinite structures!
> Not in arrow as this is almost never useful
- `foldLeft` (with `Eval`) This builds a lazy computation that is left nested, which means to produce the final lazy computation we must traverse the entire list first. Highly inefficient when we want to short circuit or when we actually need every result applied.

So out of the 4 only the strict `fold` and `foldRight` with `Eval` seem useful. `fold` for obvious reasons, and lazy `foldRight` because it can short circuit at any point by simply not forcing more of the accumulator.

The stdlib includes the strict left fold and the strict right fold, so why no lazy folds? Well all of the folds inside the stdlib are inline and thus non-local returns can handle the use-case of short-circuiting way better. It is cleaner, faster and easier to understand to return from a local inline fold function than to explicitly not-bind the lazy accumulator.

The other useful part of lazy folds is that their results themselves are lazy. Top level laziness can be  achieved by wrapping them in `Eval.later { .. }` instead.

Here is an example how a lazy right fold can be replaced by a normal fold for exactly the same functionality:
```kotlin
fun <A> List<A>.find(p: Predicat<A>): A? = foldRight(Eval.now(null)) { a, acc -> 
  if (p(a))
    Eval.now(a) // short circuit since we don't evaluate acc anymore
  else
    acc // bind acc and thus force one more step of evaluation
}.value() // evaluate computation
// This now becomes
fun <A> List<A>.find(p: Predicat<A>): A? = fold(null) { acc, a ->
  if (p(a)) return@find a else acc
}
// This can be done without a fold as well, but lets ignore that for the sake of the example.
```