### PR TITLE
CU-m3dyef Either, Option and Validated tap effect

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -821,11 +821,53 @@ public sealed class Either<out A, out B> {
    * Example:
    * ```
    * Right(12).mapLeft { "flower" } // Result: Right(12)
-   * Left(12).mapLeft { "flower" }  // Result: Left("flower)
+   * Left(12).mapLeft { "flower" }  // Result: Left("flower")
    * ```
    */
   public inline fun <C> mapLeft(f: (A) -> C): Either<C, B> =
     fold({ Left(f(it)) }, { Right(it) })
+
+  /**
+   * The given function is applied as a fire and forget effect
+   * if this is a `Left`.
+   * When applied the result is ignored and the original
+   * Either value is returned
+   *
+   * Example:
+   * ```
+   * Right(12).tapLeft { println("flower") } // Result: Right(12)
+   * Left(12).tapLeft { println("flower") }  // Result: prints "flower" and returns: Left(12)
+   * ```
+   */
+  public inline fun tapLeft(f: (A) -> Unit): Either<A, B> =
+    when (this) {
+      is Left -> {
+        f(this.value)
+        this
+      }
+      is Right -> this
+    }
+
+  /**
+   * The given function is applied as a fire and forget effect
+   * if this is a `Right`.
+   * When applied the result is ignored and the original
+   * Either value is returned
+   *
+   * Example:
+   * ```
+   * Right(12).tap { println("flower") } // Result: prints "flower" and returns: Right(12)
+   * Left(12).tap { println("flower") }  // Result: Left(12)
+   * ```
+   */
+  public inline fun tap(f: (B) -> Unit): Either<A, B> =
+    when (this) {
+      is Left -> this
+      is Right -> {
+        f(this.value)
+        this
+      }
+    }
 
   /**
    * Map over Left and Right of this Either

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -411,6 +411,48 @@ public sealed class Option<out A> {
       Some.unit
     ) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
+  /**
+   * The given function is applied as a fire and forget effect
+   * if this is a `None`.
+   * When applied the result is ignored and the original
+   * None value is returned
+   *
+   * Example:
+   * ```
+   * Some(12).tapNone { println("flower") } // Result: Some(12)
+   * none<Int>().tapNone { println("flower") }  // Result: prints "flower" and returns: None
+   * ```
+   */
+  public inline fun tapNone(f: () -> Unit): Option<A> =
+    when (this) {
+      is None -> {
+        f()
+        this
+      }
+      is Some -> this
+    }
+
+  /**
+   * The given function is applied as a fire and forget effect
+   * if this is a `some`.
+   * When applied the result is ignored and the original
+   * Some value is returned
+   *
+   * Example:
+   * ```
+   * Some(12).tap { println("flower") } // Result: prints "flower" and returns: Some(12)
+   * none<Int>().tap { println("flower") }  // Result: None
+   * ```
+   */
+  public inline fun tap(f: (A) -> Unit): Option<A> =
+    when (this) {
+      is None -> this
+      is Some -> {
+        f(this.value)
+        this
+      }
+    }
+
   public inline fun <B, C, D, E> zip(
     b: Option<B>,
     c: Option<C>,

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Validated.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Validated.kt
@@ -704,6 +704,48 @@ public sealed class Validated<out E, out A> {
     bimap(f, ::identity)
 
   /**
+   * The given function is applied as a fire and forget effect
+   * if this is `Invalid`.
+   * When applied the result is ignored and the original
+   * Validated value is returned
+   *
+   * Example:
+   * ```
+   * Valid(12).tapInvalid { println("flower") } // Result: Valid(12)
+   * Invalid(12).tapInvalid { println("flower") }  // Result: prints "flower" and returns: Invalid(12)
+   * ```
+   */
+  public inline fun tapInvalid(f: (E) -> Unit): Validated<E, A> =
+    when (this) {
+      is Invalid -> {
+        f(this.value)
+        this
+      }
+      is Valid -> this
+    }
+
+  /**
+   * The given function is applied as a fire and forget effect
+   * if this is `Valid`.
+   * When applied the result is ignored and the original
+   * Validated value is returned
+   *
+   * Example:
+   * ```
+   * Valid(12).tap { println("flower") } // Result: prints "flower" and returns: Valid(12)
+   * Invalid(12).tap { println("flower") }  // Result: Invalid(12)
+   * ```
+   */
+  public inline fun tap(f: (A) -> Unit): Validated<E, A> =
+    when (this) {
+      is Invalid -> this
+      is Valid -> {
+        f(this.value)
+        this
+      }
+    }
+
+  /**
    * apply the given function to the value with the given B when
    * valid, otherwise return the given B
    */

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
@@ -16,16 +16,17 @@ import arrow.core.test.generators.suspendFunThatThrows
 import arrow.core.test.laws.FxLaws
 import arrow.core.test.laws.MonoidLaws
 import arrow.typeclasses.Monoid
-import io.kotest.property.Arb
-import io.kotest.property.checkAll
-import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.negativeInts
 import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
 
 class EitherTest : UnitSpec() {
 
@@ -61,6 +62,32 @@ class EitherTest : UnitSpec() {
     "isRight should return false if Left and true if Right" {
       checkAll { a: Int ->
         !Left(a).isRight() && Right(a).isRight()
+      }
+    }
+
+    "tap applies effects returning the original value" {
+      checkAll(Arb.either(Arb.long(), Arb.int())) { either ->
+        var effect = 0
+        val res = either.tap { effect += 1 }
+        val expected = when (either) {
+          is Left -> 0
+          is Right -> 1
+        }
+        effect shouldBe expected
+        res shouldBe either
+      }
+    }
+
+    "tapLeft applies effects returning the original value" {
+      checkAll(Arb.either(Arb.long(), Arb.int())) { either ->
+        var effect = 0
+        val res = either.tapLeft { effect += 1 }
+        val expected = when (either) {
+          is Left -> 1
+          is Right -> 0
+        }
+        effect shouldBe expected
+        res shouldBe either
       }
     }
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
@@ -5,21 +5,20 @@ import arrow.core.computations.RestrictedOptionEffect
 import arrow.core.computations.ensureNotNull
 import arrow.core.computations.option
 import arrow.core.test.UnitSpec
-import arrow.core.test.generators.either
 import arrow.core.test.generators.option
 import arrow.core.test.laws.FxLaws
 import arrow.core.test.laws.MonoidLaws
 import arrow.typeclasses.Monoid
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.property.checkAll
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bool
-import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
 
 class OptionTest : UnitSpec() {
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
@@ -5,6 +5,7 @@ import arrow.core.computations.RestrictedOptionEffect
 import arrow.core.computations.ensureNotNull
 import arrow.core.computations.option
 import arrow.core.test.UnitSpec
+import arrow.core.test.generators.either
 import arrow.core.test.generators.option
 import arrow.core.test.laws.FxLaws
 import arrow.core.test.laws.MonoidLaws
@@ -16,6 +17,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 
@@ -73,6 +75,32 @@ class OptionTest : UnitSpec() {
         x
         throw IllegalStateException("This should not be executed")
       } shouldBe None
+    }
+
+    "tap applies effects returning the original value" {
+      checkAll(Arb.option(Arb.long())) { option ->
+        var effect = 0
+        val res = option.tap { effect += 1 }
+        val expected = when (option) {
+          is Some -> 1
+          is None -> 0
+        }
+        effect shouldBe expected
+        res shouldBe option
+      }
+    }
+
+    "tapNone applies effects returning the original value" {
+      checkAll(Arb.option(Arb.long())) { option ->
+        var effect = 0
+        val res = option.tapNone { effect += 1 }
+        val expected = when (option) {
+          is Some -> 0
+          is None -> 1
+        }
+        effect shouldBe expected
+        res shouldBe option
+      }
     }
 
     "fromNullable should work for both null and non-null values of nullable types" {

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ValidatedTest.kt
@@ -136,6 +136,32 @@ class ValidatedTest : UnitSpec() {
       }
     }
 
+    "tap applies effects returning the original value" {
+      checkAll(Arb.validated(Arb.long(), Arb.int())) { validated ->
+        var effect = 0
+        val res = validated.tap { effect += 1 }
+        val expected = when (validated) {
+          is Validated.Valid -> 1
+          is Validated.Invalid -> 0
+        }
+        effect shouldBe expected
+        res shouldBe validated
+      }
+    }
+
+    "tapInvalid applies effects returning the original value" {
+      checkAll(Arb.validated(Arb.long(), Arb.int())) { validated ->
+        var effect = 0
+        val res = validated.tapInvalid { effect += 1 }
+        val expected = when (validated) {
+          is Validated.Valid -> 0
+          is Validated.Invalid -> 1
+        }
+        effect shouldBe expected
+        res shouldBe validated
+      }
+    }
+
     "zip is derived from flatMap" {
       checkAll(
         Arb.validated(Arb.long().orNull(), Arb.int().orNull()),


### PR DESCRIPTION
Addresses https://github.com/arrow-kt/arrow/issues/2416 and https://github.com/arrow-kt/arrow/issues/2410
In the second case in https://github.com/arrow-kt/arrow/issues/2410 `tap` is the same as `foreach` and there is also `tapNone` 