### PR TITLE
Deprecate arrow test modules

### DIFF
--- a/arrow-libs/core/arrow-core-test/api/arrow-core-test.api
+++ b/arrow-libs/core/arrow-core-test/api/arrow-core-test.api
@@ -55,6 +55,10 @@ public final class arrow/core/test/concurrency/SideEffect {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class arrow/core/test/concurrency/SideEffectKt {
+	public static final field deprecateArrowTestModules Ljava/lang/String;
+}
+
 public final class arrow/core/test/generators/GeneratorsJvmKt {
 	public static final fun fatalThrowable (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
 	public static final fun suspendFunThatThrowsFatalThrowable (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/Platform.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/Platform.kt
@@ -1,8 +1,14 @@
 package arrow.core.test
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
+
+@Deprecated(deprecateArrowTestModules)
 public expect fun isJvm(): Boolean
+@Deprecated(deprecateArrowTestModules)
 public expect fun isJs(): Boolean
+@Deprecated(deprecateArrowTestModules)
 public expect fun isNative(): Boolean
 
+@Deprecated(deprecateArrowTestModules)
 public fun stackSafeIteration(): Int =
   if (isJvm()) 500_000 else 1000

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/UnitSpec.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/UnitSpec.kt
@@ -1,6 +1,7 @@
 package arrow.core.test
 
 import arrow.core.*
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.core.test.generators.unit
 import arrow.core.test.laws.Law
 import io.kotest.core.names.TestName
@@ -22,17 +23,21 @@ import kotlin.math.max
 /**
  * Base class for unit tests
  */
+@Deprecated(deprecateArrowTestModules)
 public abstract class UnitSpec(
   public val iterations: Int = 250,
   public val maxDepth: Int = 15,
   spec: UnitSpec.() -> Unit = {}
 ) : StringSpec() {
 
+  @Deprecated(deprecateArrowTestModules)
   public constructor(spec: UnitSpec.() -> Unit) : this(250, 15, spec)
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A> Arb.Companion.list(gen: Gen<A>, range: IntRange = 0..maxDepth): Arb<List<A>> =
     Arb.KList(gen, range)
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A> Arb.Companion.nonEmptyList(arb: Arb<A>, depth: Int = maxDepth): Arb<NonEmptyList<A>> {
     return Arb.list(arb, 1..max(1, depth))
       .map { Option.fromNullable(it.toNonEmptyListOrNull()) }
@@ -40,13 +45,16 @@ public abstract class UnitSpec(
       .map { it.value }
   }
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A> Arb.Companion.sequence(arbA: Arb<A>, range: IntRange = 0..maxDepth): Arb<Sequence<A>> =
     Arb.list(arbA, range).map { it.asSequence() }
 
   @JvmOverloads
+  @Deprecated(deprecateArrowTestModules)
   public inline fun <reified A> Arb.Companion.array(gen: Arb<A>, range: IntRange = 0..maxDepth): Arb<Array<A>> =
     Arb.list(gen, range).map { it.toTypedArray() }
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <K, V> Arb.Companion.map(
     keyArb: Arb<K>,
     valueArb: Arb<V>,
@@ -59,6 +67,7 @@ public abstract class UnitSpec(
     spec()
   }
 
+  @Deprecated(deprecateArrowTestModules)
   public fun testLaws(vararg laws: List<Law>): Unit = laws
     .flatMap { list: List<Law> -> list.asIterable() }
     .distinctBy { law: Law -> law.name }
@@ -68,6 +77,7 @@ public abstract class UnitSpec(
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public fun testLaws(prefix: String, vararg laws: List<Law>): Unit = laws
     .flatMap { list: List<Law> -> list.asIterable() }
     .distinctBy { law: Law -> law.name }
@@ -77,9 +87,11 @@ public abstract class UnitSpec(
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun checkAll(property: suspend PropertyContext.() -> Unit): PropertyContext =
     checkAll(iterations, Arb.unit()) { property() }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A> checkAll(
     genA: Arb<A>,
     property: suspend PropertyContext.(A) -> Unit
@@ -90,6 +102,7 @@ public abstract class UnitSpec(
       property
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> checkAll(
     genA: Arb<A>,
     genB: Arb<B>,
@@ -102,6 +115,7 @@ public abstract class UnitSpec(
       property
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C> checkAll(
     genA: Arb<A>,
     genB: Arb<B>,
@@ -116,6 +130,7 @@ public abstract class UnitSpec(
       property
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D> checkAll(
     genA: Arb<A>,
     genB: Arb<B>,
@@ -132,6 +147,7 @@ public abstract class UnitSpec(
       property
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D, E> checkAll(
     genA: Arb<A>,
     genB: Arb<B>,
@@ -150,6 +166,7 @@ public abstract class UnitSpec(
       property
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D, E, F> checkAll(
     genA: Arb<A>,
     genB: Arb<B>,
@@ -170,6 +187,7 @@ public abstract class UnitSpec(
       property
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D, E, F, G> checkAll(
     gena: Arb<A>,
     genb: Arb<B>,
@@ -185,6 +203,7 @@ public abstract class UnitSpec(
     }
   }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D, E, F, G, H> checkAll(
     gena: Arb<A>,
     genb: Arb<B>,
@@ -201,6 +220,7 @@ public abstract class UnitSpec(
     }
   }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
     gena: Arb<A>,
     genb: Arb<B>,
@@ -218,6 +238,7 @@ public abstract class UnitSpec(
     }
   }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
     gena: Arb<A>,
     genb: Arb<B>,
@@ -243,6 +264,7 @@ public abstract class UnitSpec(
     }
   }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun forFew(
     iterations: Int,
     property: suspend PropertyContext.(Unit) -> Unit

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/concurrency/SideEffect.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/concurrency/SideEffect.kt
@@ -1,7 +1,12 @@
 package arrow.core.test.concurrency
 
+@Deprecated(deprecateArrowTestModules)
 public data class SideEffect(var counter: Int = 0) {
+  @Deprecated(deprecateArrowTestModules)
   public fun increment() {
     counter++
   }
 }
+
+public const val deprecateArrowTestModules: String =
+  "arrow test modules are being deprecated in favour of kotest-arrow-extension libraries"

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/generators/Generators.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/generators/Generators.kt
@@ -16,6 +16,7 @@ import arrow.core.Tuple9
 import arrow.core.Validated
 import arrow.core.left
 import arrow.core.right
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.core.toOption
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
@@ -37,51 +38,65 @@ import io.kotest.property.arbitrary.string
 import kotlin.Result.Companion.failure
 import kotlin.Result.Companion.success
 import kotlin.math.abs
-
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B> Arb.Companion.functionAToB(arb: Arb<B>): Arb<(A) -> B> =
   arb.map { b: B -> { _: A -> b } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb.Companion.functionAAToA(arb: Arb<A>): Arb<(A, A) -> A> =
   arb.map { a: A -> { _: A, _: A -> a } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B> Arb.Companion.functionBAToB(arb: Arb<B>): Arb<(B, A) -> B> =
   arb.map { b: B -> { _: B, _: A -> b } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B> Arb.Companion.functionABToB(arb: Arb<B>): Arb<(A, B) -> B> =
   arb.map { b: B -> { _: A, _: B -> b } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb.Companion.functionToA(arb: Arb<A>): Arb<() -> A> =
   arb.map { a: A -> { a } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.throwable(): Arb<Throwable> =
   Arb.of(listOf(RuntimeException(), NoSuchElementException(), IllegalArgumentException()))
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb.Companion.result(arbA: Arb<A>): Arb<Result<A>> =
   Arb.choice(arbA.map(::success), throwable().map(::failure))
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.doubleSmall(): Arb<Double> =
   Arb.numericDoubles(from = 0.0, to = 100.0)
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.floatSmall(): Arb<Float> =
   Arb.numericFloats(from = 0F, to = 100F)
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.intSmall(factor: Int = 10000): Arb<Int> =
   Arb.int((Int.MIN_VALUE / factor)..(Int.MAX_VALUE / factor))
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.byteSmall(): Arb<Byte> =
   Arb.byte(min = (Byte.MIN_VALUE / 10).toByte(), max = (Byte.MAX_VALUE / 10).toByte())
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.shortSmall(): Arb<Short> {
   val range = (Short.MIN_VALUE / 1000)..(Short.MAX_VALUE / 1000)
   return Arb.short().filter { it in range }
 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.longSmall(): Arb<Long> =
   Arb.long((Long.MIN_VALUE / 100000L)..(Long.MAX_VALUE / 100000L))
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D> Arb.Companion.tuple4(arbA: Arb<A>, arbB: Arb<B>, arbC: Arb<C>, arbD: Arb<D>): Arb<Tuple4<A, B, C, D>> =
   Arb.bind(arbA, arbB, arbC, arbD, ::Tuple4)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D, E> Arb.Companion.tuple5(
   arbA: Arb<A>,
   arbB: Arb<B>,
@@ -91,6 +106,7 @@ public fun <A, B, C, D, E> Arb.Companion.tuple5(
 ): Arb<Tuple5<A, B, C, D, E>> =
   Arb.bind(arbA, arbB, arbC, arbD, arbE, ::Tuple5)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D, E, F> Arb.Companion.tuple6(
   arbA: Arb<A>,
   arbB: Arb<B>,
@@ -101,6 +117,7 @@ public fun <A, B, C, D, E, F> Arb.Companion.tuple6(
 ): Arb<Tuple6<A, B, C, D, E, F>> =
   Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, ::Tuple6)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D, E, F, G> Arb.Companion.tuple7(
   arbA: Arb<A>,
   arbB: Arb<B>,
@@ -112,6 +129,7 @@ public fun <A, B, C, D, E, F, G> Arb.Companion.tuple7(
 ): Arb<Tuple7<A, B, C, D, E, F, G>> =
   Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG, ::Tuple7)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D, E, F, G, H> Arb.Companion.tuple8(
   arbA: Arb<A>,
   arbB: Arb<B>,
@@ -129,6 +147,7 @@ public fun <A, B, C, D, E, F, G, H> Arb.Companion.tuple8(
     Tuple8(a, b, c, d, e, f, g, h)
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D, E, F, G, H, I> Arb.Companion.tuple9(
   arbA: Arb<A>,
   arbB: Arb<B>,
@@ -147,6 +166,7 @@ public fun <A, B, C, D, E, F, G, H, I> Arb.Companion.tuple9(
     Tuple9(a, b, c, d, e, f, g, h, i)
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B, C, D, E, F, G, H, I, J> Arb.Companion.tuple10(
   arbA: Arb<A>,
   arbB: Arb<B>,
@@ -166,8 +186,10 @@ public fun <A, B, C, D, E, F, G, H, I, J> Arb.Companion.tuple10(
     Tuple10(a, b, c, d, e, f, g, h, i, j)
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.nonZeroInt(): Arb<Int> = Arb.int().filter { it != 0 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.intPredicate(): Arb<(Int) -> Boolean> =
   Arb.nonZeroInt().flatMap { num ->
     val absNum = abs(num)
@@ -181,37 +203,48 @@ public fun Arb.Companion.intPredicate(): Arb<(Int) -> Boolean> =
     )
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb.Companion.endo(arb: Arb<A>): Arb<Endo<A>> = arb.map { a: A -> Endo<A> { a } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <B> Arb.Companion.option(arb: Arb<B>): Arb<Option<B>> =
   arb.orNull().map { it.toOption() }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <E, A> Arb.Companion.either(arbE: Arb<E>, arbA: Arb<A>): Arb<Either<E, A>> {
   val arbLeft = arbE.map { Either.Left(it) }
   val arbRight = arbA.map { Either.Right(it) }
   return Arb.choice(arbLeft, arbRight)
 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <E, A> Arb<E>.or(arbA: Arb<A>): Arb<Either<E, A>> = Arb.either(this, arbA)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <E, A> Arb.Companion.validated(arbE: Arb<E>, arbA: Arb<A>): Arb<Validated<E, A>> =
   Arb.either(arbE, arbA).map { Validated.fromEither(it) }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.unit(): Arb<Unit> =
   Arb.constant(Unit)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B> Arb.Companion.ior(arbA: Arb<A>, arbB: Arb<B>): Arb<Ior<A, B>> =
   arbA.alignWith(arbB) { it }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B> Arb.Companion.arbConst(arb: Arb<A>): Arb<Const<A, B>> =
   arb.map { Const<A, B>(it) }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb<A>.eval(): Arb<Eval<A>> =
   map { Eval.now(it) }
 
+@Deprecated(deprecateArrowTestModules)
 private fun <A, B, R> Arb<A>.alignWith(arbB: Arb<B>, transform: (Ior<A, B>) -> R): Arb<R> =
   Arb.bind(this, arbB) { a, b -> transform(Ior.Both(a, b)) }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.suspendFunThatReturnsEitherAnyOrAnyOrThrows(): Arb<suspend () -> Either<Any, Any>> =
   choice(
     suspendFunThatReturnsAnyRight(),
@@ -219,15 +252,19 @@ public fun Arb.Companion.suspendFunThatReturnsEitherAnyOrAnyOrThrows(): Arb<susp
     suspendFunThatThrows()
   )
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.suspendFunThatReturnsAnyRight(): Arb<suspend () -> Either<Any, Any>> =
   any().map { suspend { it.right() } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.suspendFunThatReturnsAnyLeft(): Arb<suspend () -> Either<Any, Any>> =
   any().map { suspend { it.left() } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.suspendFunThatThrows(): Arb<suspend () -> Either<Any, Any>> =
   throwable().map { suspend { throw it } } as Arb<suspend () -> Either<Any, Any>>
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.any(): Arb<Any> =
   choice(
     Arb.string() as Arb<Any>,

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/generators/utils.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/generators/utils.kt
@@ -1,5 +1,6 @@
 package arrow.core.test.generators
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.intercepted
@@ -7,6 +8,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.startCoroutine
 import kotlinx.coroutines.Dispatchers
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun Throwable.suspend(): Nothing =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { throw this }.startCoroutine(
@@ -18,6 +20,7 @@ public suspend fun Throwable.suspend(): Nothing =
     COROUTINE_SUSPENDED
   }
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun <A> A.suspend(): A =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { this }.startCoroutine(

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/FxLaws.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/FxLaws.kt
@@ -2,6 +2,7 @@ package arrow.core.test.laws
 
 import arrow.continuations.Effect
 import arrow.core.Either
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.core.test.generators.throwable
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
@@ -17,8 +18,10 @@ import kotlin.coroutines.startCoroutine
 private typealias EagerFxBlock<Eff, F, A> = (suspend Eff.() -> A) -> F
 private typealias SuspendFxBlock<Eff, F, A> = suspend (suspend Eff.() -> A) -> F
 
+@Deprecated(deprecateArrowTestModules)
 public object FxLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <Eff : Effect<*>, F, A> suspended(
     pureArb: Arb<F>,
     G: Arb<F>,
@@ -44,6 +47,7 @@ public object FxLaws {
     }
   )
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <Eff : Effect<*>, F, A> eager(
     pureArb: Arb<F>,
     G: Arb<F>,
@@ -157,6 +161,7 @@ public object FxLaws {
 }
 
 // TODO expose for tests
+@Deprecated(deprecateArrowTestModules)
 internal suspend fun Throwable.suspend(): Nothing =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { throw this }.startCoroutine(
@@ -168,6 +173,7 @@ internal suspend fun Throwable.suspend(): Nothing =
     COROUTINE_SUSPENDED
   }
 
+@Deprecated(deprecateArrowTestModules)
 internal suspend fun <A> A.suspend(): A =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { this }.startCoroutine(

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/Law.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/Law.kt
@@ -1,9 +1,12 @@
 package arrow.core.test.laws
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import io.kotest.assertions.fail
 import io.kotest.core.test.TestContext
 
+@Deprecated(deprecateArrowTestModules)
 public data class Law(val name: String, val test: suspend TestContext.() -> Unit)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> A.equalUnderTheLaw(b: A, f: (A, A) -> Boolean = { a, b -> a == b }): Boolean =
   if (f(this, b)) true else fail("Found $this but expected: $b")

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/MonoidLaws.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/MonoidLaws.kt
@@ -1,5 +1,6 @@
 package arrow.core.test.laws
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.typeclasses.Monoid
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
@@ -7,8 +8,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.PropertyContext
 import io.kotest.property.arbitrary.list
 
+@Deprecated(deprecateArrowTestModules)
 public object MonoidLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <F> laws(M: Monoid<F>, GEN: Arb<F>, eq: (F, F) -> Boolean = { a, b -> a == b }): List<Law> =
     SemigroupLaws.laws(M, GEN, eq) +
       listOf(
@@ -18,21 +21,25 @@ public object MonoidLaws {
         Law("Monoid Laws: combineAll of empty list is empty") { M.combineAllOfEmptyIsEmpty(eq) }
       )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <F> Monoid<F>.monoidLeftIdentity(GEN: Arb<F>, eq: (F, F) -> Boolean): PropertyContext =
     checkAll(GEN) { a ->
       (empty().combine(a)).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <F> Monoid<F>.monoidRightIdentity(GEN: Arb<F>, eq: (F, F) -> Boolean): PropertyContext =
     checkAll(GEN) { a ->
       a.combine(empty()).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <F> Monoid<F>.combineAllIsDerived(GEN: Arb<F>, eq: (F, F) -> Boolean): PropertyContext =
     checkAll(5, Arb.list(GEN)) { list ->
       list.combineAll().equalUnderTheLaw(if (list.isEmpty()) empty() else list.reduce { acc, f -> acc.combine(f) }, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <F> Monoid<F>.combineAllOfEmptyIsEmpty(eq: (F, F) -> Boolean): Unit =
     emptyList<F>().combineAll().equalUnderTheLaw(empty(), eq) shouldBe true
 }

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/SemigroupLaws.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/SemigroupLaws.kt
@@ -1,15 +1,19 @@
 package arrow.core.test.laws
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.typeclasses.Semigroup
 import io.kotest.property.Arb
 import io.kotest.property.PropertyContext
 import io.kotest.property.checkAll
 
+@Deprecated(deprecateArrowTestModules)
 public object SemigroupLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <F> laws(SG: Semigroup<F>, G: Arb<F>, eq: (F, F) -> Boolean = { a, b -> a == b }): List<Law> =
     listOf(Law("Semigroup: associativity") { SG.semigroupAssociative(G, eq) })
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <F> Semigroup<F>.semigroupAssociative(G: Arb<F>, eq: (F, F) -> Boolean): PropertyContext =
     checkAll(G, G, G) { A, B, C ->
       A.combine(B).combine(C).equalUnderTheLaw(A.combine(B.combine(C)), eq)

--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/SemiringLaws.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/laws/SemiringLaws.kt
@@ -1,13 +1,16 @@
 package arrow.core.test.laws
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.typeclasses.Semiring
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import io.kotest.matchers.shouldBe
 import io.kotest.property.PropertyContext
 
+@Deprecated(deprecateArrowTestModules)
 public object SemiringLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <F> laws(SG: Semiring<F>, GEN: Arb<F>, eq: (F, F) -> Boolean = { a, b -> a == b }): List<Law> =
     listOf(
       Law("Semiring: Additive commutativity") { SG.semiringAdditiveCommutativity(GEN, eq) },

--- a/arrow-libs/core/arrow-core-test/src/jsMain/kotlin/arrow.core/test/Platform-js.kt
+++ b/arrow-libs/core/arrow-core-test/src/jsMain/kotlin/arrow.core/test/Platform-js.kt
@@ -1,5 +1,10 @@
 package arrow.core.test
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
+
+@Deprecated(deprecateArrowTestModules)
 public actual fun isJvm(): Boolean = false
+@Deprecated(deprecateArrowTestModules)
 public actual fun isJs(): Boolean = true
+@Deprecated(deprecateArrowTestModules)
 public actual fun isNative(): Boolean = false

--- a/arrow-libs/core/arrow-core-test/src/jvmMain/kotlin/arrow/core/test/Platform-jvm.kt
+++ b/arrow-libs/core/arrow-core-test/src/jvmMain/kotlin/arrow/core/test/Platform-jvm.kt
@@ -1,5 +1,10 @@
 package arrow.core.test
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
+
+@Deprecated(deprecateArrowTestModules)
 public actual fun isJvm(): Boolean = true
+@Deprecated(deprecateArrowTestModules)
 public actual fun isJs(): Boolean = false
+@Deprecated(deprecateArrowTestModules)
 public actual fun isNative(): Boolean = false

--- a/arrow-libs/core/arrow-core-test/src/jvmMain/kotlin/arrow/core/test/generators/GeneratorsJvm.kt
+++ b/arrow-libs/core/arrow-core-test/src/jvmMain/kotlin/arrow/core/test/generators/GeneratorsJvm.kt
@@ -1,12 +1,15 @@
 package arrow.core.test.generators
 
 import arrow.core.Either
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.of
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.suspendFunThatThrowsFatalThrowable(): Arb<suspend () -> Either<Any, Any>> =
   fatalThrowable().map { suspend { throw it } } as Arb<suspend () -> Either<Any, Any>>
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.fatalThrowable(): Arb<Throwable> =
   Arb.of(listOf(ThreadDeath(), StackOverflowError(), OutOfMemoryError(), InterruptedException()))

--- a/arrow-libs/core/arrow-core-test/src/nativeMain/kotlin/arrow/core/test/Platform-native.kt
+++ b/arrow-libs/core/arrow-core-test/src/nativeMain/kotlin/arrow/core/test/Platform-native.kt
@@ -1,5 +1,10 @@
 package arrow.core.test
 
+import arrow.core.test.concurrency.deprecateArrowTestModules
+
+@Deprecated(deprecateArrowTestModules)
 public actual fun isJvm(): Boolean = false
+@Deprecated(deprecateArrowTestModules)
 public actual fun isJs(): Boolean = false
+@Deprecated(deprecateArrowTestModules)
 public actual fun isNative(): Boolean = true

--- a/arrow-libs/fx/arrow-fx-coroutines-test/src/commonMain/kotlin/arrow/fx/coroutines/ArrowFxSpec.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines-test/src/commonMain/kotlin/arrow/fx/coroutines/ArrowFxSpec.kt
@@ -1,8 +1,10 @@
 package arrow.fx.coroutines
 
 import arrow.core.test.UnitSpec
+import arrow.core.test.concurrency.deprecateArrowTestModules
 
 /** Simple overwritten Kotest StringSpec (UnitSpec) to reduce stress on tests. */
+@Deprecated(deprecateArrowTestModules)
 public abstract class ArrowFxSpec(
   iterations: Int = 250,
   spec: ArrowFxSpec.() -> Unit = {}

--- a/arrow-libs/fx/arrow-fx-coroutines-test/src/commonMain/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines-test/src/commonMain/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -8,6 +8,7 @@ import arrow.core.invalid
 import arrow.core.invalidNel
 import arrow.core.left
 import arrow.core.right
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.core.valid
 import arrow.core.validNel
 import io.kotest.assertions.fail
@@ -42,12 +43,15 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emptyFlow
 
+@Deprecated(deprecateArrowTestModules)
 public data class SideEffect(var counter: Int = 0) {
+  @Deprecated(deprecateArrowTestModules)
   public fun increment() {
     counter++
   }
 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb.Companion.flow(arbA: Arb<A>): Arb<Flow<A>> =
   Arb.choose(
     10 to Arb.list(arbA).map { it.asFlow() },
@@ -55,61 +59,75 @@ public fun <A> Arb.Companion.flow(arbA: Arb<A>): Arb<Flow<A>> =
     1 to Arb.constant(emptyFlow()),
   )
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.throwable(): Arb<Throwable> =
   Arb.string().map(::RuntimeException)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <L, R> Arb.Companion.either(left: Arb<L>, right: Arb<R>): Arb<Either<L, R>> {
   val failure: Arb<Either<L, R>> = left.map { l -> l.left() }
   val success: Arb<Either<L, R>> = right.map { r -> r.right() }
   return Arb.choice(failure, success)
 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <L, R> Arb.Companion.validated(left: Arb<L>, right: Arb<R>): Arb<Validated<L, R>> {
   val failure: Arb<Validated<L, R>> = left.map { l -> l.invalid() }
   val success: Arb<Validated<L, R>> = right.map { r -> r.valid() }
   return Arb.choice(failure, success)
 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <L, R> Arb.Companion.validatedNel(left: Arb<L>, right: Arb<R>): Arb<ValidatedNel<L, R>> {
   val failure: Arb<ValidatedNel<L, R>> = left.map { l -> l.invalidNel() }
   val success: Arb<ValidatedNel<L, R>> = right.map { r -> r.validNel() }
   return Arb.choice(failure, success)
 }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.intRange(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Arb<IntRange> =
   Arb.bind(Arb.int(min, max), Arb.int(min, max)) { a, b ->
     if (a < b) a..b else b..a
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.longRange(min: Long = Long.MIN_VALUE, max: Long = Long.MAX_VALUE): Arb<LongRange> =
   Arb.bind(Arb.long(min, max), Arb.long(min, max)) { a, b ->
     if (a < b) a..b else b..a
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.charRange(): Arb<CharRange> =
   Arb.bind(Arb.char(), Arb.char()) { a, b ->
     if (a < b) a..b else b..a
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <O> Arb.Companion.function(arb: Arb<O>): Arb<() -> O> =
   arb.map { { it } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun Arb.Companion.unit(): Arb<Unit> =
   Arb.constant(Unit)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A, B> Arb.Companion.functionAToB(arb: Arb<B>): Arb<(A) -> B> =
   arb.map { b: B -> { _: A -> b } }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Arb.Companion.nullable(arb: Arb<A>): Arb<A?> =
   Arb.Companion.choice(arb, arb.map { null })
 
 /** Useful for testing success & error scenarios with an `Either` generator **/
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Either<Throwable, A>.rethrow(): A =
   fold({ throw it }, ::identity)
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> Result<A>.toEither(): Either<Throwable, A> =
   fold({ a -> Either.Right(a) }, { e -> Either.Left(e) })
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun Throwable.suspend(): Nothing =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { throw this }.startCoroutine(
@@ -121,6 +139,7 @@ public suspend fun Throwable.suspend(): Nothing =
     COROUTINE_SUSPENDED
   }
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun <A> A.suspend(): A =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { this }.startCoroutine(
@@ -132,6 +151,7 @@ public suspend fun <A> A.suspend(): A =
     COROUTINE_SUSPENDED
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> A.suspended(): suspend () -> A =
   suspend { suspend() }
 
@@ -150,6 +170,7 @@ public fun <A> A.suspended(): suspend () -> A =
  * <!--- KNIT example-predef-test-01.kt -->
  * @see Assertions.assertThrows
  */
+@Deprecated(deprecateArrowTestModules)
 public inline fun <A> assertThrowable(executable: () -> A): Throwable {
   val a = try {
     executable.invoke()
@@ -160,6 +181,7 @@ public inline fun <A> assertThrowable(executable: () -> A): Throwable {
   return if (a is Throwable) a else fail("Expected an exception but found: $a")
 }
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun CoroutineContext.shift(): Unit =
   suspendCoroutineUninterceptedOrReturn { cont ->
     suspend { this }.startCoroutine(
@@ -171,6 +193,7 @@ public suspend fun CoroutineContext.shift(): Unit =
     COROUTINE_SUSPENDED
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun leftException(e: Throwable): Matcher<Either<Throwable, *>> =
   object : Matcher<Either<Throwable, *>> {
     override fun test(value: Either<Throwable, *>): MatcherResult =
@@ -200,6 +223,7 @@ public fun leftException(e: Throwable): Matcher<Either<Throwable, *>> =
       }
   }
 
+@Deprecated(deprecateArrowTestModules)
 public fun <A> either(e: Either<Throwable, A>): Matcher<Either<Throwable, A>> =
   object : Matcher<Either<Throwable, A>> {
     override fun test(value: Either<Throwable, A>): MatcherResult =
@@ -225,12 +249,14 @@ public fun <A> either(e: Either<Throwable, A>): Matcher<Either<Throwable, A>> =
       }
   }
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun <A> awaitExitCase(send: Channel<Unit>, exit: CompletableDeferred<ExitCase>): A =
   guaranteeCase({
     send.receive()
     awaitCancellation()
   }) { ex -> exit.complete(ex) }
 
+@Deprecated(deprecateArrowTestModules)
 public suspend fun <A> awaitExitCase(start: CompletableDeferred<Unit>, exit: CompletableDeferred<ExitCase>): A =
   guaranteeCase({
     start.complete(Unit)

--- a/arrow-libs/fx/arrow-fx-coroutines-test/src/jvmMain/kotlin/arrow/fx/coroutines/predef-test-jvm.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines-test/src/jvmMain/kotlin/arrow/fx/coroutines/predef-test-jvm.kt
@@ -1,15 +1,21 @@
 package arrow.fx.coroutines
 
 import arrow.core.continuations.AtomicRef
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import java.util.concurrent.ThreadFactory
 import kotlin.coroutines.CoroutineContext
 
+@Deprecated(deprecateArrowTestModules)
 public val singleThreadName: String = "single"
+
+@Deprecated(deprecateArrowTestModules)
 public val single: Resource<CoroutineContext> = Resource.singleThreadContext(singleThreadName)
 
+@Deprecated(deprecateArrowTestModules)
 public val threadName: suspend () -> String =
   { Thread.currentThread().name }
 
+@Deprecated(deprecateArrowTestModules)
 public class NamedThreadFactory(private val mkName: (Int) -> String) : ThreadFactory {
   private val count = AtomicRef(0)
   override fun newThread(r: Runnable): Thread =

--- a/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/IsoLaws.kt
+++ b/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/IsoLaws.kt
@@ -2,6 +2,7 @@ package arrow.optics.test.laws
 
 import arrow.core.compose
 import arrow.core.identity
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.optics.Iso
 import arrow.core.test.laws.Law
 import arrow.core.test.laws.equalUnderTheLaw
@@ -9,8 +10,9 @@ import io.kotest.property.Arb
 import io.kotest.property.PropertyContext
 import io.kotest.property.checkAll
 
-public object IsoLaws {
+@Deprecated(deprecateArrowTestModules)public object IsoLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     iso: Iso<A, B>,
     aGen: Arb<A>,
@@ -27,26 +29,31 @@ public object IsoLaws {
       Law("Iso Law: consitent set with modify") { iso.consistentSetModify(aGen, bGen, eqa) }
     )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Iso<A, B>.roundTripOneWay(aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen) { a ->
       reverseGet(get(a)).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Iso<A, B>.roundTripOtherWay(bGen: Arb<B>, eq: (B, B) -> Boolean): PropertyContext =
     checkAll(100, bGen) { b ->
       get(reverseGet(b)).equalUnderTheLaw(b, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Iso<A, B>.modifyIdentity(aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen) { a ->
       modify(a, ::identity).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Iso<A, B>.composeModify(aGen: Arb<A>, funcGen: Arb<(B) -> B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen, funcGen, funcGen) { a, f, g ->
       modify(modify(a, f), g).equalUnderTheLaw(modify(a, g compose f), eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Iso<A, B>.consistentSetModify(aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen, bGen) { a, b ->
       set(b).equalUnderTheLaw(modify(a) { b }, eq)

--- a/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/LensLaws.kt
+++ b/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/LensLaws.kt
@@ -2,6 +2,7 @@ package arrow.optics.test.laws
 
 import arrow.core.compose
 import arrow.core.identity
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.optics.Lens
 import arrow.core.test.laws.Law
 import arrow.core.test.laws.equalUnderTheLaw
@@ -10,8 +11,10 @@ import io.kotest.property.PropertyContext
 import io.kotest.property.arbitrary.constant
 import io.kotest.property.checkAll
 
+@Deprecated(deprecateArrowTestModules)
 public object LensLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     lensGen: Arb<Lens<A, B>>,
     aGen: Arb<A>,
@@ -32,6 +35,7 @@ public object LensLaws {
   /**
    * Warning: Use only when a `Gen.constant()` applies
    */
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     lens: Lens<A, B>,
     aGen: Arb<A>,
@@ -41,6 +45,7 @@ public object LensLaws {
     eqb: (B, B) -> Boolean = { a, b -> a == b }
   ): List<Law> = laws(Arb.constant(lens), aGen, bGen, funcGen, eqa, eqb)
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> lensGetSet(lensGen: Arb<Lens<A, B>>, aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, lensGen, aGen) { lens, a ->
       lens.run {
@@ -48,6 +53,7 @@ public object LensLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> lensSetGet(lensGen: Arb<Lens<A, B>>, aGen: Arb<A>, bGen: Arb<B>, eq: (B, B) -> Boolean): PropertyContext =
     checkAll(100, lensGen, aGen, bGen) { lens, a, b ->
       lens.run {
@@ -55,6 +61,7 @@ public object LensLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> lensSetIdempotent(lensGen: Arb<Lens<A, B>>, aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, lensGen, aGen, bGen) { lens, a, b ->
       lens.run {
@@ -62,6 +69,7 @@ public object LensLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> lensModifyIdentity(lensGen: Arb<Lens<A, B>>, aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, lensGen, aGen) { lens, a ->
       lens.run {
@@ -69,6 +77,7 @@ public object LensLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> lensComposeModify(lensGen: Arb<Lens<A, B>>, aGen: Arb<A>, funcGen: Arb<(B) -> B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, lensGen, aGen, funcGen, funcGen) { lens, a, f, g ->
       lens.run {
@@ -76,6 +85,7 @@ public object LensLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> lensConsistentSetModify(lensGen: Arb<Lens<A, B>>, aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, lensGen, aGen, bGen) { lens, a, b ->
       lens.run {

--- a/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/OptionalLaws.kt
+++ b/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/OptionalLaws.kt
@@ -2,6 +2,7 @@ package arrow.optics.test.laws
 
 import arrow.core.compose
 import arrow.core.identity
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.optics.Optional
 import arrow.core.test.laws.Law
 import arrow.core.test.laws.equalUnderTheLaw
@@ -10,8 +11,10 @@ import io.kotest.property.PropertyContext
 import io.kotest.property.arbitrary.constant
 import io.kotest.property.checkAll
 
+@Deprecated(deprecateArrowTestModules)
 public object OptionalLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,
@@ -31,6 +34,7 @@ public object OptionalLaws {
   /**
    * Warning: Use only when a `Gen.constant()` applies
    */
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     optional: Optional<A, B>,
     aGen: Arb<A>,
@@ -40,6 +44,7 @@ public object OptionalLaws {
     eqb: (B?, B?) -> Boolean = { a, b -> a == b }
   ): List<Law> = laws(Arb.constant(optional), aGen, bGen, funcGen, eqa, eqb)
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> getOptionSet(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,
@@ -52,6 +57,7 @@ public object OptionalLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> setGetOption(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,
@@ -65,6 +71,7 @@ public object OptionalLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> setIdempotent(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,
@@ -78,6 +85,7 @@ public object OptionalLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> modifyIdentity(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,
@@ -90,6 +98,7 @@ public object OptionalLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> composeModify(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,
@@ -103,6 +112,7 @@ public object OptionalLaws {
       }
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> consistentSetModify(
     optionalGen: Arb<Optional<A, B>>,
     aGen: Arb<A>,

--- a/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/PrismLaws.kt
+++ b/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/PrismLaws.kt
@@ -2,6 +2,7 @@ package arrow.optics.test.laws
 
 import arrow.core.compose
 import arrow.core.identity
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.optics.Prism
 import arrow.core.test.laws.Law
 import arrow.core.test.laws.equalUnderTheLaw
@@ -9,8 +10,10 @@ import io.kotest.property.Arb
 import io.kotest.property.PropertyContext
 import io.kotest.property.checkAll
 
+@Deprecated(deprecateArrowTestModules)
 public object PrismLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     prism: Prism<A, B>,
     aGen: Arb<A>,
@@ -26,28 +29,33 @@ public object PrismLaws {
     Law("Prism law: consistent set modify") { prism.consistentSetModify(aGen, bGen, eqa) }
   )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Prism<A, B>.partialRoundTripOneWay(aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen) { a ->
       getOrModify(a).fold(::identity, ::reverseGet)
         .equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Prism<A, B>.roundTripOtherWay(bGen: Arb<B>, eq: (B?, B?) -> Boolean): PropertyContext =
     checkAll(100, bGen) { b ->
       getOrNull(reverseGet(b))
         .equalUnderTheLaw(b, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Prism<A, B>.modifyIdentity(aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen) { a ->
       modify(a, ::identity).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Prism<A, B>.composeModify(aGen: Arb<A>, funcGen: Arb<(B) -> B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen, funcGen, funcGen) { a, f, g ->
       modify(modify(a, f), g).equalUnderTheLaw(modify(a, g compose f), eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Prism<A, B>.consistentSetModify(aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen, bGen) { a, b ->
       set(a, b).equalUnderTheLaw(modify(a) { b }, eq)

--- a/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/SetterLaws.kt
+++ b/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/SetterLaws.kt
@@ -2,6 +2,7 @@ package arrow.optics.test.laws
 
 import arrow.core.compose
 import arrow.core.identity
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.optics.Setter
 import arrow.core.test.laws.Law
 import arrow.core.test.laws.equalUnderTheLaw
@@ -9,8 +10,10 @@ import io.kotest.property.Arb
 import io.kotest.property.PropertyContext
 import io.kotest.property.checkAll
 
+@Deprecated(deprecateArrowTestModules)
 public object SetterLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B> laws(
     setter: Setter<A, B>,
     aGen: Arb<A>,
@@ -24,21 +27,25 @@ public object SetterLaws {
     Law("Setter law: consistent set modify") { setter.consistentSetModify(aGen, bGen, eq) }
   )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Setter<A, B>.setIdempotent(aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen, bGen) { a, b ->
       set(set(a, b), b).equalUnderTheLaw(set(a, b), eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Setter<A, B>.modifyIdentity(aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen) { a ->
       modify(a, ::identity).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Setter<A, B>.composeModify(aGen: Arb<A>, eq: (A, A) -> Boolean, funcGen: Arb<(B) -> B>): PropertyContext =
     checkAll(100, aGen, funcGen, funcGen) { a, f, g ->
       modify(modify(a, f), g).equalUnderTheLaw(modify(a, g compose f), eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Setter<A, B>.consistentSetModify(aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(100, aGen, bGen) { a, b ->
       modify(a) { b }.equalUnderTheLaw(set(a, b), eq)

--- a/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/TraversalLaws.kt
+++ b/arrow-libs/optics/arrow-optics-test/src/commonMain/kotlin/arrow/optics/test/laws/TraversalLaws.kt
@@ -2,6 +2,7 @@ package arrow.optics.test.laws
 
 import arrow.core.compose
 import arrow.core.identity
+import arrow.core.test.concurrency.deprecateArrowTestModules
 import arrow.optics.Traversal
 import arrow.core.test.laws.Law
 import arrow.core.test.laws.equalUnderTheLaw
@@ -10,8 +11,10 @@ import io.kotest.property.PropertyContext
 import io.kotest.property.checkAll
 import kotlin.math.max
 
+@Deprecated(deprecateArrowTestModules)
 public object TraversalLaws {
 
+  @Deprecated(deprecateArrowTestModules)
   public fun <A, B : Any> laws(
     traversal: Traversal<A, B>,
     aGen: Arb<A>,
@@ -24,17 +27,20 @@ public object TraversalLaws {
     Law("Traversal law: compose modify") { traversal.composeModify(aGen, funcGen, eq) }
   )
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Traversal<A, B>.setIdempotent(aGen: Arb<A>, bGen: Arb<B>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(max(aGen.minIterations(), bGen.minIterations()), aGen, bGen) { a, b ->
       set(set(a, b), b)
         .equalUnderTheLaw(set(a, b), eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Traversal<A, B>.modifyIdentity(aGen: Arb<A>, eq: (A, A) -> Boolean): PropertyContext =
     checkAll(aGen.minIterations(), aGen) { a ->
       modify(a, ::identity).equalUnderTheLaw(a, eq)
     }
 
+  @Deprecated(deprecateArrowTestModules)
   public suspend fun <A, B> Traversal<A, B>.composeModify(
     aGen: Arb<A>,
     funcGen: Arb<(B) -> B>,


### PR DESCRIPTION
We're deprecating them in favour of https://github.com/kotest/kotest-extensions-arrow