### PR TITLE
[2743] Migrate internal use of CircuitBreaker double to duration

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -40,7 +40,7 @@ public final class arrow/fx/coroutines/BuildersKt {
 
 public final class arrow/fx/coroutines/CircuitBreaker {
 	public static final field Companion Larrow/fx/coroutines/CircuitBreaker$Companion;
-	public synthetic fun <init> (Ljava/util/concurrent/atomic/AtomicReference;IDDDLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/concurrent/atomic/AtomicReference;IJDJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun awaitClose (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun doOnClosed (Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/CircuitBreaker;
 	public final fun doOnHalfOpen (Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/CircuitBreaker;
@@ -76,18 +76,18 @@ public final class arrow/fx/coroutines/CircuitBreaker$State$Closed : arrow/fx/co
 }
 
 public final class arrow/fx/coroutines/CircuitBreaker$State$HalfOpen : arrow/fx/coroutines/CircuitBreaker$State {
-	public fun <init> (D)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getResetTimeoutNanos ()D
+	public final fun getResetTimeout-UwyO8pc ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class arrow/fx/coroutines/CircuitBreaker$State$Open : arrow/fx/coroutines/CircuitBreaker$State {
-	public fun <init> (JD)V
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpiresAt ()J
-	public final fun getResetTimeoutNanos ()D
+	public final fun getResetTimeout-UwyO8pc ()J
 	public final fun getStartedAt ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -40,7 +40,7 @@ public final class arrow/fx/coroutines/BuildersKt {
 
 public final class arrow/fx/coroutines/CircuitBreaker {
 	public static final field Companion Larrow/fx/coroutines/CircuitBreaker$Companion;
-	public synthetic fun <init> (Ljava/util/concurrent/atomic/AtomicReference;IJDJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/concurrent/atomic/AtomicReference;IDDDLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun awaitClose (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun doOnClosed (Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/CircuitBreaker;
 	public final fun doOnHalfOpen (Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/CircuitBreaker;
@@ -76,18 +76,22 @@ public final class arrow/fx/coroutines/CircuitBreaker$State$Closed : arrow/fx/co
 }
 
 public final class arrow/fx/coroutines/CircuitBreaker$State$HalfOpen : arrow/fx/coroutines/CircuitBreaker$State {
+	public fun <init> (D)V
 	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getResetTimeout-UwyO8pc ()J
+	public final fun getResetTimeoutNanos ()D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class arrow/fx/coroutines/CircuitBreaker$State$Open : arrow/fx/coroutines/CircuitBreaker$State {
+	public fun <init> (JD)V
 	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getExpiresAt ()J
 	public final fun getResetTimeout-UwyO8pc ()J
+	public final fun getResetTimeoutNanos ()D
 	public final fun getStartedAt ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -528,7 +528,7 @@ private constructor(
      * @param maxFailures is the maximum count for failures before
      *        opening the circuit breaker.
      *
-     * @param resetTimeout is the timeout to wait in the `Open` state
+     * @param resetTimeoutNanos is the timeout to wait in the `Open` state
      *        before attempting a close of the circuit breaker (but without
      *        the backoff factor applied) in nanoseconds.
      *
@@ -625,7 +625,7 @@ private constructor(
           .let { requireNotNull(it) { "maxFailures expected to be greater than or equal to 0, but was $maxFailures" } },
         resetTimeout = resetTimeout
           .takeIf { it.isPositive() && it != Duration.ZERO }
-          .let { requireNotNull(it) { "resetTimeoutNanos expected to be greater than ${Duration.ZERO}, but was $resetTimeout" } },
+          .let { requireNotNull(it) { "resetTimeout expected to be greater than ${Duration.ZERO}, but was $resetTimeout" } },
         exponentialBackoffFactor = exponentialBackoffFactor
           .takeIf { it > 0 }
           .let { requireNotNull(it) { "exponentialBackoffFactor expected to be greater than 0, but was $exponentialBackoffFactor" } },

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -11,7 +11,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 
 /**
  * A [CircuitBreaker] is used to `protect` resources or services from being overloaded
@@ -570,10 +569,20 @@ private constructor(
       onOpen: suspend () -> Unit = { }
     ): CircuitBreaker =
       of(
-        maxFailures = requireNotNull(maxFailures.takeIf { it >= 0 }) { "maxFailures expected to be higher than 0" },
-        resetTimeout = requireNotNull(resetTimeoutNanos.takeIf { it > 0 }) { "resetTimeoutNanos expected to be higher than 0" }.nanoseconds,
-        exponentialBackoffFactor = requireNotNull(exponentialBackoffFactor.takeIf { it > 0 }) { "exponentialBackoffFactor expected to be higher than 0" },
-        maxResetTimeout = requireNotNull(maxResetTimeout.takeIf { it > 0 }) { "maxResetTimeout expected to be higher than 0" }.nanoseconds,
+        maxFailures = maxFailures
+          .takeIf { it >= 0 }
+          .let { requireNotNull(it) { "maxFailures expected to be higher than 0" } },
+        resetTimeout = resetTimeoutNanos
+          .takeIf { it > 0 }
+          .let { requireNotNull(it) { "resetTimeoutNanos expected to be higher than 0" } }
+          .nanoseconds,
+        exponentialBackoffFactor = exponentialBackoffFactor
+          .takeIf { it > 0 }
+          .let { requireNotNull(it) { "exponentialBackoffFactor expected to be higher than 0" } },
+        maxResetTimeout = maxResetTimeout
+          .takeIf { it > 0 }
+          .let { requireNotNull(it) { "maxResetTimeout expected to be higher than 0" } }
+          .nanoseconds,
         onRejected = onRejected,
         onClosed = onClosed,
         onHalfOpen = onHalfOpen,
@@ -621,10 +630,18 @@ private constructor(
     ): CircuitBreaker =
       CircuitBreaker(
         state = AtomicRef(Closed(0)),
-        maxFailures = requireNotNull(maxFailures.takeIf { it >= 0 }) { "maxFailures expected to be higher than 0" },
-        resetTimeout = requireNotNull(resetTimeout.takeIf { it.isPositive() }) { "resetTimeoutNanos expected to be higher than 0" },
-        exponentialBackoffFactor = requireNotNull(exponentialBackoffFactor.takeIf { it > 0 }) { "exponentialBackoffFactor expected to be higher than 0" },
-        maxResetTimeout = requireNotNull(maxResetTimeout.takeIf { it.isPositive() }) { "maxResetTimeout expected to be higher than 0" },
+        maxFailures = maxFailures
+          .takeIf { it >= 0 }
+          .let { requireNotNull(it) { "maxFailures expected to be greater than or equal to 0, but was $maxFailures" } },
+        resetTimeout = resetTimeout
+          .takeIf { it.isPositive() && it != Duration.ZERO }
+          .let { requireNotNull(it) { "resetTimeoutNanos expected to be greater than ${Duration.ZERO}, but was $resetTimeout" } },
+        exponentialBackoffFactor = exponentialBackoffFactor
+          .takeIf { it > 0 }
+          .let { requireNotNull(it) { "exponentialBackoffFactor expected to be greater than 0, but was $exponentialBackoffFactor" } },
+        maxResetTimeout = maxResetTimeout
+          .takeIf { it.isPositive() && it != Duration.ZERO }
+          .let { requireNotNull(it) { "maxResetTimeout expected to be greater than ${Duration.ZERO}, but was $maxResetTimeout" } },
         onRejected = onRejected,
         onClosed = onClosed,
         onHalfOpen = onHalfOpen,

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -552,6 +552,13 @@ private constructor(
      * @param onOpen is a callback for signaling transitions to [CircuitBreaker.State.Open].
      *
      */
+    @Deprecated(
+      "Prefer the kotlin.time.Duration constructor instead",
+      ReplaceWith(
+        "of(maxFailures, resetTimeoutNanos.nanoseconds, exponentialBackoffFactor, maxResetTimeout, onRejected, onClosed, onHalfOpen, onOpen)",
+        "import kotlin.time.Duration.Companion.nanoseconds"
+      )
+    )
     public suspend fun of(
       maxFailures: Int,
       resetTimeoutNanos: Double,
@@ -562,8 +569,7 @@ private constructor(
       onHalfOpen: suspend () -> Unit = { },
       onOpen: suspend () -> Unit = { }
     ): CircuitBreaker =
-      CircuitBreaker(
-        state = AtomicRef(Closed(0)),
+      of(
         maxFailures = requireNotNull(maxFailures.takeIf { it >= 0 }) { "maxFailures expected to be higher than 0" },
         resetTimeout = requireNotNull(resetTimeoutNanos.takeIf { it > 0 }) { "resetTimeoutNanos expected to be higher than 0" }.nanoseconds,
         exponentialBackoffFactor = requireNotNull(exponentialBackoffFactor.takeIf { it > 0 }) { "exponentialBackoffFactor expected to be higher than 0" },
@@ -603,7 +609,6 @@ private constructor(
      * @param onOpen is a callback for signaling transitions to [CircuitBreaker.State.Open].
      *
      */
-    @ExperimentalTime
     public suspend fun of(
       maxFailures: Int,
       resetTimeout: Duration,
@@ -614,15 +619,16 @@ private constructor(
       onHalfOpen: suspend () -> Unit = suspend { },
       onOpen: suspend () -> Unit = suspend { }
     ): CircuitBreaker =
-      of(
-        maxFailures,
-        resetTimeout.toDouble(DurationUnit.NANOSECONDS),
-        exponentialBackoffFactor,
-        maxResetTimeout.toDouble(DurationUnit.NANOSECONDS),
-        onRejected,
-        onClosed,
-        onHalfOpen,
-        onOpen
+      CircuitBreaker(
+        state = AtomicRef(Closed(0)),
+        maxFailures = requireNotNull(maxFailures.takeIf { it >= 0 }) { "maxFailures expected to be higher than 0" },
+        resetTimeout = requireNotNull(resetTimeout.takeIf { it.isPositive() }) { "resetTimeoutNanos expected to be higher than 0" },
+        exponentialBackoffFactor = requireNotNull(exponentialBackoffFactor.takeIf { it > 0 }) { "exponentialBackoffFactor expected to be higher than 0" },
+        maxResetTimeout = requireNotNull(maxResetTimeout.takeIf { it.isPositive() }) { "maxResetTimeout expected to be higher than 0" },
+        onRejected = onRejected,
+        onClosed = onClosed,
+        onHalfOpen = onHalfOpen,
+        onOpen = onOpen
       )
   }
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -569,20 +569,10 @@ private constructor(
       onOpen: suspend () -> Unit = { }
     ): CircuitBreaker =
       of(
-        maxFailures = maxFailures
-          .takeIf { it >= 0 }
-          .let { requireNotNull(it) { "maxFailures expected to be higher than 0" } },
-        resetTimeout = resetTimeoutNanos
-          .takeIf { it > 0 }
-          .let { requireNotNull(it) { "resetTimeoutNanos expected to be higher than 0" } }
-          .nanoseconds,
-        exponentialBackoffFactor = exponentialBackoffFactor
-          .takeIf { it > 0 }
-          .let { requireNotNull(it) { "exponentialBackoffFactor expected to be higher than 0" } },
-        maxResetTimeout = maxResetTimeout
-          .takeIf { it > 0 }
-          .let { requireNotNull(it) { "maxResetTimeout expected to be higher than 0" } }
-          .nanoseconds,
+        maxFailures = maxFailures,
+        resetTimeout = resetTimeoutNanos.nanoseconds,
+        exponentialBackoffFactor = exponentialBackoffFactor,
+        maxResetTimeout = maxResetTimeout.nanoseconds,
         onRejected = onRejected,
         onClosed = onClosed,
         onHalfOpen = onHalfOpen,

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -294,6 +294,15 @@ class CircuitBreakerTest : ArrowFxSpec(
               maxResetTimeout.toDouble(DurationUnit.NANOSECONDS)
             )
           }
+
+          shouldThrow<IllegalArgumentException> {
+            CircuitBreaker.of(
+              maxFailures,
+              resetTimeout,
+              exponentialBackoffFactor,
+              maxResetTimeout
+            )
+          }
         }
       }
     }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -15,6 +15,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
@@ -283,6 +284,15 @@ class CircuitBreakerTest : ArrowFxSpec(
         value.asClue { (maxFailures, resetTimeout, exponentialBackoffFactor, maxResetTimeout) ->
           shouldThrow<IllegalArgumentException> {
             CircuitBreaker.of(maxFailures, resetTimeout, exponentialBackoffFactor, maxResetTimeout)
+          }
+
+          shouldThrow<IllegalArgumentException> {
+            CircuitBreaker.of(
+              maxFailures,
+              resetTimeout.toDouble(DurationUnit.NANOSECONDS),
+              exponentialBackoffFactor,
+              maxResetTimeout.toDouble(DurationUnit.NANOSECONDS)
+            )
           }
         }
       }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -79,7 +79,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.Open -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
       }
@@ -106,7 +106,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.Open -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
       }
@@ -121,7 +121,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.Open -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
       }
@@ -143,7 +143,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.HalfOpen -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
       }
@@ -186,7 +186,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.Open -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
       }
@@ -201,7 +201,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.Open -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
       }
@@ -226,7 +226,7 @@ class CircuitBreakerTest : ArrowFxSpec(
 
       when (val s = cb.state()) {
         is CircuitBreaker.State.HalfOpen -> {
-          s.resetTimeoutNanos shouldBe resetTimeout.toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
       }
@@ -243,7 +243,7 @@ class CircuitBreakerTest : ArrowFxSpec(
       // resetTimeout should've applied
       when (val s = cb.state()) {
         is CircuitBreaker.State.Open -> {
-          s.resetTimeoutNanos shouldBe (resetTimeout * exponentialBackoffFactor).toDouble(NANOSECONDS)
+          s.resetTimeout shouldBe resetTimeout * exponentialBackoffFactor
         }
         else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
       }


### PR DESCRIPTION
Fixes #2743 

 * Changes internal usage of `Double` to `Duration`.
 * No changes made to public factory methods (`CircuitBreaker::of`). Questionable to accept a `Duration`, convert it to `Double` and then covert it back to a `Duration` again to pass to the internal constructor. Would appreciate some guidance here on how to manage the `@ExperimentalTime` annotation here.