### PR TITLE
rename Sequence sequenceX, traverseX and deprecate Sequence.some

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -1411,12 +1411,17 @@ public final class arrow/core/SequenceKt {
 	public static final fun salign (Lkotlin/sequences/Sequence;Larrow/typeclasses/Semigroup;Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
 	public static final fun separateEither (Lkotlin/sequences/Sequence;)Lkotlin/Pair;
 	public static final fun separateValidated (Lkotlin/sequences/Sequence;)Lkotlin/Pair;
+	public static final fun sequence (Lkotlin/sequences/Sequence;)Larrow/core/Either;
+	public static final fun sequence (Lkotlin/sequences/Sequence;)Larrow/core/Option;
 	public static final fun sequenceEither (Lkotlin/sequences/Sequence;)Larrow/core/Either;
 	public static final fun sequenceOption (Lkotlin/sequences/Sequence;)Larrow/core/Option;
 	public static final fun sequenceValidated (Lkotlin/sequences/Sequence;Larrow/typeclasses/Semigroup;)Larrow/core/Validated;
 	public static final fun some (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
 	public static final fun split (Lkotlin/sequences/Sequence;)Lkotlin/Pair;
 	public static final fun tail (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+	public static final fun traverse (Lkotlin/sequences/Sequence;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
+	public static final fun traverse (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun traverse (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun traverseEither (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun traverseOption (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun traverseValidated (Lkotlin/sequences/Sequence;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -1413,6 +1413,7 @@ public final class arrow/core/SequenceKt {
 	public static final fun separateValidated (Lkotlin/sequences/Sequence;)Lkotlin/Pair;
 	public static final fun sequence (Lkotlin/sequences/Sequence;)Larrow/core/Either;
 	public static final fun sequence (Lkotlin/sequences/Sequence;)Larrow/core/Option;
+	public static final fun sequence (Lkotlin/sequences/Sequence;Larrow/typeclasses/Semigroup;)Larrow/core/Validated;
 	public static final fun sequenceEither (Lkotlin/sequences/Sequence;)Larrow/core/Either;
 	public static final fun sequenceOption (Lkotlin/sequences/Sequence;)Larrow/core/Option;
 	public static final fun sequenceValidated (Lkotlin/sequences/Sequence;Larrow/typeclasses/Semigroup;)Larrow/core/Validated;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -641,7 +641,7 @@ public fun <E, A> Sequence<Validated<E, A>>.sequence(semigroup: Semigroup<E>): V
 public fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
   sequence(semigroup).map { it.asSequence() }
 
-@Deprecated("Deprecated legacy Api", ReplaceWith("map { generateSequence { this } }"))
+@Deprecated("some is being deprecated in favor of map", ReplaceWith("map { generateSequence { this } }"))
 public fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
   if (none()) emptySequence()
   else map { generateSequence { it } }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -613,14 +613,14 @@ public fun <A, B> Sequence<Validated<A, B>>.separateValidated(): Pair<Sequence<A
 public fun <E, A> Sequence<Either<E, A>>.sequence(): Either<E, List<A>> =
   traverse(::identity)
 
-@Deprecated("use sequence", ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence"))
+@Deprecated("use sequence instead", ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence"))
 public fun <E, A> Sequence<Either<E, A>>.sequenceEither(): Either<E, Sequence<A>> =
   traverse(::identity).map { it.asSequence() }
 
 public fun <A> Sequence<Option<A>>.sequence(): Option<List<A>> =
   traverse(::identity)
 
-@Deprecated("use sequence", ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence"))
+@Deprecated("use sequence instead", ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence"))
 public fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
   traverse(::identity).map { it.asSequence() }
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -624,7 +624,6 @@ public fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
 public fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
   traverseValidated(semigroup, ::identity)
 
-@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
   if (none()) emptySequence()
   else map { generateSequence { it } }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -614,21 +614,30 @@ public fun <A, B> Sequence<Validated<A, B>>.separateValidated(): Pair<Sequence<A
 public fun <E, A> Sequence<Either<E, A>>.sequence(): Either<E, List<A>> =
   traverse(::identity)
 
-@Deprecated("use sequence instead", ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence"))
+@Deprecated(
+  "sequenceEither is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence")
+)
 public fun <E, A> Sequence<Either<E, A>>.sequenceEither(): Either<E, Sequence<A>> =
-  traverse(::identity).map { it.asSequence() }
+  sequence().map { it.asSequence() }
 
 public fun <A> Sequence<Option<A>>.sequence(): Option<List<A>> =
   traverse(::identity)
 
-@Deprecated("use sequence instead", ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence"))
+@Deprecated(
+  "sequenceOption is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence().map { it.asSequence() }", "arrow.core.sequence")
+)
 public fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
-  traverse(::identity).map { it.asSequence() }
+  sequence().map { it.asSequence() }
 
 public fun <E, A> Sequence<Validated<E, A>>.sequence(semigroup: Semigroup<E>): Validated<E, List<A>> =
   traverse(semigroup, ::identity)
 
-@Deprecated("use sequence instead", ReplaceWith("sequence(semigroup).map { it.asSequence() }", "arrow.core.sequence"))
+@Deprecated(
+  "sequenceValidated is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence(semigroup).map { it.asSequence() }", "arrow.core.sequence")
+)
 public fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
   sequence(semigroup).map { it.asSequence() }
 
@@ -676,7 +685,10 @@ public fun <E, A, B> Sequence<A>.traverse(f: (A) -> Either<E, B>): Either<E, Lis
   return acc.toList().right()
 }
 
-@Deprecated("use traverse instead", ReplaceWith("traverse(f).map { it.asSequence() }", "arrow.core.traverse"))
+@Deprecated(
+  "traverseEither is being renamed to traverse to simplify the Arrow API",
+  ReplaceWith("traverse(f).map { it.asSequence() }", "arrow.core.traverse")
+)
 public fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequence<B>> =
   traverse(f).map { it.asSequence() }
 
@@ -696,7 +708,10 @@ public fun <A, B> Sequence<A>.traverse(f: (A) -> Option<B>): Option<List<B>> {
   return Some(acc)
 }
 
-@Deprecated("use traverse instead", ReplaceWith("traverse(f).map { it.asSequence() }", "arrow.core.traverse"))
+@Deprecated(
+  "traverseOption is being renamed to traverse to simplify the Arrow API",
+  ReplaceWith("traverse(f).map { it.asSequence() }", "arrow.core.traverse")
+)
 public fun <A, B> Sequence<A>.traverseOption(f: (A) -> Option<B>): Option<Sequence<B>> =
   traverse(f).map { it.asSequence() }
 
@@ -719,7 +734,10 @@ public fun <E, A, B> Sequence<A>.traverse(
     }
   }
 
-@Deprecated("traverse(semigroup, f).map { it.asSequence() }", ReplaceWith("arrow.core.traverse"))
+@Deprecated(
+  "traverseValidated is being renamed to traverse to simplify the Arrow API",
+  ReplaceWith("traverse(semigroup, f).map { it.asSequence() }", "arrow.core.traverse")
+)
 public fun <E, A, B> Sequence<A>.traverseValidated(
   semigroup: Semigroup<E>,
   f: (A) -> Validated<E, B>

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -612,15 +612,19 @@ public fun <A, B> Sequence<Validated<A, B>>.separateValidated(): Pair<Sequence<A
   return asep to bsep
 }
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <E, A> Sequence<Either<E, A>>.sequenceEither(): Either<E, Sequence<A>> =
   traverseEither(::identity)
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
   traverseOption(::identity)
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
   traverseValidated(semigroup, ::identity)
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
   if (none()) emptySequence()
   else map { generateSequence { it } }
@@ -648,6 +652,7 @@ public fun <A> Sequence<A>.split(): Pair<Sequence<A>, A>? =
 public fun <A> Sequence<A>.tail(): Sequence<A> =
   drop(1)
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequence<B>> {
   // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
   //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
@@ -662,6 +667,7 @@ public fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<
   return acc.asSequence().right()
 }
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <A, B> Sequence<A>.traverseOption(f: (A) -> Option<B>): Option<Sequence<B>> {
   // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
   //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
@@ -676,6 +682,7 @@ public fun <A, B> Sequence<A>.traverseOption(f: (A) -> Option<B>): Option<Sequen
   return Some(acc.asSequence())
 }
 
+@Deprecated("Terminal operators on Sequence are being deprecated. Please use either one of the supported terminal operators of Sequence and opt for supported [traverse] functions")
 public fun <E, A, B> Sequence<A>.traverseValidated(
   semigroup: Semigroup<E>,
   f: (A) -> Validated<E, B>
@@ -833,4 +840,5 @@ public fun <A> Sequence<A>.void(): Sequence<Unit> =
 public fun <B, A : B> Sequence<A>.widen(): Sequence<B> =
   this
 
-public fun <A> Sequence<Option<A>>.filterOption(): Sequence<A> = this.mapNotNull { it.orNull() }
+public fun <A> Sequence<Option<A>>.filterOption(): Sequence<A> =
+  mapNotNull { it.orNull() }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -624,6 +624,7 @@ public fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
 public fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
   traverseValidated(semigroup, ::identity)
 
+@Deprecated("Deprecated legacy Api", ReplaceWith("map { generateSequence { this } }"))
 public fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
   if (none()) emptySequence()
   else map { generateSequence { it } }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -4,6 +4,7 @@ import arrow.core.Either.Left
 import arrow.core.Either.Right
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
+import kotlin.experimental.ExperimentalTypeInference
 
 public fun <B, C, D, E> Sequence<B>.zip(
   c: Sequence<C>,
@@ -624,8 +625,12 @@ public fun <A> Sequence<Option<A>>.sequence(): Option<List<A>> =
 public fun <A> Sequence<Option<A>>.sequenceOption(): Option<Sequence<A>> =
   traverse(::identity).map { it.asSequence() }
 
+public fun <E, A> Sequence<Validated<E, A>>.sequence(semigroup: Semigroup<E>): Validated<E, List<A>> =
+  traverse(semigroup, ::identity)
+
+@Deprecated("use sequence instead", ReplaceWith("sequence(semigroup).map { it.asSequence() }", "arrow.core.sequence"))
 public fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
-  traverseValidated(semigroup, ::identity)
+  sequence(semigroup).map { it.asSequence() }
 
 @Deprecated("Deprecated legacy Api", ReplaceWith("map { generateSequence { this } }"))
 public fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
@@ -655,6 +660,8 @@ public fun <A> Sequence<A>.split(): Pair<Sequence<A>, A>? =
 public fun <A> Sequence<A>.tail(): Sequence<A> =
   drop(1)
 
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
 public fun <E, A, B> Sequence<A>.traverse(f: (A) -> Either<E, B>): Either<E, List<B>> {
   // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
   //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
@@ -673,6 +680,8 @@ public fun <E, A, B> Sequence<A>.traverse(f: (A) -> Either<E, B>): Either<E, Lis
 public fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequence<B>> =
   traverse(f).map { it.asSequence() }
 
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
 public fun <A, B> Sequence<A>.traverse(f: (A) -> Option<B>): Option<List<B>> {
   // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
   //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
@@ -691,6 +700,8 @@ public fun <A, B> Sequence<A>.traverse(f: (A) -> Option<B>): Option<List<B>> {
 public fun <A, B> Sequence<A>.traverseOption(f: (A) -> Option<B>): Option<Sequence<B>> =
   traverse(f).map { it.asSequence() }
 
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
 public fun <E, A, B> Sequence<A>.traverse(
   semigroup: Semigroup<E>,
   f: (A) -> Validated<E, B>

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/SequenceKTest.kt
@@ -10,8 +10,7 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.list
-import io.kotest.property.arbitrary.positiveInts
+import io.kotest.property.arbitrary.positiveInt
 import io.kotest.property.arbitrary.string
 import kotlin.math.max
 import kotlin.math.min
@@ -25,7 +24,7 @@ class SequenceKTest : UnitSpec() {
     "traverseEither stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
-      val res = generateSequence(0) { it + 1 }.traverseEither { a ->
+      val res = generateSequence(0) { it + 1 }.traverse { a ->
         if (a > 20_000) {
           Either.Left(Unit)
         } else {
@@ -40,7 +39,7 @@ class SequenceKTest : UnitSpec() {
     "traverseOption stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
-      val res = generateSequence(0) { it + 1 }.traverseOption { a ->
+      val res = generateSequence(0) { it + 1 }.traverse { a ->
         (a <= 20_000).maybe {
           acc.add(a)
           a
@@ -53,7 +52,7 @@ class SequenceKTest : UnitSpec() {
     "traverseValidated stack-safe" {
       // also verifies result order and execution order (l to r)
       val acc = mutableListOf<Int>()
-      val res = (0..20_000).asSequence().traverseValidated(Semigroup.string()) {
+      val res = (0..20_000).asSequence().traverse(Semigroup.string()) {
         acc.add(it)
         Validated.Valid(it)
       }.map { it.toList() }
@@ -63,8 +62,8 @@ class SequenceKTest : UnitSpec() {
 
     "traverseValidated acummulates" {
       checkAll(Arb.sequence(Arb.int())) { ints ->
-        val res: ValidatedNel<Int, Sequence<Int>> = ints.map { i -> if (i % 2 == 0) i.validNel() else i.invalidNel() }
-          .sequenceValidated(Semigroup.nonEmptyList())
+        val res: ValidatedNel<Int, List<Int>> = ints.map { i -> if (i % 2 == 0) i.validNel() else i.invalidNel() }
+          .sequence(Semigroup.nonEmptyList())
 
         val expected: ValidatedNel<Int, Sequence<Int>> = NonEmptyList.fromList(ints.filterNot { it % 2 == 0 }.toList())
           .fold({ ints.filter { it % 2 == 0 }.validNel() }, { it.invalid() })
@@ -273,7 +272,7 @@ class SequenceKTest : UnitSpec() {
 
       val seq2 = generateSequence(0) { it + 1 }
 
-      checkAll(10, Arb.positiveInts(max = 10_000)) { idx: Int ->
+      checkAll(10, Arb.positiveInt(max = 10_000)) { idx: Int ->
         val element = seq1.align(seq2).drop(idx).first()
 
         element shouldBe Ior.Both("A", idx)


### PR DESCRIPTION
Rename to either `sequence` or `traverse`: 
- sequenceEither
- sequenceValidated
- sequenceOption
- traverseEither
- traverseOption
- traverseValidated

Deprecate:
- some
