### PR TITLE
Overview boxes in Core and Optics CU-m560pn CU-u3qa4p

### DIFF
--- a/arrow-site/docs/_data/sidebar-core.yml
+++ b/arrow-site/docs/_data/sidebar-core.yml
@@ -2,23 +2,7 @@ options:
   - title: Quick Start
     url: /core/
 
-  - title: Tutorials
-
-    nested_options:
-
-      - title: Error Handling
-        url: /patterns/error_handling/
-
-      - title: The Monad Tutorial
-        url: /patterns/monads/
-
-      - title: Monad Comprehensions
-        url: /patterns/monad_comprehensions/
-
-      - title: Coroutines & Computation blocks
-        url: /fx/coroutines/
-
-  - title: Types
+  - title: Extensions and data types
 
     nested_options:
 
@@ -52,10 +36,26 @@ options:
       - title: Extensions
         url: /apidocs/arrow-core/arrow.core/index.html#functions
 
+  - title: Tutorials
+
+    nested_options:
+
+      - title: Error Handling
+        url: /patterns/error_handling/
+
+      - title: The Monad Tutorial
+        url: /patterns/monads/
+
+      - title: Monad Comprehensions
+        url: /patterns/monad_comprehensions/
+
+      - title: Coroutines & Computation blocks
+        url: /fx/coroutines/
+
   - title: Media
     url: https://media.arrow-kt.io/tags/core/
 
-  - title: Docs
+  - title: Api Docs
     url: /apidocs/arrow-core/arrow.core
 
   - title: License

--- a/arrow-site/docs/docs/core/README.md
+++ b/arrow-site/docs/docs/core/README.md
@@ -22,6 +22,49 @@ Arrow Core includes types such as [`Either`]({{ '/apidocs/arrow-core/arrow.core/
 Core also includes the base continuation effects system, which includes patterns to remove callbacks and enables controlled effects in direct syntax. Some applications of the effect system reduce boilerplate and enable direct syntax including [monad comprehensions and computation expressions]({{ '/patterns/monad_comprehensions/' | relative_url }}).
 </div>
 
+<div class="quickstart-intro" markdown="1">
+## Arrow Core Overview
+
+<div class="quickstart-coroutines-list" markdown="1">
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Quick Start
+  - [Gradle Setup]({{ '/core/#Gradle-kotlin' | relative_url }})
+  - [Maven Setup]({{ '/core/#Maven' | relative_url }})
+</div>
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Extensions and data types
+  - [Either]({{ '/apidocs/arrow-core/arrow.core/-either/' | relative_url }})
+  - [Validated]({{ '/apidocs/arrow-core/arrow.core/-validated/' | relative_url }})
+  - [Option]({{ '/apidocs/arrow-core/arrow.core/-option/' | relative_url }})
+  - [NonEmptyList]({{ '/apidocs/arrow-core/arrow.core/-non-empty-list/' | relative_url }})
+  - [Ior]({{ '/apidocs/arrow-core/arrow.core/-ior/' | relative_url }})
+  - [Eval]({{ '/apidocs/arrow-core/arrow.core/-eval/' | relative_url }})
+  - [Monoid]({{ '/arrow/typeclasses/monoid/' | relative_url }})
+  - [Semiring]({{ '/apidocs/arrow-core/arrow.typeclasses/-semiring/' | relative_url }})
+  - [Extensions]({{ '/apidocs/arrow-core/arrow.core/index.html#functions' | relative_url }})
+
+</div>
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Tutorials 
+  - [Error Handling]({{ '/patterns/error_handling/' | relative_url }})
+  - [Monads]({{ '/patterns/monads/' | relative_url }})
+  - [Monad Comprehensions]({{ '/patterns/monad_comprehensions/' | relative_url }})
+  - [Coroutines & Computation blocks]({{ '/fx/coroutines/' | relative_url }})
+
+</div>
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Additional information
+  - [Kotlin's Std Lib Guide](https://kotlinlang.org/api/latest/jvm/stdlib/)
+  - [Pure & Referentially Transparent Functions]({{ '/fx/purity-and-referentially-transparent-functions/' | relative_url }})
+  - [Why suspend over IO monad]({{ '/effects/io/' | relative_url }})
+</div>
+</div>
+</div>
+
 <div class="setup" markdown="1">
 ## Setup
 

--- a/arrow-site/docs/docs/dsl/README.md
+++ b/arrow-site/docs/docs/dsl/README.md
@@ -8,15 +8,23 @@ permalink: /optics/dsl/
 
 
 Arrow offers an Optics DSL to compose different Optics while improving ease of use and readability.
-To avoid boilerplate, Arrow will generate this property-like DSL using `@optics` annotation.
+To avoid boilerplate, Arrow will generate this property-like DSL using `@optics` annotation. For Arrow Optics to generate the DSL all the annotated classes should declare a `companion object` where the optics properties will be projected as extensions.
 
 ```kotlin
 package com.example.domain
 
-@optics data class Street(val number: Int, val name: String)
-@optics data class Address(val city: String, val street: Street)
-@optics data class Company(val name: String, val address: Address)
-@optics data class Employee(val name: String, val company: Company?)
+@optics data class Street(val number: Int, val name: String) {
+  companion object
+}
+@optics data class Address(val city: String, val street: Street) {
+  companion object
+}
+@optics data class Company(val name: String, val address: Address) {
+  companion object
+}
+@optics data class Employee(val name: String, val company: Company?) {
+  companion object
+}
 ```
 
 The DSL will be generated in the same package as your `data class`, and can be used on the `Companion` of your class.
@@ -37,10 +45,18 @@ Arrow can also generate DSL for a `sealed class`, which can help reduce boilerpl
 ```kotlin
 package com.example.domain
 
-@optics sealed class NetworkResult
-@optics data class Success(val content: String): NetworkResult()
-@optics sealed class NetworkError : NetworkResult()
-@optics data class HttpError(val message: String): NetworkError()
+@optics sealed class NetworkResult {
+  companion object
+}
+@optics data class Success(val content: String): NetworkResult() {
+  companion object
+}
+@optics sealed class NetworkError : NetworkResult() {
+  companion object
+}
+@optics data class HttpError(val message: String): NetworkError() {
+  companion object
+}
 object TimeoutError: NetworkError()
 ```
 
@@ -69,7 +85,9 @@ The DSL also has special support for [Every]({{ '/optics/every' | relative_url }
 `Every` can be used to focus into a structure `S` and see all its foci `A`. Here, we focus into all `Employee`s in the `Employees`.
 
 ```kotlin
-@optics data class Employees(val employees: List<Employee>)
+@optics data class Employees(val employees: List<Employee>) {
+  companion object
+}
 ```
 
 ```kotlin:ank
@@ -94,7 +112,9 @@ Every.list<Employee>().run {
 `At` can be used to focus in `A` at a given index `I` for a given structure `S`.
 
 ```kotlin
-@optics data class Db(val content: Map<Int, String>)
+@optics data class Db(val content: Map<Int, String>) {
+  companion object
+}
 ```
 
 Here we focus into the value of a given key in `MapK`.

--- a/arrow-site/docs/docs/optics/README.md
+++ b/arrow-site/docs/docs/optics/README.md
@@ -22,6 +22,49 @@ Arrow Optics provides an automatic DSL that allows users to use `.` notation whe
 Optics also offers all the base types such as [Lens]({{ "/optics/lens/" | relative_url }}), [Prism]({{ '/optics/prism/' | relative_url }}), and others from which we can generalize accessing and traversing deep values in sealed and data classes models.s
 </div>
 
+<div class="quickstart-intro" markdown="1">
+## Arrow Optics Overview
+
+<div class="quickstart-coroutines-list" markdown="1">
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Quick Start
+  - [Gradle Setup]({{ '/optics/#Gradle-kotlin' | relative_url }})
+  - [Maven Setup]({{ '/optics/#Maven' | relative_url }})
+</div>
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### DSL 
+  - [Optics DSL]({{ '/optics/dsl/' | relative_url }})
+</div>
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Extensions and data types
+  - [Iso]({{ '/optics/iso/' | relative_url }})
+  - [Lens]({{ '/optics/lens/' | relative_url }})
+  - [Optional]({{ '/optics/optional/' | relative_url }})
+  - [Prism]({{ '/optics/prims/' | relative_url }})
+  - [Getter]({{ '/optics/getter/' | relative_url }})
+  - [Setter]({{ '/optics/setter/' | relative_url }})
+  - [Fold]({{ '/optics/fold/' | relative_url }})
+  - [Traversal]({{ '/optics/traversal/' | relative_url }})
+  - [Every]({{ '/optics/every/' | relative_url }})
+  - [Cons]({{ '/optics/cons/' | relative_url }})
+  - [Snoc]({{ '/optics/snoc/' | relative_url }})
+  - [At]({{ '/optics/at/' | relative_url }})
+  - [Index]({{ '/optics/index/' | relative_url }})
+  - [FilterIndex]({{ '/optics/filterindex/' | relative_url }})
+</div>
+
+<div class="quickstart-coroutines-item" markdown="1">
+#### Additional information
+  - [Kotlin Data classes](https://kotlinlang.org/docs/data-classes.html)
+  - [Kotlin Sealed classes](https://kotlinlang.org/docs/sealed-classes.html)
+</div>
+</div>
+</div>
+
+
 <!--- Setup
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------


### PR DESCRIPTION
In preparation for the release adds the same overview box that was on Fx in Core and Optics.
Meta still needs a full menu overhaul and the content that would appear there needs more tinkering.

@israelperezglez I noticed we need to recompile CSS with new ids for each page, currently, I'm using `quickstart-coroutines-item` so it renders properly. The optics one does not render properly because the content seems to have a fixed height.

I also noticed the go-to `Maven` setup button does not work when clicked from the content menu.
@nomisRev Made some changes to the optics docs to clarify regarding companions. Not sure if you want the overview featured differently or with fewer data types. 

<img width="1496" alt="Screenshot 2021-09-07 at 23 39 55" src="https://user-images.githubusercontent.com/456796/132414425-c3f9afe7-903a-411a-8853-5053cdf88526.png">
<img width="1440" alt="Screenshot 2021-09-07 at 23 39 39" src="https://user-images.githubusercontent.com/456796/132414434-311f39d2-e99f-4b72-b97d-9419261fb93a.png">
