### PR TITLE
Specify type variance for `compose` and `plus` methods across the lenses

### DIFF
--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Every.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Every.kt
@@ -33,7 +33,7 @@ interface PEvery<S, T, A, B> : PTraversal<S, T, A, B>, Fold<S, A>, PSetter<S, T,
   /**
    * Compose a [PEvery] with a [PEvery]
    */
-  infix fun <C, D> compose(other: PEvery<A, B, C, D>): PEvery<S, T, C, D> =
+  infix fun <C, D> compose(other: PEvery<in A, out B, out C, in D>): PEvery<S, T, C, D> =
     object : PEvery<S, T, C, D> {
       override fun <R> foldMap(M: Monoid<R>, source: S, map: (C) -> R): R =
         this@PEvery.foldMap(M, source) { c -> other.foldMap(M, c, map) }
@@ -42,7 +42,7 @@ interface PEvery<S, T, A, B> : PTraversal<S, T, A, B>, Fold<S, A>, PSetter<S, T,
         this@PEvery.modify(source) { b -> other.modify(b, map) }
     }
 
-  operator fun <C, D> plus(other: PEvery<A, B, C, D>): PEvery<S, T, C, D> =
+  operator fun <C, D> plus(other: PEvery<in A, out B, out C, in D>): PEvery<S, T, C, D> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Fold.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Fold.kt
@@ -133,13 +133,13 @@ interface Fold<S, A> {
   /**
    * Compose a [Fold] with a [Fold]
    */
-  infix fun <C> compose(other: Fold<A, C>): Fold<S, C> =
+  infix fun <C> compose(other: Fold<in A, out C>): Fold<S, C> =
     object : Fold<S, C> {
       override fun <R> foldMap(M: Monoid<R>, source: S, map: (focus: C) -> R): R =
         this@Fold.foldMap(M, source) { c -> other.foldMap(M, c, map) }
     }
 
-  operator fun <C> plus(other: Fold<A, C>): Fold<S, C> =
+  operator fun <C> plus(other: Fold<in A, out C>): Fold<S, C> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Getter.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Getter.kt
@@ -69,10 +69,10 @@ fun interface Getter<S, A> : Fold<S, A> {
   /**
    * Compose a [Getter] with a [Getter]
    */
-  infix fun <C> compose(other: Getter<A, C>): Getter<S, C> =
+  infix fun <C> compose(other: Getter<in A, out C>): Getter<S, C> =
     Getter(other::get compose this::get)
 
-  operator fun <C> plus(other: Getter<A, C>): Getter<S, C> =
+  operator fun <C> plus(other: Getter<in A, out C>): Getter<S, C> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Iso.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Iso.kt
@@ -123,12 +123,12 @@ interface PIso<S, T, A, B> : PPrism<S, T, A, B>, PLens<S, T, A, B>, Getter<S, A>
   /**
    * Compose a [PIso] with a [PIso]
    */
-  infix fun <C, D> compose(other: PIso<A, B, C, D>): PIso<S, T, C, D> = PIso(
+  infix fun <C, D> compose(other: PIso<in A, out B, out C, in D>): PIso<S, T, C, D> = PIso(
     other::get compose this::get,
     this::reverseGet compose other::reverseGet
   )
 
-  operator fun <C, D> plus(other: PIso<A, B, C, D>): PIso<S, T, C, D> =
+  operator fun <C, D> plus(other: PIso<in A, out B, out C, in D>): PIso<S, T, C, D> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Lens.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Lens.kt
@@ -76,12 +76,12 @@ interface PLens<S, T, A, B> : Getter<S, A>, POptional<S, T, A, B>, PSetter<S, T,
   /**
    * Compose a [PLens] with another [PLens]
    */
-  infix fun <C, D> compose(other: PLens<A, B, C, D>): PLens<S, T, C, D> = Lens(
+  infix fun <C, D> compose(other: PLens<in A, out B, out C, in D>): PLens<S, T, C, D> = Lens(
     { a -> other.get(get(a)) },
     { s, c -> set(s, other.set(get(s), c)) }
   )
 
-  operator fun <C, D> plus(other: PLens<A, B, C, D>): PLens<S, T, C, D> =
+  operator fun <C, D> plus(other: PLens<in A, out B, out C, in D>): PLens<S, T, C, D> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
@@ -139,13 +139,13 @@ interface POptional<S, T, A, B> : PSetter<S, T, A, B>, Fold<S, A>, PTraversal<S,
   /**
    * Compose a [POptional] with a [POptional]
    */
-  infix fun <C, D> compose(other: POptional<A, B, C, D>): POptional<S, T, C, D> =
+  infix fun <C, D> compose(other: POptional<in A, out B, out C, in D>): POptional<S, T, C, D> =
     POptional(
       { source -> getOrModify(source).flatMap { a -> other.getOrModify(a).bimap({ b -> set(source, b) }, ::identity) } },
       { source, d -> modify(source) { a -> other.set(a, d) } }
     )
 
-  operator fun <C, D> plus(other: POptional<A, B, C, D>): POptional<S, T, C, D> =
+  operator fun <C, D> plus(other: POptional<in A, out B, out C, in D>): POptional<S, T, C, D> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Prism.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Prism.kt
@@ -103,13 +103,13 @@ interface PPrism<S, T, A, B> : POptional<S, T, A, B>, PSetter<S, T, A, B>, Fold<
   /**
    * Compose a [PPrism] with another [PPrism]
    */
-  infix fun <C, D> compose(other: PPrism<A, B, C, D>): PPrism<S, T, C, D> =
+  infix fun <C, D> compose(other: PPrism<in A, out B, out C, in D>): PPrism<S, T, C, D> =
     PPrism(
       getOrModify = { s -> getOrModify(s).flatMap { a -> other.getOrModify(a).bimap({ set(s, it) }, ::identity) } },
       reverseGet = this::reverseGet compose other::reverseGet
     )
 
-  operator fun <C, D> plus(other: PPrism<A, B, C, D>): PPrism<S, T, C, D> =
+  operator fun <C, D> plus(other: PPrism<in A, out B, out C, in D>): PPrism<S, T, C, D> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Setter.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Setter.kt
@@ -53,10 +53,10 @@ fun interface PSetter<S, T, A, B> {
   /**
    * Compose a [PSetter] with a [PSetter]
    */
-  infix fun <C, D> compose(other: PSetter<A, B, C, D>): PSetter<S, T, C, D> =
+  infix fun <C, D> compose(other: PSetter<in A, out B, out C, in D>): PSetter<S, T, C, D> =
     PSetter { s, fb -> modify(s) { a -> other.modify(a, fb) } }
 
-  operator fun <C, D> plus(other: PSetter<A, B, C, D>): PSetter<S, T, C, D> =
+  operator fun <C, D> plus(other: PSetter<in A, out B, out C, in D>): PSetter<S, T, C, D> =
     this compose other
 
   companion object {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Traversal.kt
@@ -44,10 +44,10 @@ fun interface PTraversal<S, T, A, B> : PSetter<S, T, A, B> {
   /**
    * Compose a [PTraversal] with a [PTraversal]
    */
-  infix fun <C, D> compose(other: PTraversal<A, B, C, D>): PTraversal<S, T, C, D> =
+  infix fun <C, D> compose(other: PTraversal<in A, out B, out C, in D>): PTraversal<S, T, C, D> =
     PTraversal { s, f -> this@PTraversal.modify(s) { b -> other.modify(b, f) } }
 
-  operator fun <C, D> plus(other: PTraversal<A, B, C, D>): PTraversal<S, T, C, D> =
+  operator fun <C, D> plus(other: PTraversal<in A, out B, out C, in D>): PTraversal<S, T, C, D> =
     this compose other
 
   companion object {


### PR DESCRIPTION
These all must be specified, otherwise the compiler is unable to determine which function to call when there are multiple (e.g. when using `Getter compose Getter` to create a `Getter` instead of a `Fold`).

Closes #2414