### PR TITLE
Expose CoroutineScope in Fx

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -16,13 +16,23 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
+public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(n: Int): List<A> =
+  parSequenceN(Dispatchers.Default, n)
+
 /**
  * Sequences all tasks in [n] parallel processes on [Dispatchers.Default] and return the result.
  *
  * Cancelling this operation cancels all running tasks
  */
-public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(n: Int): List<A> =
+public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(n: Int): List<A> =
   parSequenceN(Dispatchers.Default, n)
+
+public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineContext = EmptyCoroutineContext, n: Int): List<A> {
+  val s = Semaphore(n)
+  return parTraverse(ctx) {
+    s.withPermit { it.invoke() }
+  }
+}
 
 /**
  * Sequences all tasks in [n] parallel processes and return the result.
@@ -33,12 +43,15 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(n: Int): List<A> =
  *
  * Cancelling this operation cancels all running tasks
  */
-public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineContext = EmptyCoroutineContext, n: Int): List<A> {
+public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(ctx: CoroutineContext = EmptyCoroutineContext, n: Int): List<A> {
   val s = Semaphore(n)
   return parTraverse(ctx) {
-    s.withPermit { it.invoke() }
+    s.withPermit { it.invoke(this) }
   }
 }
+
+public suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
+  parSequence(Dispatchers.Default)
 
 /**
  * Sequences all tasks in parallel on [Dispatchers.Default] and return the result
@@ -63,8 +76,11 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineCont
  * }
  * ```
  */
-public suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
+public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequence(): List<A> =
   parSequence(Dispatchers.Default)
+
+public suspend fun <A> Iterable<suspend () -> A>.parSequence(ctx: CoroutineContext = EmptyCoroutineContext): List<A> =
+  parTraverse(ctx) { it.invoke() }
 
 /**
  * Sequences all tasks in parallel and return the result
@@ -94,14 +110,14 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
  * }
  * ```
  */
-public suspend fun <A> Iterable<suspend () -> A>.parSequence(ctx: CoroutineContext = EmptyCoroutineContext): List<A> =
-  parTraverse(ctx) { it.invoke() }
+public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequence(ctx: CoroutineContext = EmptyCoroutineContext): List<A> =
+  parTraverse(ctx) { it.invoke(this) }
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
  * Cancelling this operation cancels all running tasks.
  */
-public suspend fun <A, B> Iterable<A>.parTraverseN(n: Int, f: suspend (A) -> B): List<B> =
+public suspend fun <A, B> Iterable<A>.parTraverseN(n: Int, f: suspend CoroutineScope.(A) -> B): List<B> =
   parTraverseN(Dispatchers.Default, n, f)
 
 /**
@@ -116,7 +132,7 @@ public suspend fun <A, B> Iterable<A>.parTraverseN(n: Int, f: suspend (A) -> B):
 public suspend fun <A, B> Iterable<A>.parTraverseN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int,
-  f: suspend (A) -> B
+  f: suspend CoroutineScope.(A) -> B
 ): List<B> {
   val s = Semaphore(n)
   return parTraverse(ctx) { a ->
@@ -145,7 +161,7 @@ public suspend fun <A, B> Iterable<A>.parTraverseN(
  * }
  * ```
  */
-public suspend fun <A, B> Iterable<A>.parTraverse(f: suspend (A) -> B): List<B> =
+public suspend fun <A, B> Iterable<A>.parTraverse(f: suspend CoroutineScope.(A) -> B): List<B> =
   parTraverse(Dispatchers.Default, f)
 
 /**
@@ -177,7 +193,7 @@ public suspend fun <A, B> Iterable<A>.parTraverse(f: suspend (A) -> B): List<B> 
  */
 public suspend fun <A, B> Iterable<A>.parTraverse(
   ctx: CoroutineContext = EmptyCoroutineContext,
-  f: suspend (A) -> B
+  f: suspend CoroutineScope.(A) -> B
 ): List<B> = coroutineScope {
-  map { async(ctx) { f.invoke(it) } }.awaitAll()
+  map { async(ctx) { f.invoke(this, it) } }.awaitAll()
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -24,6 +24,7 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(n: Int): List<A> =
  *
  * Cancelling this operation cancels all running tasks
  */
+@JvmName("parSequenceNScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(n: Int): List<A> =
   parSequenceN(Dispatchers.Default, n)
 
@@ -43,6 +44,7 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineCont
  *
  * Cancelling this operation cancels all running tasks
  */
+@JvmName("parSequenceNScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(ctx: CoroutineContext = EmptyCoroutineContext, n: Int): List<A> {
   val s = Semaphore(n)
   return parTraverse(ctx) {
@@ -76,6 +78,7 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
  * }
  * ```
  */
+@JvmName("parSequenceScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequence(): List<A> =
   parSequence(Dispatchers.Default)
 
@@ -110,6 +113,7 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequence(ctx: CoroutineConte
  * }
  * ```
  */
+@JvmName("parSequenceScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequence(ctx: CoroutineContext = EmptyCoroutineContext): List<A> =
   parTraverse(ctx) { it.invoke(this) }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
@@ -25,6 +25,7 @@ import kotlin.jvm.JvmName
 public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEitherN(n: Int): Either<A, List<B>> =
   parTraverseEitherN(Dispatchers.Default, n) { it() }
 
+@JvmName("parSequenceEitherNScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEitherN(n: Int): Either<A, List<B>> =
   parTraverseEitherN(Dispatchers.Default, n) { it() }
 
@@ -37,6 +38,7 @@ public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.pa
  *
  * Cancelling this operation cancels all running tasks
  */
+@JvmName("parSequenceEitherNScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEitherN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int
@@ -59,6 +61,7 @@ public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither
 public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither(): Either<A, List<B>> =
   parTraverseEither(Dispatchers.Default) { it() }
 
+@JvmName("parSequenceEitherScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEither(): Either<A, List<B>> =
   parTraverseEither(Dispatchers.Default) { it() }
 
@@ -94,6 +97,7 @@ public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.pa
  * }
  * ```
  */
+@JvmName("parSequenceEitherScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEither(
   ctx: CoroutineContext = EmptyCoroutineContext
 ): Either<A, List<B>> =

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
@@ -25,6 +25,7 @@ import kotlin.jvm.JvmName
  *
  * Cancelling this operation cancels all running tasks.
  */
+@JvmName("parSequenceValidatedNScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidatedN(semigroup: Semigroup<E>, n: Int): Validated<E, List<A>> =
   parTraverseValidatedN(Dispatchers.Default, semigroup, n) { it() }
 
@@ -41,6 +42,7 @@ public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceVal
  *
  * Cancelling this operation cancels all running tasks.
  */
+@JvmName("parSequenceValidatedNScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidatedN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>,
@@ -96,6 +98,7 @@ public suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@JvmName("parSequenceEitherScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceEither(semigroup: Semigroup<E>): Validated<E, List<A>> =
   parTraverseValidated(Dispatchers.Default, semigroup) { it() }
 
@@ -133,6 +136,7 @@ public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceEit
  * }
  * ```
  */
+@JvmName("parSequenceValidatedScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidated(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Platform.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Platform.kt
@@ -1,5 +1,6 @@
 package arrow.fx.coroutines
 
+import arrow.core.NonEmptyList
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.updateAndGet
 import kotlin.jvm.JvmName
@@ -78,6 +79,9 @@ public object Platform {
     all.firstOrNull()?.let { first ->
       composeErrors(first, all.drop(1))
     }
+
+  public fun composeErrors(all: NonEmptyList<Throwable>): Throwable =
+      composeErrors(all.head, all.tail)
 }
 
 public class AtomicRefW<A>(a: A) {

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Race2.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Race2.kt
@@ -45,7 +45,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  * @see racePair for a version that does not automatically cancel the loser.
  * @see raceN for the same function that can race on any [CoroutineContext].
  */
-public suspend inline fun <A, B> raceN(crossinline fa: suspend () -> A, crossinline fb: suspend () -> B): Either<A, B> =
+public suspend inline fun <A, B> raceN(crossinline fa: suspend CoroutineScope.() -> A, crossinline fb: suspend CoroutineScope.() -> B): Either<A, B> =
   raceN(Dispatchers.Default, fa, fb)
 
 /**
@@ -87,8 +87,8 @@ public suspend inline fun <A, B> raceN(crossinline fa: suspend () -> A, crossinl
  */
 public suspend inline fun <A, B> raceN(
   ctx: CoroutineContext = EmptyCoroutineContext,
-  crossinline fa: suspend () -> A,
-  crossinline fb: suspend () -> B
+  crossinline fa: suspend CoroutineScope.() -> A,
+  crossinline fb: suspend CoroutineScope.() -> B
 ): Either<A, B> =
   coroutineScope {
     val a = async(ctx) { fa() }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Race3.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Race3.kt
@@ -36,9 +36,9 @@ public sealed class Race3<out A, out B, out C> {
  * @see raceN for the same function that can race on any [CoroutineContext].
  */
 public suspend inline fun <A, B, C> raceN(
-  crossinline fa: suspend () -> A,
-  crossinline fb: suspend () -> B,
-  crossinline fc: suspend () -> C
+  crossinline fa: suspend CoroutineScope.() -> A,
+  crossinline fb: suspend CoroutineScope.() -> B,
+  crossinline fc: suspend CoroutineScope.() -> C
 ): Race3<A, B, C> = raceN(Dispatchers.Default, fa, fb, fc)
 
 /**
@@ -54,9 +54,9 @@ public suspend inline fun <A, B, C> raceN(
  */
 public suspend inline fun <A, B, C> raceN(
   ctx: CoroutineContext = EmptyCoroutineContext,
-  crossinline fa: suspend () -> A,
-  crossinline fb: suspend () -> B,
-  crossinline fc: suspend () -> C
+  crossinline fa: suspend CoroutineScope.() -> A,
+  crossinline fb: suspend CoroutineScope.() -> B,
+  crossinline fc: suspend CoroutineScope.() -> C
 ): Race3<A, B, C> =
   coroutineScope {
     val a = async(ctx) { fa() }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ParTraverseValidatedTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ParTraverseValidatedTest.kt
@@ -3,7 +3,6 @@ package arrow.fx.coroutines
 import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.Validated
-import arrow.core.identity
 import arrow.core.invalidNel
 import arrow.core.sequenceValidated
 import arrow.core.validNel
@@ -61,7 +60,7 @@ class ParTraverseValidatedTest : ArrowFxSpec(
 
     "parTraverseValidated identity is identity" {
       checkAll(Arb.list(Arb.validatedNel(Arb.int(), Arb.int()))) { l ->
-        val res: Validated<NonEmptyList<Int>, List<Int>> = l.parTraverseValidated(Semigroup.nonEmptyList(), ::identity)
+        val res: Validated<NonEmptyList<Int>, List<Int>> = l.parTraverseValidated(Semigroup.nonEmptyList()) { it }
         res shouldBe l.sequenceValidated(Semigroup.nonEmptyList())
       }
     }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/RaceNTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/RaceNTest.kt
@@ -11,6 +11,7 @@ import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.int
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 
@@ -34,8 +35,8 @@ class RaceNTest : ArrowFxSpec(
         val pa = CompletableDeferred<Pair<Int, ExitCase>>()
         val pb = CompletableDeferred<Pair<Int, ExitCase>>()
 
-        val loserA = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
-        val loserB = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+        val loserA: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+        val loserB: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
 
         val f = async { raceN(loserA, loserB) }
 
@@ -64,8 +65,8 @@ class RaceNTest : ArrowFxSpec(
         val s = Channel<Unit>()
         val pa = CompletableDeferred<Pair<Int, ExitCase>>()
 
-        val winner = suspend { s.send(Unit); eith.rethrow() }
-        val loserA = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+        val winner: suspend CoroutineScope.() -> Int = { s.send(Unit); eith.rethrow() }
+        val loserA: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never() }) { ex -> pa.complete(Pair(a, ex)) } }
 
         val res = Either.catch {
           if (leftWinner) raceN(winner, loserA)
@@ -105,9 +106,9 @@ class RaceNTest : ArrowFxSpec(
         val pb = CompletableDeferred<Pair<Int, ExitCase>>()
         val pc = CompletableDeferred<Pair<Int, ExitCase>>()
 
-        val loserA = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
-        val loserB = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
-        val loserC = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pc.complete(Pair(c, ex)) } }
+        val loserA: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never() }) { ex -> pa.complete(Pair(a, ex)) } }
+        val loserB: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never() }) { ex -> pb.complete(Pair(b, ex)) } }
+        val loserC: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never() }) { ex -> pc.complete(Pair(c, ex)) } }
 
         val f = async { raceN(loserA, loserB, loserC) }
 
@@ -142,9 +143,9 @@ class RaceNTest : ArrowFxSpec(
         val pa = CompletableDeferred<Pair<Int, ExitCase>>()
         val pb = CompletableDeferred<Pair<Int, ExitCase>>()
 
-        val winner = suspend { s.send(Unit); s.send(Unit); eith.rethrow() }
-        val loserA = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
-        val loserB = suspend { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+        val winner: suspend CoroutineScope.() -> Int = { s.send(Unit); s.send(Unit); eith.rethrow() }
+        val loserA: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+        val loserB: suspend CoroutineScope.() -> Int = { guaranteeCase({ s.receive(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
 
         val res = Either.catch {
           when (leftWinner) {

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/arrow/fx/coroutines/RaceNJvmTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/arrow/fx/coroutines/RaceNJvmTest.kt
@@ -56,7 +56,7 @@ class RaceNJvmTest : ArrowFxSpec(
 
     "first racer out of 2 always wins on a single thread" {
       single.use { ctx ->
-        raceN(ctx, threadName, threadName)
+        raceN(ctx, { threadName() }, { threadName() })
       }.swap().orNull() shouldStartWith "single"
     }
 
@@ -119,7 +119,7 @@ class RaceNJvmTest : ArrowFxSpec(
 
     "first racer out of 3 always wins on a single thread" {
       (single.use { ctx ->
-        raceN(ctx, threadName, threadName, threadName)
+        raceN(ctx, { threadName() }, { threadName() }, { threadName() })
       } as? Race3.First)?.winner shouldStartWith "single"
     }
   }

--- a/arrow-site/docs/_code/fx-home-code.md
+++ b/arrow-site/docs/_code/fx-home-code.md
@@ -32,7 +32,7 @@ suspend fun main() {
     val audrey = parZip({ "Audrey" }, { company("Arrow") }) { name, company -> Employee(name, company) }
     val pepe   = parZip({  "Pepe"  }, { company("Arrow") }) { name, company -> Employee(name, company) }
     val candidates = listOf(audrey, pepe)
-    val employees = candidates.parTraverse(::hire) //hires in parallel
+    val employees = candidates.parTraverse { hire(it) } //hires in parallel
     //sampleEnd
     println(employees)
 }


### PR DESCRIPTION
This an binary breaking change, and this is a "semi" API breaking change.

Semi-breaking in that it only breaks for method references since the Kotlin compiler doesn't automatically ignore the unused receiver scope. Only `parSequence` can be overloaded without causing type ambuigity.

```kotlin
suspend fun add(i: Int): Int = i + 1
listOf(1, 2, 3).parTraverse(::add) // expected CoroutineScope.() -> Int
```

- [ ] We should fix binary break using visbility HIDDEN for `0.13.2` -> `0.13.3`