### PR TITLE
Propagate Arrow version to publish_doc job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,9 @@ jobs:
     timeout-minutes: 120
     runs-on: macos-latest
 
+    outputs:
+      arrow-version: ${{ steps.get-arrow-version.outputs.arrow-version }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -84,6 +87,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+
+      - id: get-arrow-version
+        name: Get Arrow version
+        run: echo "::set-output name=arrow-version::${{needs.build.outputs.arrow-version}}"
 
       - name: Publish alpha/beta/rc version
         uses: gradle/gradle-build-action@v2.1.0
@@ -159,19 +166,19 @@ jobs:
       - name: Build release directory (/docs)
         working-directory: arrow-site
         if: |
-          !contains(needs.build.outputs.arrow-version, 'alpha') &&
-          !contains(needs.build.outputs.arrow-version, 'beta') &&
-          !contains(needs.build.outputs.arrow-version, 'rc')
+          !contains(needs.publish.outputs.arrow-version, 'alpha') &&
+          !contains(needs.publish.outputs.arrow-version, 'beta') &&
+          !contains(needs.publish.outputs.arrow-version, 'rc')
         run: |
           bundle exec jekyll build -b docs -s docs
-          tree _site > $BASEDIR/logs/content_docs-${{ needs.build.outputs.arrow-version }}.log
+          tree _site > $BASEDIR/logs/content_docs-${{ needs.publish.outputs.arrow-version }}.log
 
       - name: Publish documentation (/docs)
         working-directory: arrow-site
         if: |
-          !contains(needs.build.outputs.arrow-version, 'alpha') &&
-          !contains(needs.build.outputs.arrow-version, 'beta') &&
-          !contains(needs.build.outputs.arrow-version, 'rc')
+          !contains(needs.publish.outputs.arrow-version, 'alpha') &&
+          !contains(needs.publish.outputs.arrow-version, 'beta') &&
+          !contains(needs.publish.outputs.arrow-version, 'rc')
         run: |
           echo ">>> Latest release" >> $BASEDIR/logs/aws_sync.log
           ${GITHUB_WORKSPACE}/.github/scripts/sync-docs-with-aws.sh
@@ -179,21 +186,21 @@ jobs:
       - name: Build release directory (/docs/<major.minor>)
         working-directory: arrow-site
         if: |
-          !contains(needs.build.outputs.arrow-version, 'alpha') &&
-          !contains(needs.build.outputs.arrow-version, 'beta') &&
-          !contains(needs.build.outputs.arrow-version, 'rc')
+          !contains(needs.publish.outputs.arrow-version, 'alpha') &&
+          !contains(needs.publish.outputs.arrow-version, 'beta') &&
+          !contains(needs.publish.outputs.arrow-version, 'rc')
         run: |
-          bundle exec jekyll build -b docs/${{ needs.build.outputs.arrow-version }} -s docs
-          tree _site > $BASEDIR/logs/content_docs-${{ needs.build.outputs.arrow-version }}.log
+          bundle exec jekyll build -b docs/${{ needs.publish.outputs.arrow-version }} -s docs
+          tree _site > $BASEDIR/logs/content_docs-${{ needs.publish.outputs.arrow-version }}.log
 
       - name: Publish release directory (/docs/<major.minor>)
         working-directory: arrow-site
         if: |
-          !contains(needs.build.outputs.arrow-version, 'alpha') &&
-          !contains(needs.build.outputs.arrow-version, 'beta') &&
-          !contains(needs.build.outputs.arrow-version, 'rc')
+          !contains(needs.publish.outputs.arrow-version, 'alpha') &&
+          !contains(needs.publish.outputs.arrow-version, 'beta') &&
+          !contains(needs.publish.outputs.arrow-version, 'rc')
         run: |
-          aws s3 sync _site s3://$S3_BUCKET/docs/${{ needs.build.outputs.arrow-version }} --delete --exclude "/CNAME" --exclude "/code/*" --exclude "/index.html" --exclude "/redirects.json" >> $BASEDIR/logs/aws_sync.log
+          aws s3 sync _site s3://$S3_BUCKET/docs/${{ needs.publish.outputs.arrow-version }} --delete --exclude "/CNAME" --exclude "/code/*" --exclude "/index.html" --exclude "/redirects.json" >> $BASEDIR/logs/aws_sync.log
 
       - name: Build latest version (/docs/next)
         working-directory: arrow-site
@@ -208,9 +215,9 @@ jobs:
 
       - name: Publish sitemap.xml
         if: |
-          !contains(needs.build.outputs.arrow-version, 'alpha') &&
-          !contains(needs.build.outputs.arrow-version, 'beta') &&
-          !contains(needs.build.outputs.arrow-version, 'rc')
+          !contains(needs.publish.outputs.arrow-version, 'alpha') &&
+          !contains(needs.publish.outputs.arrow-version, 'beta') &&
+          !contains(needs.publish.outputs.arrow-version, 'rc')
         run: |
           ${GITHUB_WORKSPACE}/.github/scripts/create-sitemap.sh > sitemap.xml
           aws s3 cp sitemap.xml s3://$S3_BUCKET/sitemap.xml >> $BASEDIR/logs/aws_sync.log


### PR DESCRIPTION
The `publish_doc` can't access the Arrow version defined as an output for the `build` job because it doesn't depend on that job directly. So we need to propagate that value from the `publish` job to be able to read the version of the library.