### PR TITLE
Deprecate Float & Double comparison operators

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Comparison.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Comparison.kt
@@ -84,6 +84,10 @@ fun sort(a: Long, b: Long, c: Long): Triple<Long, Long, Long> =
 fun sort(a: Long, vararg aas: Long): List<Long> =
   (arrayOf(a) + aas.toTypedArray()).sorted()
 
+const val FloatInstanceDeprecation: String =
+  "Comparison operators for Float are deprecated. Due to how equality of floating-point numbers work, they're not lawful under equality."
+
+@Deprecated(FloatInstanceDeprecation)
 fun sort(a: Float, b: Float): Pair<Float, Float> =
   when {
     a.isNaN() -> Pair(b, a)
@@ -91,6 +95,7 @@ fun sort(a: Float, b: Float): Pair<Float, Float> =
     else -> if (a <= b) Pair(a, b) else Pair(b, a)
   }
 
+@Deprecated(FloatInstanceDeprecation)
 fun sort(a: Float, b: Float, c: Float): Triple<Float, Float, Float> =
   when {
     a.isNaN() -> when {
@@ -109,9 +114,14 @@ fun sort(a: Float, b: Float, c: Float): Triple<Float, Float, Float> =
     else -> if (c <= b) Triple(c, b, a) else Triple(b, c, a)
   }
 
+@Deprecated(FloatInstanceDeprecation)
 fun sort(a: Float, vararg aas: Float): List<Float> =
   (arrayOf(a) + aas.toTypedArray()).sorted()
 
+const val DoubleInstanceDeprecation: String =
+  "Comparison operators for Double are deprecated. Due to how equality of floating-point numbers work, they're not lawful under equality."
+
+@Deprecated(DoubleInstanceDeprecation)
 fun sort(a: Double, b: Double): Pair<Double, Double> =
   when {
     a.isNaN() -> Pair(b, a)
@@ -119,6 +129,7 @@ fun sort(a: Double, b: Double): Pair<Double, Double> =
     else -> if (a <= b) Pair(a, b) else Pair(b, a)
   }
 
+@Deprecated(DoubleInstanceDeprecation)
 fun sort(a: Double, b: Double, c: Double): Triple<Double, Double, Double> =
   when {
     a.isNaN() -> when {
@@ -137,5 +148,6 @@ fun sort(a: Double, b: Double, c: Double): Triple<Double, Double, Double> =
     else -> if (c <= b) Triple(c, b, a) else Triple(b, c, a)
   }
 
+@Deprecated(DoubleInstanceDeprecation)
 fun sort(a: Double, vararg aas: Double): List<Double> =
   (arrayOf(a) + aas.toTypedArray()).sorted()

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ComparisonKtTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ComparisonKtTest.kt
@@ -8,8 +8,6 @@ import io.kotest.property.checkAll
 import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.byte
-import io.kotest.property.arbitrary.double
-import io.kotest.property.arbitrary.float
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.short
@@ -225,96 +223,5 @@ class ComparisonKtTest : StringSpec() {
         res shouldBe expected
       }
     }
-
-    // TODO equals is not total for Double
-    "Float - sort2".config(enabled = false) {
-      checkAll(Arb.float(), Arb.float()) { a, b ->
-        val (first, second) = sort(a, b)
-        val (aa, bb) = listOf(a, b).sorted()
-
-        first.eqv(aa) && second.eqv(bb)
-      }
-    }
-
-    // TODO equals is not total for Double
-    "Float - sort3".config(enabled = false) {
-      checkAll(Arb.float(), Arb.float(), Arb.float()) { a, b, c ->
-        val (first, second, third) = sort(a, b, c)
-        val (aa, bb, cc) = listOf(a, b, c).sorted()
-
-        assertSoftly {
-          first shouldBe aa
-          second shouldBe bb
-          third shouldBe cc
-        }
-      }
-    }
-
-    // TODO equals is not total for Double
-    "Float - sortAll".config(enabled = false) {
-      checkAll(Arb.float(), Arb.float(), Arb.float(), Arb.float()) { a, b, c, d ->
-        val res = sort(a, b, c, d)
-        val expected = listOf(a, b, c, d).sorted()
-
-        res shouldBe expected
-      }
-    }
-
-    // TODO equals is not total for Double
-    "Double - sort2".config(enabled = false) {
-      checkAll(Arb.double(), Arb.double()) { a, b ->
-        val (first, second) = sort(a, b)
-        val (aa, bb) = listOf(a, b).sorted()
-
-        assertSoftly {
-          first shouldBe aa
-          second shouldBe bb
-        }
-      }
-    }
-
-    // TODO equals is not total for Double
-    "Double - sort3".config(enabled = false) {
-      checkAll(Arb.double(), Arb.double(), Arb.double()) { a, b, c ->
-        val (first, second, third) = sort(a, b, c)
-        val (aa, bb, cc) = listOf(a, b, c).sorted()
-
-        assertSoftly {
-          first shouldBe aa
-          second shouldBe bb
-          third shouldBe cc
-        }
-      }
-    }
-
-    // TODO equals is not total for Double
-    "Double - sortAll".config(enabled = false) {
-      checkAll(Arb.double(), Arb.double(), Arb.double(), Arb.double()) { a, b, c, d ->
-        val res = sort(a, b, c, d)
-        val expected = listOf(a, b, c, d).sorted()
-
-        res shouldBe expected
-      }
-    }
   }
 }
-
-/**
- * Equality for Float to check sorting order.
- * So we need `NaN == NaN` to be true.
- */
-fun Float.eqv(other: Float): Boolean =
-  if (isNaN() && other.isNaN()) true else {
-    this shouldBe other
-    true
-  }
-
-/**
- * Equality for Double to check sorting order.
- * So we need `NaN == NaN` to be true.
- */
-fun Double.eqv(other: Double): Boolean =
-  if (isNaN() && other.isNaN()) true else {
-    this shouldBe other
-    true
-  }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/extensions/NumberInstancesTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/extensions/NumberInstancesTest.kt
@@ -1,12 +1,6 @@
 package arrow.core.extensions
 
-import arrow.core.eqv
 import arrow.core.test.UnitSpec
-import arrow.core.test.generators.byteSmall
-import arrow.core.test.generators.floatSmall
-import arrow.core.test.generators.intSmall
-import arrow.core.test.generators.longSmall
-import arrow.core.test.generators.shortSmall
 import arrow.core.test.laws.MonoidLaws
 import arrow.core.test.laws.SemiringLaws
 import arrow.typeclasses.Monoid
@@ -14,6 +8,8 @@ import arrow.typeclasses.Semiring
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.byte
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.numericDoubles
 import io.kotest.property.arbitrary.numericFloats
 import io.kotest.property.arbitrary.short
@@ -32,11 +28,10 @@ class NumberInstancesTest : UnitSpec() {
   }
 
   init {
-    testAllLaws(Semiring.byte(), Monoid.byte(), Arb.byteSmall())
-    testAllLaws(Semiring.short(), Monoid.short(), Arb.shortSmall())
-    testAllLaws(Semiring.int(), Monoid.int(), Arb.intSmall())
-    testAllLaws(Semiring.long(), Monoid.long(), Arb.longSmall())
-    MonoidLaws.laws(Monoid.float(), Arb.floatSmall(), Float::eqv)
+    testAllLaws(Semiring.byte(), Monoid.byte(), Arb.byte())
+    testAllLaws(Semiring.short(), Monoid.short(), Arb.short())
+    testAllLaws(Semiring.int(), Monoid.int(), Arb.int())
+    testAllLaws(Semiring.long(), Monoid.long(), Arb.long())
 
     /** Semigroup specific instance check */
 


### PR DESCRIPTION
Due to the way that floating numbers work in Kotlin MPP, we cannot support comparison operators for them (`Float`, `Double`).

https://kotlinlang.org/docs/equality.html#floating-point-numbers-equality