### PR TITLE
Fix some compilation and test warnings

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
@@ -310,7 +310,7 @@ class EitherTest : UnitSpec() {
 
     "replicate should return Right(empty list) when n <= 0" {
       checkAll(
-        Arb.choice(Arb.negativeInts(), Arb.constant(0)),
+        Arb.nonPositiveInt(),
         Arb.int(0..100)
       ) { n: Int, a: Int ->
         val expected: Either<Int, List<Int>> = Right(emptyList())

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
@@ -16,12 +16,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.boolean
-import io.kotest.property.arbitrary.choice
-import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
-import io.kotest.property.arbitrary.negativeInts
 import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.nonPositiveInt
 
 class EitherTest : UnitSpec() {
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EvalTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EvalTest.kt
@@ -1,16 +1,9 @@
 package arrow.core
 
-import arrow.core.computations.EvalEffect
-import arrow.core.computations.RestrictedEvalEffect
-import arrow.core.computations.eval
 import arrow.core.test.UnitSpec
 import arrow.core.test.concurrency.SideEffect
-import arrow.core.test.laws.FxLaws
 import arrow.core.test.stackSafeIteration
-import io.kotest.property.Arb
 import io.kotest.matchers.shouldBe
-import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.map
 
 class EvalTest : UnitSpec() {
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/IterableTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/IterableTest.kt
@@ -165,7 +165,6 @@ class IterableTest : UnitSpec() {
       checkAll(Arb.list(Arb.int())) { ints ->
         val evens = ints.map { if (it % 2 == 0) it else null }.sequence()
 
-        val expected = ints.takeWhile { it % 2 == 0 }
         if (ints.any { it % 2 != 0 }) {
           evens.shouldBeNull()
         } else {

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
@@ -64,8 +64,7 @@ class OptionTest : UnitSpec() {
     "short circuit null" {
       option {
         val number: Int = "s".length
-        val x = ensureNotNull(number.takeIf { it > 1 })
-        x
+        ensureNotNull(number.takeIf { it > 1 })
         throw IllegalStateException("This should not be executed")
       } shouldBe None
     }
@@ -120,8 +119,8 @@ class OptionTest : UnitSpec() {
     }
 
     "map" {
-      some.map(String::toUpperCase) shouldBe Some("KOTLIN")
-      none.map(String::toUpperCase) shouldBe None
+      some.map(String::uppercase) shouldBe Some("KOTLIN")
+      none.map(String::uppercase) shouldBe None
     }
 
     "zip" {
@@ -410,15 +409,15 @@ class OptionTest : UnitSpec() {
       Option.catch(recover) { 1 } shouldBe Some(1)
     }
 
+    "catch with default recover should return Some(result) when f does not throw" {
+      Option.catch { 1 } shouldBe Some(1)
+    }
+
     "catch should return Some(recoverValue) when f throws" {
       val exception = Exception("Boom!")
       val recoverValue = 10
       val recover: (Throwable) -> Option<Int> = { _ -> Some(recoverValue) }
       Option.catch(recover) { throw exception } shouldBe Some(recoverValue)
-    }
-
-    "catch should return Some(result) when f does not throw" {
-      Option.catch { 1 } shouldBe Some(1)
     }
 
     "catch should return None when f throws" {

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/ValidatedTest.kt
@@ -204,7 +204,7 @@ class ValidatedTest : UnitSpec() {
             ) { a, b -> a + b }
           })
           else Invalid(
-            all.filterIsInstance<Invalid<Long?>>().map { it.value }.combineAll(nullableLongSemigroup)
+            all.filterIsInstance<Invalid<Long?>>().map { it.value }.fold(nullableLongSemigroup)
           )
 
         res shouldBe expected
@@ -458,15 +458,7 @@ class ValidatedTest : UnitSpec() {
       }
     }
 
-    "bitraverseNullable should wrap valid or invalid in a nullable" {
-      val valid = Valid("Who")
-      val invalid = Invalid("Nope")
-
-      valid.bitraverseNullable({ it }, { it }) shouldBe Valid("Who")
-      invalid.bitraverseNullable({ it }, { it }) shouldBe Invalid("Nope")
-    }
-
-    "bisequenceOption should yield consistent result with bitraverseOption" {
+    "bisequenceNullable should yield consistent result with bitraverseNullable" {
       checkAll(Arb.string().orNull(), Arb.string().orNull()) { a: String?, b: String? ->
         val valid: Validated<String?, String?> = Valid(a)
         val invalid: Validated<String?, String?> = Invalid(b)
@@ -476,6 +468,14 @@ class ValidatedTest : UnitSpec() {
         invalid.bimap({ it }, { it }).bisequenceNullable() shouldBe
           invalid.bitraverseNullable({ it }, { it })
       }
+    }
+
+    "bitraverseNullable should wrap valid or invalid in a nullable" {
+      val valid = Valid("Who")
+      val invalid = Invalid("Nope")
+
+      valid.bitraverseNullable({ it }, { it }) shouldBe Valid("Who")
+      invalid.bitraverseNullable({ it }, { it }) shouldBe Invalid("Nope")
     }
 
     "bitraverseEither should wrap valid or invalid in an either" {

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/OptionSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/OptionSpec.kt
@@ -24,8 +24,7 @@ class OptionSpec : StringSpec({
   "short circuit option" {
     option {
       val number: Int = "s".length
-      val x = ensureNotNull(number.takeIf { it > 1 })
-      x
+      ensureNotNull(number.takeIf { it > 1 })
       throw IllegalStateException("This should not be executed")
     } shouldBe None
   }
@@ -44,8 +43,7 @@ class OptionSpec : StringSpec({
   "eager short circuit null" {
     option.eager {
       val number: Int = "s".length
-      val x = ensureNotNull(number.takeIf { it > 1 })
-      x
+      ensureNotNull(number.takeIf { it > 1 })
       throw IllegalStateException("This should not be executed")
     } shouldBe None
   }


### PR DESCRIPTION
This PR removes following compilation/test warnings (https://github.com/arrow-kt/arrow/issues/219):
* EitherTest.kt: (313, 24): 'negativeInts(Int = ...): Arb<Int>' is deprecated. use negativeInt. Deprecated in 5.0.
* EvalTest.kt: (3, 32): 'EvalEffect<A>' is deprecated. Deprecated in favor of Effect DSL: EffectScope
* EvalTest.kt: (4, 32): 'RestrictedEvalEffect<A>' is deprecated. Deprecated in favor of Eager Effect DSL: EagerEffectScope
* EvalTest.kt: (5, 32): 'eval' is deprecated. Deprecated in favor of the Effect or EagerEffect Runtime
* IterableTest.kt: (168, 13): Variable 'expected' is never used
* ValidatedTest.kt: (207, 69): 'combineAll(Monoid<A>): A' is deprecated. use fold instead
* WARN: Duplicated test name catch should return Some(result) when f does not throw
