### PR TITLE
Add command to install bundler

### DIFF
--- a/.github/workflows/publish-landing-page.yaml
+++ b/.github/workflows/publish-landing-page.yaml
@@ -30,6 +30,7 @@ jobs:
         run: |
           mkdir logs
           brew install tree
+          gem install bundler
           bundle config set --local path 'vendor/bundle'
           bundle install --gemfile Gemfile
 


### PR DESCRIPTION
The workflow for publishing the landing page runs on Ubuntu which doesn't have Bundler installed by default, so we need to add the install command to access the tool.