### PR TITLE
Fix Retrofit adapter test configuration

### DIFF
--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
@@ -5,7 +5,7 @@ import arrow.core.right
 import arrow.core.test.UnitSpec
 import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
-import arrow.retrofit.adapter.retrofit.SuspedApiClientTest
+import arrow.retrofit.adapter.retrofit.TestSuspendApiClient
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -15,21 +15,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class ArrowEitherCallAdapterTest : UnitSpec() {
 
-  private val server = MockWebServer()
-
-  private val service: SuspedApiClientTest by lazy {
-    Retrofit.Builder()
-      .baseUrl(server.url("/"))
-      .addConverterFactory(GsonConverterFactory.create())
-      .addCallAdapterFactory(EitherCallAdapterFactory.create())
-      .build()
-      .create(SuspedApiClientTest::class.java)
-  }
+  private lateinit var server: MockWebServer
+  private lateinit var service: TestSuspendApiClient
 
   init {
 
-    beforeSpec { server.start() }
-    afterSpec { server.shutdown() }
+    beforeAny {
+      server = MockWebServer()
+      server.start()
+      service = Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(GsonConverterFactory.create())
+        .addCallAdapterFactory(EitherCallAdapterFactory.create())
+        .build()
+        .create(TestSuspendApiClient::class.java)
+    }
+
+    afterAny { server.shutdown() }
 
     "should return ResponseMock for 200 with valid JSON" {
       server.enqueue(MockResponse().setBody("""{"response":"Arrow rocks"}"""))

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
@@ -5,7 +5,7 @@ import arrow.core.right
 import arrow.core.test.UnitSpec
 import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
-import arrow.retrofit.adapter.retrofit.TestSuspendApiClient
+import arrow.retrofit.adapter.retrofit.SuspendApiTestClient
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -16,7 +16,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class ArrowEitherCallAdapterTest : UnitSpec() {
 
   private lateinit var server: MockWebServer
-  private lateinit var service: TestSuspendApiClient
+  private lateinit var service: SuspendApiTestClient
 
   init {
 
@@ -28,7 +28,7 @@ class ArrowEitherCallAdapterTest : UnitSpec() {
         .addConverterFactory(GsonConverterFactory.create())
         .addCallAdapterFactory(EitherCallAdapterFactory.create())
         .build()
-        .create(TestSuspendApiClient::class.java)
+        .create(SuspendApiTestClient::class.java)
     }
 
     afterAny { server.shutdown() }

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowResponseEAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowResponseEAdapterTest.kt
@@ -5,7 +5,7 @@ import arrow.core.right
 import arrow.core.test.UnitSpec
 import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
-import arrow.retrofit.adapter.retrofit.SuspedApiClientTest
+import arrow.retrofit.adapter.retrofit.TestSuspendApiClient
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -15,21 +15,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class ArrowResponseEAdapterTest : UnitSpec() {
 
-  private val server = MockWebServer()
-
-  private val service: SuspedApiClientTest by lazy {
-    Retrofit.Builder()
-      .baseUrl(server.url("/"))
-      .addConverterFactory(GsonConverterFactory.create())
-      .addCallAdapterFactory(EitherCallAdapterFactory.create())
-      .build()
-      .create(SuspedApiClientTest::class.java)
-  }
+  private lateinit var server: MockWebServer
+  private lateinit var service: TestSuspendApiClient
 
   init {
 
-    beforeSpec { server.start() }
-    afterSpec { server.shutdown() }
+    beforeAny {
+      server = MockWebServer()
+      server.start()
+      service = Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addConverterFactory(GsonConverterFactory.create())
+        .addCallAdapterFactory(EitherCallAdapterFactory.create())
+        .build()
+        .create(TestSuspendApiClient::class.java)
+    }
+
+    afterAny { server.shutdown() }
 
     "should return ResponseMock for 200 with valid JSON" {
       server.enqueue(MockResponse().setBody("""{"response":"Arrow rocks"}"""))

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowResponseEAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowResponseEAdapterTest.kt
@@ -5,7 +5,7 @@ import arrow.core.right
 import arrow.core.test.UnitSpec
 import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
-import arrow.retrofit.adapter.retrofit.TestSuspendApiClient
+import arrow.retrofit.adapter.retrofit.SuspendApiTestClient
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -16,7 +16,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class ArrowResponseEAdapterTest : UnitSpec() {
 
   private lateinit var server: MockWebServer
-  private lateinit var service: TestSuspendApiClient
+  private lateinit var service: SuspendApiTestClient
 
   init {
 
@@ -28,7 +28,7 @@ class ArrowResponseEAdapterTest : UnitSpec() {
         .addConverterFactory(GsonConverterFactory.create())
         .addCallAdapterFactory(EitherCallAdapterFactory.create())
         .build()
-        .create(TestSuspendApiClient::class.java)
+        .create(SuspendApiTestClient::class.java)
     }
 
     afterAny { server.shutdown() }

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/retrofit/SuspendApiTestClient.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/retrofit/SuspendApiTestClient.kt
@@ -6,7 +6,7 @@ import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
 import retrofit2.http.GET
 
-interface TestSuspendApiClient {
+interface SuspendApiTestClient {
 
   @GET("/")
   suspend fun getEither(): Either<ErrorMock, ResponseMock>

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/retrofit/TestSuspendApiClient.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/retrofit/TestSuspendApiClient.kt
@@ -6,7 +6,7 @@ import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
 import retrofit2.http.GET
 
-interface SuspedApiClientTest {
+interface TestSuspendApiClient {
 
   @GET("/")
   suspend fun getEither(): Either<ErrorMock, ResponseMock>


### PR DESCRIPTION
Current test configuration reuses one `MockWebServer` instance across all tests. This is incorrect, as any changes to the mock server configuration influence subsequent tests.
To experience the problem on the current `main` branch, change the test order in that you move any test asserting a successful response, e.g. `should return ResponseMock for 200 with valid JSON`, after the last test `should throw when server disconnects`. The test for a successful response will now start failing.

This PR fixes that in that the `server` and `service` variables have been made `lateinit var`s and are initialized before any test.
To test if this fixes the problem, just change the test order in the way described above on this PR's branch and see that the tests all still pass regardless of their order.

I have also renamed the confusingly named `SuspedApiClientTest` to `SuspendApiTestClient`. The old name suggested that it was a test (because of the `Test` suffix) when in reality it is a test client.