### PR TITLE
Configuration: disable parallel execution when publishing

### DIFF
--- a/.github/scripts/set-env.sh
+++ b/.github/scripts/set-env.sh
@@ -22,6 +22,7 @@ fi
 
 if [ $NEW_RELEASE_VERSION_EXISTS == '1' ]; then
     perl -pe "s/^VERSION_NAME=.*/VERSION_NAME=$RELEASE_VERSION/g" -i $BASEDIR/gradle.properties
+    perl -pe "s/^org.gradle.parallel=.*/org.gradle.parallel=false/g" -i $BASEDIR/gradle.properties
 fi
 
 echo "LATEST_PUBLISHED_VERSION=$LATEST_PUBLISHED_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,6 @@ jobs:
       run: ${GITHUB_WORKSPACE}/.github/scripts/set-env.sh
     - name: "Show env"
       run: ${GITHUB_WORKSPACE}/.github/scripts/show-env.sh
-    - name: "Build Core libraries"
-      working-directory: arrow-libs/core
+    - name: Build
+      working-directory: arrow-libs
       run: ./gradlew build
-    - name: "Build Fx libraries"
-      working-directory: arrow-libs/fx
-      run: ./gradlew clean build
-    - name: "Build Optics libraries"
-      working-directory: arrow-libs/optics
-      run: ./gradlew clean build
-    - name: "Build Ank library and plugin"
-      working-directory: arrow-libs/ank
-      run: ./gradlew clean build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,19 +33,10 @@ jobs:
       run: ${GITHUB_WORKSPACE}/.github/scripts/set-env.sh
     - name: "Show env"
       run: ${GITHUB_WORKSPACE}/.github/scripts/show-env.sh
-    - name: "Publish Core libraries"
-      working-directory: arrow-libs/core
-      run: ./gradlew publish
-    - name: "Publish Fx libraries"
-      working-directory: arrow-libs/fx
-      run: ./gradlew clean publish
-    - name: "Publish Optics libraries"
-      working-directory: arrow-libs/optics
-      run: ./gradlew clean publish
-    - name: "Publish Ank library and plugin"
-      working-directory: arrow-libs/ank
+    - name: "Publish"
+      working-directory: arrow-libs
       run: |
-        ./gradlew clean publish
+        ./gradlew publish
         echo "$(cat $BASEDIR/gradle.properties | grep VERSION_NAME | cut -d'=' -f2) deployed!"
     - name: "Create tag"
       if: env.NEW_RELEASE_VERSION_EXISTS == '1'


### PR DESCRIPTION
It's the reason why multiple staging repositories are created when publishing.

It also reverts #2385.