### PR TITLE
revert ksp plugin to jvm only

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id(libs.plugins.kotlin.multiplatform.get().pluginId)
+  id(libs.plugins.kotlin.jvm.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
   alias(libs.plugins.arrowGradleConfig.publish)
 }
@@ -11,27 +11,27 @@ kotlin {
 apply(from = property("TEST_COVERAGE"))
 apply(from = property("ANIMALSNIFFER_MPP"))
 
-kotlin {
-  sourceSets {
-    jvmMain {
-      dependencies {
-        implementation(libs.ksp)
-      }
-    }
-    jvmTest {
-      dependencies {
-        implementation(libs.kotlin.stdlibJDK8)
-        implementation(libs.junitJupiter)
-        implementation(libs.junitJupiterEngine)
-        implementation(libs.assertj)
-        implementation(libs.classgraph)
-        implementation(libs.kotlinCompileTesting)
-        implementation(libs.kotlinCompileTestingKsp)
-        runtimeOnly(projects.arrowOpticsKspPlugin)
-        runtimeOnly(projects.arrowAnnotations)
-        runtimeOnly(projects.arrowCore)
-        runtimeOnly(projects.arrowOptics)
-      }
-    }
+dependencies {
+  implementation(libs.ksp)
+
+  testImplementation(libs.kotlin.stdlibJDK8)
+  testImplementation(libs.junitJupiter)
+  testImplementation(libs.junitJupiterEngine)
+  testImplementation(libs.assertj)
+  testImplementation(libs.classgraph)
+  testImplementation(libs.kotlinCompileTesting) {
+    exclude(
+      group = libs.classgraph.get().module.group,
+      module = libs.classgraph.get().module.name
+    )
+    exclude(
+      group = libs.kotlin.stdlibJDK8.get().module.group,
+      module = libs.kotlin.stdlibJDK8.get().module.name
+    )
   }
+  testImplementation(libs.kotlinCompileTestingKsp)
+  testRuntimeOnly(projects.arrowOpticsKspPlugin)
+  testRuntimeOnly(projects.arrowAnnotations)
+  testRuntimeOnly(projects.arrowCore)
+  testRuntimeOnly(projects.arrowOptics)
 }


### PR DESCRIPTION
Since #2636 alpha releases are broken, as there are no mpp dependencies for ios or other native targets
e.g.: :arrow-optics-ksp-plugin:generateMetadataFileForIosArm32Publication  fails
