### PR TITLE
Add Cont<R, A>

### DIFF
--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/Effect.kt
@@ -2,6 +2,7 @@ package arrow.continuations
 
 import arrow.continuations.generic.DelimitedScope
 
+@Deprecated("Prefer using Cont<R, A>")
 public fun interface Effect<F> {
   public fun control(): DelimitedScope<F>
 

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/Effect.kt
@@ -4,9 +4,11 @@ import arrow.continuations.generic.DelimitedScope
 
 @Deprecated("Prefer using Cont<R, A>")
 public fun interface Effect<F> {
+  @Deprecated("Use ContEffect<E>.shift instead")
   public fun control(): DelimitedScope<F>
 
   public companion object {
+    // Replace by restrictedCont
     public suspend inline fun <Eff : Effect<*>, F, A> suspended(
       crossinline eff: (DelimitedScope<F>) -> Eff,
       crossinline just: (A) -> F,
@@ -14,6 +16,7 @@ public fun interface Effect<F> {
     ): F =
       Reset.suspended { just(f(eff(this))) }
 
+    // Replace by cont<R, A>
     public inline fun <Eff : Effect<*>, F, A> restricted(
       crossinline eff: (DelimitedScope<F>) -> Eff,
       crossinline just: (A) -> F,

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/Reset.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/Reset.kt
@@ -21,6 +21,7 @@ internal object Reset {
    * use `Either.catch`, `Validated.catch` etc or `e.nonFatalOrThrow()`
    * to ensure you're not catching `ShortCircuit`.
    */
+  @Deprecated("Prefer using Cont<R, A> instead")
   public suspend fun <A> suspended(block: suspend SuspendedScope<A>.() -> A): A =
     suspendCoroutineUninterceptedOrReturn { cont ->
       SuspendMonadContinuation(cont, block)
@@ -33,6 +34,7 @@ internal object Reset {
    * This doesn't allow nesting of computation blocks, or foreign suspension.
    */
   // TODO This should be @RestrictSuspension but that breaks because a superclass is not considered to be correct scope
+  // TODO Can be replaced by RestrictedCont<R, A>
   fun <A> restricted(block: suspend RestrictedScope<A>.() -> A): A =
     DelimContScope(block).invoke()
 }

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/DelimContScope.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/DelimContScope.kt
@@ -18,6 +18,7 @@ import kotlin.coroutines.resume
  *  continuation is appended to a list waiting to be invoked with the final result of the block.
  * When running a function we jump back and forth between the main function and every function inside shift via their continuations.
  */
+// TODO can be replaced by RestrictedCont<R, A>
 internal open class DelimContScope<R>(private val f: suspend RestrictedScope<R>.() -> R) : RestrictedScope<R> {
 
   /**

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/DelimitedCont.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/DelimitedCont.kt
@@ -3,6 +3,7 @@ package arrow.continuations.generic
 /**
  * Base interface for a continuation
  */
+@Deprecated("Use Cont<R, A> instead")
 public interface DelimitedContinuation<A, R> {
   public suspend operator fun invoke(a: A): R
 }
@@ -10,6 +11,7 @@ public interface DelimitedContinuation<A, R> {
 /**
  * Base interface for our scope.
  */
+@Deprecated("Use ContEffect<R> instead")
 public interface DelimitedScope<R> {
 
   /**
@@ -18,6 +20,7 @@ public interface DelimitedScope<R> {
   public suspend fun <A> shift(r: R): A
 }
 
+@Deprecated("Use RestrictedContEffect<R> instead")
 public interface RestrictedScope<R> : DelimitedScope<R> {
   /**
    * Capture the continuation and pass it to [f].
@@ -27,4 +30,5 @@ public interface RestrictedScope<R> : DelimitedScope<R> {
   public override suspend fun <A> shift(r: R): A = shift { r }
 }
 
+@Deprecated("Use ContEffect<R> instead")
 public interface SuspendedScope<R> : DelimitedScope<R>

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/MultiShotDelimCont.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/MultiShotDelimCont.kt
@@ -21,6 +21,7 @@ import kotlin.coroutines.suspendCoroutine
  *
  * As per usual understanding of [DelimContScope] is required as I will only be commenting differences for now.
  */
+@Deprecated("Broken.")
 internal open class MultiShotDelimContScope<R>(val f: suspend RestrictedScope<R>.() -> R) : RestrictedScope<R> {
 
   // TODO Since runs blocking these don't need to be atomic

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/ShortCircuit.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/ShortCircuit.kt
@@ -1,3 +1,4 @@
 package arrow.continuations.generic
 
+@Deprecated("This is deprecated in favor of using kotlin.coroutines.cancellation for short-circuiting.")
 public class ShortCircuit internal constructor(internal val token: Token, public val raiseValue: Any?) : ControlThrowable()

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/SuspendingComputation.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/SuspendingComputation.kt
@@ -10,6 +10,7 @@ internal const val UNDECIDED = 0
 internal const val SUSPENDED = 1
 
 @Suppress("UNCHECKED_CAST")
+@Deprecated("Prefer using Cont<R, A>")
 internal open class SuspendMonadContinuation<R>(
   private val parent: Continuation<R>,
   val f: suspend SuspendedScope<R>.() -> R

--- a/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/Token.kt
+++ b/arrow-libs/core/arrow-continuations/src/commonMain/kotlin/arrow/continuations/generic/Token.kt
@@ -1,6 +1,7 @@
 package arrow.continuations.generic
 
 /** Represents a unique identifier using object equality. */
+@Deprecated("Deprecated together with SuspendingComputation.")
 internal class Token {
   @ExperimentalUnsignedTypes
   override fun toString(): String = "Token(${hashCode().toUInt().toString(16)})"

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -63,6 +63,55 @@ public final class arrow/core/ConstKt {
 	public static final fun contramap (Larrow/core/Const;Lkotlin/jvm/functions/Function1;)Larrow/core/Const;
 }
 
+public abstract interface class arrow/core/Cont {
+	public abstract fun attempt ()Larrow/core/Cont;
+	public abstract fun flatMap (Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public abstract fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun handleError (Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public abstract fun handleErrorWith (Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public abstract fun map (Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public abstract fun redeem (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public abstract fun redeemWith (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public abstract fun toEither (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun toValidated (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/core/Cont$DefaultImpls {
+	public static fun attempt (Larrow/core/Cont;)Larrow/core/Cont;
+	public static fun flatMap (Larrow/core/Cont;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static fun handleError (Larrow/core/Cont;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static fun handleErrorWith (Larrow/core/Cont;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static fun map (Larrow/core/Cont;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static fun redeem (Larrow/core/Cont;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static fun redeemWith (Larrow/core/Cont;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static fun toEither (Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun toValidated (Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class arrow/core/ContEffect {
+	public abstract fun bind (Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun shift (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/core/ContEffect$DefaultImpls {
+	public static fun bind (Larrow/core/ContEffect;Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/ContEffect;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/ContEffect;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/ContEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/ContEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun ensure (Larrow/core/ContEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/core/ContKt {
+	public static final fun cont (Lkotlin/jvm/functions/Function2;)Larrow/core/Cont;
+	public static final fun ensureNotNull (Larrow/core/ContEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class arrow/core/Currying {
 	public static final fun curried (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function1;
 	public static final fun curried (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function1;
@@ -2385,17 +2434,21 @@ public final class arrow/core/ValidatedKt {
 	public static final fun zip (Larrow/core/Validated;Larrow/typeclasses/Semigroup;Larrow/core/Validated;Lkotlin/jvm/functions/Function2;)Larrow/core/Validated;
 }
 
-public abstract interface class arrow/core/computations/EitherEffect : arrow/continuations/Effect {
+public abstract interface class arrow/core/computations/EitherEffect : arrow/continuations/Effect, arrow/core/ContEffect {
 	public abstract fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun control ()Larrow/continuations/generic/DelimitedScope;
 	public abstract fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/computations/EitherEffect$DefaultImpls {
+	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun control (Larrow/core/computations/EitherEffect;)Larrow/continuations/generic/DelimitedScope;
 	public static fun ensure (Larrow/core/computations/EitherEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -2442,12 +2495,16 @@ public final class arrow/core/computations/OptionKt {
 }
 
 public abstract interface class arrow/core/computations/RestrictedEitherEffect : arrow/core/computations/EitherEffect {
+	public abstract fun bind (Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/computations/RestrictedEitherEffect$DefaultImpls {
+	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Cont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun control (Larrow/core/computations/RestrictedEitherEffect;)Larrow/continuations/generic/DelimitedScope;
 	public static fun ensure (Larrow/core/computations/RestrictedEitherEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2438,8 +2438,8 @@ public abstract interface class arrow/core/computations/EitherEffect : arrow/con
 	public abstract fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun control ()Larrow/continuations/generic/DelimitedScope;
 	public abstract fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun shift (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/computations/EitherEffect$DefaultImpls {
@@ -2448,8 +2448,8 @@ public final class arrow/core/computations/EitherEffect$DefaultImpls {
 	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/EitherEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun control (Larrow/core/computations/EitherEffect;)Larrow/continuations/generic/DelimitedScope;
 	public static fun ensure (Larrow/core/computations/EitherEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun shift (Larrow/core/computations/EitherEffect;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/computations/EitherKt {
@@ -2504,8 +2504,8 @@ public final class arrow/core/computations/RestrictedEitherEffect$DefaultImpls {
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/computations/RestrictedEitherEffect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun control (Larrow/core/computations/RestrictedEitherEffect;)Larrow/continuations/generic/DelimitedScope;
 	public static fun ensure (Larrow/core/computations/RestrictedEitherEffect;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun shift (Larrow/core/computations/RestrictedEitherEffect;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class arrow/core/computations/RestrictedEvalEffect : arrow/core/computations/EvalEffect {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Cont.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Cont.kt
@@ -137,7 +137,7 @@ private value class Continuation<R, A>(private val f: suspend ContEffect<R>.() -
         // This is needed because this function will never yield a result,
         // so it needs to be cancelled to properly support coroutine cancellation
         override suspend fun <B> shift(r: R): B =
-          //Some interesting consequences of how Continuation Cancellation works in Kotlin.
+          // Some interesting consequences of how Continuation Cancellation works in Kotlin.
           // We have to throw CancellationException to signal the Continuation was cancelled, and we shifted away.
           // This however also means that the user can try/catch shift and recover from the CancellationException and thus effectively recovering from the cancellation/shift.
           // This means try/catch is also capable of recovering from monadic errors.

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Cont.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Cont.kt
@@ -1,0 +1,186 @@
+package arrow.core
+
+import arrow.continuations.generic.AtomicRef
+import arrow.continuations.generic.loop
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
+import kotlin.jvm.JvmInline
+
+public fun <R, A> cont(f: suspend ContEffect<R>.() -> A): Cont<R, A> =
+  Continuation(f)
+
+/**
+ * [Cont] represents a suspending computation that runs will either
+ *  - Complete with a value of [A].
+ *  - Short-circuit with a value of [R].
+ *
+ * So [Cont] is defined by [fold], to map both values of [R] and [A] to a value of `B`.
+ */
+public interface Cont<R, A> {
+  public suspend fun <B> fold(f: suspend (R) -> B, g: suspend (A) -> B): B
+
+  public suspend fun toEither(): Either<R, A> =
+    fold({ Either.Left(it) }) { Either.Right(it) }
+
+  public suspend fun toValidated(): Validated<R, A> =
+    fold({ Validated.Invalid(it) }) { Validated.Valid(it) }
+
+  public fun attempt(): Cont<R, Result<A>> =
+    cont { runCatching { bind() } }
+
+  public fun <B> map(f: suspend (A) -> B): Cont<R, B> =
+    cont { fold(this::shift, f) }
+
+  public fun <B> flatMap(f: suspend (A) -> Cont<R, B>): Cont<R, B> =
+    cont { fold(this::shift, f).bind() }
+
+  public fun handleError(f: suspend (R) -> A): Cont<Nothing, A> =
+    cont { fold(f, ::identity) }
+
+  public fun <R2> handleErrorWith(f: suspend (R) -> Cont<R2, A>): Cont<R2, A> =
+    cont { fold({ f(it).bind() }, ::identity) }
+
+  public fun <B> redeem(f: suspend (R) -> B, g: suspend (A) -> B): Cont<Nothing, B> =
+    cont { fold(f, g) }
+
+  public fun <R2, B> redeemWith(f: suspend (R) -> Cont<R2, B>, g: suspend (A) -> Cont<R2, B>): Cont<R2, B> =
+    cont { fold(f, g).bind() }
+}
+
+/** Context of the [Cont] DSL. */
+public interface ContEffect<R> {
+  /**
+   * Short-circuit the [Cont] computation with value [R].
+   */
+  public suspend fun <B> shift(r: R): B
+
+  public suspend fun <B> Cont<R, B>.bind(): B =
+    fold(this@ContEffect::shift, ::identity)
+
+  public suspend fun <B> Either<R, B>.bind(): B =
+    when (this) {
+      is Either.Left -> shift(value)
+      is Either.Right -> value
+    }
+
+  public suspend fun <B> Validated<R, B>.bind(): B =
+    when (this) {
+      is Validated.Valid -> value
+      is Validated.Invalid -> shift(value)
+    }
+
+  public suspend fun <B> Result<B>.bind(transform: (Throwable) -> R): B =
+    fold(::identity) { throwable ->
+      shift(transform(throwable))
+    }
+
+  public suspend fun <B> Option<B>.bind(shift: () -> R): B =
+    when (this) {
+      None -> shift(shift())
+      is Some -> value
+    }
+
+  /**
+   * Ensure check if the [value] is `true`.
+   * if it is true it will allow the continuation to continue running,
+   * if it is `false`, then it cancel the continuation and return the provided [R].
+   * Monadic version of kotlin.require
+   *
+   * ```kotlin:ank:playground
+   * import arrow.core.cont
+   *
+   * //sampleStart
+   * suspend fun main() {
+   *   cont<String, Int> {
+   *     ensure(true) { "this will not fail" }
+   *     println("ensure(true) passes")
+   *     ensure(false) { "failed" }
+   *     TODO("The program will never reach this point")
+   *   }.toEither()
+   * //sampleEnd
+   * }
+   * // println: "ensure(true) passes"
+   * // res: Either.Left("failed")
+   * ```
+   */
+  public suspend fun ensure(value: Boolean, shift: () -> R): Unit =
+    if (value) Unit else shift(shift())
+}
+
+// Monadic version of kotlin.requireNotNull
+@OptIn(ExperimentalContracts::class) // Contracts not available on open functions, so top-level.
+public suspend fun <R, B : Any> ContEffect<R>.ensureNotNull(value: B?, shift: () -> R): B {
+  contract { returns() implies (value != null) }
+  return value ?: shift(shift())
+}
+
+// We create a `Token` for every scope, so we can properly differentiate between nested scopes
+private class ShiftCancellationException(val token: Token) : CancellationException("Shifted Continuation")
+
+// Class that represents a unique token by hash comparison
+private class Token {
+  override fun toString(): String = "Token(${hashCode().toUInt().toString(16)})"
+}
+
+@JvmInline
+private value class Shifted<A>(private val state: AtomicRef<Any?> = AtomicRef(EmptyValue)) {
+  inline fun update(f: () -> A): Boolean {
+    var backing: Any? = EmptyValue
+    state.loop { a ->
+      if (a === EmptyValue) {
+        if (state.compareAndSet(
+            EmptyValue,
+            if (backing === EmptyValue) {
+              backing = f()
+              backing
+            } else backing
+          )
+        ) return true
+      } else {
+        return false
+      }
+    }
+  }
+
+  fun value(): A = EmptyValue.unbox(state.get())
+}
+
+// Reification of Cont program
+@JvmInline
+private value class Continuation<R, A>(private val f: suspend ContEffect<R>.() -> A) : Cont<R, A> {
+  override suspend fun <B> fold(f: suspend (R) -> B, g: suspend (A) -> B): B =
+    suspendCoroutineUninterceptedOrReturn { cont ->
+      val token = Token()
+      val shifted = Shifted<B>()
+
+      val effect = object : ContEffect<R> {
+        // Shift away from this Continuation by intercepting it, and completing it with ShiftCancellationException
+        // This is needed because this function will never yield a result,
+        // so it needs to be cancelled to properly support coroutine cancellation
+        override suspend fun <B> shift(r: R): B {
+          // TODO if a concurrent coroutine called shift, do we also complete with `ShiftCancellationException`?
+          //      NOTE: This _should_ only possible if coroutines are already coupled to each-other with structured concurrency
+          //      So re-emitting CancellationException might not be needed ??
+          //      Related test: https://github.com/nomisRev/Continuation/blob/main/src/commonTest/kotlin/ContSpec.kt#L161
+          shifted.update { f(r) }
+          throw ShiftCancellationException(token)
+        }
+      }
+
+      try {
+        suspend { g(f(effect)) }.startCoroutineUninterceptedOrReturn(Continuation(cont.context) { res ->
+          res.fold(cont::resume) { throwable ->
+            if (throwable is ShiftCancellationException && token == throwable.token) cont.resume(shifted.value())
+            else cont.resumeWith(res)
+          }
+        })
+      } catch (e: ShiftCancellationException) {
+        if (token == e.token) shifted.value() else throw e
+      }
+    }
+}

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ContSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ContSpec.kt
@@ -1,0 +1,265 @@
+package arrow.core
+
+import arrow.core.test.UnitSpec
+import arrow.core.test.generators.throwable
+import io.kotest.assertions.fail
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.arbitrary.string
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.startCoroutine
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+
+@OptIn(ExperimentalTime::class)
+class ContSpec : UnitSpec({
+
+  suspend fun <A> Cont<Nothing, A>.value(): A =
+    fold(::identity, ::identity)
+
+  suspend fun Cont<*, *>.runCont(): Unit =
+    fold({ }, { })
+
+  "try/catch - can recover from shift" {
+    checkAll(Arb.int(), Arb.string()) { i, s ->
+      cont<String, Int> {
+        try {
+          shift(s)
+        } catch (e: Throwable) {
+          i
+        }
+      }.fold({ fail("Should never come here") }, ::identity) shouldBe i
+    }
+  }
+
+  "try/catch - First shift is ignored and second is returned" {
+    checkAll(Arb.int(), Arb.string(), Arb.string()) { i, s, s2 ->
+      cont<String, Int> {
+        val x: Int = try {
+          shift(s)
+        } catch (e: Throwable) {
+          i
+        }
+        shift(s2)
+      }.fold(::identity) { fail("Should never come here") } shouldBe s2
+    }
+  }
+
+  "try/catch - finally works" {
+    checkAll(Arb.string(), Arb.int()) { s, i ->
+      val promise = CompletableDeferred<Int>()
+      cont<String, Int> {
+        try {
+          shift(s)
+        } finally {
+          require(promise.complete(i))
+        }
+      }.fold(::identity) { fail("Should never come here") } shouldBe s
+      promise.await() shouldBe i
+    }
+  }
+
+  "immediate values" {
+    checkAll(Arb.int()) { i ->
+      cont<Nothing, Int> {
+        i
+      }.value() shouldBe i
+    }
+  }
+
+  "suspended value" {
+    checkAll(Arb.int()) { i ->
+      cont<Nothing, Int> {
+        i.suspend()
+      }.value() shouldBe i
+    }
+  }
+
+  "immediate short-circuit" {
+    checkAll(Arb.string()) { s ->
+      cont<String, Nothing> {
+        shift(s)
+      }.fold(::identity, ::identity) shouldBe s
+    }
+  }
+
+  "suspended short-circuit" {
+    checkAll(Arb.string()) { s ->
+      cont<String, Nothing> {
+        shift(s.suspend())
+      }.fold(::identity, ::identity) shouldBe s
+    }
+  }
+
+  "Rethrows immediate exceptions" {
+    checkAll(Arb.throwable()) { e ->
+      Either.catch {
+        cont<Nothing, Nothing> {
+          throw e
+        }.runCont()
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "Rethrows suspended exceptions" {
+    checkAll(Arb.throwable()) { e ->
+      Either.catch {
+        cont<Nothing, Nothing> {
+          e.suspend()
+        }.runCont()
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "Can short-circuit immediately from nested blocks" {
+    checkAll(Arb.string()) { s ->
+      cont<String, Int> {
+        cont<Nothing, Long> { shift(s) }.runCont()
+        fail("Should never reach this point")
+      }.fold(::identity, ::identity) shouldBe s
+    }
+  }
+
+  "Can short-circuit suspended from nested blocks" {
+    checkAll(Arb.string()) { s ->
+      cont<String, Int> {
+        cont<Nothing, Long> { shift(s.suspend()) }.runCont()
+        fail("Should never reach this point")
+      }.fold(::identity, ::identity) shouldBe s
+    }
+  }
+
+  "Can short-circuit immediately after suspending from nested blocks" {
+    checkAll(Arb.string()) { s ->
+      cont<String, Int> {
+        cont<Nothing, Long> {
+          1L.suspend()
+          shift(s.suspend())
+        }.runCont()
+        fail("Should never reach this point")
+      }.fold(::identity, ::identity) shouldBe s
+    }
+  }
+
+  // Fails https://github.com/Kotlin/kotlinx.coroutines/issues/3005
+  "ensure null in either computation" {
+    checkAll(Arb.boolean(), Arb.int(), Arb.string()) { predicate, success, shift ->
+      cont<String, Int> {
+        ensure(predicate) { shift }
+        success
+      }.toEither() shouldBe if (predicate) success.right() else shift.left()
+    }
+  }
+
+  // Fails https://github.com/Kotlin/kotlinx.coroutines/issues/3005
+  "ensureNotNull in either computation" {
+    fun square(i: Int): Int = i * i
+
+    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, shift->
+      val res = cont<String, Int> {
+        ensureNotNull(i) { shift }
+        square(i) // Smart-cast by contract
+      }.toEither()
+      val expected = i?.let(::square)?.right() ?: shift.left()
+      res shouldBe expected
+    }
+  }
+
+  "Short-circuiting co-operates with KotlinX Structured Concurrency" {
+    checkAll(Arb.string()) { s ->
+      val latch = CompletableDeferred<Unit>()
+      val cancelled = CompletableDeferred<Throwable?>()
+
+      cont<String, Nothing> {
+        coroutineScope {
+          val never = async<Nothing>(Dispatchers.Default) { completeOnCancellation(latch, cancelled) }
+          val fail = async<Int>(Dispatchers.Default) {
+            latch.await()
+            shift(s)
+          }
+          fail.await() // When this fails, it should also close never
+          never.await()
+        }
+      }.fold(::identity, ::identity) shouldBe s
+
+      withTimeout(Duration.Companion.seconds(2)) {
+        cancelled.await().shouldNotBeNull().message shouldBe "Shifted Continuation"
+      }
+    }
+  }
+
+  "Computation blocks run on parent context" {
+    val parentCtx = currentContext()
+    cont<Nothing, Unit> {
+      currentContext() shouldBe parentCtx
+    }.runCont()
+  }
+
+  "Concurrent shift" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      cont<Int, String> {
+        coroutineScope {
+          val fa = async<Nothing>(start = CoroutineStart.UNDISPATCHED) { shift(a) }
+          val fb = async<Nothing>(start = CoroutineStart.UNDISPATCHED) { shift(b) }
+          fa.await()
+          fb.await()
+        }
+      }.fold(::identity, ::identity) shouldBeIn listOf(a, b)
+    }
+  }
+})
+
+suspend fun currentContext(): CoroutineContext =
+  kotlin.coroutines.coroutineContext
+
+internal suspend fun Throwable.suspend(): Nothing =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    suspend { throw this }.startCoroutine(
+      Continuation(Dispatchers.Default) {
+        cont.intercepted().resumeWith(it)
+      }
+    )
+
+    COROUTINE_SUSPENDED
+  }
+
+internal suspend fun <A> A.suspend(): A =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    suspend { this }.startCoroutine(
+      Continuation(Dispatchers.Default) {
+        cont.intercepted().resumeWith(it)
+      }
+    )
+
+    COROUTINE_SUSPENDED
+  }
+
+suspend fun <A> completeOnCancellation(
+  latch: CompletableDeferred<Unit>,
+  cancelled: CompletableDeferred<Throwable?>
+): A =
+  suspendCancellableCoroutine { cont ->
+    cont.invokeOnCancellation { cause ->
+      if (!cancelled.complete(cause)) throw AssertionError("cancelled latch was completed twice")
+      else Unit
+    }
+
+    if (!latch.complete(Unit)) throw AssertionError("latch was completed twice")
+    else Unit
+  }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ContSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ContSpec.kt
@@ -171,7 +171,7 @@ class ContSpec : UnitSpec({
   "ensureNotNull in either computation" {
     fun square(i: Int): Int = i * i
 
-    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, shift->
+    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, shift ->
       val res = cont<String, Int> {
         ensureNotNull(i) { shift }
         square(i) // Smart-cast by contract


### PR DESCRIPTION
Add `Cont<A, R>` and `ContEffect` into Arrow Core.

Ideally in the future the `cont<R, A>` DSL can completely replace the current Arrow Computations machinery.

I'm afraid to fully switch to the `Cont` runtime for the existing computation blocks is not possible in a binary compatible way since the receiver of the DSL needs to change. `either` would simply work in terms of `ContEffect<E>`, and no longer needs a specific interface `EitherEffect<E, A>`. This will also allow us to drop the `A` constraint, and avoid the `*` projection and casting many cases (and downstream implementations).

Switching to this new `Cont` system for the computation blocks has serveral benefits.
 - It uses `kotlin.coroutines.CancellationException` to properly signal cancellation to the coroutine system
 - Much simpler runtime, so easier to understand and maintain.
 - Implements a generic runtime for computation that result in `E`, `A` or `Throwable` so we can generically implement monadic operations, and `fold` these `Continuation` based programs over the different cases.
 
 
TODO:
 - [ ] Write docs
 - [x] Add test suite for Cont

 As a deprecation path we could take following approach:
   - [x] 1.0.x we deprecate all the related effect types (done in this PR)
   - [ ] 1.1.x (or 1.2.x) we set the deprecated stuff to `level = DeprecationLevel.HIDDEN`, and that allows us to declare a new `either { }` block by lowering the receiver from `EitherEffect<E, A>` to `ContEffect<E>`. (See example below)
    => This doesn't break the binary, but hides the code from the Kotlin API. 
    => Only removing code from Arrow Computations but fully preserving Arrow Core's API.
   - [ ] 2.x.x (or later) we remove the HIDDEN deprecated code (breaking the binary)
   
   
```kotlin
object either {
  @Deprecated("Gone from Kotlin API", level = DeprecationLevel.HIDDEN)
  public suspend inline operator fun <E, A> invoke(crossinline c: suspend EitherEffect<E, *>.() -> A): Either<E, A> =
    Effect.suspended(eff = { EitherEffect { it } }, f = c, just = { it.right() })
  
  public suspend operator fun <E, A> invoke(c: suspend ContEffect<E>.() -> A): Either<E, A> =
    cont(c).toEither()
}  
```

See reference implementation, also includes `restrictedCont` mentioned in code comments.
https://github.com/nomisRev/Continuation