### PR TITLE
Adds a andThen extension method to Validated to chain Validated

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2331,6 +2331,7 @@ public final class arrow/core/Validated$Valid$Companion {
 }
 
 public final class arrow/core/ValidatedKt {
+	public static final fun andThen (Larrow/core/Validated;Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
 	public static final fun attempt (Larrow/core/Validated;)Larrow/core/Validated;
 	public static final fun bisequence (Larrow/core/Validated;)Ljava/util/List;
 	public static final fun bisequenceEither (Larrow/core/Validated;)Larrow/core/Either;

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ValidatedTest.kt
@@ -498,5 +498,23 @@ class ValidatedTest : UnitSpec() {
           invalid.bitraverseEither({ it.left() }, { it.right() })
       }
     }
+
+    "andThen should return Valid(result) if f return Valid" {
+      checkAll(Arb.int(), Arb.int()) { x, y ->
+        Valid(x).andThen { Valid(it + y) } shouldBe Valid(x + y)
+      }
+    }
+
+    "andThen should only run f on valid instances " {
+      checkAll(Arb.int(), Arb.int()) { x, y ->
+        Invalid(x).andThen { Valid(y) } shouldBe Invalid(x)
+      }
+    }
+
+    "andThen should return Invalid(result) if f return Invalid " {
+      checkAll(Arb.int(), Arb.int()) { x, y ->
+        Valid(x).andThen { Invalid(it + y) } shouldBe Invalid(x + y)
+      }
+    }
   }
 }


### PR DESCRIPTION
As discussed on slack [https://kotlinlang.slack.com/archives/C5UPMM0A0/p1632399994123800] proposing a andThen method for `Validated` to easier chain Validations without going through `withEither`