### PR TITLE
Allow to recover to Option<A> in Option.catch

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -338,6 +338,30 @@ public sealed class Option<out A> {
     public operator fun <A> invoke(a: A): Option<A> = Some(a)
 
     @JvmStatic
+    @JvmName("tryCatchOrSideEffect")
+    @Deprecated(
+      "Side-effecting recover which loses Throwable is no longer supported",
+      ReplaceWith("Option.catch({ recover(it); None }, f)")
+    )
+    public inline fun <A> catch(recover: (Throwable) -> Unit, f: () -> A): Option<A> =
+      try {
+        Some(f())
+      } catch (t: Throwable) {
+        recover(t.nonFatalOrThrow())
+        None
+      }
+
+    @JvmStatic
+    @JvmName("tryCatchOrNone")
+    /**
+     * Ignores exceptions and returns None if one is thrown
+     */
+    public inline fun <A> catch(f: () -> A): Option<A> {
+      val recover: (Throwable) -> Option<A> = { None }
+      return catch(recover, f)
+    }
+
+    @JvmStatic
     @JvmName("tryCatch")
     public inline fun <A> catch(recover: (Throwable) -> Option<A>, f: () -> A): Option<A> =
       try {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -339,12 +339,11 @@ public sealed class Option<out A> {
 
     @JvmStatic
     @JvmName("tryCatch")
-    public inline fun <A> catch(recover: (Throwable) -> Unit, f: () -> A): Option<A> =
+    public inline fun <A> catch(recover: (Throwable) -> Option<A>, f: () -> A): Option<A> =
       try {
         Some(f())
       } catch (t: Throwable) {
         recover(t.nonFatalOrThrow())
-        None
       }
 
     @JvmStatic

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
@@ -232,5 +232,17 @@ class OptionTest : UnitSpec() {
         option.map { it.valid() }.sequenceValidated() shouldBe option.traverseValidated { it.valid() }
       }
     }
+
+    "catch should return Some(result) when f does not throw" {
+      val recover: (Throwable) -> Option<Int> = { _ -> None}
+      Option.catch(recover) { 1 } shouldBe Some(1)
+    }
+
+    "catch should return Some(recoverValue) when f throws" {
+      val exception = Exception("Boom!")
+      val recoverValue = 10
+      val recover: (Throwable) -> Option<Int> = { _ -> Some(recoverValue) }
+      Option.catch(recover) { throw exception } shouldBe Some(recoverValue)
+    }
   }
 }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
@@ -244,5 +244,14 @@ class OptionTest : UnitSpec() {
       val recover: (Throwable) -> Option<Int> = { _ -> Some(recoverValue) }
       Option.catch(recover) { throw exception } shouldBe Some(recoverValue)
     }
+
+    "catch should return Some(result) when f does not throw" {
+      Option.catch { 1 } shouldBe Some(1)
+    }
+
+    "catch should return None when f throws" {
+      val exception = Exception("Boom!")
+      Option.catch { throw exception } shouldBe None
+    }
   }
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/OptionUsage.java
+++ b/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/OptionUsage.java
@@ -1,6 +1,5 @@
 package arrow.core;
 
-import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
 
 public class OptionUsage {
@@ -9,7 +8,7 @@ public class OptionUsage {
         Option<Integer> fromNullable = Option.fromNullable(null);
         Option.tryCatch((throwable) -> {
             throwable.printStackTrace();
-            return Unit.INSTANCE;
+            return None.INSTANCE;
         }, () -> 1);
         
         Option<Integer> invoke = Option.invoke(1);


### PR DESCRIPTION
The current version of `catch` that has `(Throwable) -> Unit` as recover action does not allow to handle the exception in any usable way. The only possible action is a side effect (ie. to log the exception).

I think that we should have the possibility to recover from `Throwable` to `Opton<A>` -> recover type should be `(Throwable) -> Option<A>`.  This is much more useful than executing some side effect.

I have changed the current function. Maybe it should be deprecated and a new one added?
