### PR TITLE
Fix the monadcomprehensions examples to have the chaining: student -> university -> dean

### DIFF
--- a/arrow-site/docs/docs/patterns/monadcomprehensions/README.md
+++ b/arrow-site/docs/docs/patterns/monadcomprehensions/README.md
@@ -73,7 +73,7 @@ private val universities = mapOf(
 
 /* in memory db of deans */
 private val deans = mapOf(
-  UniversityId("UCA") to Dean(Name("James"))
+  Name("James") to Dean(Name("James"))
 )
 
 /* gets a student by name */
@@ -84,15 +84,15 @@ suspend fun student(name: Name): Either<NotFound, Student> =
 suspend fun university(id: UniversityId): Either<NotFound, University> =
   universities[id]?.let(::Right) ?: Left(NotFound)
 
-/* gets a university by id */
-suspend fun dean(id: UniversityId): Either<NotFound, Dean> =
-  deans[id]?.let(::Right) ?: Left(NotFound)
+/* gets a dean by name */
+suspend fun dean(name: Name): Either<NotFound, Dean> =
+  deans[name]?.let(::Right) ?: Left(NotFound)
 
 suspend fun main(): Unit {
   //sampleStart
   val dean = student(Name("Alice")).flatMap { alice ->
     university(alice.universityId).flatMap { university ->
-      dean(alice.universityId)
+      dean(university.deanName)
     }
   }
   //sampleEnd
@@ -214,7 +214,7 @@ private val universities = mapOf(
 
 /* in memory db of deans */
 private val deans = mapOf(
-  UniversityId("UCA") to Dean(Name("James"))
+  Name("James") to Dean(Name("James"))
 )
 
 /* gets a student by name */
@@ -225,16 +225,16 @@ suspend fun student(name: Name): Either<NotFound, Student> =
 suspend fun university(id: UniversityId): Either<NotFound, University> =
   universities[id]?.let(::Right) ?: Left(NotFound)
 
-/* gets a university by id */
-suspend fun dean(id: UniversityId): Either<NotFound, Dean> =
-  deans[id]?.let(::Right) ?: Left(NotFound)
+/* gets a dean by name */
+suspend fun dean(name: Name): Either<NotFound, Dean> =
+  deans[name]?.let(::Right) ?: Left(NotFound)
 
 suspend fun main(): Unit {
   //sampleStart
   val dean = either<NotFound, Dean> {
     val alice = student(Name("Alice")).bind()
     val uca = university(alice.universityId).bind()
-    val james = dean(alice.universityId).bind()
+    val james = dean(uca.deanName).bind()
     james
   }
   //sampleEnd


### PR DESCRIPTION
Fixed the examples to be compatible with the ones in the current 0.13.0 release.
Put the request in a linear dependency ```student -> university -> dean``` as it was in 0.13.0 instead of getting the both university and dean from the student 
```
student -> university 
student -> dean
```