### PR TITLE
Fix test impl atomic on JS

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/AtomicTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/AtomicTest.kt
@@ -36,12 +36,12 @@ class AtomicTest : ArrowFxSpec(
     }
 
     "access - setter should fail if value is modified before setter is called" {
-      checkAll(Arb.int(), Arb.int(), Arb.int()) { x, y, z ->
+      checkAll(Arb.int(), Arb.int()) { x, z ->
         val ref = Atomic(x)
         val (_, setter) = ref.access()
-        ref.set(y)
+        ref.update { it + 1 }
         setter(z) shouldBe false
-        ref.get() shouldBe y
+        ref.get() shouldBe x + 1
       }
     }
 


### PR DESCRIPTION
There was a failing test on JS for values `x, y, z => 1f, 1f, 0f`.

It does a reference check in `compareAndSet` underneath, and on JS this made the test fail for `x` and `y` of the same value.