### PR TITLE
[Optics KSP] Update docs to talk about IDEs

### DIFF
--- a/arrow-site/docs/docs/optics/README.md
+++ b/arrow-site/docs/docs/optics/README.md
@@ -122,11 +122,11 @@ allprojects {
 
 #### Step 2: add the library
 
-Add the dependencies into the project's `build.gradle.kts`:
+Add the dependencies into the project's `build.gradle.kts` (change `$arrowVersion` to a specific version, or define the corresponding property in `gradle.properties`):
 
 ```
 dependencies {
-    implementation("io.arrow-kt:arrow-optics:1.0.1")
+    implementation("io.arrow-kt:arrow-optics:$arrowVersion")
 }
 ```
 
@@ -134,7 +134,7 @@ If you are using more than one Arrow dependency, you can avoid specifying the sa
 
 ```
 dependencies {
-    implementation(platform("io.arrow-kt:arrow-stack:1.0.1"))
+    implementation(platform("io.arrow-kt:arrow-stack:$arrowVersion"))
 
     implementation("io.arrow-kt:arrow-core")
     implementation("io.arrow-kt:arrow-optics")
@@ -142,7 +142,7 @@ dependencies {
 }
 ```
 
-#### Step 3: add the plug-in
+#### Step 3: add the plug-in (optional)
 
 To get the most of Arrow Optics you can add out Kotlin plug-in to your build, which takes care of generating optics for your data types.
 
@@ -152,9 +152,11 @@ plugins {
 }
 
 dependencies {
-    ksp("io.arrow-kt:arrow-optics-ksp-plugin:1.0.1")
+    ksp("io.arrow-kt:arrow-optics-ksp-plugin:$arrowVersion")
 }
 ```
+
+If you are using IntelliJ as your IDE of choice, you also need to [add some new paths as sources](https://kotlinlang.org/docs/ksp-quickstart.html#make-ide-aware-of-generated-code) to make it aware of the generated sources.
 
 Now you are ready to learn about the [Optics DSL]({{ '/optics/dsl/' | relative_url }})!
 
@@ -200,7 +202,7 @@ dependencies {
 }
 ```
 
-#### Step 3: add the plug-in
+#### Step 3: add the plug-in (optional)
 
 To get the most of Arrow Optics you can add out Kotlin plug-in to your build, which takes care of generating optics for your data types.
 
@@ -210,7 +212,7 @@ plugins {
 }
 
 dependencies {
-    ksp "io.arrow-kt:arrow-optics-ksp-plugin:1.0.1"
+    ksp "io.arrow-kt:arrow-optics-ksp-plugin:$arrow_version"
 }
 ```
 


### PR DESCRIPTION
This is the final step in fixing #2646: adding docs explaning how to make IntelliJ aware of the generated code.