### PR TITLE
Add new workflow for publishing the landing page

### DIFF
--- a/.github/workflows/publish-landing-page.yaml
+++ b/.github/workflows/publish-landing-page.yaml
@@ -1,0 +1,65 @@
+name: Publish landing page
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'arrow-site/**'
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_CLOUDFRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
+  AWS_DEFAULT_REGION: eu-west-1
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  JEKYLL_ENV: production
+  S3_BUCKET: ${{ secrets.S3_BUCKET }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Prepare documentation environment
+        working-directory: arrow-site
+        run: |
+          mkdir logs
+          brew install tree
+          bundle config set --local path 'vendor/bundle'
+          bundle install --gemfile Gemfile
+
+      - name: Build landing page
+        working-directory: arrow-site
+        run: |
+          bundle exec jekyll build -b docs -s docs --config docs/_config_for_landing_page.yml
+          tree _site > logs/content.log
+
+      - name: Publish landing page
+        working-directory: arrow-site
+        run: |
+          echo ">>> Landing page" >> logs/aws_sync.log
+          set -e
+          cd _site/
+          for file in *; do
+            if [ -f "$file" ]; then
+              echo "Copying $file ..."
+              aws s3 cp $file s3://$S3_BUCKET/$file >> logs/aws_sync.log
+              continue
+            fi
+
+            echo "Sync $file ..."
+            aws s3 sync $file s3://$S3_BUCKET/$file --delete >> logs/aws_sync.log
+          done
+
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_ID --paths "/*" >> logs/aws_cloudfront.log
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: landing-page-logs
+          path: logs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,18 +151,6 @@ jobs:
         with:
           arguments: --full-stacktrace dokkaGfm
 
-      - name: Build landing page
-        working-directory: arrow-site
-        run: |
-          bundle exec jekyll build -b docs -s docs --config docs/_config_for_landing_page.yml
-          tree _site > $BASEDIR/logs/content.log
-
-      - name: Publish landing page
-        working-directory: arrow-site
-        run: |
-          echo ">>> Landing page" >> $BASEDIR/logs/aws_sync.log
-          ${GITHUB_WORKSPACE}/.github/scripts/sync-main-with-aws.sh
-
       - name: Build release directory (/docs)
         working-directory: arrow-site
         if: |


### PR DESCRIPTION
The landing page for the Arrow site should only be updated when there are changes in the `arrow-site` folder and shouldn't be related to any other GitHub Action workflow for generating and publishing artifacts.

Having a dedicated workflow for the landing page will help us to simplify the rest of the workflows by removing unrelated steps.