### PR TITLE
add common extensions for option

### DIFF
--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
@@ -516,7 +516,11 @@ sealed class Ior<out A, out B> {
     )
 
   inline fun <C> traverseOption(fa: (B) -> Option<C>): Option<Ior<A, C>> =
-    traverseEither { fa(it).toEither { Unit } }.orNone()
+    fold(
+      { a -> Some(Left(a)) },
+      { b -> fa(b).map { Right(it) } },
+      { a, b -> fa(b).map { Both(a, it) } }
+    )
 
   inline fun <AA, C> traverseValidated(fa: (B) -> Validated<AA, C>): Validated<AA, Ior<A, C>> =
     fold(

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
@@ -428,6 +428,15 @@ sealed class Ior<out A, out B> {
       { a, b -> fa(a).zip(fb(b)) { aa, c -> Both(aa, c) } }
     )
 
+  inline fun <C, D> bitraverseOption(
+    fa: (A) -> Option<C>,
+    fb: (B) -> Option<D>
+  ): Option<Ior<C, D>> =
+    bitraverseEither(
+      { fa(it).toEither { Unit } },
+      { fb(it).toEither { Unit } }
+    ).orNone()
+
   inline fun <AA, C, D> bitraverseValidated(
     SA: Semigroup<AA>,
     fa: (A) -> Validated<AA, C>,
@@ -505,6 +514,9 @@ sealed class Ior<out A, out B> {
       { a, b -> fa(b).map { Both(a, it) } }
     )
 
+  inline fun <C> traverseOption(fa: (B) -> Option<C>): Option<Ior<A, C>> =
+    traverseEither { fa(it).toEither { Unit } }.orNone()
+
   inline fun <AA, C> traverseValidated(fa: (B) -> Validated<AA, C>): Validated<AA, Ior<A, C>> =
     fold(
       { a -> Valid(Left(a)) },
@@ -548,6 +560,9 @@ fun <A, B> Ior<Iterable<A>, Iterable<B>>.bisequence(): List<Ior<A, B>> =
 
 fun <A, B, C> Ior<Either<A, B>, Either<A, C>>.bisequenceEither(): Either<A, Ior<B, C>> =
   bitraverseEither(::identity, ::identity)
+
+fun <B, C> Ior<Option<B>, Option<C>>.bisequenceOption(): Option<Ior<B, C>> =
+  bitraverseOption(::identity, ::identity)
 
 fun <A, B, C> Ior<Validated<A, B>, Validated<A, C>>.bisequenceValidated(SA: Semigroup<A>): Validated<A, Ior<B, C>> =
   bitraverseValidated(SA, ::identity, ::identity)
@@ -606,6 +621,9 @@ fun <A, B> Ior<A, Iterable<B>>.sequence(): List<Ior<A, B>> =
 
 fun <A, B, C> Ior<A, Either<B, C>>.sequenceEither(): Either<B, Ior<A, C>> =
   traverseEither(::identity)
+
+fun <A, B> Ior<A, Option<B>>.sequenceOption(): Option<Ior<A, B>> =
+  traverseOption(::identity)
 
 fun <A, B, C> Ior<A, Validated<B, C>>.sequenceValidated(): Validated<B, Ior<A, C>> =
   traverseValidated(::identity)

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Ior.kt
@@ -432,10 +432,11 @@ sealed class Ior<out A, out B> {
     fa: (A) -> Option<C>,
     fb: (B) -> Option<D>
   ): Option<Ior<C, D>> =
-    bitraverseEither(
-      { fa(it).toEither { Unit } },
-      { fb(it).toEither { Unit } }
-    ).orNone()
+    fold(
+      { fa(it).map { Left(it) } },
+      { fb(it).map { Right(it) } },
+      { a, b -> fa(a).zip(fb(b)) { aa, c -> Both(aa, c) } }
+    )
 
   inline fun <AA, C, D> bitraverseValidated(
     SA: Semigroup<AA>,

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
@@ -329,6 +329,12 @@ fun <E, A> Iterable<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>):
 fun <E, A> Iterable<ValidatedNel<E, A>>.sequenceValidated(): ValidatedNel<E, List<A>> =
   traverseValidated(Semigroup.nonEmptyList(), ::identity)
 
+inline fun <A, B> Iterable<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>> =
+  traverseEither { f(it).toEither { Unit } }.orNone()
+
+fun <A> Iterable<Option<A>>.sequenceOption(): Option<List<A>> =
+  this.traverseOption { it }
+
 fun <A> Iterable<A>.void(): List<Unit> =
   map { Unit }
 
@@ -895,3 +901,5 @@ infix fun <T> T.prependTo(list: Iterable<T>): List<T> =
 
 fun <T> Iterable<Option<T>>.filterOption(): List<T> =
   flatMap { it.fold(::emptyList, ::listOf) }
+
+fun <T> Iterable<Option<T>>.flattenOption(): List<T> = filterOption()

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
@@ -329,8 +329,16 @@ fun <E, A> Iterable<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>):
 fun <E, A> Iterable<ValidatedNel<E, A>>.sequenceValidated(): ValidatedNel<E, List<A>> =
   traverseValidated(Semigroup.nonEmptyList(), ::identity)
 
-inline fun <A, B> Iterable<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>> =
-  traverseEither { f(it).toEither { Unit } }.orNone()
+inline fun <A, B> Iterable<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>>  {
+  val acc = mutableListOf<B>()
+  forEach { a ->
+    when (val res = f(a)) {
+      is Some -> acc.add(res.value)
+      is None -> return@traverseOption res
+    }
+  }
+  return acc.some()
+}
 
 fun <A> Iterable<Option<A>>.sequenceOption(): Option<List<A>> =
   this.traverseOption { it }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Iterable.kt
@@ -1,4 +1,5 @@
 @file:Suppress("unused", "FunctionName")
+
 package arrow.core
 
 import arrow.core.Either.Left
@@ -281,7 +282,10 @@ inline fun <B, C, D, E, F, G, H, I, J, K, L> Iterable<B>.zip(
 internal fun <T> Iterable<T>.collectionSizeOrDefault(default: Int): Int =
   if (this is Collection<*>) this.size else default
 
-@Deprecated("Iterable.foldRight is being deprecated because its functionality differs from other foldRight definitions within arrow. Use the stdlib foldRight instead", replaceWith = ReplaceWith("foldRight(initial) { acc, b -> operation(b, acc) }"))
+@Deprecated(
+  "Iterable.foldRight is being deprecated because its functionality differs from other foldRight definitions within arrow. Use the stdlib foldRight instead",
+  replaceWith = ReplaceWith("foldRight(initial) { acc, b -> operation(b, acc) }")
+)
 inline fun <A, B> Iterable<A>.foldRight(initial: B, operation: (A, acc: B) -> B): B =
   when (this) {
     is List -> _foldRight(initial, operation)
@@ -329,7 +333,7 @@ fun <E, A> Iterable<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>):
 fun <E, A> Iterable<ValidatedNel<E, A>>.sequenceValidated(): ValidatedNel<E, List<A>> =
   traverseValidated(Semigroup.nonEmptyList(), ::identity)
 
-inline fun <A, B> Iterable<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>>  {
+inline fun <A, B> Iterable<A>.traverseOption(f: (A) -> Option<B>): Option<List<B>> {
   val acc = mutableListOf<B>()
   forEach { a ->
     when (val res = f(a)) {

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -447,3 +447,9 @@ inline fun <E, A, B> NonEmptyList<A>.traverseValidated(
 
 fun <E, A> NonEmptyList<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, NonEmptyList<A>> =
   traverseValidated(semigroup, ::identity)
+
+inline fun <A, B> NonEmptyList<A>.traverseOption(f: (A) -> Option<B>): Option<NonEmptyList<B>> =
+  traverseEither { f(it).toEither { Unit } }.orNone()
+
+fun <A> NonEmptyList<Option<A>>.sequenceOption(): Option<NonEmptyList<A>> =
+  traverseOption { it }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -357,14 +357,34 @@ sealed class Option<out A> {
     b: Option<B>,
     map: (A, B) -> C
   ): Option<C> =
-    zip(b, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+    zip(
+      b,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit
+    ) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
   inline fun <B, C, D> zip(
     b: Option<B>,
     c: Option<C>,
     map: (A, B, C) -> D
   ): Option<D> =
-    zip(b, c, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+    zip(
+      b,
+      c,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit
+    ) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
   inline fun <B, C, D, E> zip(
     b: Option<B>,
@@ -372,7 +392,17 @@ sealed class Option<out A> {
     d: Option<D>,
     map: (A, B, C, D) -> E
   ): Option<E> =
-    zip(b, c, d, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit) { a, b, c, d, _, _, _, _, _, _ -> map(a, b, c, d) }
+    zip(
+      b,
+      c,
+      d,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit,
+      Some.unit
+    ) { a, b, c, d, _, _, _, _, _, _ -> map(a, b, c, d) }
 
   inline fun <B, C, D, E, F> zip(
     b: Option<B>,
@@ -381,7 +411,15 @@ sealed class Option<out A> {
     e: Option<E>,
     map: (A, B, C, D, E) -> F
   ): Option<F> =
-    zip(b, c, d, e, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit) { a, b, c, d, e, f, _, _, _, _ -> map(a, b, c, d, e) }
+    zip(b, c, d, e, Some.unit, Some.unit, Some.unit, Some.unit, Some.unit) { a, b, c, d, e, f, _, _, _, _ ->
+      map(
+        a,
+        b,
+        c,
+        d,
+        e
+      )
+    }
 
   inline fun <B, C, D, E, F, G> zip(
     b: Option<B>,
@@ -391,7 +429,16 @@ sealed class Option<out A> {
     f: Option<F>,
     map: (A, B, C, D, E, F) -> G
   ): Option<G> =
-    zip(b, c, d, e, f, Some.unit, Some.unit, Some.unit, Some.unit) { a, b, c, d, e, f, _, _, _, _ -> map(a, b, c, d, e, f) }
+    zip(b, c, d, e, f, Some.unit, Some.unit, Some.unit, Some.unit) { a, b, c, d, e, f, _, _, _, _ ->
+      map(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f
+      )
+    }
 
   inline fun <B, C, D, E, F, G, H, I> zip(
     b: Option<B>,
@@ -689,6 +736,11 @@ sealed class Option<out A> {
   fun void(): Option<Unit> =
     map { Unit }
 
+
+  fun <L> pairLeft(left: L): Option<Pair<L, A>> = this.map { left to it }
+
+  fun <R> pairRight(right: R): Option<Pair<A, R>> = this.map { it to right }
+
   infix fun <X> and(value: Option<X>): Option<X> = if (isEmpty()) {
     None
   } else {
@@ -917,6 +969,8 @@ inline fun <A, B, C> Option<C>.unzip(f: (C) -> Pair<A, B>): Pair<Option<A>, Opti
  */
 fun <B, A : B> Option<A>.widen(): Option<B> =
   this
+
+fun <K, V> Option<Pair<K, V>>.toMap(): Map<K, V> = this.toList().toMap()
 
 fun <A> Option<A>.combine(SGA: Semigroup<A>, b: Option<A>): Option<A> =
   when (this) {

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Option.kt
@@ -736,7 +736,6 @@ sealed class Option<out A> {
   fun void(): Option<Unit> =
     map { Unit }
 
-
   fun <L> pairLeft(left: L): Option<Pair<L, A>> = this.map { left to it }
 
   fun <R> pairRight(right: R): Option<Pair<A, R>> = this.map { it to right }

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Sequence.kt
@@ -617,6 +617,9 @@ fun <A, B> Sequence<Validated<A, B>>.separateValidated(): Pair<Sequence<A>, Sequ
 fun <E, A> Sequence<Either<E, A>>.sequenceEither(): Either<E, Sequence<A>> =
   traverseEither(::identity)
 
+fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
+  traverseOption(::identity)
+
 fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
   traverseValidated(semigroup, ::identity)
 
@@ -658,6 +661,9 @@ fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequ
   }
   return acc.asSequence().right()
 }
+
+fun <A, B> Sequence<A>.traverseOption(f: (A) -> Option<B>): Option<Sequence<B>> =
+  traverseEither { f(it).toEither { Unit } }.orNone()
 
 fun <E, A, B> Sequence<A>.traverseValidated(
   semigroup: Semigroup<E>,

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/Validated.kt
@@ -907,7 +907,7 @@ inline fun <E, A, B, C, D, EE, F, G, H, I, J, Z> Validated<E, A>.zip(
     accumulatedError =
       if (ff is Validated.Invalid) emptyCombine(accumulatedError, ff.value) else accumulatedError
     accumulatedError =
-      if (g is Validated.Invalid) emptyCombine(accumulatedError, g.value)else accumulatedError
+      if (g is Validated.Invalid) emptyCombine(accumulatedError, g.value) else accumulatedError
     accumulatedError =
       if (h is Validated.Invalid) emptyCombine(accumulatedError, h.value) else accumulatedError
     accumulatedError =
@@ -1060,7 +1060,7 @@ fun <E, A> Validated<E, Iterable<A>>.sequence(): List<Validated<E, A>> =
 fun <E, A, B> Validated<A, Either<E, B>>.sequenceEither(): Either<E, Validated<A, B>> =
   traverseEither(::identity)
 
-fun <E, A, B> Validated<A, Option<B>>.sequenceOption(): Option<Validated<A, B>> =
+fun <A, B> Validated<A, Option<B>>.sequenceOption(): Option<Validated<A, B>> =
   traverseOption(::identity)
 
 operator fun <E : Comparable<E>, A : Comparable<A>> Validated<E, A>.compareTo(other: Validated<E, A>): Int =
@@ -1080,6 +1080,9 @@ inline fun <E, A> Validated<E, A>.getOrElse(default: () -> A): A =
  */
 fun <E, A> Validated<E, A>.orNull(): A? =
   getOrElse { null }
+
+fun <E, A> Validated<E, A>.orNone(): Option<A> =
+  fold({ None }, { Some(it) })
 
 /**
  * Return the Valid value, or the result of f if Invalid

--- a/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core/src/main/kotlin/arrow/core/map.kt
@@ -224,6 +224,12 @@ inline fun <K, E, A, B> Map<K, A>.traverseValidated(
 fun <K, E, A> Map<K, Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Map<K, A>> =
   traverseValidated(semigroup, ::identity)
 
+inline fun <K, A, B> Map<K, A>.traverseOption(f: (A) -> Option<B>): Option<Map<K, B>> =
+  traverseEither { f(it).toEither { Unit } }.orNone()
+
+fun <K, V> Map<K, Option<V>>.sequenceOption(): Option<Map<K, V>> =
+  traverseOption { it }
+
 fun <K, A> Map<K, A>.void(): Map<K, Unit> =
   mapValues { Unit }
 
@@ -237,6 +243,8 @@ fun <K, A, B> Map<K, A>.filterMap(f: (A) -> B?): Map<K, B> {
   }
   return destination
 }
+
+fun <K, A> Map<K, Option<A>>.filterOption(): Map<K, A> = filterMap { it.orNull() }
 
 /**
  * Returns a Map containing all elements that are instances of specified type parameter R.
@@ -404,6 +412,8 @@ fun <K, A, B> Map<K, Pair<A, B>>.unzip(): Pair<Map<K, A>, Map<K, B>> =
  */
 fun <K, A, B, C> Map<K, C>.unzip(fc: (Map.Entry<K, C>) -> Pair<A, B>): Pair<Map<K, A>, Map<K, B>> =
   mapValues(fc).unzip()
+
+fun <K, V> Map<K, V>.getOrNone(key: K): Option<V> = this[key].toOption()
 
 fun <K, A> Map<K, A>.combine(SG: Semigroup<A>, b: Map<K, A>): Map<K, A> = with(SG) {
   if (size < b.size) foldLeft(b) { my, (k, b) -> my + Pair(k, b.maybeCombine(my[k])) }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
@@ -338,12 +338,83 @@ class EitherTest : UnitSpec() {
       left.traverse { listOf(it, 2, 3) } shouldBe emptyList()
     }
 
+    "sequence should be consistent with traverse" {
+      forAll(Gen.either(Gen.string(), Gen.int())) { either ->
+        either.map { listOf(it) }.sequence() == either.traverse { listOf(it) }
+      }
+    }
+
     "traverseOption should return option if either is right" {
       val right: Either<String, Int> = Right(1)
       val left: Either<String, Int> = Left("foo")
 
       right.traverseOption { Some(it) } shouldBe Some(Right(1))
       left.traverseOption { Some(it) } shouldBe None
+    }
+
+    "sequenceOption should be consistent with traverseOption" {
+      forAll(Gen.either(Gen.string(), Gen.int())) { either ->
+        either.map { Some(it) }.sequenceOption() == either.traverseOption { Some(it) }
+      }
+    }
+
+    "traverseValidated should return validated of either" {
+      val right: Either<String, Int> = Right(1)
+      val left: Either<String, Int> = Left("foo")
+
+      right.traverseValidated { it.valid() } shouldBe Valid(Right(1))
+      left.traverseValidated { it.valid() } shouldBe Valid(Left("foo"))
+    }
+
+    "sequenceValidated should be consistent with traverseValidated" {
+      forAll(Gen.either(Gen.string(), Gen.int())) { either ->
+        either.map { it.valid() }.sequenceValidated() == either.traverseValidated { it.valid() }
+      }
+    }
+
+    "bitraverse should wrap either in a list" {
+      val right: Either<String, Int> = Right(1)
+      val left: Either<String, Int> = Left("foo")
+
+      right.bitraverse({ listOf(it, "bar", "baz") }, { listOf(it, 2, 3) }) shouldBe listOf(Right(1), Right(2), Right(3))
+      left.bitraverse({ listOf(it, "bar", "baz") }, { listOf(it, 2, 3) }) shouldBe
+        listOf(Left("foo"), Left("bar"), Left("baz"))
+    }
+
+    "bisequence should be consistent with bitraverse" {
+      forAll(Gen.either(Gen.string(), Gen.int())) { either ->
+        either.bimap({ listOf(it) }, { listOf(it) }).bisequence() == either.bitraverse({ listOf(it) }, { listOf(it) })
+      }
+    }
+
+    "bitraverseOption should wrap either in an option" {
+      val right: Either<String, Int> = Right(1)
+      val left: Either<String, Int> = Left("foo")
+
+      right.bitraverseOption({ Some(it) }, { Some(it.toString()) }) shouldBe Some(Right("1"))
+      left.bitraverseOption({ Some(it) }, { Some(it.toString()) }) shouldBe Some(Left("foo"))
+    }
+
+    "bisequenceOption should be consistent with bitraverseOption" {
+      forAll(Gen.either(Gen.string(), Gen.int())) { either ->
+        either.bimap({ Some(it) }, { Some(it) }).bisequenceOption() ==
+          either.bitraverseOption({ Some(it) }, { Some(it) })
+      }
+    }
+
+    "bitraverseValidated should return validated of either" {
+      val right: Either<String, Int> = Right(1)
+      val left: Either<String, Int> = Left("foo")
+
+      right.bitraverseValidated({ it.invalid() }, { it.valid() }) shouldBe Valid(Right(1))
+      left.bitraverseValidated({ it.invalid() }, { it.valid() }) shouldBe Invalid("foo")
+    }
+
+    "bisequenceValidated should be consistent with bitraverseValidated" {
+      forAll(Gen.either(Gen.string(), Gen.int())) { either ->
+        either.bimap({ it.invalid() }, { it.valid() }).bisequenceValidated() ==
+          either.bitraverseValidated({ it.invalid() }, { it.valid() })
+      }
     }
   }
 }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/EitherTest.kt
@@ -30,10 +30,20 @@ class EitherTest : UnitSpec() {
   init {
     testLaws(
       MonoidLaws.laws(Monoid.either(Monoid.string(), Monoid.int()), GEN),
-      FxLaws.suspended<EitherEffect<String, *>, Either<String, Int>, Int>(Gen.int().map(::Right), GEN.map { it }, Either<String, Int>::equals, either::invoke) {
+      FxLaws.suspended<EitherEffect<String, *>, Either<String, Int>, Int>(
+        Gen.int().map(::Right),
+        GEN.map { it },
+        Either<String, Int>::equals,
+        either::invoke
+      ) {
         it.bind()
       },
-      FxLaws.eager<RestrictedEitherEffect<String, *>, Either<String, Int>, Int>(Gen.int().map(::Right), GEN.map { it }, Either<String, Int>::equals, either::eager) {
+      FxLaws.eager<RestrictedEitherEffect<String, *>, Either<String, Int>, Int>(
+        Gen.int().map(::Right),
+        GEN.map { it },
+        Either<String, Int>::equals,
+        either::eager
+      ) {
         it.bind()
       }
     )
@@ -83,6 +93,18 @@ class EitherTest : UnitSpec() {
     "orNull should return value" {
       forAll { a: Int ->
         Either.Right(a).orNull() == a
+      }
+    }
+
+    "orNone should return Some(value)" {
+      forAll { a: Int ->
+        Either.Right(a).orNone() == Some(a)
+      }
+    }
+
+    "orNone should return None when left" {
+      forAll { a: String ->
+        Left(a).orNone() == None
       }
     }
 
@@ -306,6 +328,22 @@ class EitherTest : UnitSpec() {
         }
         true
       }
+    }
+
+    "traverse should return list if either is right" {
+      val right: Either<String, Int> = Right(1)
+      val left: Either<String, Int> = Left("foo")
+
+      right.traverse { listOf(it, 2, 3) } shouldBe listOf(Right(1), Right(2), Right(3))
+      left.traverse { listOf(it, 2, 3) } shouldBe emptyList()
+    }
+
+    "traverseOption should return option if either is right" {
+      val right: Either<String, Int> = Right(1)
+      val left: Either<String, Int> = Left("foo")
+
+      right.traverseOption { Some(it) } shouldBe Some(Right(1))
+      left.traverseOption { Some(it) } shouldBe None
     }
   }
 }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/IorTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/IorTest.kt
@@ -200,5 +200,119 @@ class IorTest : UnitSpec() {
         }
       }
     }
+
+    "traverse should wrap ior in a list" {
+      forAll { a: Int, b: String ->
+        val iorL: Ior<Int, String> = a.leftIor()
+        val iorR: Ior<Int, String> = b.rightIor()
+        val iorBoth: Ior<Int, String> = (a to b).bothIor()
+
+        iorL.traverse { listOf(it) } == listOf(Ior.Left(a)) &&
+          iorR.traverse { listOf(it) } == listOf(Ior.Right(b)) &&
+          iorBoth.traverse { listOf(it) } == listOf(Ior.Both(a, b))
+      }
+    }
+
+    "sequence should be consistent with traverse" {
+      forAll(Gen.ior(Gen.int(), Gen.string())) { ior ->
+        ior.map { listOf(it) }.sequence() == ior.traverse { listOf(it) }
+      }
+    }
+
+    "traverseOption should wrap ior in an Option" {
+      forAll { a: Int, b: String ->
+        val iorL: Ior<Int, String> = a.leftIor()
+        val iorR: Ior<Int, String> = b.rightIor()
+        val iorBoth: Ior<Int, String> = (a to b).bothIor()
+
+        iorL.traverseOption { Some(it) } == Some(Ior.Left(a)) &&
+          iorR.traverseOption { Some(it) } == Some(Ior.Right(b)) &&
+          iorBoth.traverseOption { Some(it) } == Some(Ior.Both(a, b))
+      }
+    }
+
+    "sequenceOption should be consistent with traverseOption" {
+      forAll(Gen.ior(Gen.int(), Gen.string())) { ior ->
+        ior.map { Some(it) }.sequenceOption() == ior.traverseOption { Some(it) }
+      }
+    }
+
+    "traverseEither should wrap ior in an Option" {
+      forAll { a: Int, b: String ->
+        val iorL: Ior<Int, String> = a.leftIor()
+        val iorR: Ior<Int, String> = b.rightIor()
+        val iorBoth: Ior<Int, String> = (a to b).bothIor()
+
+        iorL.traverseEither { it.right() } == Either.Right(Ior.Left(a)) &&
+          iorR.traverseEither { it.right() } == Either.Right(Ior.Right(b)) &&
+          iorBoth.traverseEither { it.right() } == Either.Right(Ior.Both(a, b))
+      }
+    }
+
+    "sequenceEither should be consistent with traverseEither" {
+      forAll(Gen.ior(Gen.int(), Gen.string())) { ior ->
+        ior.map { it.right() }.sequenceEither() == ior.traverseEither { it.right() }
+      }
+    }
+
+    "bitraverse should wrap ior in a list" {
+      forAll { a: Int, b: String ->
+        val iorL: Ior<Int, String> = a.leftIor()
+        val iorR: Ior<Int, String> = b.rightIor()
+        val iorBoth: Ior<Int, String> = (a to b).bothIor()
+
+        println(iorBoth.bitraverse({ listOf(it, 2, 3) }, { listOf(it) }))
+
+        iorL.bitraverse({ listOf(it, 2, 3) }, { listOf(it) }) == listOf(Ior.Left(a), Ior.Left(2), Ior.Left(3)) &&
+          iorR.bitraverse({ listOf(it, 2, 3) }, { listOf(it) }) == listOf(Ior.Right(b)) &&
+          iorBoth.bitraverse({ listOf(it, 2, 3) }, { listOf(it, 4, 5) }) ==
+          listOf(Ior.Both(a, b), Ior.Both(2, 4), Ior.Both(3, 5))
+      }
+    }
+
+    "bisequence should be consistent with bitraverse" {
+      forAll(Gen.ior(Gen.int(), Gen.string())) { ior ->
+        ior.bimap({ listOf(it) }, { listOf(it) }).bisequence() ==
+          ior.bitraverse({ listOf(it) }, { listOf(it) })
+      }
+    }
+
+    "bitraverseOption should wrap ior in an Option" {
+      forAll { a: Int, b: String ->
+        val iorL: Ior<Int, String> = a.leftIor()
+        val iorR: Ior<Int, String> = b.rightIor()
+        val iorBoth: Ior<Int, String> = (a to b).bothIor()
+
+        iorL.bitraverseOption({ None }, { Some(it) }) == None &&
+          iorR.bitraverseOption({ None }, { Some(it) }) == Some(Ior.Right(b)) &&
+          iorBoth.bitraverseOption({ None }, { Some(it) }) == None
+      }
+    }
+
+    "bisequenceOption should be consistent with bitraverseOption" {
+      forAll(Gen.ior(Gen.int(), Gen.string())) { ior ->
+        ior.bimap({ None }, { Some(it) }).bisequenceOption() ==
+          ior.bitraverseOption({ None }, { Some(it) })
+      }
+    }
+
+    "bitraverseEither should wrap ior in an Either" {
+      forAll { a: Int, b: String ->
+        val iorL: Ior<Int, String> = a.leftIor()
+        val iorR: Ior<Int, String> = b.rightIor()
+        val iorBoth: Ior<Int, String> = (a to b).bothIor()
+
+        iorL.bitraverseEither({ it.left() }, { it.right() }) == Either.Left(a) &&
+          iorR.bitraverseEither({ it.left() }, { it.right() }) == Either.Right(Ior.Right(b)) &&
+          iorBoth.bitraverseEither({ it.left() }, { it.right() }) == Either.Left(a)
+      }
+    }
+
+    "bisequenceEither should be consistent with bitraverseEither" {
+      forAll(Gen.ior(Gen.int(), Gen.string())) { ior ->
+        ior.bimap({ it.left() }, { it.right() }).bisequenceEither() ==
+          ior.bitraverseEither({ it.left() }, { it.right() })
+      }
+    }
   }
 }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/IterableTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/IterableTest.kt
@@ -40,6 +40,12 @@ class IterableTest : UnitSpec() {
       }
     }
 
+    "sequenceEither should be consistent with traverseEither" {
+      forAll(Gen.list(Gen.int())) { ints ->
+        ints.map { it.right() }.sequenceEither() == ints.traverseEither { it.right() }
+      }
+    }
+
     "traverseOption is stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
@@ -71,6 +77,12 @@ class IterableTest : UnitSpec() {
       }
     }
 
+    "sequenceOption should be consistent with traverseOption" {
+      forAll(Gen.list(Gen.int())) { ints ->
+        ints.map { Some(it) }.sequenceOption() == ints.traverseOption { Some(it) }
+      }
+    }
+
     "traverseValidated stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
@@ -91,6 +103,13 @@ class IterableTest : UnitSpec() {
           .fold({ ints.filter { it % 2 == 0 }.validNel() }, { it.invalid() })
 
         res == expected
+      }
+    }
+
+    "sequenceValidated should be consistent with traverseValidated" {
+      forAll(Gen.list(Gen.int())) { ints ->
+        ints.map { it.valid() as Validated<String, Int> }.sequenceValidated(Semigroup.string()) ==
+          ints.traverseValidated(Semigroup.string()) { it.valid() as Validated<String, Int> }
       }
     }
 

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/NonEmptyListTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/NonEmptyListTest.kt
@@ -43,6 +43,13 @@ class NonEmptyListTest : UnitSpec() {
       }
     }
 
+    "sequenceEither should be consistent with traverseEither" {
+      forAll(Gen.nonEmptyList(Gen.int())) { ints ->
+        ints.map { Either.conditionally(it % 2 == 0, { it }, { it }) }.sequenceEither() ==
+          ints.traverseEither { Either.conditionally(it % 2 == 0, { it }, { it }) }
+      }
+    }
+
     "traverseOption is stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
@@ -74,6 +81,13 @@ class NonEmptyListTest : UnitSpec() {
       }
     }
 
+    "sequenceOption should be consistent with traverseOption" {
+      forAll(Gen.nonEmptyList(Gen.int())) { ints ->
+        ints.map { (it % 2 == 0).maybe { it } }.sequenceOption() ==
+          ints.traverseOption { (it % 2 == 0).maybe { it } }
+      }
+    }
+
     "traverseValidated stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
@@ -94,6 +108,13 @@ class NonEmptyListTest : UnitSpec() {
           .fold({ NonEmptyList.fromListUnsafe(ints.filter { it % 2 == 0 }).validNel() }, { it.invalid() })
 
         res == expected
+      }
+    }
+
+    "sequenceValidated should be consistent with traverseValidated" {
+      forAll(Gen.nonEmptyList(Gen.int())) { ints ->
+        ints.map { if (it % 2 == 0) it.valid() else it.invalid() }.sequenceValidated(Semigroup.int()) ==
+          ints.traverseValidated(Semigroup.int()) { if (it % 2 == 0) it.valid() else it.invalid() }
       }
     }
 

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/OptionTest.kt
@@ -22,10 +22,20 @@ class OptionTest : UnitSpec() {
 
     testLaws(
       MonoidLaws.laws(Monoid.option(Monoid.int()), Gen.option(Gen.int())),
-      FxLaws.suspended<OptionEffect<*>, Option<String>, String>(Gen.string().map(Option.Companion::invoke), Gen.option(Gen.string()), Option<String>::equals, option::invoke) {
+      FxLaws.suspended<OptionEffect<*>, Option<String>, String>(
+        Gen.string().map(Option.Companion::invoke),
+        Gen.option(Gen.string()),
+        Option<String>::equals,
+        option::invoke
+      ) {
         it.bind()
       },
-      FxLaws.eager<RestrictedOptionEffect<*>, Option<String>, String>(Gen.string().map(Option.Companion::invoke), Gen.option(Gen.string()), Option<String>::equals, option::eager) {
+      FxLaws.eager<RestrictedOptionEffect<*>, Option<String>, String>(
+        Gen.string().map(Option.Companion::invoke),
+        Gen.option(Gen.string()),
+        Option<String>::equals,
+        option::eager
+      ) {
         it.bind()
       }
     )
@@ -76,7 +86,7 @@ class OptionTest : UnitSpec() {
       forAll { a: Int ->
         val op: Option<Int> = a.some()
         some.zip(op) { a, b -> a + b } == Some("kotlin$a") &&
-        none.zip(op) { a, b -> a + b } == None &&
+          none.zip(op) { a, b -> a + b } == None &&
           some.zip(op) == Some(Pair("kotlin", a))
       }
     }
@@ -158,6 +168,27 @@ class OptionTest : UnitSpec() {
       1.leftIor().leftOrNull() shouldBe 1
       2.rightIor().leftOrNull() shouldBe null
       (1 to 2).bothIor().leftOrNull() shouldBe 1
+    }
+
+    "pairLeft" {
+      val some: Option<Int> = Some(2)
+      val none: Option<Int> = None
+      some.pairLeft("key") shouldBe Some("key" to 2)
+      none.pairLeft("key") shouldBe None
+    }
+
+    "pairRight" {
+      val some: Option<Int> = Some(2)
+      val none: Option<Int> = None
+      some.pairRight("right") shouldBe Some(2 to "right")
+      none.pairRight("right") shouldBe None
+    }
+
+    "Option<Pair<L, R>>.toMap()" {
+      val some: Option<Pair<String, String>> = Some("key" to "value")
+      val none: Option<Pair<String, String>> = None
+      some.toMap() shouldBe mapOf("key" to "value")
+      none.toMap() shouldBe emptyMap()
     }
   }
 }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/OptionTest.kt
@@ -190,5 +190,44 @@ class OptionTest : UnitSpec() {
       some.toMap() shouldBe mapOf("key" to "value")
       none.toMap() shouldBe emptyMap()
     }
+
+    "traverse should yield list of option" {
+      val some: Option<String> = Some("value")
+      val none: Option<String> = None
+      some.traverse { listOf(it) } shouldBe listOf(Some("value"))
+      none.traverse { listOf(it) } shouldBe emptyList()
+    }
+
+    "sequence should be consistent with traverse" {
+      forAll(Gen.option(Gen.int())) { option ->
+        option.map { listOf(it) }.sequence() == option.traverse { listOf(it) }
+      }
+    }
+
+    "traverseEither should yield either of option" {
+      val some: Option<String> = Some("value")
+      val none: Option<String> = None
+      some.traverseEither { it.right() } shouldBe some.right()
+      none.traverseEither { it.right() } shouldBe none.right()
+    }
+
+    "sequenceEither should be consistent with traverseEither" {
+      forAll(Gen.option(Gen.int())) { option ->
+        option.map { it.right() }.sequenceEither() == option.traverseEither { it.right() }
+      }
+    }
+
+    "traverseValidated should yield validated of option" {
+      val some: Option<String> = Some("value")
+      val none: Option<String> = None
+      some.traverseValidated { it.valid() } shouldBe some.valid()
+      none.traverseValidated { it.valid() } shouldBe none.valid()
+    }
+
+    "sequenceValidated should be consistent with traverseValidated" {
+      forAll(Gen.option(Gen.int())) { option ->
+        option.map { it.valid() }.sequenceValidated() == option.traverseValidated { it.valid() }
+      }
+    }
   }
 }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -1,6 +1,7 @@
 package arrow.core
 
 import arrow.core.test.UnitSpec
+import arrow.core.test.generators.option
 import arrow.core.test.generators.sequence
 import arrow.core.test.laws.MonoidLaws
 import arrow.typeclasses.Monoid
@@ -79,7 +80,12 @@ class SequenceKTest : UnitSpec() {
     }
 
     "zip4" {
-      forAll(Gen.sequence(Gen.int()), Gen.sequence(Gen.int()), Gen.sequence(Gen.int()), Gen.sequence(Gen.int())) { a, b, c, d ->
+      forAll(
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int()),
+        Gen.sequence(Gen.int())
+      ) { a, b, c, d ->
         val result = a.zip(b, c, d, ::Tuple4)
         val expected = a.zip(b, ::Pair)
           .zip(c) { (a, b), c -> Triple(a, b, c) }
@@ -287,6 +293,12 @@ class SequenceKTest : UnitSpec() {
             .asSequence()
 
         result.toList() == expected.toList()
+      }
+    }
+
+    "filterOption should filter None" {
+      forAll(Gen.list(Gen.option(Gen.int()))) { ints ->
+        ints.asSequence().filterOption().toList() == ints.filterOption()
       }
     }
   }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -33,6 +33,19 @@ class SequenceKTest : UnitSpec() {
       res shouldBe Either.Left(Unit)
     }
 
+    "traverseOption stack-safe" {
+      // also verifies result order and execution order (l to r)
+      val acc = mutableListOf<Int>()
+      val res = generateSequence(0) { it + 1 }.traverseOption { a ->
+        (a <= 20_000).maybe {
+          acc.add(a)
+          a
+        }
+      }
+      acc shouldBe (0..20_000).toList()
+      res shouldBe None
+    }
+
     "traverseValidated stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/ValidatedTest.kt
@@ -298,5 +298,21 @@ class ValidatedTest : UnitSpec() {
 
       invalid.combine(Monoid.string(), Monoid.string(), invalid) shouldBe (Invalid("NopeNope"))
     }
+
+    "traverse should yield list when validated is valid" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.traverse { listOf(it) } shouldBe listOf(Valid("Who"))
+      invalid.traverse { listOf(it) } shouldBe emptyList()
+    }
+
+    "traverseOption should yield option when validated is valid" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.traverseOption { Some(it) } shouldBe Some(Valid("Who"))
+      invalid.traverseOption { Some(it) } shouldBe None
+    }
   }
 }

--- a/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-libs/core/arrow-core/src/test/kotlin/arrow/core/ValidatedTest.kt
@@ -64,6 +64,12 @@ class ValidatedTest : UnitSpec() {
       invalid.orNull() shouldBe null
     }
 
+    "orNone should return value if is Valid or None otherwise" {
+      Valid(13).orNone() shouldBe Some(13)
+      val invalid: Validated<Int, Int> = Invalid(13)
+      invalid.orNone() shouldBe None
+    }
+
     "valueOr should return value if is Valid or the the result of f otherwise" {
       Valid(13).valueOr { fail("None should not be called") } shouldBe 13
       Invalid(13).valueOr { e -> "$e is the defaultValue" } shouldBe "13 is the defaultValue"
@@ -161,8 +167,15 @@ class ValidatedTest : UnitSpec() {
         val all = listOf(a, b, c, d, e, f, g, h, i, j)
         val isValid = all.all(Validated<Long?, Int?>::isValid)
         val expected: Validated<Long?, Int?> =
-          if (isValid) Valid(all.fold<Validated<Long?, Int?>, Int?>(0) { acc, validated -> Nullable.zip(acc, validated.orNull()) { a, b -> a + b } })
-          else Invalid(all.filterIsInstance<Invalid<Long?>>().map(Invalid<Long?>::value).combineAll(nullableLongSemigroup))
+          if (isValid) Valid(all.fold<Validated<Long?, Int?>, Int?>(0) { acc, validated ->
+            Nullable.zip(
+              acc,
+              validated.orNull()
+            ) { a, b -> a + b }
+          })
+          else Invalid(
+            all.filterIsInstance<Invalid<Long?>>().map(Invalid<Long?>::value).combineAll(nullableLongSemigroup)
+          )
 
         res == expected
       }
@@ -307,12 +320,110 @@ class ValidatedTest : UnitSpec() {
       invalid.traverse { listOf(it) } shouldBe emptyList()
     }
 
+    "sequence should yield consistent result with traverse" {
+      forAll { a: String, b: String ->
+        val valid = Valid(a)
+        val invalid = Invalid(b)
+
+        valid.traverse { listOf(it) } == valid.map { listOf(it) }.sequence() &&
+          invalid.traverse { listOf(it) } == invalid.map { listOf(it) }.sequence()
+      }
+    }
+
     "traverseOption should yield option when validated is valid" {
       val valid = Valid("Who")
       val invalid = Invalid("Nope")
 
       valid.traverseOption { Some(it) } shouldBe Some(Valid("Who"))
       invalid.traverseOption { Some(it) } shouldBe None
+    }
+
+    "sequenceOption should yield consistent result with traverseOption" {
+      forAll { a: String, b: String ->
+        val valid = Valid(a)
+        val invalid = Invalid(b)
+
+        valid.traverseOption { Some(it) } == valid.map { Some(it) }.sequenceOption() &&
+          invalid.traverseOption { Some(it) } == invalid.map { Some(it) }.sequenceOption()
+      }
+    }
+
+    "traverseEither should wrap validated in either" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.traverseEither { it.right() } shouldBe Valid("Who").right()
+      invalid.traverseEither { it.right() } shouldBe Invalid("Nope").right()
+    }
+
+    "sequenceEither should yield consistent result with traverseEither" {
+      forAll { a: String, b: String ->
+        val valid = Valid(a)
+        val invalid = Invalid(b)
+
+        valid.traverseEither { Right(it) } == valid.map { Right(it) }.sequenceEither() &&
+          invalid.traverseEither { Right(it) } == invalid.map { Right(it) }.sequenceEither()
+      }
+    }
+
+    "bitraverse should wrap valid or invalid in a list" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.bitraverse({ listOf(it) }, { listOf(it) }) shouldBe listOf(Valid("Who"))
+      invalid.bitraverse({ listOf(it) }, { listOf(it) }) shouldBe listOf(Invalid("Nope"))
+    }
+
+    "bisequence should yield consistent result with bitraverse" {
+      forAll { a: String, b: String ->
+        val valid: Validated<String, String> = Valid(a)
+        val invalid: Validated<String, String> = Invalid(b)
+
+        valid.bimap({ listOf(it) }, { listOf(it) }).bisequence() == valid.bitraverse({ listOf(it) }, { listOf(it) }) &&
+          invalid.bimap({ listOf(it) }, { listOf(it) }).bisequence() == invalid.bitraverse(
+          { listOf(it) },
+          { listOf(it) })
+      }
+    }
+
+    "bitraverseOption should wrap valid or invalid in an option" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.bitraverseOption({ Some(it) }, { Some(it) }) shouldBe Some(Valid("Who"))
+      invalid.bitraverseOption({ Some(it) }, { Some(it) }) shouldBe Some(Invalid("Nope"))
+    }
+
+    "bisequenceOption should yield consistent result with bitraverseOption" {
+      forAll { a: String, b: String ->
+        val valid: Validated<String, String> = Valid(a)
+        val invalid: Validated<String, String> = Invalid(b)
+
+        valid.bimap({ Some(it) }, { Some(it) }).bisequenceOption() ==
+          valid.bitraverseOption({ Some(it) }, { Some(it) }) &&
+          invalid.bimap({ Some(it) }, { Some(it) }).bisequenceOption() ==
+          invalid.bitraverseOption({ Some(it) }, { Some(it) })
+      }
+    }
+
+    "bitraverseEither should wrap valid or invalid in an either" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.bitraverseEither({ it.left() }, { it.right() }) shouldBe Valid("Who").right()
+      invalid.bitraverseEither({ it.left() }, { it.right() }) shouldBe "Nope".left()
+    }
+
+    "bisequenceEither should yield consistent result with bitraverseEither" {
+      forAll { a: String, b: String ->
+        val valid: Validated<String, String> = Valid(a)
+        val invalid: Validated<String, String> = Invalid(b)
+
+        valid.bimap({ it.left() }, { it.right() }).bisequenceEither() ==
+          valid.bitraverseEither({ it.left() }, { it.right() }) &&
+          invalid.bimap({ it.left() }, { it.right() }).bisequenceEither() ==
+          invalid.bitraverseEither({ it.left() }, { it.right() })
+      }
     }
   }
 }


### PR DESCRIPTION
### In this PR
- added strong `Option<A>.pairLeft(l: L): Option<Pair<L, A>>` and `Option<A>.pairRight(r: R): Option<Pair<A, R>>`
- added `List<Option<A>>.flattenOption(): List<A>`
- added `Map<K, Option<V>>.filterOption(): Map<K, V>` 
- added `Sequence<Option<A>>.filterOption(): Sequence<A>` 
- added `F<A>.traverseOption(f: (A) -> Option<B>): Option<F<B>>` and `F<Option<T>>.sequence(): Option<F<T>>` for either, option, validated, ior, lists, nonemptylists, sequence, and maps.
- added some missing tests for Traverse

fixes #2374 