### PR TITLE
Refine the Arrow version selector

### DIFF
--- a/arrow-site/docs/_data/doc-versions.yml
+++ b/arrow-site/docs/_data/doc-versions.yml
@@ -1,34 +1,25 @@
 docVersions:
 
-  - title: "v0.10.5"
-    url: https://arrow-kt.io/docs/0.10/
-    previous: https://arrow-kt.io/docs/0.9/
-
-  - title: "v0.11.0"
-    url: https://arrow-kt.io/docs/0.11/
-    previous: https://arrow-kt.io/docs/0.10/
-
-  - title: "v0.12.1"
+  - title: "Version 0.12.x"
     url: https://arrow-kt.io/docs/0.12/
     previous: https://arrow-kt.io/docs/0.11/
 
-  - title: "v0.13.2"
+  - title: "Version 0.13.x"
     url: https://arrow-kt.io/docs/0.13/
     previous: https://arrow-kt.io/docs/0.12/
 
-  - title: "v1.0.0"
-    url: https://arrow-kt.io/
+  - title: "Version 1.0.x"
+    url: https://arrow-kt.io/docs/1.0/
     previous: https://arrow-kt.io/docs/0.13/
 
-  - title: "v1.0.1"
+  - title: "Version 1.1.x"
     url: https://arrow-kt.io/
-    previous: https://arrow-kt.io/docs/1.0.0/
+    previous: https://arrow-kt.io/docs/1.0/
 
-  - title: "v1.0.2-SNAPSHOT"
+  - title: "Latest Alpha version"
     url: https://arrow-kt.io/docs/next/
     previous: https://arrow-kt.io/
 
 # Literals
-previous: PREVIOUS
-stable: STABLE
-next: NEXT
+stable: Current version
+next: Latest Alpha version

--- a/arrow-site/docs/_data/doc-versions.yml
+++ b/arrow-site/docs/_data/doc-versions.yml
@@ -2,24 +2,19 @@ docVersions:
 
   - title: "Version 0.12.x"
     url: https://arrow-kt.io/docs/0.12/
-    previous: https://arrow-kt.io/docs/0.11/
 
   - title: "Version 0.13.x"
     url: https://arrow-kt.io/docs/0.13/
-    previous: https://arrow-kt.io/docs/0.12/
 
   - title: "Version 1.0.x"
     url: https://arrow-kt.io/docs/1.0/
-    previous: https://arrow-kt.io/docs/0.13/
 
   - title: "Version 1.1.x"
     url: https://arrow-kt.io/
-    previous: https://arrow-kt.io/docs/1.0/
 
-  - title: "Latest Alpha version"
+  - title: "Latest Alpha/RC version"
     url: https://arrow-kt.io/docs/next/
-    previous: https://arrow-kt.io/
 
 # Literals
 stable: Current version
-next: Latest Alpha version
+next: Latest Alpha/RC version

--- a/arrow-site/docs/_includes/_sidebar-doc-versions.html
+++ b/arrow-site/docs/_includes/_sidebar-doc-versions.html
@@ -17,7 +17,7 @@
         {% assign stable_base_doc_link = site.data.commons.stable_version | append: 'docs/' %}
         <a href="{{ stable_base_doc_link | append: doc-link }}">
           <span>
-            {{ stable_version.title }} - {{ site.data.doc-versions.stable }}
+            {{ site.data.doc-versions.stable }} - {{ stable_version.title }}
           </span>
         </a>
       </li>
@@ -25,29 +25,13 @@
       <li>
         <a href="{{ next_version.url | append: doc-link }}">
           <span>
-            {{ next_version.title }} - {{ site.data.doc-versions.next }}
+            {{ next_version.title }}
           </span>
-        </a>
-      </li>
-
-      <li>
-        <a href="{{ previous_version.url | append: doc-link }}">
-          <span>
-            {{ previous_version.title }} - {{ site.data.doc-versions.previous }}
-          </span>
-        </a>
-      </li>
-
-      <li>
-        <a href="https://arrow-kt.io/docs/0.9/">
-          <span>v0.9.0</span>
         </a>
       </li>
 
       {% for item in site.data.doc-versions.docVersions %}
-      {% if item.url != stable_version.url
-            and item.url != next_version.url
-            and item.url != previous_version.url %}
+      {% if item.url != stable_version.url and item.url != next_version.url %}
       <li>
         <a href="{{ item.url | append: doc-link }}">
           <span>{{ item.title }}</span>

--- a/arrow-site/docs/_sass/components/docs/_sidebar-menu.scss
+++ b/arrow-site/docs/_sass/components/docs/_sidebar-menu.scss
@@ -110,7 +110,7 @@
                  }
                }
 
-               li:nth-child(4) {
+               li:nth-child(3) {
                  border-top: solid 1px rgba(255, 255, 255, 0.5);
                }
            }


### PR DESCRIPTION
The current Arrow version selector is not fully up-to-date. It's showing old versions for which there are no longer documentation and pointing out version `1.0.1` as the latest stable version.

This pull request proposes a few changes:
- Remove the old versions
- Update the latest stable version to `1.1.x`
- Remove the previous version item, which is a bit confusing

This is a screenshot of how the Arrow version selector would look like after applying these changes:

![Screen Shot 2022-07-21 at 12 40 22](https://user-images.githubusercontent.com/1200151/180209325-1cf5bd77-7487-4609-a037-90670d5f361e.png)
