### PR TITLE
Fix build, inject kotlin.mpp.enableCompatibilityMetadataVariant in CI

### DIFF
--- a/.github/workflows/generate-alpha-tag.yaml
+++ b/.github/workflows/generate-alpha-tag.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Gradle build
         uses: gradle/gradle-build-action@v2.2.0
         with:
-          arguments: --full-stacktrace assemble "-Psemver.stage=alpha"
+          arguments: --full-stacktrace build "-Psemver.stage=alpha"
 
       - name: Stop Gradle daemons
         run: ./gradlew --stop

--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Gradle build
         uses: gradle/gradle-build-action@v2.2.0
         with:
-          arguments: --full-stacktrace assemble "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
+          arguments: --full-stacktrace build "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
 
       - name: Stop Gradle daemons
         run: ./gradlew --stop

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2.2.0
         with:
-          arguments: assemble --full-stacktrace
+          arguments: assemble -Pkotlin.mpp.enableCompatibilityMetadataVariant=true --full-stacktrace
 
       - name: Get Arrow version
         id: version
@@ -65,7 +65,7 @@ jobs:
           contains(steps.version.outputs.arrow, 'beta') ||
           contains(steps.version.outputs.arrow, 'rc')
         with:
-          arguments: --full-stacktrace publishToSonatype closeAndReleaseSonatypeStagingRepository
+          arguments: --full-stacktrace -Pkotlin.mpp.enableCompatibilityMetadataVariant=true publishToSonatype closeAndReleaseSonatypeStagingRepository
 
       - name: Publish final version
         uses: gradle/gradle-build-action@v2.2.0
@@ -74,7 +74,7 @@ jobs:
           !contains(steps.version.outputs.arrow, 'beta') &&
           !contains(steps.version.outputs.arrow, 'rc')
         with:
-          arguments: --full-stacktrace publishToSonatype closeSonatypeStagingRepository
+          arguments: --full-stacktrace -Pkotlin.mpp.enableCompatibilityMetadataVariant=true publishToSonatype closeSonatypeStagingRepository
 
       - name: Prepare environment
         working-directory: arrow-site
@@ -87,7 +87,7 @@ jobs:
       - name: Create API doc
         uses: gradle/gradle-build-action@v2.2.0
         with:
-          arguments: --full-stacktrace dokkaGfm
+          arguments: --full-stacktrace -Pkotlin.mpp.enableCompatibilityMetadataVariant=true dokkaGfm
 
       - name: Build release directory (/docs)
         working-directory: arrow-site
@@ -160,4 +160,4 @@ jobs:
           path: arrow-libs/logs.
 
       - name: Stop Gradle daemons
-        run: ./gradlew --stop
+        run: ./gradlew -Pkotlin.mpp.enableCompatibilityMetadataVariant=true --stop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,13 +29,13 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.0
         if: matrix.os != 'windows-latest'
         with:
-          arguments: --full-stacktrace assemble
+          arguments: --full-stacktrace build
 
       - name: mingwX64Test
         uses: gradle/gradle-build-action@v2.2.0
         if: matrix.os == 'windows-latest'
         with:
-          arguments: --full-stacktrace assemble
+          arguments: --full-stacktrace mingwX64Test
 
       - name: Upload reports
         uses: actions/upload-artifact@v3.1.0

--- a/arrow-libs/core/arrow-continuations/build.gradle.kts
+++ b/arrow-libs/core/arrow-continuations/build.gradle.kts
@@ -15,7 +15,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/arrow-libs/core/arrow-core-retrofit/build.gradle.kts
+++ b/arrow-libs/core/arrow-core-retrofit/build.gradle.kts
@@ -14,7 +14,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -16,7 +16,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
@@ -13,7 +13,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
@@ -14,7 +14,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 
@@ -30,7 +30,7 @@ kotlin {
     if (!enableCompatibilityMetadataVariant) {
       commonTest {
         dependencies {
-          implementation(project(":arrow-coroutines-fx-test"))
+          implementation(project(":arrow-fx-coroutines-test"))
         }
       }
       jvmTest {

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/arrow-libs/optics/arrow-optics-reflect/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-reflect/build.gradle.kts
@@ -13,7 +13,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -16,7 +16,7 @@ val enableCompatibilityMetadataVariant =
 
 if (enableCompatibilityMetadataVariant) {
   tasks.withType<Test>().configureEach {
-    enabled = false
+    exclude("**/*")
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.mpp.enableCompatibilityMetadataVariant=true
+kotlin.mpp.enableCompatibilityMetadataVariant=false
 # https://youtrack.jetbrains.com/issue/KT-45545#focus=Comments-27-4773544.0-0
 kapt.use.worker.api=false
 


### PR DESCRIPTION
The [1.1.3-alpha.23](https://github.com/arrow-kt/arrow/tree/1.1.3-alpha.23) release on the Arrow Fx Coroutines Utils project, and confirmed that the `kotlin.mpp.enableCompatibilityMetadataVariant` flag fixes the issue.

To still run tests on CI, and to still publish Arrow with the `kotlin.mpp.enableCompatibilityMetadataVariant` I made it `false` by default and inject it during the `publish.yml`.
This way CI can still run with the same guarantees as before.