### PR TITLE
Support generics and inner classes in `@optics`

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
@@ -38,12 +38,6 @@ class OpticsProcessor(private val codegen: CodeGenerator, private val logger: KS
       return
     }
 
-    // check that it does not have type arguments
-    /* if (klass.typeParameters.isNotEmpty()) {
-      logger.error(klass.qualifiedNameOrSimpleName.typeParametersErrorMessage, klass)
-      return
-    } */
-
     // check that the companion object exists
     if (klass.companionObject == null) {
       logger.error(klass.qualifiedNameOrSimpleName.noCompanion, klass)

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
@@ -39,10 +39,10 @@ class OpticsProcessor(private val codegen: CodeGenerator, private val logger: KS
     }
 
     // check that it does not have type arguments
-    if (klass.typeParameters.isNotEmpty()) {
+    /* if (klass.typeParameters.isNotEmpty()) {
       logger.error(klass.qualifiedNameOrSimpleName.typeParametersErrorMessage, klass)
       return
-    }
+    } */
 
     // check that the companion object exists
     if (klass.companionObject == null) {

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/isos.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/isos.kt
@@ -63,9 +63,17 @@ private fun processElement(iso: ADT, target: Target): String {
         "tuple: ${focusType()} -> ${(foci.indices).joinToString(prefix = "${iso.sourceClassName}(", postfix = ")", transform = { "tuple.${letters[it]}" })}"
     }
 
+  val sourceClassNameWithParams = "${iso.sourceClassName}${iso.angledTypeParameters}"
+  val firstLine = when {
+    iso.typeParameters.isEmpty() ->
+      "${iso.visibilityModifierName} inline val ${iso.sourceClassName}.Companion.iso: $Iso<${iso.sourceClassName}, ${focusType()}> inline get()"
+    else ->
+      "${iso.visibilityModifierName} inline fun ${iso.angledTypeParameters} ${iso.sourceClassName}.Companion.iso(): $Iso<$sourceClassNameWithParams, ${focusType()}>"
+  }
+
   return """
-        |${iso.visibilityModifierName} inline val ${iso.sourceClassName}.Companion.iso: $Iso<${iso.sourceClassName}, ${focusType()}> inline get()= $Iso(
-        |  get = { ${iso.sourceName}: ${iso.sourceClassName} -> ${tupleConstructor()} },
+        |$firstLine = $Iso(
+        |  get = { ${iso.sourceName}: $sourceClassNameWithParams -> ${tupleConstructor()} },
         |  reverseGet = { ${classConstructorFromTuple()} }
         |)
         |""".trimMargin()

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
@@ -20,17 +20,24 @@ private fun String.toUpperCamelCase(): String =
       }
     )
 
-private fun processElement(adt: ADT, foci: List<Focus>): String =
-  foci.joinToString(separator = "\n") { focus ->
+private fun processElement(adt: ADT, foci: List<Focus>): String {
+  val sourceClassNameWithParams = "${adt.sourceClassName}${adt.angledTypeParameters}"
+  return foci.joinToString(separator = "\n") { focus ->
+    val firstLine = when {
+      adt.typeParameters.isEmpty() ->
+        "${adt.visibilityModifierName} inline val ${adt.sourceClassName}.Companion.${focus.lensParamName()}: $Lens<${adt.sourceClassName}, ${focus.className}> inline get()"
+      else ->
+        "${adt.visibilityModifierName} inline fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.lensParamName()}(): $Lens<$sourceClassNameWithParams, ${focus.className}>"
+    }
     """
-  |${adt.visibilityModifierName} inline val ${adt.sourceClassName}.Companion.${focus.lensParamName()}: $Lens<${adt.sourceClassName}, ${focus.className}> inline get()= $Lens(
-  |  get = { ${adt.sourceName}: ${adt.sourceClassName} -> ${adt.sourceName}.${
+  |$firstLine = $Lens(
+  |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.${
       focus.paramName.plusIfNotBlank(
         prefix = "`",
         postfix = "`"
       )
     } },
-  |  set = { ${adt.sourceName}: ${adt.sourceClassName}, value: ${focus.className} -> ${adt.sourceName}.copy(${
+  |  set = { ${adt.sourceName}: $sourceClassNameWithParams, value: ${focus.className} -> ${adt.sourceName}.copy(${
       focus.paramName.plusIfNotBlank(
         prefix = "`",
         postfix = "`"
@@ -39,6 +46,7 @@ private fun processElement(adt: ADT, foci: List<Focus>): String =
   |)
   |""".trimMargin()
   }
+}
 
 fun Focus.lensParamName(): String =
   when (this) {

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/IsoTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/IsoTests.kt
@@ -21,6 +21,20 @@ class IsoTests {
   }
 
   @Test
+  fun `Isos will be generated for generic data class`() {
+    """
+      |$imports
+      |@optics
+      |data class IsoData<A>(
+      |  val field1: A
+      |) { companion object }
+      |
+      |val i: Iso<IsoData<String>, String> = IsoData.iso()
+      |val r = i != null
+      """.evals("r" to true)
+  }
+
+  @Test
   fun `Isos will be generated for data class with secondary constructors`() {
     """
       |$imports

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
@@ -58,8 +58,54 @@ class LensTests {
       |  companion object
       |}
       |
-      |val i: Lens<OpticsTest, Int> = OpticsTest<Int>.time
+      |val i: Lens<OpticsTest<Int>, Int> = OpticsTest.field()
       |val r = i != null
-      """.failsWith { it.contains("OpticsTest".typeParametersErrorMessage) }
+      """.evals("r" to true)
+  }
+
+  @Test
+  fun `Lenses for nested classes`() {
+    """
+      |$imports
+      |@optics
+      |data class LensData(val field1: String) {
+      |  @optics
+      |  data class InnerLensData(val field2: String) {
+      |    companion object
+      |  }
+      |  companion object 
+      |}
+      |
+      |val i: Lens<LensData.InnerLensData, String> = LensData.InnerLensData.field2
+      |val r = i != null
+      """.evals("r" to true)
+  }
+
+  @Test
+  fun `Lenses for nested classes with repeated names (#2718)`() {
+    """
+      |$imports
+      |@optics
+      |data class LensData(val field1: String) {
+      |  @optics
+      |  data class InnerLensData(val field2: String) {
+      |    companion object
+      |  }
+      |  companion object 
+      |}
+      |
+      |@optics
+      |data class OtherLensData(val field1: String) {
+      |  @optics
+      |  data class InnerLensData(val field2: String) {
+      |    companion object
+      |  }
+      |  companion object 
+      |}
+      |
+      |val i: Lens<LensData.InnerLensData, String> = LensData.InnerLensData.field2
+      |val j: Lens<OtherLensData.InnerLensData, String> = OtherLensData.InnerLensData.field2
+      |val r = i != null && j != null
+      """.evals("r" to true)
   }
 }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/OptionalTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/OptionalTests.kt
@@ -19,6 +19,20 @@ class OptionalTests {
   }
 
   @Test
+  fun `Optional will be generated for generic data class`() {
+    """
+      |$imports
+      |@optics
+      |data class OptionalData<A>(
+      |  val field1: A?
+      |) { companion object }
+      |
+      |val i: Optional<OptionalData<String>, String> = OptionalData.field1()
+      |val r = i != null
+      """.evals("r" to true)
+  }
+
+  @Test
   fun `Optional will be generated for data class with secondary constructors`() {
     """
       |$imports

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/PrismTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/PrismTests.kt
@@ -20,6 +20,21 @@ class PrismTests {
   }
 
   @Test
+  fun `Prism will be generated for generic sealed class`() {
+    """
+      |$imports
+      |@optics
+      |sealed class PrismSealed<A,B>(val field: A, val nullable: B?) {
+      | data class PrismSealed1(private val a: String?) : PrismSealed<String, String>("", a)
+      | data class PrismSealed2<C>(private val b: C?) : PrismSealed<String, C>("", b)
+      | companion object
+      |}
+      |val i: Prism<PrismSealed<String, String>, PrismSealed.PrismSealed1> = PrismSealed.prismSealed1()
+      |val r = i != null
+      """.evals("r" to true)
+  }
+
+  @Test
   fun `Prism will not be generated for sealed class if DSL Target is specified`() {
     """
       |$imports


### PR DESCRIPTION
Fices #2718 and #2552

The optics generated for classes with generics are (inline) functions instead of `val`s, due to the way companion objects work in Kotlin (only one instance per class, not per generic instantiation).

Most of the code is straightforward, except for prisms. The hard part there is that if you have:

```kotlin
@optics
sealed class PrismSealed<A,B>(val field: A, val nullable: B?) {
 data class PrismSealed1(private val a: String?) : PrismSealed<String, String>("", a)
 data class PrismSealed2<C>(private val b: C?) : PrismSealed<String, C>("", b)
 companion object
}
```

you need to take the type parameters **of the subclass** into account.