### PR TITLE
Configuration: remove Bintray et al. (step 3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,10 @@ jobs:
     env:
       BASEDIR: ${{github.workspace}}/arrow-libs
       JAVA_OPTS: -Xms512m -Xmx1024m
-      BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-      BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+      SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+      SONATYPE_PWD: ${{ secrets.SONATYPE_PWD }}
+      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
       GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 
     runs-on: macos-latest

--- a/.github/workflows/publish_arrow-stack.yml
+++ b/.github/workflows/publish_arrow-stack.yml
@@ -14,8 +14,10 @@ jobs:
 
     env:
       BASEDIR: ${{github.workspace}}/arrow-libs
-      BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-      BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+      SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+      SONATYPE_PWD: ${{ secrets.SONATYPE_PWD }}
+      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
 
     runs-on: macos-latest
     defaults:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Both successful or failed build checks allow to download the tests report to rev
 
 #### What happens when merging a pull request
 
-When merging the pull request, a new SNAPSHOT library will be published into [OSS repository](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/).
+When merging the pull request, a new SNAPSHOT library will be published into [Sonatype OSSRH](https://oss.sonatype.org/service/local/repositories/snapshots/content/io/arrow-kt/).
 
 On the other hand, the documentation for the next version (SNAPSHOT) will be updated:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a href="https://arrow-kt.io" title="Arrow website"><img src="img/logo/arrow-dark.svg" width="200" alt=""></a>
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-core?color=4caf50&label=latest%20release)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=important&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
-[![Kotlin version badge](https://img.shields.io/badge/Kotlin-1.4-blue)](https://kotlinlang.org/docs/reference/whatsnew14.html)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.sonatype.org%2Fservice%2Flocal%2Frepositories%2Fsnapshots%2Fcontent%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.sonatype.org/service/local/repositories/snapshots/content/io/arrow-kt/)
+[![Kotlin version](https://img.shields.io/badge/Kotlin-1.4-blue)](https://kotlinlang.org/docs/reference/whatsnew14.html)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![StackOverflow](https://img.shields.io/badge/arrow--kt-grey.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/arrow-kt)
@@ -208,7 +208,7 @@ If you want to try the latest features, replace `0.13.1` with `1.0.0-SNAPSHOT` a
 allprojects {
     repositories {
         ...
-        maven { url "https://oss.jfrog.org/artifactory/oss-snapshot-local/" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,9 +16,15 @@ LATEST_VERSION=0.10.5
 
 When merging that pull request:
 
-* New RELEASE version will be published into Bintray for all the Arrow libraries.
+* New RELEASE version will be published for all the Arrow libraries into Sonatype staging repository.
 * A tag will be created with the RELEASE version.
 * Release notes will be created and associated to that tag.
 * The website will be updated with a new RELEASE version (`doc` and `doc/major.minor` directories)
 
-Then, it will be necessary to sync Bintray with Maven.
+Then, it will be necessary to close and release the Sonatype repository to sync with Maven Central:
+
+1. Login to https://oss.sonatype.org/ > `Staging repositories`
+3. Check the content and then: **Close** (it will check if the content meet the requirements)
+4. **Release** to sync with Maven Central (**Drop** and repeat if there are issues).
+
+NOTE: [This plugin](https://github.com/gradle-nexus/publish-plugin) provides tasks for closing and releasing the staging repositories. However, that plugin must be applied to the root project and it would be necessary to discard modules for publication. Let's keep this note here to give it a try later on.

--- a/arrow-libs/gradle.properties
+++ b/arrow-libs/gradle.properties
@@ -41,8 +41,8 @@ RETROFIT_VERSION=2.8.1
 RX_JAVA_VERSION=2.2.13
 SCALA_LIBRARY_VERSION=2.13.1
 # Publication
-RELEASE_REPOSITORY=https://api.bintray.com/maven/arrow-kt/arrow-kt/arrow
-SNAPSHOT_REPOSITORY=https://oss.jfrog.org/artifactory/oss-snapshot-local
+RELEASE_REPOSITORY=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+SNAPSHOT_REPOSITORY=https://oss.sonatype.org/content/repositories/snapshots/
 # Pomfile definitions
 POM_DESCRIPTION=Functional companion to Kotlin's Standard Library
 POM_URL=https://github.com/arrow-kt/arrow/

--- a/arrow-libs/gradle/publication.gradle
+++ b/arrow-libs/gradle/publication.gradle
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 afterEvaluate {
     publishing {
@@ -59,11 +60,22 @@ afterEvaluate {
         repositories {
             maven {
                 credentials {
-                    username "$System.env.BINTRAY_USER"
-                    password "$System.env.BINTRAY_API_KEY"
+                    username "$System.env.SONATYPE_USER"
+                    password "$System.env.SONATYPE_PWD"
                 }
                 url = VERSION_NAME.endsWith('SNAPSHOT') ? SNAPSHOT_REPOSITORY : RELEASE_REPOSITORY
             }
+        }
+    }
+
+    // Guide: https://docs.gradle.org/current/userguide/signing_plugin.html
+    if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
+        signing {
+            def signingKey = findProperty("signingKey")
+            def signingPassword = findProperty("signingPassword")
+            useInMemoryPgpKeys(signingKey, signingPassword)
+
+            sign publishing.publications.mavenJava
         }
     }
 }

--- a/arrow-libs/settings.gradle
+++ b/arrow-libs/settings.gradle
@@ -3,14 +3,14 @@
   This file includes the configuration of 'projectDir' beyond 'include' to
   allow to work with:
 
-    - All the      libraries when opening 'arrow-libs'
-    - CORE         libraries when opening 'arrow-libs/core'
-    - FX           libraries when opening 'arrow-libs/fx'
-    - OPTICS       libraries when opening 'arrow-libs/optics'
-    - ANK          libraries when opening 'arrow-libs/ank'
+    - All the libraries when opening 'arrow-libs'
+    - CORE    libraries when opening 'arrow-libs/core'
+    - FX      libraries when opening 'arrow-libs/fx'
+    - OPTICS  libraries when opening 'arrow-libs/optics'
+    - ANK     libraries when opening 'arrow-libs/ank'
 
-  This distribution is also useful to publish the artifacts from GitHub tasks (the number of
-  artifacts for publication into Bintray in a single task is limited).  
+  This distribution is also useful to publish the artifacts in case there is any limit about
+  the number of artifacts in a single task.
 
 */
 

--- a/arrow-site/docs/docs/quickstart/README.md
+++ b/arrow-site/docs/docs/quickstart/README.md
@@ -5,8 +5,8 @@ permalink: /core/
 ---
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.arrow-kt/arrow-core?color=4caf50&label=latest%20release)](https://maven-badges.herokuapp.com/maven-central/io.arrow-kt/arrow-core)
-[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=important&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-core/)
-[![Kotlin version badge](https://img.shields.io/badge/Kotlin-1.4-blue)](https://kotlinlang.org/docs/reference/whatsnew14.html)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.sonatype.org%2Fservice%2Flocal%2Frepositories%2Fsnapshots%2Fcontent%2Fio%2Farrow-kt%2Farrow-core%2Fmaven-metadata.xml)](https://oss.sonatype.org/service/local/repositories/snapshots/content/io/arrow-kt/)
+[![Kotlin version](https://img.shields.io/badge/Kotlin-1.4-blue)](https://kotlinlang.org/docs/reference/whatsnew14.html)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![StackOverflow](https://img.shields.io/badge/arrow--kt-grey.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/arrow-kt)
 [![Twitter](https://img.shields.io/twitter/follow/arrow_kt?color=blue&style=flat)](https://twitter.com/arrow_kt)
@@ -199,7 +199,7 @@ If you want to try the latest features, replace `0.13.1` with `1.0.0-SNAPSHOT` a
 allprojects {
     repositories {
         ...
-        maven { url "https://oss.jfrog.org/artifactory/oss-snapshot-local/" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 ```

--- a/arrow-stack/build.gradle
+++ b/arrow-stack/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 plugins {
     id "maven-publish"
     id "java-platform"
+    id "signing"
 }
 
 dependencies {
@@ -67,10 +68,20 @@ publishing {
     repositories {
         maven {
             credentials {
-                username System.getenv('BINTRAY_USER')
-                password System.getenv('BINTRAY_API_KEY')
+                username System.getenv('SONATYPE_USER')
+                password System.getenv('SONATYPE_PWD')
             }
             url = VERSION_NAME.endsWith('SNAPSHOT') ? SNAPSHOT_REPOSITORY : RELEASE_REPOSITORY
         }
+    }
+}
+
+if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
+    signing {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+
+        sign publishing.publications.myPlatform
     }
 }


### PR DESCRIPTION
## Previous steps

- Get credentials for Sonatype.
- Create signing resources:
```
# Generate a key pair (a passphrase will protect the private key = signingPassword)
gpg2 --gen-key

# Distribute the public key
gpg2 --keyserver hkp://pool.sks-keyservers.net:80 --send-keys [KEY-ID]

# Export the private key (= signingKey)
gpg -a --export-secret-key [KEY-ID] > [KEY-ID].asc
```
- Create new secrets:
  * `SONATYPE_USER`
  * `SONATYPE_PWD`
  * `ORG_GRADLE_PROJECT_signingKey`
  * `ORG_GRADLE_PROJECT_signingPassword`

## Changes

- Replace OSS JFrog snapshots repository by Sonatype OSSRH snapshots repository.
- Replace Bintray repository by Sonatype OSSRH releases repository (a staging repository is created before).
- Check signing resources to be able to publishToMavenLocal without failures.
- Update badges.
- Update documentation.

## Next steps

- Remove Bintray secrets.
- Notify the new SNAPSHOTS repository.
- Remove `1.0.0-SNAPSHOT` from OSS JFrog to avoid misunderstandings.
- Update `arrow-meta` repository because it's using the same configuration for publication.