### PR TITLE
Retrofit adapter: allow null response body for methods returning Unit

### DIFF
--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapter.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapter.kt
@@ -23,13 +23,14 @@ internal class ArrowEitherCallAdapter<E, R>(
   private val errorConverter: Converter<ResponseBody, E> =
     retrofit.responseBodyConverter(errorType, arrayOfNulls(0))
 
-  override fun adapt(call: Call<R>): Call<Either<E, R>> = EitherCall(call, errorConverter)
+  override fun adapt(call: Call<R>): Call<Either<E, R>> = EitherCall(call, errorConverter, bodyType)
 
   override fun responseType(): Type = bodyType
 
   class EitherCall<E, R>(
     private val original: Call<R>,
-    private val errorConverter: Converter<ResponseBody, E>
+    private val errorConverter: Converter<ResponseBody, E>,
+    private val bodyType: Type
   ) : Call<Either<E, R>> {
 
     override fun enqueue(callback: Callback<Either<E, R>>) {
@@ -44,6 +45,7 @@ internal class ArrowEitherCallAdapter<E, R>(
             callback,
             this@EitherCall,
             errorConverter,
+            bodyType,
             response,
             { body, _ ->
               Response.success(response.code(), body.right())
@@ -60,7 +62,7 @@ internal class ArrowEitherCallAdapter<E, R>(
 
     override fun timeout(): Timeout = original.timeout()
 
-    override fun clone(): Call<Either<E, R>> = EitherCall(original.clone(), errorConverter)
+    override fun clone(): Call<Either<E, R>> = EitherCall(original.clone(), errorConverter, bodyType)
 
     override fun isCanceled(): Boolean = original.isCanceled
 

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/EitherCallAdapterFactory.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/EitherCallAdapterFactory.kt
@@ -56,7 +56,10 @@ public class EitherCallAdapterFactory : CallAdapter.Factory() {
     }
   }
 
-  private fun eitherAdapter(returnType: ParameterizedType, retrofit: Retrofit): CallAdapter<Type, out Call<out Any>>? {
+  private fun eitherAdapter(
+    returnType: ParameterizedType,
+    retrofit: Retrofit
+  ): CallAdapter<Type, out Call<out Any>>? {
     val wrapperType = getParameterUpperBound(0, returnType)
     return when (getRawType(wrapperType)) {
       Either::class.java -> {

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/eitherAdapter.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/eitherAdapter.kt
@@ -5,11 +5,13 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Converter
 import retrofit2.Response
+import java.lang.reflect.Type
 
 internal inline fun <E, R, T> onResponseFn(
   callback: Callback<T>,
   call: Call<T>,
   errorConverter: Converter<ResponseBody, E>,
+  bodyType: Type,
   response: Response<R>,
   newResponseFn: (R, Response<R>) -> Response<T>,
   errorResponseFn: (E, Response<R>) -> Response<T>
@@ -17,7 +19,14 @@ internal inline fun <E, R, T> onResponseFn(
   if (response.isSuccessful) {
     val body = response.body()
     if (body == null) {
-      callback.onFailure(call, IllegalStateException("Null body found!"))
+      // if we defined Unit as body type it means we expected no response body
+      // e.g. in case of 204 No Content
+      if (bodyType == Unit::class.java) {
+        @Suppress("UNCHECKED_CAST")
+        callback.onResponse(call, newResponseFn(Unit as R, response))
+      } else {
+        callback.onFailure(call, IllegalStateException("Null body found!"))
+      }
     } else {
       callback.onResponse(call, newResponseFn(body, response))
     }

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
@@ -39,6 +39,14 @@ class ArrowEitherCallAdapterTest : UnitSpec() {
       body shouldBe ResponseMock("Arrow rocks").right()
     }
 
+    "should return Unit when service method returns Unit and null body received" {
+      server.enqueue(MockResponse().setResponseCode(204))
+
+      val body = service.postSomething("Sample string")
+
+      body shouldBe Unit.right()
+    }
+
     "should return ErrorMock for 400 with valid JSON" {
       server.enqueue(MockResponse().setBody("""{"errorCode":666}""").setResponseCode(400))
 

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowResponseEAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowResponseEAdapterTest.kt
@@ -42,6 +42,17 @@ class ArrowResponseEAdapterTest : UnitSpec() {
       }
     }
 
+    "should return Unit when service method returns Unit and null body received" {
+      server.enqueue(MockResponse().setResponseCode(204))
+
+      val responseE = service.postSomethingResponseE("Sample string")
+
+      with(responseE) {
+        code shouldBe 204
+        body shouldBe Unit.right()
+      }
+    }
+
     "should return ErrorMock for 400 with valid JSON" {
       server.enqueue(MockResponse().setBody("""{"errorCode":42}""").setResponseCode(400))
 

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/retrofit/SuspedApiClientTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/retrofit/SuspedApiClientTest.kt
@@ -4,13 +4,21 @@ import arrow.core.Either
 import arrow.retrofit.adapter.either.ResponseE
 import arrow.retrofit.adapter.mock.ErrorMock
 import arrow.retrofit.adapter.mock.ResponseMock
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface SuspedApiClientTest {
 
   @GET("/")
   suspend fun getEither(): Either<ErrorMock, ResponseMock>
 
+  @POST("/")
+  suspend fun postSomething(@Body something: String): Either<ErrorMock, Unit>
+
   @GET("/")
   suspend fun getResponseE(): ResponseE<ErrorMock, ResponseMock>
+
+  @POST("/")
+  suspend fun postSomethingResponseE(@Body something: String): ResponseE<ErrorMock, Unit>
 }


### PR DESCRIPTION
If the developer defined some service methods as returning `Unit` it means he's not interested in the response body. It will be mostly the case for responses like `204 No Content` for which the server may return a null response body.

The current implementation will always throw an exception when null response body has been received, regardless of the expected return type defined by the developer.

This PR fixes that. It adds support for receiving `null` response body for methods defined like in the example below (note that the right type is defined as `Unit`):
```
@POST("/")
suspend fun postSomething(@Body something: String): Either<Error, Unit>
```