### PR TITLE
Optimise Github Actions

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -1,4 +1,4 @@
-name: "Build documentation"
+name: "KtLint & Build documentation"
 
 on: pull_request
 
@@ -25,6 +25,9 @@ jobs:
       run: |
         echo "Additional step to avoid a random failure with Dokka 0.10.0 and MPP"
         ./gradlew assemble
+    - name: "Run KtLint"
+      working-directory: arrow-libs
+      run: ./gradlew ktlintCheck
     - name: "Create API doc"
       working-directory: arrow-libs
       run: ./gradlew dokka

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -1,4 +1,4 @@
-name: "Build libraries"
+name: "Run test JS"
 
 on: pull_request
 
@@ -16,14 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: 8
       - name: Build
         working-directory: arrow-libs
-        run: ./gradlew build
+        run: ./gradlew ktlintCheck jsIrTest jsLegacyTest
       - name: "Prepare test reports"
         if: ${{ always() }}
         run: |

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - name: Build
         working-directory: arrow-libs
-        run: ./gradlew ktlintCheck jsIrTest jsLegacyTest
+        run: ./gradlew jsIrTest jsLegacyTest
       - name: "Prepare test reports"
         if: ${{ always() }}
         run: |

--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -1,4 +1,4 @@
-name: "Verify JDK compilation"
+name: "Run test with JDK"
 
 on: pull_request
 
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [macos-latest]
         java: [8, 11, 13, 15]
-    name: Verify compilation with JDK ${{ matrix.java }} on ${{ matrix.os }}
+    name: Run test with JDK ${{ matrix.java }} on ${{ matrix.os }}
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
This PR changes a couple things to make deduplicate some tasks we run more than once on CI.

- Remove `jvm` from `build` step and turn it into `build_js`.
- Rename build/verify steps to running tests, since we removed ktlint and splits running the different platforms in different actions.
- Run KtLint only once in documentation step