### PR TITLE
define Dsl as public

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -346,6 +346,17 @@ public final class arrow/fx/coroutines/Resource$Defer : arrow/fx/coroutines/Reso
 	public final fun getResource ()Lkotlin/jvm/functions/Function1;
 }
 
+public final class arrow/fx/coroutines/Resource$Dsl : arrow/fx/coroutines/Resource {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Lkotlin/jvm/functions/Function2;)Larrow/fx/coroutines/Resource$Dsl;
+	public static synthetic fun copy$default (Larrow/fx/coroutines/Resource$Dsl;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Larrow/fx/coroutines/Resource$Dsl;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDsl ()Lkotlin/jvm/functions/Function2;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class arrow/fx/coroutines/ResourceExtensionsKt {
 	public static final fun fromAutoCloseable (Larrow/fx/coroutines/Resource$Companion;Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/Resource;
 	public static final fun fromCloseable (Larrow/fx/coroutines/Resource$Companion;Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/Resource;

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -501,7 +501,7 @@ public sealed class Resource<out A> {
   )
   public class Defer<A>(public val resource: suspend () -> Resource<A>) : Resource<A>()
 
-  internal data class Dsl<A>(public val dsl: suspend ResourceScope.() -> A) : Resource<A>()
+  public data class Dsl<A>(public val dsl: suspend ResourceScope.() -> A) : Resource<A>()
 
   public companion object {
 


### PR DESCRIPTION
fixes when expression with Resource:
currently
```kotlin
when(val x: Resource<Int> = myResource()) {
  is Bind<*,*> -> ...
  is Allocate -> ...
  is Defer -> ...
  is Dsl -> ... // error bc this is internal
  else -> ... // only work around
}
```

after this PR, the when expression is exhaustive and there is no need to use else: 

```kotlin
when(val x: Resource<Int> = myResource()) {
  is Bind<*,*> -> ...
  is Allocate -> ...
  is Defer -> ...
  is Dsl -> 
}
```