### PR TITLE
Fix typo on docs

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Atomic.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Atomic.kt
@@ -6,7 +6,7 @@ import arrow.continuations.generic.AtomicRef
  * An [Atomic] with an initial value of [A].
  *
  * [Atomic] wraps `atomic`, so that you can also use it on a top-level function or pass it around.
- * In other languages this data type is also now as `Ref`, `IORef` or Concurrent safe Reference.
+ * In other languages this data type is also known as `Ref`, `IORef` or Concurrent safe Reference.
  * So in case you don't need to pass around an atomic reference, or use it in top-level functions
  * it's advised to use `atomic` from Atomic Fu directly.
  *


### PR DESCRIPTION
Just fix a typo in the docs

PD: Congrats for 1.0 milestone ;)