### PR TITLE
fix sitemap titles

### DIFF
--- a/arrow-site/docs/_data/sidebar-core.yml
+++ b/arrow-site/docs/_data/sidebar-core.yml
@@ -40,16 +40,16 @@ options:
 
     nested_options:
 
-      - title: arrow.core.continutions.Effect
+      - title: Effect
         url: /apidocs/arrow-core/arrow.core.continuations/-effect/
 
-      - title: arrow.core.continuations.EffectScope
+      - title: EffectScope
         url: /apidocs/arrow-core/arrow.core.continuations/-effect-scope/
 
-      - title: arrow.core.continuations.EagerEffect
+      - title: EagerEffect
         url: /apidocs/arrow-core/arrow.core.continuations/-eager-effect/
 
-      - title: arrow.core.continuations.EagerEffectScope
+      - title: EagerEffectScope
         url: /apidocs/arrow-core/arrow.core.continuations/-eager-effect-scope/
 
       - title: Semantics of Structured Concurrency and Effect

--- a/arrow-site/docs/docs/arrow/core/continuations/README.md
+++ b/arrow-site/docs/docs/arrow/core/continuations/README.md
@@ -1,3 +1,9 @@
+---
+layout: docs-core
+title: Semantics of Structured Concurrency + Effect<R, A>
+permalink: /arrow/core/continuations/
+---
+
 # Semantics of Structured Concurrency + Effect<R, A>
 
 KotlinX Structured Concurrency is super important for eco-system,  and thus important to us for wide-adoption of this pattern


### PR DESCRIPTION
On some devices the long names aren't displayed properly (or only partially) in the widget