### PR TITLE
Add mapLeft to Effect and EagerEffect

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2600,6 +2600,7 @@ public abstract interface class arrow/core/continuations/EagerEffect {
 	public abstract fun handleError (Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public abstract fun handleErrorWith (Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public abstract fun map (Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
+	public abstract fun mapLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public abstract fun orNull ()Ljava/lang/Object;
 	public abstract fun redeem (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public abstract fun redeemWith (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
@@ -2616,6 +2617,7 @@ public final class arrow/core/continuations/EagerEffect$DefaultImpls {
 	public static fun handleError (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public static fun handleErrorWith (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public static fun map (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
+	public static fun mapLeft (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public static fun orNull (Larrow/core/continuations/EagerEffect;)Ljava/lang/Object;
 	public static fun redeem (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
 	public static fun redeemWith (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/EagerEffect;
@@ -2659,6 +2661,7 @@ public abstract interface class arrow/core/continuations/Effect {
 	public abstract fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun handleError (Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public abstract fun handleErrorWith (Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
+	public abstract fun mapLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/Effect;
 	public abstract fun orNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun redeem (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public abstract fun redeemWith (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
@@ -2673,6 +2676,7 @@ public final class arrow/core/continuations/Effect$DefaultImpls {
 	public static fun fold (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun handleError (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public static fun handleErrorWith (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
+	public static fun mapLeft (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/Effect;
 	public static fun orNull (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun redeem (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public static fun redeemWith (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EagerEffect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EagerEffect.kt
@@ -117,7 +117,7 @@ public interface EagerEffect<out R, out A> {
 
   public fun <R2> mapLeft(f: (R) -> R2): EagerEffect<R2, A> =
     eagerEffect {
-      toEither().fold({ shift(f(it)) }, { it })
+      toEither().fold({ shift(f(it)) }, ::identity)
     }
 
   public fun <B> redeem(f: (R) -> B, g: (A) -> B): EagerEffect<Nothing, B> = eagerEffect {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EagerEffect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EagerEffect.kt
@@ -116,8 +116,8 @@ public interface EagerEffect<out R, out A> {
     }
 
   public fun <R2> mapLeft(f: (R) -> R2): EagerEffect<R2, A> =
-    handleErrorWith {
-      eagerEffect { shift(f(it)) }
+    eagerEffect {
+      toEither().fold({ shift(f(it)) }, { it })
     }
 
   public fun <B> redeem(f: (R) -> B, g: (A) -> B): EagerEffect<Nothing, B> = eagerEffect {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EagerEffect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EagerEffect.kt
@@ -115,6 +115,11 @@ public interface EagerEffect<out R, out A> {
       toEither().fold({ r -> f(r).bind() }, ::identity)
     }
 
+  public fun <R2> mapLeft(f: (R) -> R2): EagerEffect<R2, A> =
+    handleErrorWith {
+      eagerEffect { shift(f(it)) }
+    }
+
   public fun <B> redeem(f: (R) -> B, g: (A) -> B): EagerEffect<Nothing, B> = eagerEffect {
     fold(f, g)
   }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -663,8 +663,8 @@ public sealed interface Effect<out R, out A> {
   }
 
   public fun <R2> mapLeft(f: (R) -> R2): Effect<R2, A> =
-    handleErrorWith {
-      effect { shift(f(it)) }
+    effect {
+      fold({ shift(f(it)) }, { it })
     }
 
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -662,6 +662,11 @@ public sealed interface Effect<out R, out A> {
     fold({ recover(it).bind() }, ::identity)
   }
 
+  public fun <R2> mapLeft(f: (R) -> R2): Effect<R2, A> =
+    handleErrorWith {
+      effect { shift(f(it)) }
+    }
+
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =
     effect {
       fold(recover, transform)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -664,7 +664,7 @@ public sealed interface Effect<out R, out A> {
 
   public fun <R2> mapLeft(f: (R) -> R2): Effect<R2, A> =
     effect {
-      fold({ shift(f(it)) }, { it })
+      fold({ shift(f(it)) }, ::identity)
     }
 
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
@@ -88,7 +88,7 @@ class EagerEffectSpec : StringSpec({
     checkAll(Arb.string()) { a ->
       eagerEffect<String, Nothing> { shift(a) }
         .mapLeft { it.length }
-        .fold(::identity) { fail("Should never come here") } shouldBe a.length
+        .runCont() shouldBe a.length
     }
   }
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
@@ -60,7 +60,7 @@ class EagerEffectSpec : StringSpec({
   "can map over left value" {
     checkAll(Arb.string()) { a ->
       eagerEffect<String, Nothing> { shift(a) }
-        .mapLeft { a.length }
+        .mapLeft { it.length }
         .fold(::identity) { fail("Should never come here") } shouldBe a.length
     }
   }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
@@ -57,6 +57,14 @@ class EagerEffectSpec : StringSpec({
     }
   }
 
+  "can map over left value" {
+    checkAll(Arb.string()) { a ->
+      eagerEffect<String, Nothing> { shift(a) }
+        .mapLeft { a.length }
+        .fold(::identity) { fail("Should never come here") } shouldBe a.length
+    }
+  }
+
   "immediate values" { eagerEffect<Nothing, Int> { 1 }.toEither().orNull() shouldBe 1 }
 
   "immediate short-circuit" { eagerEffect<String, Nothing> { shift("hello") }.runCont() shouldBe "hello" }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -133,6 +133,14 @@ class EffectSpec :
       }
     }
 
+    "can map over left value" {
+      checkAll(Arb.string()) { a ->
+        effect<String, Nothing> { shift(a) }
+          .mapLeft { a.length }
+          .fold(::identity) { fail("Should never come here") } shouldBe a.length
+      }
+    }
+
     "immediate values" { effect<Nothing, Int> { 1 }.value() shouldBe 1 }
 
     "suspended value" { effect<Nothing, Int> { 1.suspend() }.value() shouldBe 1 }
@@ -242,14 +250,14 @@ class EffectSpec :
         }.runCont()
       } shouldBe Either.Left(e)
     }
-    
+
     "#2760 - dispatching in nested Effect blocks does not make the nested Continuation to hang" {
       checkAll(Arb.string()) { msg ->
         fun failure(): Effect<Failure, String> = effect {
           withContext(Dispatchers.Default) {}
           shift(Failure(msg))
         }
-        
+
         effect<Failure, Int> {
           failure().bind()
           1

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -164,7 +164,7 @@ class EffectSpec :
       checkAll(Arb.string()) { a ->
         effect<String, Nothing> { shift(a) }
           .mapLeft { it.length }
-          .fold(::identity) { fail("Should never come here") } shouldBe a.length
+          .runCont() shouldBe a.length
       }
     }
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -136,7 +136,7 @@ class EffectSpec :
     "can map over left value" {
       checkAll(Arb.string()) { a ->
         effect<String, Nothing> { shift(a) }
-          .mapLeft { a.length }
+          .mapLeft { it.length }
           .fold(::identity) { fail("Should never come here") } shouldBe a.length
       }
     }


### PR DESCRIPTION
On the new Effect and EagerEffect types there was no easy way to map an `Effect<R, A>` to an `Effect<R2, A>`. This is useful for instance when error types need to be refined from lower level errors to higher level errors. This PR simplifies that by adding a `mapLeft` function to both `Effect` and `EagerEffect` implemented in terms of `handleErrorWith`.
