### PR TITLE
staged publication for final release

### DIFF
--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -21,7 +21,6 @@ on:
         default: 'auto'
         type: choice
         options:
-          - 'patch'
           - 'minor'
           - 'major'
           - 'auto'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
           !contains(needs.build.outputs.arrow-version, 'beta') &&
           !contains(needs.build.outputs.arrow-version, 'rc')
         with:
-          arguments: --full-stacktrace publishToSonatype closeSonatypeStagingRepository
+          arguments: --full-stacktrace publishToSonatype
 
       - name: Stop Gradle daemons
         run: ./gradlew --stop


### PR DESCRIPTION
instead of immediately close the staging repository, it adds a manual step for admins to verify and approve a final publication.