### PR TITLE
Add ensure, and ensureNotNull in computation DSL

### DIFF
--- a/arrow-libs/core/arrow-continuations/src/commonTest/kotlin/generic/SuspendingComputationTest.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonTest/kotlin/generic/SuspendingComputationTest.kt
@@ -143,11 +143,13 @@ class SuspendingComputationTest : StringSpec({
     fun square(i: Int): Int = i * i
 
     checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, lValue: String ->
-      either<String, Int> {
+      val res = either<String, Int> {
         val ii = i
         ensureNotNull(ii) { lValue }
         square(ii) // Smart-cast by contract
-      } shouldBe i?.let(::square)?.right() ?: lValue.left()
+      }
+      val expected = i?.let(::square)?.right() ?: lValue.left()
+      res shouldBe expected
     }
   }
 

--- a/arrow-libs/core/arrow-continuations/src/commonTest/kotlin/generic/SuspendingComputationTest.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonTest/kotlin/generic/SuspendingComputationTest.kt
@@ -5,10 +5,19 @@ import arrow.core.computations.either
 import arrow.core.Either.Right
 import arrow.core.Either.Left
 import arrow.core.Eval
+import arrow.core.computations.ensureNotNull
 import arrow.core.computations.eval
+import arrow.core.left
+import arrow.core.right
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bool
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -119,6 +128,27 @@ class SuspendingComputationTest : StringSpec({
       println(x)
       1
     } shouldBe Left("test")
+  }
+
+  "ensure null in either computation" {
+    checkAll(Arb.bool(), Arb.int(), Arb.string()) { predicate, rValue, lValue ->
+      either<String, Int> {
+        ensure(predicate) { lValue }
+        rValue
+      } shouldBe if (predicate) rValue.right() else lValue.left()
+    }
+  }
+
+  "ensureNotNull in either computation" {
+    fun square(i: Int): Int = i * i
+
+    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, lValue: String ->
+      either<String, Int> {
+        val ii = i
+        ensureNotNull(ii) { lValue }
+        square(ii) // Smart-cast by contract
+      } shouldBe i?.let(::square)?.right() ?: lValue.left()
+    }
   }
 
   "Short-circuiting cancels KotlinX Coroutines" {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/either.kt
@@ -59,6 +59,7 @@ public fun interface EitherEffect<E, A> : Effect<Either<E, A>> {
  *
  * ```kotlin:ank
  * import arrow.core.computations.either
+ * import arrow.core.computations.ensureNotNull
  *
  * //sampleStart
  * suspend fun main() {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/either.kt
@@ -30,14 +30,19 @@ public fun interface EitherEffect<E, A> : Effect<Either<E, A>> {
    * In case it is `false`, then it short-circuits the binding and returns
    * the provided value by [orLeft] inside an [Either.Left].
    *
-   * ```kotlin:ank
+   * ```kotlin:ank:playground
    * import arrow.core.computations.either
    *
-   * either<String, Int> {
-   *   ensure(true) { "" }
-   *   println("ensure(true) passes")
-   *   ensure(false) { "failed" }
-   *   1
+   * //sampleStart
+   * suspend fun main() {
+   *   either<String, Int> {
+   *     ensure(true) { "" }
+   *     println("ensure(true) passes")
+   *     ensure(false) { "failed" }
+   *     1
+   *   }
+   * //sampleEnd
+   *   .let(::println)
    * }
    * // println: "ensure(true) passes"
    * // res: Either.Left("failed")
@@ -55,11 +60,16 @@ public fun interface EitherEffect<E, A> : Effect<Either<E, A>> {
  * ```kotlin:ank
  * import arrow.core.computations.either
  *
- * either<String, Int> {
- *   val x: Int? = 1
- *   ensureNotNull(x) { "passes" }
- *   println(x)
- *   ensureNotNull(null) { "failed" }
+ * //sampleStart
+ * suspend fun main() {
+ *   either<String, Int> {
+ *     val x: Int? = 1
+ *     ensureNotNull(x) { "passes" }
+ *     println(x)
+ *     ensureNotNull(null) { "failed" }
+ *   }
+ * //sampleEnd
+ *   .let(::println)
  * }
  * // println: "1"
  * // res: Either.Left("failed")

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/nullable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/nullable.kt
@@ -22,11 +22,16 @@ public fun interface NullableEffect<A> : Effect<A?> {
    * ```kotlin:ank
    * import arrow.core.computations.nullable
    *
-   * nullable<Int> {
-   *   ensure(true)
-   *   println("ensure(true) passes")
-   *   ensure(false)
-   *   1
+   * //sampleStart
+   * suspend fun main() {
+   *   nullable<Int> {
+   *     ensure(true)
+   *     println("ensure(true) passes")
+   *     ensure(false)
+   *     1
+   *   }
+   * //sampleEnd
+   *   .let(::println)
    * }
    * // println: "ensure(true) passes"
    * // res: null
@@ -44,11 +49,16 @@ public fun interface NullableEffect<A> : Effect<A?> {
  * ```kotlin:ank
  * import arrow.core.computations.nullable
  *
- * nullable<Int> {
- *   val x: Int? = 1
- *   ensureNotNull(x)
- *   println(x)
- *   ensureNotNull(null)
+ * //sampleStart
+ * suspend fun main() {
+ *   nullable<Int> {
+ *     val x: Int? = 1
+ *     ensureNotNull(x)
+ *     println(x)
+ *     ensureNotNull(null)
+ *   }
+ * //sampleEnd
+ *   .let(::println)
  * }
  * // println: "1"
  * // res: null

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/nullable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/nullable.kt
@@ -2,6 +2,8 @@ package arrow.core.computations
 
 import arrow.continuations.Effect
 import arrow.core.Option
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.coroutines.RestrictsSuspension
 
 public fun interface NullableEffect<A> : Effect<A?> {
@@ -10,6 +12,18 @@ public fun interface NullableEffect<A> : Effect<A?> {
 
   public suspend fun <B> Option<B>.bind(): B =
     orNull().bind()
+
+  public suspend fun ensure(boolean: Boolean): Unit =
+    if (boolean) Unit else control().shift(null)
+}
+
+@OptIn(ExperimentalContracts::class) // Contracts not available on open functions, so made it top-level.
+public suspend fun <B : Any> NullableEffect<*>.ensureNotNull(value: B?): B {
+  contract {
+    returns() implies (value != null)
+  }
+
+  return value ?: control().shift(null)
 }
 
 @RestrictsSuspension

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/nullable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/nullable.kt
@@ -1,6 +1,7 @@
 package arrow.core.computations
 
 import arrow.continuations.Effect
+import arrow.core.None
 import arrow.core.Option
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -13,10 +14,46 @@ public fun interface NullableEffect<A> : Effect<A?> {
   public suspend fun <B> Option<B>.bind(): B =
     orNull().bind()
 
-  public suspend fun ensure(boolean: Boolean): Unit =
-    if (boolean) Unit else control().shift(null)
+  /**
+   * Ensure check if the [value] is `true`,
+   * and if it is it allows the `nullable { }` binding to continue.
+   * In case it is `false`, then it short-circuits the binding and returns `null`.
+   *
+   * ```kotlin:ank
+   * import arrow.core.computations.nullable
+   *
+   * nullable<Int> {
+   *   ensure(true)
+   *   println("ensure(true) passes")
+   *   ensure(false)
+   *   1
+   * }
+   * // println: "ensure(true) passes"
+   * // res: null
+   * ```
+   */
+  public suspend fun ensure(value: Boolean): Unit =
+    if (value) Unit else control().shift(null)
 }
 
+/**
+ * Ensures that [value] is not null.
+ * When the value is not null, then it will be returned as non null and the check value is now smart-checked to non-null.
+ * Otherwise, if the [value] is null then the [option] binding will short-circuit with [None].
+ *
+ * ```kotlin:ank
+ * import arrow.core.computations.nullable
+ *
+ * nullable<Int> {
+ *   val x: Int? = 1
+ *   ensureNotNull(x)
+ *   println(x)
+ *   ensureNotNull(null)
+ * }
+ * // println: "1"
+ * // res: null
+ * ```
+ */
 @OptIn(ExperimentalContracts::class) // Contracts not available on open functions, so made it top-level.
 public suspend fun <B : Any> NullableEffect<*>.ensureNotNull(value: B?): B {
   contract {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/option.kt
@@ -16,10 +16,46 @@ public fun interface OptionEffect<A> : Effect<Option<A>> {
   public suspend fun <B> Option<B>.bind(): B =
     fold({ control().shift(None) }, ::identity)
 
-  public suspend fun ensure(boolean: Boolean): Unit =
-    if (boolean) Unit else control().shift(None)
+  /**
+   * Ensure check if the [value] is `true`,
+   * and if it is it allows the `option { }` binding to continue.
+   * In case it is `false`, then it short-circuits the binding and returns [None].
+   *
+   * ```kotlin:ank
+   * import arrow.core.computations.option
+   *
+   * option<Int> {
+   *   ensure(true)
+   *   println("ensure(true) passes")
+   *   ensure(false)
+   *   1
+   * }
+   * // println: "ensure(true) passes"
+   * // res: None
+   * ```
+   */
+  public suspend fun ensure(value: Boolean): Unit =
+    if (value) Unit else control().shift(None)
 }
 
+/**
+ * Ensures that [value] is not null.
+ * When the value is not null, then it will be returned as non null and the check value is now smart-checked to non-null.
+ * Otherwise, if the [value] is null then the [option] binding will short-circuit with [None].
+ *
+ * ```kotlin:ank
+ * import arrow.core.computations.option
+ *
+ * option<Int> {
+ *   val x: Int? = 1
+ *   ensureNotNull(x)
+ *   println(x)
+ *   ensureNotNull(null)
+ * }
+ * // println: "1"
+ * // res: None
+ * ```
+ */
 @OptIn(ExperimentalContracts::class) // Contracts not available on open functions, so made it top-level.
 public suspend fun <B : Any> OptionEffect<*>.ensureNotNull(value: B?): B {
   contract {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/option.kt
@@ -24,11 +24,16 @@ public fun interface OptionEffect<A> : Effect<Option<A>> {
    * ```kotlin:ank
    * import arrow.core.computations.option
    *
-   * option<Int> {
-   *   ensure(true)
-   *   println("ensure(true) passes")
-   *   ensure(false)
-   *   1
+   * //sampleStart
+   * suspend fun main() {
+   *   option<Int> {
+   *     ensure(true)
+   *     println("ensure(true) passes")
+   *     ensure(false)
+   *     1
+   *   }
+   * //sampleEnd
+   *   .let(::println)
    * }
    * // println: "ensure(true) passes"
    * // res: None
@@ -46,11 +51,16 @@ public fun interface OptionEffect<A> : Effect<Option<A>> {
  * ```kotlin:ank
  * import arrow.core.computations.option
  *
- * option<Int> {
- *   val x: Int? = 1
- *   ensureNotNull(x)
- *   println(x)
- *   ensureNotNull(null)
+ * //sampleStart
+ * suspend fun main() {
+ *   option<Int> {
+ *     val x: Int? = 1
+ *     ensureNotNull(x)
+ *     println(x)
+ *     ensureNotNull(null)
+ *   }
+ * //sampleEnd
+ *   .let(::println)
  * }
  * // println: "1"
  * // res: None

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/computations/NullableTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/computations/NullableTest.kt
@@ -3,6 +3,10 @@ package arrow.core.computations
 import arrow.core.Some
 import arrow.core.test.UnitSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bool
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
 
 class NullableTest : UnitSpec() {
 
@@ -71,6 +75,25 @@ class NullableTest : UnitSpec() {
         }.bind()
         string
       } shouldBe null
+    }
+    "ensure null in nullable computation" {
+      checkAll(Arb.bool(), Arb.int()) { predicate, i ->
+        nullable {
+          ensure(predicate)
+          i
+        } shouldBe if (predicate) i else null
+      }
+    }
+
+    "ensureNotNull in nullable computation" {
+      fun square(i: Int): Int = i * i
+      checkAll(Arb.int().orNull()) { i: Int? ->
+        nullable {
+          val ii = i
+          ensureNotNull(ii)
+          square(ii) // Smart-cast by contract
+        } shouldBe i?.let(::square)
+      }
     }
   }
 }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/computations/NullableTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/computations/NullableTest.kt
@@ -7,6 +7,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.orNull
+import io.kotest.property.checkAll
 
 class NullableTest : UnitSpec() {
 


### PR DESCRIPTION
This PR adds some convenient syntax for mixing the `nullable` effect/monad with other effect/monads such as `either`, `option` and `nullable` itself.

It also deprecates the currently gotcha behavior of nullable `bind` syntax in `option { }`.
Example of gotcha behavior:

```kotlin
either<Int, String> {
  option<Int> {
     Either.Left(1).bind() // Expected to short-circuit but uses `fun <A> A?.bind(): A` instead and *doesnt* short-circuit,
     
  }.fold({ "0" }, Int::toString)
}
```


This was originally proposed in #2311.
The proposed `require`/`requireNotNull` syntax conflicts with with `kotlin.require` and `kotlin.requireNotNull` which is auto-imported and it can be easily confused. If it's mistake it leads to an exception instead of participating in the computation block.