### PR TITLE
Add bind with error mapping for Either

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2386,14 +2386,18 @@ public final class arrow/core/ValidatedKt {
 
 public abstract interface class arrow/core/computations/EitherEffect : arrow/continuations/Effect {
 	public abstract fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Larrow/core/Either;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Larrow/core/Validated;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/computations/EitherEffect$DefaultImpls {
 	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Either;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Validated;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun ensure (Larrow/core/computations/EitherEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -2445,7 +2449,9 @@ public abstract interface class arrow/core/computations/RestrictedEitherEffect :
 
 public final class arrow/core/computations/RestrictedEitherEffect$DefaultImpls {
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Either;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Validated;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun ensure (Larrow/core/computations/RestrictedEitherEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/computations/either.kt
@@ -18,11 +18,23 @@ public fun interface EitherEffect<E, A> : Effect<Either<E, A>> {
       is Either.Right -> value
       is Left -> control().shift(this@bind)
     }
+    
+  public suspend fun <A, B> Either<A, B>.bind(transform: (A) -> E): B =
+    when (this) {
+      is Either.Right -> value
+      is Left -> control().shift(this@bind.mapLeft(transform))
+    }
 
   public suspend fun <B> Validated<E, B>.bind(): B =
     when (this) {
       is Validated.Valid -> value
       is Validated.Invalid -> control().shift(Left(value))
+    }
+  
+  public suspend fun <A, B> Validated<A, B>.bind(transform: (A) -> E): B =
+    when (this) {
+      is Validated.Valid -> value
+      is Validated.Invalid -> control().shift(Left(transform(value)))
     }
 
   public suspend fun <B> Result<B>.bind(transform: (Throwable) -> E): B =


### PR DESCRIPTION
Add a helper function that allows working on any `either` within a comprehension, or map the errors of an existing one.

Done from github directly, pls don't judge hahaha

```
suspend fun leftThrow(): Either<Throwable, Int>

suspend fun leftString(): Either<String, Int> = either {
  // current
  leftThrow().mapLeft { it.message }.bind()

  // new
  leftThrow().bind { it.message }
}
```

Maybe it needs another name such as `bindOr` but I suspect that'd make it look like the recovery value instead.