### PR TITLE
WIP: Use patched version of Dokka's Jekyll Renderer

### DIFF
--- a/arrow-libs/ank/settings.gradle
+++ b/arrow-libs/ank/settings.gradle
@@ -28,3 +28,6 @@ include 'arrow-fx-coroutines-test'
 
 project(":arrow-fx-coroutines").projectDir = file("../fx/arrow-fx-coroutines")
 project(":arrow-fx-coroutines-test").projectDir = file("../fx/arrow-fx-coroutines-test")
+
+include 'jekyll'
+project(":jekyll").projectDir = file("dokka/jekyll")

--- a/arrow-libs/core/settings.gradle
+++ b/arrow-libs/core/settings.gradle
@@ -9,3 +9,6 @@ include 'arrow-core'
 include 'arrow-core-test'
 include 'arrow-continuations'
 include 'arrow-core-retrofit'
+
+include 'jekyll'
+project(":jekyll").projectDir = file("dokka/jekyll")

--- a/arrow-libs/dokka/jekyll/build.gradle
+++ b/arrow-libs/dokka/jekyll/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jlleitschuh.gradle.ktlint"
+}
+
+apply from: "$SUB_PROJECT"
+
+dependencies {
+    compileOnly "org.jetbrains.dokka:dokka-core:$DOKKA_VERSION"
+    implementation "org.jetbrains.dokka:dokka-base:$DOKKA_VERSION"
+    implementation "org.jetbrains.dokka:gfm-plugin:$DOKKA_VERSION"
+}

--- a/arrow-libs/dokka/jekyll/gradle.properties
+++ b/arrow-libs/dokka/jekyll/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow Dokka Jekyll
+POM_ARTIFACT_ID=arrow-dokka-jekyll
+POM_PACKAGING=jar

--- a/arrow-libs/dokka/jekyll/src/main/kotlin/com/github/nomisRev/DokkaFenceWorkaroundPlugin.kt
+++ b/arrow-libs/dokka/jekyll/src/main/kotlin/com/github/nomisRev/DokkaFenceWorkaroundPlugin.kt
@@ -1,0 +1,125 @@
+package com.github.nomisRev
+
+import org.jetbrains.dokka.CoreExtensions
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.renderers.PackageListCreator
+import org.jetbrains.dokka.base.renderers.RootCreator
+import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProviderFactory
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
+import org.jetbrains.dokka.base.resolvers.shared.RecognizedLinkFormat
+import org.jetbrains.dokka.base.transformers.pages.comments.CommentsToContentConverter
+import org.jetbrains.dokka.base.transformers.pages.comments.DocTagToContentConverter
+import org.jetbrains.dokka.gfm.GfmPlugin
+import org.jetbrains.dokka.gfm.renderer.BriefCommentPreprocessor
+import org.jetbrains.dokka.gfm.renderer.CommonmarkRenderer
+import org.jetbrains.dokka.model.doc.CodeBlock
+import org.jetbrains.dokka.model.doc.DocTag
+import org.jetbrains.dokka.model.properties.PropertyContainer
+import org.jetbrains.dokka.model.toDisplaySourceSets
+import org.jetbrains.dokka.pages.ContentCodeBlock
+import org.jetbrains.dokka.pages.ContentCodeInline
+import org.jetbrains.dokka.pages.ContentNode
+import org.jetbrains.dokka.pages.ContentPage
+import org.jetbrains.dokka.pages.DCI
+import org.jetbrains.dokka.pages.SimpleAttr
+import org.jetbrains.dokka.pages.Style
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.jetbrains.dokka.plugability.Extension
+import org.jetbrains.dokka.plugability.ExtensionPoint
+import org.jetbrains.dokka.plugability.plugin
+import org.jetbrains.dokka.plugability.query
+import org.jetbrains.dokka.renderers.Renderer
+import org.jetbrains.dokka.transformers.pages.PageTransformer
+
+public class DokkaFenceWorkaround : DokkaPlugin() {
+  public val jekyllPreprocessors: ExtensionPoint<PageTransformer> by extensionPoint()
+
+  private val dokkaBase by lazy { plugin<DokkaBase>() }
+  private val gfmPlugin by lazy { plugin<GfmPlugin>() }
+
+  public val renderer: Extension<Renderer, *, *> by extending {
+    (CoreExtensions.renderer
+      providing { JekyllRenderer(it) }
+      override plugin<GfmPlugin>().renderer)
+  }
+
+  public val comments: Extension<CommentsToContentConverter, *, *> by extending {
+    dokkaBase.commentsToContentConverter with PatchedDocTagToContentConverter() override dokkaBase.docTagToContentConverter
+  }
+
+  public val rootCreator: Extension<PageTransformer, *, *> by extending {
+    jekyllPreprocessors with RootCreator
+  }
+
+  public val briefCommentPreprocessor: Extension<PageTransformer, *, *> by extending {
+    jekyllPreprocessors with BriefCommentPreprocessor()
+  }
+
+  public val packageListCreator: Extension<PageTransformer, *, *> by extending {
+    jekyllPreprocessors providing {
+      PackageListCreator(it, RecognizedLinkFormat.DokkaJekyll)
+    } order { after(rootCreator) }
+  }
+
+  public val locationProvider: Extension<LocationProviderFactory, *, *> by extending {
+    dokkaBase.locationProviderFactory providing ::DokkaLocationProviderFactory override listOf(gfmPlugin.locationProvider)
+  }
+}
+
+public class JekyllRenderer(context: DokkaContext) : CommonmarkRenderer(context) {
+
+  override val preprocessors: List<PageTransformer> =
+    context.plugin<DokkaFenceWorkaround>().query { jekyllPreprocessors }
+
+  override fun StringBuilder.buildNewLine() {
+    append("\n")
+  }
+
+  override fun buildPage(page: ContentPage, content: (StringBuilder, ContentPage) -> Unit): String {
+    val builder = StringBuilder()
+    builder.append("---\n")
+    builder.append("title: ${page.name}\n")
+    builder.append("---\n")
+    content(builder, page)
+    return builder.toString()
+  }
+
+  override fun StringBuilder.buildCodeBlock(code: ContentCodeBlock, pageContext: ContentPage) {
+    append("```${code.language}\n")
+    code.children.forEach { buildContentNode(it, pageContext) }
+    append("\n```")
+  }
+
+  override fun StringBuilder.buildCodeInline(code: ContentCodeInline, pageContext: ContentPage) {
+    append('`')
+    code.children.forEach { buildContentNode(it, pageContext) }
+    append('`')
+  }
+}
+
+public class PatchedDocTagToContentConverter : DocTagToContentConverter() {
+  override fun buildContent(
+    docTag: DocTag,
+    dci: DCI,
+    sourceSets: Set<DokkaConfiguration.DokkaSourceSet>,
+    styles: Set<Style>,
+    extra: PropertyContainer<ContentNode>
+  ): List<ContentNode> {
+    fun buildChildren(docTag: DocTag, newStyles: Set<Style> = emptySet(), newExtras: SimpleAttr? = null) =
+      docTag.children.flatMap {
+        buildContent(it, dci, sourceSets, styles + newStyles, newExtras?.let { extra + it } ?: extra)
+      }
+
+    return if (docTag is CodeBlock) listOf(
+      ContentCodeBlock(
+        buildChildren(docTag),
+        docTag.params.getOrDefault("lang", ""),
+        dci,
+        sourceSets.toDisplaySourceSets(),
+        styles
+      )
+    ) else super.buildContent(docTag, dci, sourceSets, styles, extra)
+  }
+}

--- a/arrow-libs/dokka/jekyll/src/main/resources/META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin
+++ b/arrow-libs/dokka/jekyll/src/main/resources/META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin
@@ -1,0 +1,1 @@
+com.github.nomisRev.DokkaFenceWorkaround

--- a/arrow-libs/fx/settings.gradle
+++ b/arrow-libs/fx/settings.gradle
@@ -26,3 +26,6 @@ project(":arrow-continuations").projectDir = file("../core/arrow-continuations")
 project(":arrow-meta:arrow-meta-test-models").projectDir = file("../core/arrow-meta/arrow-meta-test-models")
 project(":arrow-meta").projectDir = file("../core/arrow-meta")
 project(":arrow-core-retrofit").projectDir = file("../core/arrow-core-retrofit")
+
+include 'jekyll'
+project(":jekyll").projectDir = file("dokka/jekyll")

--- a/arrow-libs/gradle/apidoc-creation.gradle
+++ b/arrow-libs/gradle/apidoc-creation.gradle
@@ -16,7 +16,7 @@
 
 apply plugin: "org.jetbrains.dokka"
 
-dokkaJekyll {
+dokkaGfm {
     enabled = file("README.md").exists()
     outputDirectory = file("${rootDir}/../arrow-site/docs/apidocs")
     dokkaSourceSets {
@@ -38,4 +38,8 @@ dokkaJekyll {
             }
         }
     }
+}
+
+dependencies {
+    dokkaGfmPlugin(project(":jekyll"))
 }

--- a/arrow-libs/optics/settings.gradle
+++ b/arrow-libs/optics/settings.gradle
@@ -22,3 +22,6 @@ project(":arrow-continuations").projectDir = file("../core/arrow-continuations")
 project(":arrow-meta:arrow-meta-test-models").projectDir = file("../core/arrow-meta/arrow-meta-test-models")
 project(":arrow-meta").projectDir = file("../core/arrow-meta")
 project(":arrow-core-retrofit").projectDir = file("../core/arrow-core-retrofit")
+
+include 'jekyll'
+project(":jekyll").projectDir = file("dokka/jekyll")

--- a/arrow-libs/settings.gradle
+++ b/arrow-libs/settings.gradle
@@ -56,5 +56,8 @@ include 'arrow-ank-gradle'
 project(":arrow-ank").projectDir = file("ank/arrow-ank")
 project(":arrow-ank-gradle").projectDir = file("ank/arrow-ank-gradle")
 
+include 'jekyll'
+project(":jekyll").projectDir = file("dokka/jekyll")
+
 // Examples
 include 'examples'


### PR DESCRIPTION
The Dokka Gfm/Jekyll render doesn't correctly work with code fences, and uses `//n` for new lines instead of `/n`.
This PR fixes both issues and would allow us to upgrade Dokka to 1.5.0 without having to wait for upstream to fix these things.

Continuting using the older Dokka version 0.10.x has other issues, like not having support for the new MPP functionality.