### PR TITLE
revert arrow-gradle-config to 0.10.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 animalSniffer = "1.5.4"
-arrowGradleConfig = "0.10.2"
+arrowGradleConfig = "0.10.1"
 assertj = "3.22.0"
 coroutines = "1.6.1"
 classgraph = "4.8.147"


### PR DESCRIPTION
there was an error introduced in 0.10.2, which is still under development, to maintain compatibility to Arrow 1.1.2 this PR reverts it back to 0.10.1, 

For context, Kotlin slack discussion:
https://kotlinlang.slack.com/archives/C8UK6RTHU/p1653734285366849
