### PR TITLE
Implement filter function for Optional

### DIFF
--- a/arrow-libs/optics/arrow-optics/api/arrow-optics.api
+++ b/arrow-libs/optics/arrow-optics/api/arrow-optics.api
@@ -447,6 +447,7 @@ public abstract interface class arrow/optics/POptional : arrow/optics/Fold, arro
 	public static final field Companion Larrow/optics/POptional$Companion;
 	public abstract fun choice (Larrow/optics/POptional;)Larrow/optics/POptional;
 	public abstract fun compose (Larrow/optics/POptional;)Larrow/optics/POptional;
+	public static fun filter (Lkotlin/jvm/functions/Function1;)Larrow/optics/POptional;
 	public abstract fun first ()Larrow/optics/POptional;
 	public abstract fun foldMap (Larrow/typeclasses/Monoid;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun getOrModify (Ljava/lang/Object;)Larrow/core/Either;
@@ -463,6 +464,7 @@ public abstract interface class arrow/optics/POptional : arrow/optics/Fold, arro
 
 public final class arrow/optics/POptional$Companion {
 	public final fun codiagonal ()Larrow/optics/POptional;
+	public final fun filter (Lkotlin/jvm/functions/Function1;)Larrow/optics/POptional;
 	public final fun id ()Larrow/optics/PIso;
 	public final fun invoke (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Larrow/optics/POptional;
 	public final fun listHead ()Larrow/optics/POptional;

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
@@ -207,8 +207,36 @@ public interface POptional<S, T, A, B> : PSetter<S, T, A, B>, Fold<S, A>, PTrave
 
     /**
      * [Optional] to itself if it satisfies the predicate.
-     * Filter can break the fusion property, if replace or modify do not preserve the predicate.
+     *
+     * Select all the elements which satisfies the predicate.
+     * ```kotlin
+     *
+     * import arrow.optics.Traversal
+     * import arrow.optics.Optional
+     *
+     * val positiveNumbers = Traversal.list<Int>() compose Optional.filter { it >= 0 }
+     *
+     * positiveNumbers.getAll(listOf(1,2,-3,4,-5)) == listOf(1,2,4)
+     * positiveNumbers.modify(listOf(1,2,-3,4,-5)) { it * 10 } == listOf(10,20,-3,40,-5)
+     *
+     * `filter` can break the fusion property, if `replace` or `modify` do not preserve the predicate. For example, here
+     * the first `modify` {`x - 3`} transform the positive number 1 into the negative number -2.
+     *
+     *```
+     * ```kotlin
+     *
+     * import arrow.optics.Traversal
+     * import arrow.optics.Optional
+     *
+     * val positiveNumbers = Traversal.list<Int>() compose Optional.filter { it >= 0 }
+     * val list            = listOf(1, 5, -3)
+     * val firstStep       = positiveNumbers.modify(list){ it - 3 }            // List(-2, 2, -3)
+     * val secondStep      = positiveNumbers.modify(firstStep) { it * 2 }      // List(-2, 4, -3)
+     * val bothSteps       = positiveNumbers.modify(list){ (it - 3) * 2)       // List(-4, 4, -3)
+     *  // secondStep != bothSteps
+     * ```
      */
+
     @JvmStatic
     public fun <A> filter(predicate: (A) -> Boolean): Optional<A, A> =
       Optional(

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
@@ -204,5 +204,16 @@ public interface POptional<S, T, A, B> : PSetter<S, T, A, B>, Fold<S, A>, PTrave
       getOption = { if (it.isEmpty()) None else Some(it.drop(1)) },
       set = { list, newTail -> if (list.isNotEmpty()) list[0] prependTo newTail else emptyList() }
     )
+
+    /**
+     * [Optional] to itself if it satisfies the predicate.
+     * Filter can break the fusion property, if replace or modify do not preserve the predicate.
+     */
+    @JvmStatic
+    public fun <A> filter(predicate: (A) -> Boolean): Optional<A, A> =
+      Optional(
+        getOption = { if (predicate(it)) Some(it) else None },
+        set = { current, newValue -> if (predicate(current)) newValue else current }
+      )
   }
 }

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
@@ -210,7 +210,6 @@ public interface POptional<S, T, A, B> : PSetter<S, T, A, B>, Fold<S, A>, PTrave
      *
      * Select all the elements which satisfies the predicate.
      * ```kotlin
-     *
      * import arrow.optics.Traversal
      * import arrow.optics.Optional
      *
@@ -218,13 +217,12 @@ public interface POptional<S, T, A, B> : PSetter<S, T, A, B>, Fold<S, A>, PTrave
      *
      * positiveNumbers.getAll(listOf(1,2,-3,4,-5)) == listOf(1,2,4)
      * positiveNumbers.modify(listOf(1,2,-3,4,-5)) { it * 10 } == listOf(10,20,-3,40,-5)
+     *```
      *
      * `filter` can break the fusion property, if `replace` or `modify` do not preserve the predicate. For example, here
      * the first `modify` {`x - 3`} transform the positive number 1 into the negative number -2.
      *
-     *```
-     * ```kotlin
-     *
+     *```kotlin
      * import arrow.optics.Traversal
      * import arrow.optics.Optional
      *
@@ -233,7 +231,7 @@ public interface POptional<S, T, A, B> : PSetter<S, T, A, B>, Fold<S, A>, PTrave
      * val firstStep       = positiveNumbers.modify(list){ it - 3 }            // List(-2, 2, -3)
      * val secondStep      = positiveNumbers.modify(firstStep) { it * 2 }      // List(-2, 4, -3)
      * val bothSteps       = positiveNumbers.modify(list){ (it - 3) * 2)       // List(-4, 4, -3)
-     *  // secondStep != bothSteps
+     * // secondStep != bothSteps
      * ```
      */
 


### PR DESCRIPTION
The same functionality `filer` in Monocle [Optional.filter](https://www.optics.dev/Monocle/api/monocle/Optional$.html#filter[A](predicate:A=%3EBoolean):monocle.Optional[A,A])
- [x] Tests
- [x] More document
- [x] Update Api description
- [ ] Laws