### PR TITLE
value class impl of Option (called Maybe) prototype

### DIFF
--- a/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/generators/Generators.kt
+++ b/arrow-libs/core/arrow-core-test/src/commonMain/kotlin/arrow/core/test/generators/Generators.kt
@@ -1,23 +1,7 @@
 package arrow.core.test.generators
 
-import arrow.core.Const
-import arrow.core.Either
-import arrow.core.Endo
-import arrow.core.Eval
-import arrow.core.Ior
-import arrow.core.Option
-import arrow.core.Tuple10
-import arrow.core.Tuple4
-import arrow.core.Tuple5
-import arrow.core.Tuple6
-import arrow.core.Tuple7
-import arrow.core.Tuple8
-import arrow.core.Tuple9
-import arrow.core.Validated
-import arrow.core.left
-import arrow.core.right
+import arrow.core.*
 import arrow.core.test.concurrency.deprecateArrowTestModules
-import arrow.core.toOption
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
@@ -209,6 +193,10 @@ public fun <A> Arb.Companion.endo(arb: Arb<A>): Arb<Endo<A>> = arb.map { a: A ->
 @Deprecated(deprecateArrowTestModules)
 public fun <B> Arb.Companion.option(arb: Arb<B>): Arb<Option<B>> =
   arb.orNull().map { it.toOption() }
+
+@Deprecated(deprecateArrowTestModules)
+public fun <B : Any> Arb.Companion.maybe(arb: Arb<B>): Arb<Maybe<B>> =
+  arb.orNull().map { it.toMaybe() }
 
 @Deprecated(deprecateArrowTestModules)
 public fun <E, A> Arb.Companion.either(arbE: Arb<E>, arbA: Arb<A>): Arb<Either<E, A>> {

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -692,6 +692,136 @@ public final class arrow/core/MapKt {
 	public static final fun zip (Ljava/util/Map;Ljava/util/Map;Lkotlin/jvm/functions/Function3;)Ljava/util/Map;
 }
 
+public final class arrow/core/Maybe {
+	public static final field Companion Larrow/core/Maybe$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/Object;)Larrow/core/Maybe;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun fromNullable-a5TdXEY (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun fromNullable-rCUBF3A (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/Object;)I
+	public static final fun invoke-rCUBF3A (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun isDefined-impl (Ljava/lang/Object;)Z
+	public static final fun isEmpty-impl (Ljava/lang/Object;)Z
+	public static final fun isJust-impl (Ljava/lang/Object;)Z
+	public static final fun isNotEmpty-impl (Ljava/lang/Object;)Z
+	public static final fun isNothing-impl (Ljava/lang/Object;)Z
+	public static final fun nonEmpty-impl (Ljava/lang/Object;)Z
+	public static final fun tapNothing-rCUBF3A (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun tryCatch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun tryCatchMaybe (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun tryCatchOrNothing (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun tryCatchOrNothingMaybe (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final synthetic fun unbox-impl ()Ljava/lang/Object;
+}
+
+public final class arrow/core/Maybe$Companion {
+	public final fun construct-rCUBF3A (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun fromNullable-a5TdXEY (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun fromNullable-rCUBF3A (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getNothing-wpGVQLU ()Ljava/lang/Object;
+	public final fun invoke-rCUBF3A (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun tryCatch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun tryCatchMaybe (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun tryCatchOrNothing (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun tryCatchOrNothingMaybe (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class arrow/core/MaybeKt {
+	public static final fun Just (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun _Just (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun and-xyn11ak (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun bindMaybe (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun bindMaybe (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun combineToMaybe (Larrow/typeclasses/Semigroup;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun elementAtOrNothing (Ljava/lang/Iterable;I)Ljava/lang/Object;
+	public static final fun emptyMaybe (Larrow/typeclasses/Monoid;)Ljava/lang/Object;
+	public static final fun firstOrNothing (Ljava/lang/Iterable;)Ljava/lang/Object;
+	public static final fun firstOrNothing (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun flatten-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun getBoxedJustUnit ()Ljava/lang/Object;
+	public static final fun getJustUnit ()Ljava/lang/Object;
+	public static final fun getOrNothing (Ljava/util/Map;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun getValue-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun handleError-AN_zAo4 (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun handleErrorWith-AN_zAo4 (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun invokeBlockOnMaybe-AN_zAo4 (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun just (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun lastOrNothing (Ljava/lang/Iterable;)Ljava/lang/Object;
+	public static final fun lastOrNothing (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun maybe2 (ZLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun maybeCombineAll (Ljava/lang/Object;Larrow/typeclasses/Monoid;)Ljava/lang/Object;
+	public static final fun maybeFindOrNull (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun maybeGetOrElse (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun maybeMaybe (Larrow/typeclasses/Monoid$Companion;Larrow/typeclasses/Semigroup;)Larrow/typeclasses/Monoid;
+	public static final fun nothing ()Ljava/lang/Object;
+	public static final fun or-xyn11ak (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun orElse-AN_zAo4 (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun orNothing (Larrow/core/Either;)Ljava/lang/Object;
+	public static final fun orNothing (Larrow/core/Validated;)Ljava/lang/Object;
+	public static final fun orNullMaybe (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun rebox-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun replicateMaybe (Ljava/lang/Object;ILarrow/typeclasses/Monoid;)Ljava/lang/Object;
+	public static final fun rethrow-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun separateEither-zmXLuQU (Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun separateValidated-zmXLuQU (Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun sequence-zmXLuQU (Ljava/lang/Object;)Larrow/core/Either;
+	public static final fun sequence-zmXLuQU (Ljava/lang/Object;)Larrow/core/Validated;
+	public static final fun sequence-zmXLuQU (Ljava/lang/Object;)Ljava/util/List;
+	public static final fun sequenceEither-zmXLuQU (Ljava/lang/Object;)Larrow/core/Either;
+	public static final fun sequenceValidated-zmXLuQU (Ljava/lang/Object;)Larrow/core/Validated;
+	public static final fun singleOrNothing (Ljava/lang/Iterable;)Ljava/lang/Object;
+	public static final fun singleOrNothing (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun toMap-zmXLuQU (Ljava/lang/Object;)Ljava/util/Map;
+	public static final fun toMaybe (Larrow/core/Validated;)Ljava/lang/Object;
+	public static final fun toMaybe (Larrow/core/continuations/EagerEffect;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun toMaybe (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toMaybe (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun toMaybe-UwYdzBo (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun unalign-zmXLuQU (Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun unite-AN_zAo4 (Ljava/lang/Object;Larrow/typeclasses/Monoid;)Ljava/lang/Object;
+	public static final fun uniteEither-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun uniteValidated-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun unzip-zmXLuQU (Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun void-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun widen-zmXLuQU (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public class arrow/core/MaybeMonoid : arrow/typeclasses/Monoid {
+	public fun <init> (Larrow/typeclasses/Semigroup;)V
+	public synthetic fun combine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun combine-pYfRoAM (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun combineAll (Ljava/util/Collection;)Ljava/lang/Object;
+	public synthetic fun combineAll (Ljava/util/List;)Ljava/lang/Object;
+	public fun combineAll-rCUBF3A (Ljava/util/Collection;)Ljava/lang/Object;
+	public fun combineAll-rCUBF3A (Ljava/util/List;)Ljava/lang/Object;
+	public synthetic fun empty ()Ljava/lang/Object;
+	public fun empty-wpGVQLU ()Ljava/lang/Object;
+	public synthetic fun fold (Ljava/util/Collection;)Ljava/lang/Object;
+	public synthetic fun fold (Ljava/util/List;)Ljava/lang/Object;
+	public fun fold-rCUBF3A (Ljava/util/Collection;)Ljava/lang/Object;
+	public fun fold-rCUBF3A (Ljava/util/List;)Ljava/lang/Object;
+	protected final fun getMA ()Larrow/typeclasses/Semigroup;
+	public synthetic fun maybeCombine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun maybeCombine-Sk8IHYk (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun plus (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun plus-pYfRoAM (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class arrow/core/MaybeMonoidNested : arrow/core/MaybeMonoid {
+	public fun <init> (Larrow/typeclasses/Semigroup;)V
+	public synthetic fun combine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun combine-pYfRoAM (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun empty ()Ljava/lang/Object;
+	public fun empty-wpGVQLU ()Ljava/lang/Object;
+	public synthetic fun maybeCombine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun maybeCombine-Sk8IHYk (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class arrow/core/Memoization {
 	public static final fun memoize (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function0;
 	public static final fun memoize (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
@@ -699,6 +829,22 @@ public final class arrow/core/Memoization {
 	public static final fun memoize (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function3;
 	public static final fun memoize (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function4;
 	public static final fun memoize (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function5;
+}
+
+public final class arrow/core/NestedNothing {
+	public static final field Companion Larrow/core/NestedNothing$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun copy (I)Larrow/core/NestedNothing;
+	public static synthetic fun copy$default (Larrow/core/NestedNothing;IILjava/lang/Object;)Larrow/core/NestedNothing;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNesting ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/core/NestedNothing$Companion {
+	public final fun invoke (I)Larrow/core/NestedNothing;
 }
 
 public final class arrow/core/NonEmptyList : kotlin/collections/AbstractList {
@@ -2765,6 +2911,83 @@ public final class arrow/core/continuations/IorEffectScope : arrow/core/continua
 	public fun shift (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class arrow/core/continuations/MaybeEagerEffectScope : arrow/core/continuations/EagerEffectScope {
+	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun attempt-impl (Larrow/core/continuations/EagerEffectScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun bind-cPdpwD0 (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun box-impl (Larrow/core/continuations/EagerEffectScope;)Larrow/core/continuations/MaybeEagerEffectScope;
+	public fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static fun catch-impl (Larrow/core/continuations/EagerEffectScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static fun constructor-impl (Larrow/core/continuations/EagerEffectScope;)Larrow/core/continuations/EagerEffectScope;
+	public fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun ensure-impl (Larrow/core/continuations/EagerEffectScope;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun ensure-impl (Larrow/core/continuations/EagerEffectScope;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Larrow/core/continuations/EagerEffectScope;Larrow/core/continuations/EagerEffectScope;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Larrow/core/continuations/EagerEffectScope;)I
+	public synthetic fun shift (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun shift-AN_zAo4 (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shift-AN_zAo4 (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Larrow/core/continuations/EagerEffectScope;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Larrow/core/continuations/EagerEffectScope;
+}
+
+public final class arrow/core/continuations/MaybeEffectScope : arrow/core/continuations/EffectScope {
+	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun attempt-impl (Larrow/core/continuations/EffectScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun bind-cPdpwD0 (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun box-impl (Larrow/core/continuations/EffectScope;)Larrow/core/continuations/MaybeEffectScope;
+	public fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun catch-impl (Larrow/core/continuations/EffectScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun constructor-impl (Larrow/core/continuations/EffectScope;)Larrow/core/continuations/EffectScope;
+	public fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun ensure-impl (Larrow/core/continuations/EffectScope;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun ensure-impl (Larrow/core/continuations/EffectScope;ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Larrow/core/continuations/EffectScope;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Larrow/core/continuations/EffectScope;Larrow/core/continuations/EffectScope;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Larrow/core/continuations/EffectScope;)I
+	public synthetic fun shift (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun shift-AN_zAo4 (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shift-AN_zAo4 (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Larrow/core/continuations/EffectScope;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Larrow/core/continuations/EffectScope;
+}
+
+public final class arrow/core/continuations/MaybeKt {
+	public static final fun ensureNotNull-dEk6xB0 (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun ensureNotNull-nXMeK7E (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toMaybe (Larrow/core/continuations/EagerEffect;)Ljava/lang/Object;
+	public static final fun toMaybe (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class arrow/core/continuations/NullableEagerEffectScope : arrow/core/continuations/EagerEffectScope {
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun attempt-impl (Larrow/core/continuations/EagerEffectScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2773,6 +2996,7 @@ public final class arrow/core/continuations/NullableEagerEffectScope : arrow/cor
 	public fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun bind-cPdpwD0 (Larrow/core/continuations/EagerEffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/EagerEffectScope;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2809,6 +3033,7 @@ public final class arrow/core/continuations/NullableEffectScope : arrow/core/con
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun bind-cPdpwD0 (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/EffectScope;Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3018,6 +3243,12 @@ public final class arrow/core/continuations/ior {
 	public static final field INSTANCE Larrow/core/continuations/ior;
 	public final fun eager (Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function2;)Larrow/core/Ior;
 	public final fun invoke (Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/core/continuations/maybe {
+	public static final field INSTANCE Larrow/core/continuations/maybe;
+	public final fun eager-rCUBF3A (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public final fun invoke-_ZUWMMM (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/continuations/nullable {

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -55,12 +55,11 @@ kotlin {
         implementation(libs.kotlin.stdlibJS)
       }
     }
+    all {
+      // enables Opt in annotations for Maybe
+      languageSettings.optIn("kotlin.RequiresOptIn")
+    }
   }
-}
-
-// enables Opt in annotations for Maybe
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }
 
 // enables context receivers for Jvm Tests

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -58,6 +58,11 @@ kotlin {
   }
 }
 
+// enables Opt in annotations for Maybe
+tasks.withType<KotlinCompile>().configureEach {
+  kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+}
+
 // enables context receivers for Jvm Tests
 tasks.named<KotlinCompile>("compileTestKotlinJvm") {
   kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -21,38 +21,36 @@ import kotlin.jvm.JvmStatic
 internal annotation class MaybeInternals
 
 @JvmInline
-public value class Maybe<out A : Any>
+public value class Maybe<out A>
 @MaybeInternals
 private constructor(@property:MaybeInternals @PublishedApi internal val underlying: Any) {
 
   public companion object {
     // This is simply an alias to constructor-impl
-    @PublishedApi
-    @MaybeInternals
-    internal fun <A : Any> construct(value: Any): Maybe<A> = Maybe(value)
+    @PublishedApi @MaybeInternals internal fun <A> construct(value: Any): Maybe<A> = Maybe(value)
 
-    @OptIn(MaybeInternals::class) public val Nothing: Maybe<Nothing> = construct(NestedNothing(0))
+    @OptIn(MaybeInternals::class) public val Nothing: Maybe<Nothing> = construct(NestedNothing(0U))
 
     @JvmStatic
-    public inline fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
+    public inline fun <A> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
     @JvmStatic public inline fun fromNullable(a: Nothing?): Maybe<Nothing> = Nothing
 
     @JvmStatic
-    public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> =
+    public inline fun <A> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> =
       if (a != null) Just(a) else Nothing
 
-    @JvmStatic public inline operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
+    @JvmStatic public inline operator fun <A> invoke(a: A): Maybe<A> = Just(a)
 
     @JvmStatic
     @JvmName("tryCatchOrNothing")
     /** Ignores exceptions and returns Nothing if one is thrown */
-    public inline fun <A : Any> catch(f: () -> A): Maybe<A> {
+    public inline fun <A> catch(f: () -> A): Maybe<A> {
       return catch({ Nothing }, f)
     }
 
     @JvmStatic
     @JvmName("tryCatch")
-    public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> =
+    public inline fun <A> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> =
       try {
         Just(f())
       } catch (t: Throwable) {
@@ -60,15 +58,15 @@ private constructor(@property:MaybeInternals @PublishedApi internal val underlyi
       }
 
     @JvmStatic
-    public inline fun <reified A : Any, B : Any> lift(
-      crossinline f: (A) -> B
-    ): (Maybe<A>) -> Maybe<B> = { it.map(f) }
+    public inline fun <reified A, B> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> = {
+      it.map(f)
+    }
   }
 
   public inline fun tapNothing(f: () -> Unit): Maybe<A> = this.also { if (isEmpty()) f() }
 
   /** Returns true if the maybe is [Nothing], false otherwise. */
-  public fun isEmpty(): Boolean = fold<Any, Boolean>({ true }, { false })
+  public fun isEmpty(): Boolean = fold<Any?, Boolean>({ true }, { false })
 
   public fun isNotEmpty(): Boolean = !isEmpty()
 
@@ -86,7 +84,7 @@ private constructor(@property:MaybeInternals @PublishedApi internal val underlyi
   /** Returns true if the maybe is an instance of [Just], false otherwise. */
   public fun isDefined(): Boolean = isNotEmpty()
 
-  override fun toString(): String = fold<Any, String>({ "Maybe.Nothing" }, { "Maybe.Just($it)" })
+  override fun toString(): String = fold<Any?, String>({ "Maybe.Nothing" }, { "Maybe.Just($it)" })
 }
 
 @PublishedApi
@@ -95,25 +93,22 @@ internal inline fun <reified T> isTypeMaybe(): Boolean =
 
 @PublishedApi
 @MaybeInternals
-internal val <A : Any> Maybe<A>.value: A
+internal val <A> Maybe<A>.value: A
   get() =
     when (underlying) {
+      is NestedNull -> if (underlying.nesting == 0U) null else NestedNull(underlying.nesting - 1U)
       is NestedNothing ->
-        NestedNothing(underlying.nesting - 1).also {
-          if (it.nesting < 0) error("Cannot unpack the value of a Maybe.Nothing")
+        NestedNothing(underlying.nesting - 1U).also {
+          if (it.nesting < 0U) error("Cannot unpack the value of a Maybe.Nothing")
         }
       else -> underlying
     }
       as A
 
-public inline fun <reified A : Any, reified B : Any> Maybe<A>.zip(
-  other: Maybe<B>
-): Maybe<Pair<A, B>> = zip(other, ::Pair)
+public inline fun <reified A, reified B> Maybe<A>.zip(other: Maybe<B>): Maybe<Pair<A, B>> =
+  zip(other, ::Pair)
 
-public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  map: (A, B) -> C
-): Maybe<C> =
+public inline fun <reified A, reified B, C> Maybe<A>.zip(b: Maybe<B>, map: (A, B) -> C): Maybe<C> =
   zip(b, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit) {
     b,
     c,
@@ -128,7 +123,7 @@ public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.zip(
     map(b, c)
   }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, D : Any> Maybe<A>.zip(
+public inline fun <reified A, reified B, reified C, D> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   map: (A, B, C) -> D
@@ -147,8 +142,7 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, D : Any> M
     map(b, c, d)
   }
 
-public inline fun <
-  reified A : Any, reified B : Any, reified C : Any, reified D : Any, E : Any> Maybe<A>.zip(
+public inline fun <reified A, reified B, reified C, reified D, E> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -168,9 +162,7 @@ public inline fun <
     map(a, b, c, d)
   }
 
-public inline fun <
-  reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, F : Any
-> Maybe<A>.zip(
+public inline fun <reified A, reified B, reified C, reified D, reified E, F> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -182,15 +174,8 @@ public inline fun <
     map(a, b, c, d, e)
   }
 
-public inline fun <
-  reified A : Any,
-  reified B : Any,
-  reified C : Any,
-  reified D : Any,
-  reified E : Any,
-  reified F : Any,
-  G : Any
-> Maybe<A>.zip(
+public inline fun <reified A, reified B, reified C, reified D, reified E, reified F, G> Maybe<A>
+  .zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -203,15 +188,7 @@ public inline fun <
   }
 
 public inline fun <
-  reified A : Any,
-  reified B : Any,
-  reified C : Any,
-  reified D : Any,
-  reified E : Any,
-  reified F : Any,
-  reified G : Any,
-  H : Any
-> Maybe<A>.zip(
+  reified A, reified B, reified C, reified D, reified E, reified F, reified G, H> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -225,16 +202,9 @@ public inline fun <
   }
 
 public inline fun <
-  reified A : Any,
-  reified B : Any,
-  reified C : Any,
-  reified D : Any,
-  reified E : Any,
-  reified F : Any,
-  reified G : Any,
-  reified H : Any,
-  I : Any
-> Maybe<A>.zip(
+  reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, I> Maybe<
+  A>
+  .zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -249,16 +219,16 @@ public inline fun <
   }
 
 public inline fun <
-  reified A : Any,
-  reified B : Any,
-  reified C : Any,
-  reified D : Any,
-  reified E : Any,
-  reified F : Any,
-  reified G : Any,
-  reified H : Any,
-  reified I : Any,
-  J : Any
+  reified A,
+  reified B,
+  reified C,
+  reified D,
+  reified E,
+  reified F,
+  reified G,
+  reified H,
+  reified I,
+  J
 > Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
@@ -275,17 +245,17 @@ public inline fun <
   }
 
 public inline fun <
-  reified A : Any,
-  reified B : Any,
-  reified C : Any,
-  reified D : Any,
-  reified E : Any,
-  reified F : Any,
-  reified G : Any,
-  reified H : Any,
-  reified I : Any,
-  reified J : Any,
-  K : Any
+  reified A,
+  reified B,
+  reified C,
+  reified D,
+  reified E,
+  reified F,
+  reified G,
+  reified H,
+  reified I,
+  reified J,
+  K
 > Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
@@ -298,21 +268,47 @@ public inline fun <
   j: Maybe<J>,
   map: (A, B, C, D, E, F, G, H, I, J) -> K
 ): Maybe<K> {
-  Nullable.zip(
-    this.orNull(),
-    b.orNull(),
-    c.orNull(),
-    d.orNull(),
-    e.orNull(),
-    f.orNull(),
-    g.orNull(),
-    h.orNull(),
-    i.orNull(),
-    j.orNull()
-  ) { a, b, c, d, e, f, g, h, i, j ->
-    return Just(map(a, b, c, d, e, f, g, h, i, j))
-  }
-  return Nothing
+  val a =
+    this.getOrElse {
+      return Nothing
+    }
+  val b =
+    b.getOrElse {
+      return Nothing
+    }
+  val c =
+    c.getOrElse {
+      return Nothing
+    }
+  val d =
+    d.getOrElse {
+      return Nothing
+    }
+  val e =
+    e.getOrElse {
+      return Nothing
+    }
+  val f =
+    f.getOrElse {
+      return Nothing
+    }
+  val g =
+    g.getOrElse {
+      return Nothing
+    }
+  val h =
+    h.getOrElse {
+      return Nothing
+    }
+  val i =
+    i.getOrElse {
+      return Nothing
+    }
+  val j =
+    j.getOrElse {
+      return Nothing
+    }
+  return Just(map(a, b, c, d, e, f, g, h, i, j))
 }
 
 /**
@@ -323,17 +319,18 @@ public inline fun <
  * @param f the function to apply
  * @see map
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> =
+public inline fun <reified A, B> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> =
   fold({ Nothing }, f)
 
 @OptIn(MaybeInternals::class)
-public inline fun <reified A : Any, R> Maybe<A>.fold(ifEmpty: () -> R, ifJust: (A) -> R): R =
+public inline fun <reified A, R> Maybe<A>.fold(ifEmpty: () -> R, ifJust: (A) -> R): R =
   when (this) {
     Nothing -> ifEmpty()
-    else ->
-      if (isTypeMaybe<A>())
-        Maybe.construct<Any>((this as Maybe<Any>).value).invokeBlockOnMaybe(ifJust)
+    else -> {
+      val value = value
+      if (isTypeMaybe<A>() && value != null) Maybe.construct<Any>(value).invokeBlockOnMaybe(ifJust)
       else ifJust(value)
+    }
   }
 
 @PublishedApi
@@ -341,10 +338,9 @@ internal inline fun <R, A> Maybe<*>.invokeBlockOnMaybe(block: (A) -> R): R {
   return block(this as A)
 }
 
-public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> =
-  this.also { fold({}, f) }
+public inline fun <reified A> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> = this.also { fold({}, f) }
 
-public inline fun <reified A : Any> Maybe<A>.orNull(): A? =
+public inline fun <reified A> Maybe<A>.orNull(): A? =
   fold(
     {
       return null
@@ -353,7 +349,7 @@ public inline fun <reified A : Any> Maybe<A>.orNull(): A? =
   )
 
 @JvmName("orNullMaybe")
-public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? =
+public fun <A> Maybe<Maybe<A>>.orNull(): Maybe<A>? =
   fold(
     {
       return null
@@ -370,9 +366,7 @@ public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? =
  * @param f the function to apply
  * @see flatMap
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> = flatMap { a ->
-  Just(f(a))
-}
+public inline fun <reified A, B> Maybe<A>.map(f: (A) -> B): Maybe<B> = flatMap { a -> Just(f(a)) }
 
 /**
  * Returns $nothing if the result of applying $f to this $maybe's value is null. Otherwise returns
@@ -382,15 +376,12 @@ public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B>
  *
  * @param f the function to apply.
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.mapNotNull(f: (A) -> B?): Maybe<B> =
-  flatMap { a ->
-    Maybe.fromNullable(f(a))
-  }
+public inline fun <reified A, B> Maybe<A>.mapNotNull(f: (A) -> B?): Maybe<B> = flatMap { a ->
+  Maybe.fromNullable(f(a))
+}
 
 /** Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior]. */
-public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(
-  b: Maybe<B>
-): Maybe<Ior<A, B>> =
+public inline infix fun <reified A, reified B> Maybe<A>.align(b: Maybe<B>): Maybe<Ior<A, B>> =
   fold(
     { b.fold({ Nothing }, { b -> Just(b.rightIor()) }) },
     { a -> b.fold({ Just(a.leftIor()) }, { b -> Just(Pair(a, b).bothIor()) }) }
@@ -403,7 +394,7 @@ public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(
  * @note This function works like a regular `align` function, but is then mapped by the `map`
  * function.
  */
-public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.align(
+public inline fun <reified A, reified B, C> Maybe<A>.align(
   b: Maybe<B>,
   f: (Ior<A, B>) -> C
 ): Maybe<C> = align(b).map(f)
@@ -414,19 +405,16 @@ public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.align(
  *
  * @param predicate the predicate to test
  */
-public inline fun <reified A : Any> Maybe<A>.all(predicate: (A) -> Boolean): Boolean =
+public inline fun <reified A> Maybe<A>.all(predicate: (A) -> Boolean): Boolean =
   fold({ true }, predicate)
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalk(
-  f: (A) -> Maybe<B>
-): Maybe<Maybe<B>> =
-  fold({ Nothing }, { value -> f(value).map<Any, Maybe<B>> { Just(it) as Maybe<B> } })
+public inline fun <reified A, B> Maybe<A>.crosswalk(f: (A) -> Maybe<B>): Maybe<Maybe<B>> =
+  fold({ Nothing }, { value -> f(value).map<Any?, Maybe<B>> { Just(it) as Maybe<B> } })
 
-public inline fun <reified A : Any, K, V : Any> Maybe<A>.crosswalkMap(
-  f: (A) -> Map<K, V>
-): Map<K, Maybe<V>> = fold({ emptyMap() }, { value -> f(value).mapValues { Just(it.value) } })
+public inline fun <reified A, K, V> Maybe<A>.crosswalkMap(f: (A) -> Map<K, V>): Map<K, Maybe<V>> =
+  fold({ emptyMap() }, { value -> f(value).mapValues { Just(it.value) } })
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNull(f: (A) -> B?): Maybe<B>? =
+public inline fun <reified A, B> Maybe<A>.crosswalkNull(f: (A) -> B?): Maybe<B>? =
   fold(
     {
       return null
@@ -442,10 +430,9 @@ public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNull(f: (A) -> B?
  *
  * @param predicate the predicate used for testing.
  */
-public inline fun <reified A : Any> Maybe<A>.filter(predicate: (A) -> Boolean): Maybe<A> =
-  flatMap { a ->
-    if (predicate(a)) Just(a) else Nothing
-  }
+public inline fun <reified A> Maybe<A>.filter(predicate: (A) -> Boolean): Maybe<A> = flatMap { a ->
+  if (predicate(a)) Just(a) else Nothing
+}
 
 /**
  * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to this $maybe's value
@@ -453,15 +440,15 @@ public inline fun <reified A : Any> Maybe<A>.filter(predicate: (A) -> Boolean): 
  *
  * @param predicate the predicate used for testing.
  */
-public inline fun <reified A : Any> Maybe<A>.filterNot(predicate: (A) -> Boolean): Maybe<A> =
+public inline fun <reified A> Maybe<A>.filterNot(predicate: (A) -> Boolean): Maybe<A> =
   flatMap { a ->
     if (!predicate(a)) Just(a) else Nothing
   }
 
-public inline fun <reified A : Any> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean =
+public inline fun <reified A> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean =
   fold({ false }, predicate)
 
-public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolean): A? =
+public inline fun <reified A> Maybe<A>.findOrNull(predicate: (A) -> Boolean): A? =
   fold(
     {
       return null
@@ -472,9 +459,7 @@ public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolea
   )
 
 @JvmName("maybeFindOrNull")
-public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(
-  predicate: (Maybe<A>) -> Boolean
-): Maybe<A>? =
+public inline fun <A> Maybe<Maybe<A>>.findOrNull(predicate: (Maybe<A>) -> Boolean): Maybe<A>? =
   fold(
     {
       return null
@@ -484,28 +469,27 @@ public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(
     }
   )
 
-public inline fun <reified A : Any, B> Maybe<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B =
+public inline fun <reified A, B> Maybe<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B =
   MB.run { foldLeft(empty()) { b, a -> b.combine(f(a)) } }
 
 @JvmName("foldMapMaybe")
-public inline fun <reified A : Any, B : Any> Maybe<A>.foldMap(
+public inline fun <reified A, B> Maybe<A>.foldMap(
   MB: Monoid<Maybe<B>>,
   f: (A) -> Maybe<B>
 ): Maybe<B> = MB.run { foldLeft(emptyMaybe()) { b, a -> combineToMaybe(b, f(a)).flatten() } }
 
-public inline fun <reified A : Any, B> Maybe<A>.foldLeft(initial: B, operation: (B, A) -> B): B =
+public inline fun <reified A, B> Maybe<A>.foldLeft(initial: B, operation: (B, A) -> B): B =
   fold({ initial }, { operation(initial, it) })
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.foldLeft(
+public inline fun <reified A, B> Maybe<A>.foldLeft(
   initial: Maybe<B>,
   operation: (Maybe<B>, A) -> Maybe<B>
 ): Maybe<B> = fold({ initial }, { operation(initial, it) })
 
-public inline fun <reified A : Any, reified B : Any> Maybe<A>.padZip(
-  other: Maybe<B>
-): Maybe<Pair<A?, B?>> = padZip(other, ::Pair)
+public inline fun <reified A, reified B> Maybe<A>.padZip(other: Maybe<B>): Maybe<Pair<A?, B?>> =
+  padZip(other, ::Pair)
 
-public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZip(
+public inline fun <reified A, reified B, C> Maybe<A>.padZip(
   other: Maybe<B>,
   f: (A?, B?) -> C
 ): Maybe<C> =
@@ -514,7 +498,7 @@ public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZip(
     { a -> other.fold({ Just(f(a, null)) }, { b -> Just(f(a, b)) }) }
   )
 
-public inline fun <reified A : Any, B> Maybe<A>.reduceOrNull(
+public inline fun <reified A, B> Maybe<A>.reduceOrNull(
   initial: (A) -> B,
   operation: (acc: B, A) -> B
 ): B? =
@@ -525,7 +509,7 @@ public inline fun <reified A : Any, B> Maybe<A>.reduceOrNull(
     { operation(initial(it), it) }
   )
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.reduceOrNullMaybe(
+public inline fun <reified A, B> Maybe<A>.reduceOrNullMaybe(
   initial: (A) -> Maybe<B>,
   operation: (acc: Maybe<B>, A) -> Maybe<B>
 ): Maybe<B>? =
@@ -536,18 +520,17 @@ public inline fun <reified A : Any, B : Any> Maybe<A>.reduceOrNullMaybe(
     { operation(initial(it), it) }
   )
 
-public inline fun <reified A : Any> Maybe<A>.replicate(n: Int): Maybe<List<A>> =
+public inline fun <reified A> Maybe<A>.replicate(n: Int): Maybe<List<A>> =
   if (n <= 0) Just(emptyList()) else map { a -> List(n) { a } }
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <reified A : Any, B : Any> Maybe<A>.traverse(
-  fa: (A) -> Iterable<B>
-): List<Maybe<B>> = fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
+public inline fun <reified A, B> Maybe<A>.traverse(fa: (A) -> Iterable<B>): List<Maybe<B>> =
+  fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(
+public inline fun <reified A, AA, B> Maybe<A>.traverse(
   fa: (A) -> Either<AA, B>
 ): Either<AA, Maybe<B>> = fold({ Right(Nothing) }, { value -> fa(value).map { Just(it) } })
 
@@ -555,13 +538,13 @@ public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(
   "traverseEither is being renamed to traverse to simplify the Arrow API",
   ReplaceWith("traverse(fa)")
 )
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseEither(
+public inline fun <reified A, AA, B> Maybe<A>.traverseEither(
   fa: (A) -> Either<AA, B>
 ): Either<AA, Maybe<B>> = traverse(fa)
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(
+public inline fun <reified A, AA, B> Maybe<A>.traverse(
   fa: (A) -> Validated<AA, B>
 ): Validated<AA, Maybe<B>> = fold({ Valid(Nothing) }, { value -> fa(value).map { Just(it) } })
 
@@ -569,24 +552,24 @@ public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(
   "traverseValidated is being renamed to traverse to simplify the Arrow API",
   ReplaceWith("traverse(fa)")
 )
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseValidated(
+public inline fun <reified A, AA, B> Maybe<A>.traverseValidated(
   fa: (A) -> Validated<AA, B>
 ): Validated<AA, Maybe<B>> = traverse(fa)
 
-public inline fun <reified A : Any, L> Maybe<A>.toEither(ifEmpty: () -> L): Either<L, A> =
+public inline fun <reified A, L> Maybe<A>.toEither(ifEmpty: () -> L): Either<L, A> =
   fold({ ifEmpty().left() }, { it.right() })
 
-public inline fun <reified A : Any> Maybe<A>.toList(): List<A> = fold(::emptyList) { listOf(it) }
+public inline fun <reified A> Maybe<A>.toList(): List<A> = fold(::emptyList) { listOf(it) }
 
 public fun Maybe<*>.void(): Maybe<Unit> = justUnit
 
-public inline fun <reified A : Any, L> Maybe<A>.pairLeft(left: L): Maybe<Pair<L, A>> =
+public inline fun <reified A, L> Maybe<A>.pairLeft(left: L): Maybe<Pair<L, A>> =
   this.map { left to it }
 
-public inline fun <reified A : Any, R> Maybe<A>.pairRight(right: R): Maybe<Pair<A, R>> =
+public inline fun <reified A, R> Maybe<A>.pairRight(right: R): Maybe<Pair<A, R>> =
   this.map { it to right }
 
-public infix fun <A : Any, X : Any> Maybe<A>.and(value: Maybe<X>): Maybe<X> =
+public infix fun <A, X> Maybe<A>.and(value: Maybe<X>): Maybe<X> =
   if (isEmpty()) {
     Nothing
   } else {
@@ -594,31 +577,56 @@ public infix fun <A : Any, X : Any> Maybe<A>.and(value: Maybe<X>): Maybe<X> =
   }
 
 @PublishedApi
-internal data class NestedNothing private constructor(val nesting: Int) {
+internal data class NestedNothing private constructor(val nesting: UInt) {
   companion object {
-    private val cache = Array(22) { NestedNothing(it) }
-    operator fun invoke(nesting: Int) = cache.getOrElse(nesting, ::NestedNothing)
+    private val cache = Array(22) { NestedNothing(it.toUInt()) }
+    operator fun invoke(nesting: UInt) =
+      cache.getOrElse(nesting.toInt()) { NestedNothing(it.toUInt()) }
   }
 
   override fun toString(): String =
-    buildString("Maybe.Just()".length * nesting + "Maybe.Nothing".length) {
-      repeat(nesting) { this.append("Maybe.Just(") }
-      append("Maybe.Nothing")
-      repeat(nesting) { this.append(")") }
+    nesting.toInt().coerceAtLeast(0).let { nesting ->
+      buildString("Maybe.Just()".length * nesting + "Maybe.Nothing".length) {
+        repeat(nesting) { this.append("Maybe.Just(") }
+        append("Maybe.Nothing")
+        repeat(nesting) { this.append(")") }
+      }
+    }
+}
+
+@PublishedApi
+internal data class NestedNull private constructor(val nesting: UInt) {
+  companion object {
+    private val cache = Array(22) { NestedNull(it.toUInt()) }
+    operator fun invoke(nesting: UInt) =
+      cache.getOrElse(nesting.toInt()) { NestedNull(it.toUInt()) }
+  }
+
+  override fun toString(): String =
+    nesting.toInt().coerceAtLeast(0).let { nesting ->
+      buildString("Maybe.Just()".length * nesting + "null".length) {
+        repeat(nesting) { this.append("Maybe.Just(") }
+        append("null")
+        repeat(nesting) { this.append(")") }
+      }
     }
 }
 
 @OptIn(MaybeInternals::class)
-public inline fun <T : Any> Just(value: T): Maybe<T> {
+public inline fun <T> Just(value: T): Maybe<T> {
   // This `is` check gets inlined by the compiler if `value` is statically known to be Maybe
   return _Just(if (value is Maybe<*>) value.underlying else value)
 }
 
 @MaybeInternals
 @PublishedApi
-internal fun <T : Any> _Just(trueValue: Any): Maybe<T> =
+internal fun <T> _Just(trueValue: Any?): Maybe<T> =
   Maybe.construct(
-    if (trueValue is NestedNothing) NestedNothing(trueValue.nesting + 1) else trueValue
+    when (trueValue) {
+      is NestedNothing -> NestedNothing(trueValue.nesting + 1U)
+      is NestedNull -> NestedNull(trueValue.nesting + 1U)
+      else -> trueValue ?: NestedNull(0U)
+    }
   )
 
 @PublishedApi internal val justUnit: Maybe<Unit> = Just(Unit)
@@ -631,7 +639,7 @@ internal fun <T : Any> _Just(trueValue: Any): Maybe<T> =
  *
  * @param default the default expression.
  */
-public inline fun <reified T : Any> Maybe<T>.getOrElse(default: () -> T): T =
+public inline fun <reified T> Maybe<T>.getOrElse(default: () -> T): T =
   fold({ default() }, ::identity)
 
 /**
@@ -641,7 +649,7 @@ public inline fun <reified T : Any> Maybe<T>.getOrElse(default: () -> T): T =
  * @param default the default expression.
  */
 @JvmName("maybeGetOrElse")
-public inline fun <T : Any> Maybe<Maybe<T>>.getOrElse(default: () -> Maybe<T>): Maybe<T> =
+public inline fun <T> Maybe<Maybe<T>>.getOrElse(default: () -> Maybe<T>): Maybe<T> =
   fold({ default() }, ::identity)
 
 /**
@@ -650,56 +658,55 @@ public inline fun <T : Any> Maybe<Maybe<T>>.getOrElse(default: () -> Maybe<T>): 
  *
  * @param alternative the default maybe if this is empty.
  */
-public inline fun <A : Any> Maybe<A>.orElse(alternative: () -> Maybe<A>): Maybe<A> =
+public inline fun <A> Maybe<A>.orElse(alternative: () -> Maybe<A>): Maybe<A> =
   if (isEmpty()) alternative() else this
 
-public infix fun <T : Any> Maybe<T>.or(value: Maybe<T>): Maybe<T> =
+public infix fun <T> Maybe<T>.or(value: Maybe<T>): Maybe<T> =
   if (isEmpty()) {
     value
   } else {
     this
   }
 
-public inline fun <T : Any> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
+public inline fun <T> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
 
 public inline fun Nothing?.toMaybe(): Maybe<Nothing> = Nothing
 
-public fun <T : Any> Maybe<T>?.toMaybe(): Maybe<Maybe<T>> = this?.let { Just(it) } ?: Nothing
+public fun <T> Maybe<T>?.toMaybe(): Maybe<Maybe<T>> = this?.let { Just(it) } ?: Nothing
 
-public inline fun <A : Any> Boolean.maybe2(f: () -> A): Maybe<A> =
+public inline fun <A> Boolean.maybe2(f: () -> A): Maybe<A> =
   if (this) {
     Just(f())
   } else {
     Nothing
   }
 
-public inline fun <A : Any> A.just(): Maybe<A> = Just(this)
+public inline fun <A> A.just(): Maybe<A> = Just(this)
 
-public fun <A : Any> nothing(): Maybe<A> = Nothing
+public fun <A> nothing(): Maybe<A> = Nothing
 
-public inline fun <reified A : Any> Monoid.Companion.maybe(MA: Semigroup<A>): Monoid<Maybe<A>> =
+public inline fun <reified A> Monoid.Companion.maybe(MA: Semigroup<A>): Monoid<Maybe<A>> =
   if (isTypeMaybe<A>()) MaybeMonoidNested(MA as Semigroup<Maybe<A>>) as Monoid<Maybe<A>>
   else MaybeMonoid(MA)
 
 @JvmName("maybeMaybe")
-public inline fun <A : Any> Monoid.Companion.maybe(
-  MA: Semigroup<Maybe<A>>
-): Monoid<Maybe<Maybe<A>>> = MaybeMonoidNested(MA)
+public inline fun <A> Monoid.Companion.maybe(MA: Semigroup<Maybe<A>>): Monoid<Maybe<Maybe<A>>> =
+  MaybeMonoidNested(MA)
 
 @PublishedApi
-internal open class MaybeMonoid<A : Any>(protected val MA: Semigroup<A>) : Monoid<Maybe<A>> {
+internal open class MaybeMonoid<A>(protected val MA: Semigroup<A>) : Monoid<Maybe<A>> {
 
   override fun Maybe<A>.combine(b: Maybe<A>): Maybe<A> =
-    combine(MA as Semigroup<Any>, b) as Maybe<A>
+    combine(MA as Semigroup<Any?>, b) as Maybe<A>
 
   override fun Maybe<A>.maybeCombine(b: Maybe<A>?): Maybe<A> =
-    b?.let { combine(MA as Semigroup<Any>, it) as Maybe<A> } ?: this
+    b?.let { combine(MA as Semigroup<Any?>, it) as Maybe<A> } ?: this
 
   override fun empty(): Maybe<A> = Nothing
 }
 
 @PublishedApi
-internal class MaybeMonoidNested<A : Any>(MA: Semigroup<Maybe<A>>) : MaybeMonoid<Maybe<A>>(MA) {
+internal class MaybeMonoidNested<A>(MA: Semigroup<Maybe<A>>) : MaybeMonoid<Maybe<A>>(MA) {
 
   override fun Maybe<Maybe<A>>.combine(b: Maybe<Maybe<A>>): Maybe<Maybe<A>> = combine(MA, b)
 
@@ -713,19 +720,19 @@ internal class MaybeMonoidNested<A : Any>(MA: Semigroup<Maybe<A>>) : MaybeMonoid
   "use fold instead",
   ReplaceWith("fold(Monoid.maybe(MA))", "arrow.core.fold", "arrow.typeclasses.Monoid")
 )
-public inline fun <reified A : Any> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> =
+public inline fun <reified A> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> =
   fold(Monoid.maybe(MA))
 
 @Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
-public inline fun <reified A : Any> Maybe<A>.combineAll(MA: Monoid<A>): A = getOrElse { MA.empty() }
+public inline fun <reified A> Maybe<A>.combineAll(MA: Monoid<A>): A = getOrElse { MA.empty() }
 
 @JvmName("maybeCombineAll")
 @Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
-public fun <A : Any> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> = getOrElse {
+public fun <A> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> = getOrElse {
   MA.emptyMaybe()
 }
 
-public inline fun <reified A : Any> Maybe<A>.ensure(
+public inline fun <reified A> Maybe<A>.ensure(
   error: () -> Unit,
   predicate: (A) -> Boolean
 ): Maybe<A> =
@@ -741,7 +748,7 @@ public inline fun <reified A : Any> Maybe<A>.ensure(
   )
 
 /** Returns a Maybe containing all elements that are instances of specified type parameter [B]. */
-public inline fun <reified B : Any> Maybe<*>.filterIsInstance(): Maybe<B> = flatMap {
+public inline fun <reified B> Maybe<*>.filterIsInstance(): Maybe<B> = flatMap {
   when (it) {
     is B -> Just(it)
     else -> Nothing
@@ -749,33 +756,31 @@ public inline fun <reified B : Any> Maybe<*>.filterIsInstance(): Maybe<B> = flat
 }
 
 @JvmName("maybeFilterIsInstance")
-public inline fun <reified B : Any> Maybe<Maybe<*>>.filterIsInstance(): Maybe<B> = flatMap {
+public inline fun <reified B> Maybe<Maybe<*>>.filterIsInstance(): Maybe<B> = flatMap {
   when (it) {
     is B -> Just(it)
     else -> Nothing
   }
 }
 
-public inline fun <A : Any> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> = handleErrorWith {
+public inline fun <A> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> = handleErrorWith {
   Just(f(Unit))
 }
 
-public inline fun <A : Any> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> =
+public inline fun <A> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> =
   if (isEmpty()) f(Unit) else this
 
-public fun <A : Any> Maybe<Maybe<A>>.flatten(): Maybe<A> = flatMap(::identity)
+public fun <A> Maybe<Maybe<A>>.flatten(): Maybe<A> = flatMap(::identity)
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.redeem(
-  fe: (Unit) -> B,
-  fb: (A) -> B
-): Maybe<B> = map(fb).handleError(fe)
+public inline fun <reified A, B> Maybe<A>.redeem(fe: (Unit) -> B, fb: (A) -> B): Maybe<B> =
+  map(fb).handleError(fe)
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.redeemWith(
+public inline fun <reified A, B> Maybe<A>.redeemWith(
   fe: (Unit) -> Maybe<B>,
   fb: (A) -> Maybe<B>
 ): Maybe<B> = flatMap(fb).handleErrorWith(fe)
 
-public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): Maybe<A> =
+public inline fun <reified A> Maybe<A>.replicate(n: Int, MA: Monoid<A>): Maybe<A> =
   MA.run {
     if (n <= 0) Just(empty())
     else
@@ -787,7 +792,7 @@ public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): M
   }
 
 @JvmName("replicateMaybe")
-public fun <A : Any> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Maybe<Maybe<A>> =
+public fun <A> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Maybe<Maybe<A>> =
   MA.run {
     if (n <= 0) Just(emptyMaybe())
     else
@@ -799,18 +804,18 @@ public fun <A : Any> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Ma
   }
 
 @PublishedApi
-internal inline fun <A : Any> Monoid<Maybe<A>>.emptyMaybe(): Maybe<A> =
+internal inline fun <A> Monoid<Maybe<A>>.emptyMaybe(): Maybe<A> =
   when (this) {
     is MaybeMonoid<*> -> (this as MaybeMonoid<*>).empty()
     else -> this.empty()
   }
     as Maybe<A>
 
-public fun <A : Any> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> = flatMap {
+public fun <A> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> = flatMap {
   it.fold({ Nothing }, { a -> Just(a) })
 }
 
-public inline fun <reified A : Any> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A>): Maybe<A> {
+public inline fun <reified A> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A>): Maybe<A> {
   map { a ->
     b.map { b ->
       return SA.combineToMaybe(a, b)
@@ -825,7 +830,7 @@ public inline fun <reified A : Any> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A
  * @receiver Maybe of Either
  * @return a tuple containing Maybe of [Either.Left] and another Maybe of its [Either.Right] value.
  */
-public fun <A : Any, B : Any> Maybe<Either<A, B>>.separateEither(): Pair<Maybe<A>, Maybe<B>> {
+public fun <A, B> Maybe<Either<A, B>>.separateEither(): Pair<Maybe<A>, Maybe<B>> {
   val asep = flatMap { gab -> gab.fold({ Just(it) }, { Nothing }) }
   val bsep = flatMap { gab -> gab.fold({ Nothing }, { Just(it) }) }
   return asep to bsep
@@ -838,36 +843,33 @@ public fun <A : Any, B : Any> Maybe<Either<A, B>>.separateEither(): Pair<Maybe<A
  * @return a tuple containing Maybe of [Validated.Invalid] and another Maybe of its
  * [Validated.Valid] value.
  */
-public fun <A : Any, B : Any> Maybe<Validated<A, B>>.separateValidated(): Pair<Maybe<A>, Maybe<B>> {
+public fun <A, B> Maybe<Validated<A, B>>.separateValidated(): Pair<Maybe<A>, Maybe<B>> {
   val asep = flatMap { gab -> gab.fold({ Just(it) }, { Nothing }) }
   val bsep = flatMap { gab -> gab.fold({ Nothing }, { Just(it) }) }
   return asep to bsep
 }
 
-public fun <A : Any> Maybe<Iterable<A>>.sequence(): List<Maybe<A>> = traverse(::identity)
+public fun <A> Maybe<Iterable<A>>.sequence(): List<Maybe<A>> = traverse(::identity)
 
 @Deprecated(
   "sequenceEither is being renamed to sequence to simplify the Arrow API",
   ReplaceWith("sequence()", "arrow.core.sequence")
 )
-public fun <A, B : Any> Maybe<Either<A, B>>.sequenceEither(): Either<A, Maybe<B>> = sequence()
+public fun <A, B> Maybe<Either<A, B>>.sequenceEither(): Either<A, Maybe<B>> = sequence()
 
-public fun <A, B : Any> Maybe<Either<A, B>>.sequence(): Either<A, Maybe<B>> = traverse(::identity)
+public fun <A, B> Maybe<Either<A, B>>.sequence(): Either<A, Maybe<B>> = traverse(::identity)
 
 @Deprecated(
   "sequenceValidated is being renamed to sequence to simplify the Arrow API",
   ReplaceWith("sequence()", "arrow.core.sequence")
 )
-public fun <A, B : Any> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> =
-  sequence()
+public fun <A, B> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> = sequence()
 
-public fun <A, B : Any> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> =
-  traverse(::identity)
+public fun <A, B> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> = traverse(::identity)
 
-public fun <A : Any, B : Any> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> =
-  unalign(::identity)
+public fun <A, B> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> = unalign(::identity)
 
-public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unalign(
+public inline fun <A, B, reified C> Maybe<C>.unalign(
   f: (C) -> Ior<A, B>
 ): Pair<Maybe<A>, Maybe<B>> =
   this.map(f)
@@ -882,39 +884,36 @@ public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unalign(
       }
     )
 
-public fun <A : Any> Maybe<Iterable<A>>.unite(MA: Monoid<A>): Maybe<A> = map { iterable ->
+public fun <A> Maybe<Iterable<A>>.unite(MA: Monoid<A>): Maybe<A> = map { iterable ->
   iterable.fold(MA)
 }
 
-public fun <A, B : Any> Maybe<Either<A, B>>.uniteEither(): Maybe<B> = flatMap { either ->
+public fun <A, B> Maybe<Either<A, B>>.uniteEither(): Maybe<B> = flatMap { either ->
   either.fold({ Nothing }, { b -> Just(b) })
 }
 
-public fun <A, B : Any> Maybe<Validated<A, B>>.uniteValidated(): Maybe<B> = flatMap { validated ->
+public fun <A, B> Maybe<Validated<A, B>>.uniteValidated(): Maybe<B> = flatMap { validated ->
   validated.fold({ Nothing }, { b -> Just(b) })
 }
 
-public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> =
-  unzip(::identity)
+public fun <A, B> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> = unzip(::identity)
 
-public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unzip(
-  f: (C) -> Pair<A, B>
-): Pair<Maybe<A>, Maybe<B>> =
+public inline fun <A, B, reified C> Maybe<C>.unzip(f: (C) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
   fold({ Nothing to Nothing }, { f(it).let { pair -> Just(pair.first) to Just(pair.second) } })
 
-public fun <B : Any, A : B> Maybe<A>.widen(): Maybe<B> = this
+public fun <B, A : B> Maybe<A>.widen(): Maybe<B> = this
 
 public fun <K, V> Maybe<Pair<K, V>>.toMap(): Map<K, V> = this.toList().toMap()
 
-public inline fun <reified A : Any> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
+public inline fun <reified A> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
   fold({ b }, { first -> b.fold({ this }, { second -> SGA.combineToMaybe(first, second) }) })
 
 @Suppress("UNCHECKED_CAST")
 @PublishedApi
-internal inline fun <A : Any> Semigroup<A>.combineToMaybe(first: A, second: A): Maybe<A> =
+internal inline fun <A> Semigroup<A>.combineToMaybe(first: A, second: A): Maybe<A> =
   when {
     this is MaybeMonoid<*> ->
-      (this as MaybeMonoid<Any>).run {
+      (this as MaybeMonoid<Any?>).run {
         Just((first as Maybe<*>).combine(second as Maybe<*>)) as Maybe<A>
       }
     first is Maybe<*> || second is Maybe<*> ->
@@ -928,31 +927,31 @@ internal inline fun <A : Any> Semigroup<A>.combineToMaybe(first: A, second: A): 
  * Purposefully NOT inline because, as the name suggests, this will cause the [this] to be reboxed,
  * which convinces the compiler that [this] Maybe is not being used in an Any or generic context
  */
-@PublishedApi internal fun <A : Any> Maybe<A>.rebox(): Maybe<A> = this
+@PublishedApi internal fun <A> Maybe<A>.rebox(): Maybe<A> = this
 
 public inline operator fun <reified A : Comparable<A>> Maybe<A>.compareTo(other: Maybe<A>): Int =
   fold({ other.fold({ 0 }, { -1 }) }, { a1 -> other.fold({ 1 }, { a2 -> a1.compareTo(a2) }) })
 
-public fun <A, B : Any> Either<A, B>.orNothing(): Maybe<B> = fold({ Nothing }, { Just(it) })
+public fun <A, B> Either<A, B>.orNothing(): Maybe<B> = fold({ Nothing }, { Just(it) })
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, B, reified C : Any> Either<A, B>.traverse(
+public inline fun <A, B, reified C> Either<A, B>.traverse(
   fa: (B) -> Maybe<C>
 ): Maybe<Either<A, C>> = fold({ Nothing }, { right -> fa(right).map(::Right) })
 
-public inline fun <A, B, reified AA : Any, reified C : Any> Either<A, B>.bitraverseMaybe(
+public inline fun <A, B, reified AA, reified C> Either<A, B>.bitraverseMaybe(
   fl: (A) -> Maybe<AA>,
   fr: (B) -> Maybe<C>
 ): Maybe<Either<AA, C>> = fold({ fl(it).map(::Left) }, { fr(it).map(::Right) })
 
-public inline fun <A, reified B : Any> Either<A, Maybe<B>>.sequence(): Maybe<Either<A, B>> =
+public inline fun <A, reified B> Either<A, Maybe<B>>.sequence(): Maybe<Either<A, B>> =
   traverse(::identity)
 
-public inline fun <reified A : Any, reified B : Any> Either<Maybe<A>, Maybe<B>>.bisequenceMaybe():
+public inline fun <reified A, reified B> Either<Maybe<A>, Maybe<B>>.bisequenceMaybe():
   Maybe<Either<A, B>> = bitraverseMaybe(::identity, ::identity)
 
-public inline fun <A, B, reified C : Any, reified D : Any> Ior<A, B>.bitraverseMaybe(
+public inline fun <A, B, reified C, reified D> Ior<A, B>.bitraverseMaybe(
   fa: (A) -> Maybe<C>,
   fb: (B) -> Maybe<D>
 ): Maybe<Ior<C, D>> =
@@ -964,24 +963,22 @@ public inline fun <A, B, reified C : Any, reified D : Any> Ior<A, B>.bitraverseM
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, B, reified C : Any> Ior<A, B>.traverse(
-  fa: (B) -> Maybe<C>
-): Maybe<Ior<A, C>> =
+public inline fun <A, B, reified C> Ior<A, B>.traverse(fa: (B) -> Maybe<C>): Maybe<Ior<A, C>> =
   fold(
     { a -> Just(Ior.Left(a)) },
     { b -> fa(b).map { Ior.Right(it) } },
     { a, b -> fa(b).map { Ior.Both(a, it) } }
   )
 
-public inline fun <reified B : Any, reified C : Any> Ior<Maybe<B>, Maybe<C>>.bisequenceMaybe():
+public inline fun <reified B, reified C> Ior<Maybe<B>, Maybe<C>>.bisequenceMaybe():
   Maybe<Ior<B, C>> = bitraverseMaybe(::identity, ::identity)
 
-public inline fun <A, reified B : Any> Ior<A, Maybe<B>>.sequence(): Maybe<Ior<A, B>> =
+public inline fun <A, reified B> Ior<A, Maybe<B>>.sequence(): Maybe<Ior<A, B>> =
   traverse(::identity)
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, reified B : Any> Iterable<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
+public inline fun <A, reified B> Iterable<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
   val destination = ArrayList<B>(collectionSizeOrDefault(10))
   for (item in this) {
     f(item)
@@ -995,13 +992,12 @@ public inline fun <A, reified B : Any> Iterable<A>.traverse(f: (A) -> Maybe<B>):
   return destination.just()
 }
 
-public inline fun <reified A : Any> Iterable<Maybe<A>>.sequence(): Maybe<List<A>> =
-  traverse(::identity)
+public inline fun <reified A> Iterable<Maybe<A>>.sequence(): Maybe<List<A>> = traverse(::identity)
 
 /**
  * Returns the first element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty.
  */
-public fun <T : Any> Iterable<T>.firstOrNothing(): Maybe<T> =
+public fun <T> Iterable<T>.firstOrNothing(): Maybe<T> =
   when (this) {
     is Collection ->
       if (!isEmpty()) {
@@ -1014,7 +1010,7 @@ public fun <T : Any> Iterable<T>.firstOrNothing(): Maybe<T> =
     }
   }
 
-private fun <T : Any> Iterator<T>.nextOrNothing(): Maybe<T> =
+private fun <T> Iterator<T>.nextOrNothing(): Maybe<T> =
   if (hasNext()) {
     Just(next())
   } else {
@@ -1025,7 +1021,7 @@ private fun <T : Any> Iterator<T>.nextOrNothing(): Maybe<T> =
  * Returns the first element as [Just(element)][Just] matching the given [predicate], or
  * [Maybe.Nothing] if element was not found.
  */
-public inline fun <T : Any> Iterable<T>.firstOrNothing(predicate: (T) -> Boolean): Maybe<T> {
+public inline fun <T> Iterable<T>.firstOrNothing(predicate: (T) -> Boolean): Maybe<T> {
   for (element in this) {
     if (predicate(element)) {
       return Just(element)
@@ -1038,7 +1034,7 @@ public inline fun <T : Any> Iterable<T>.firstOrNothing(predicate: (T) -> Boolean
  * Returns single element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty or
  * has more than one element.
  */
-public fun <T : Any> Iterable<T>.singleOrNothing(): Maybe<T> =
+public fun <T> Iterable<T>.singleOrNothing(): Maybe<T> =
   when (this) {
     is Collection ->
       when (size) {
@@ -1046,7 +1042,7 @@ public fun <T : Any> Iterable<T>.singleOrNothing(): Maybe<T> =
         else -> Nothing
       }
     else -> {
-      iterator().run { nextOrNothing().filter<Any> { !hasNext() } as Maybe<T> }
+      iterator().run { nextOrNothing().filter<Any?> { !hasNext() } as Maybe<T> }
     }
   }
 
@@ -1054,7 +1050,7 @@ public fun <T : Any> Iterable<T>.singleOrNothing(): Maybe<T> =
  * Returns the single element as [Just(element)][Just] matching the given [predicate], or
  * [Maybe.Nothing] if element was not found or more than one element was found.
  */
-public inline fun <T : Any> Iterable<T>.singleOrNothing(predicate: (T) -> Boolean): Maybe<T> {
+public inline fun <T> Iterable<T>.singleOrNothing(predicate: (T) -> Boolean): Maybe<T> {
   var result: Maybe<T> = Nothing
   for (element in this) {
     if (predicate(element)) {
@@ -1070,7 +1066,7 @@ public inline fun <T : Any> Iterable<T>.singleOrNothing(predicate: (T) -> Boolea
 /**
  * Returns the last element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty.
  */
-public fun <T : Any> Iterable<T>.lastOrNothing(): Maybe<T> =
+public fun <T> Iterable<T>.lastOrNothing(): Maybe<T> =
   when (this) {
     is Collection ->
       if (!isEmpty()) {
@@ -1094,7 +1090,7 @@ public fun <T : Any> Iterable<T>.lastOrNothing(): Maybe<T> =
  * Returns the last element as [Just(element)][Just] matching the given [predicate], or
  * [Maybe.Nothing] if no such element was found.
  */
-public inline fun <T : Any> Iterable<T>.lastOrNothing(predicate: (T) -> Boolean): Maybe<T> {
+public inline fun <T> Iterable<T>.lastOrNothing(predicate: (T) -> Boolean): Maybe<T> {
   var value: Maybe<T> = Nothing
   for (element in this) {
     if (predicate(element)) {
@@ -1108,7 +1104,7 @@ public inline fun <T : Any> Iterable<T>.lastOrNothing(predicate: (T) -> Boolean)
  * Returns an element as [Just(element)][Just] at the given [index] or [Maybe.Nothing] if the
  * [index] is out of bounds of this iterable.
  */
-public fun <T : Any> Iterable<T>.elementAtOrNothing(index: Int): Maybe<T> =
+public fun <T> Iterable<T>.elementAtOrNothing(index: Int): Maybe<T> =
   when {
     index < 0 -> Nothing
     this is Collection ->
@@ -1128,14 +1124,14 @@ private tailrec fun <T> Iterator<T>.skip(count: Int): Iterator<T> =
     else -> this
   }
 
-public inline fun <reified T : Any> Iterable<Maybe<T>>.filterMaybe(): List<T> =
+public inline fun <reified T> Iterable<Maybe<T>>.filterMaybe(): List<T> =
   mapNotNull(Maybe<T>::orNull)
 
-public inline fun <reified T : Any> Iterable<Maybe<T>>.flattenMaybe(): List<T> = filterMaybe()
+public inline fun <reified T> Iterable<Maybe<T>>.flattenMaybe(): List<T> = filterMaybe()
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <K, A, reified B : Any> Map<K, A>.traverse(f: (A) -> Maybe<B>): Maybe<Map<K, B>> {
+public inline fun <K, A, reified B> Map<K, A>.traverse(f: (A) -> Maybe<B>): Maybe<Map<K, B>> {
   val acc = mutableMapOf<K, B>()
   forEach { (k, v) ->
     f(v)
@@ -1149,18 +1145,18 @@ public inline fun <K, A, reified B : Any> Map<K, A>.traverse(f: (A) -> Maybe<B>)
   return acc.just()
 }
 
-public inline fun <K, reified V : Any> Map<K, Maybe<V>>.sequence(): Maybe<Map<K, V>> =
+public inline fun <K, reified V> Map<K, Maybe<V>>.sequence(): Maybe<Map<K, V>> =
   traverse(::identity)
 
-public inline fun <K, reified A : Any> Map<K, Maybe<A>>.filterOption(): Map<K, A> = filterMap {
+public inline fun <K, reified A> Map<K, Maybe<A>>.filterOption(): Map<K, A> = filterMap {
   it.orNull()
 }
 
-public fun <K, V : Any> Map<K, V>.getOrNothing(key: K): Maybe<V> = this[key].toMaybe()
+public fun <K, V> Map<K, V>.getOrNothing(key: K): Maybe<V> = this[key].toMaybe()
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, reified B : Any> NonEmptyList<A>.traverse(
+public inline fun <A, reified B> NonEmptyList<A>.traverse(
   f: (A) -> Maybe<B>
 ): Maybe<NonEmptyList<B>> =
   f(head).map { newHead ->
@@ -1177,15 +1173,14 @@ public inline fun <A, reified B : Any> NonEmptyList<A>.traverse(
     NonEmptyList(newHead, acc)
   }
 
-public inline fun <reified A : Any> NonEmptyList<Maybe<A>>.sequence(): Maybe<NonEmptyList<A>> =
+public inline fun <reified A> NonEmptyList<Maybe<A>>.sequence(): Maybe<NonEmptyList<A>> =
   traverse(::identity)
 
-public inline fun <reified A : Any> Sequence<Maybe<A>>.sequence(): Maybe<List<A>> =
-  traverse(::identity)
+public inline fun <reified A> Sequence<Maybe<A>>.sequence(): Maybe<List<A>> = traverse(::identity)
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, reified B : Any> Sequence<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
+public inline fun <A, reified B> Sequence<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
   // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when
   // using
   //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
@@ -1203,21 +1198,21 @@ public inline fun <A, reified B : Any> Sequence<A>.traverse(f: (A) -> Maybe<B>):
   return Just(acc)
 }
 
-public inline fun <reified A : Any> Sequence<Maybe<A>>.filterMaybe(): Sequence<A> =
+public inline fun <reified A> Sequence<Maybe<A>>.filterMaybe(): Sequence<A> =
   mapNotNull(Maybe<A>::orNull)
 
 /**
  * Converts an `Maybe<A>` to a `Validated<E, A>`, where the provided `ifNothing` output value is
  * returned as [Invalid] when the specified `Maybe` is `Nothing`.
  */
-public inline fun <E, reified A : Any> Validated.Companion.fromMaybe(
+public inline fun <E, reified A> Validated.Companion.fromMaybe(
   o: Maybe<A>,
   ifNothing: () -> E
 ): Validated<E, A> = o.fold({ Validated.Invalid(ifNothing()) }, { Validated.Valid(it) })
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <E, A, reified B : Any> Validated<E, A>.traverse(
+public inline fun <E, A, reified B> Validated<E, A>.traverse(
   fa: (A) -> Maybe<B>
 ): Maybe<Validated<E, B>> =
   when (this) {
@@ -1225,30 +1220,28 @@ public inline fun <E, A, reified B : Any> Validated<E, A>.traverse(
     is Validated.Invalid -> Nothing
   }
 
-public inline fun <E, A, reified B : Any, reified C : Any> Validated<E, A>.bitraverseMaybe(
+public inline fun <E, A, reified B, reified C> Validated<E, A>.bitraverseMaybe(
   fe: (E) -> Maybe<B>,
   fa: (A) -> Maybe<C>
 ): Maybe<Validated<B, C>> = fold({ fe(it).map(::Invalid) }, { fa(it).map(::Valid) })
 
 /** Returns Valid values wrapped in Just, and Nothing for Invalid values */
-public fun <E, A : Any> Validated<E, A>.toMaybe(): Maybe<A> = fold({ Nothing }, ::Just)
+public fun <E, A> Validated<E, A>.toMaybe(): Maybe<A> = fold({ Nothing }, ::Just)
 
-public inline fun <reified A : Any, reified B : Any> Validated<Maybe<A>, Maybe<B>>
-  .bisequenceMaybe(): Maybe<Validated<A, B>> = bitraverseMaybe(::identity, ::identity)
+public inline fun <reified A, reified B> Validated<Maybe<A>, Maybe<B>>.bisequenceMaybe():
+  Maybe<Validated<A, B>> = bitraverseMaybe(::identity, ::identity)
 
-public inline fun <A, reified B : Any> Validated<A, Maybe<B>>.sequence(): Maybe<Validated<A, B>> =
+public inline fun <A, reified B> Validated<A, Maybe<B>>.sequence(): Maybe<Validated<A, B>> =
   traverse(::identity)
 
-public fun <E, A : Any> Validated<E, A>.orNothing(): Maybe<A> = fold({ Nothing }, { Just(it) })
+public fun <E, A> Validated<E, A>.orNothing(): Maybe<A> = fold({ Nothing }, { Just(it) })
 
 /**
  * [fold] the [EagerEffect] into a [Maybe]. Where the shifted value [R] is mapped to [Maybe] by the
  * provided function [orElse], and result value [A] is mapped to [Just].
  */
 @OptIn(MaybeInternals::class)
-public inline fun <R, A : Any> EagerEffect<R, A>.toMaybe(
-  crossinline orElse: (R) -> Maybe<A>
-): Maybe<A> {
+public inline fun <R, A> EagerEffect<R, A>.toMaybe(crossinline orElse: (R) -> Maybe<A>): Maybe<A> {
   // An effect's fold is not inline, so it will box the maybe.
   // That is, unless we pass the underlying values instead and construct the maybe on the outside
   // Also, orElse is crossinline because a normal function would just box
@@ -1260,7 +1253,7 @@ public inline fun <R, A : Any> EagerEffect<R, A>.toMaybe(
  * provided function [orElse], and result value [A] is mapped to [Just].
  */
 @OptIn(MaybeInternals::class)
-public suspend inline fun <R, A : Any> Effect<R, A>.toMaybe(
+public suspend inline fun <R, A> Effect<R, A>.toMaybe(
   crossinline orElse: (R) -> Maybe<A>
 ): Maybe<A> {
   // An effect's fold is not inline, so it will box the maybe.
@@ -1269,13 +1262,13 @@ public suspend inline fun <R, A : Any> Effect<R, A>.toMaybe(
   return Maybe.construct(fold({ orElse(it).underlying }, { Just(it).underlying }))
 }
 
-public suspend inline fun <R, reified B : Any> EagerEffectScope<R>.bind(
+public suspend inline fun <R, reified B> EagerEffectScope<R>.bind(
   maybe: Maybe<B>,
   shift: () -> R
 ): B = maybe.fold({ shift(shift()) }, { it })
 
 @JvmName("bindMaybe")
-public suspend fun <R, B : Any> EagerEffectScope<R>.bind(
+public suspend fun <R, B> EagerEffectScope<R>.bind(
   maybe: Maybe<Maybe<B>>,
   shift: () -> R
 ): Maybe<B> {
@@ -1286,16 +1279,11 @@ public suspend fun <R, B : Any> EagerEffectScope<R>.bind(
   return maybe.orNull() ?: shift(shift())
 }
 
-public suspend inline fun <R, reified B : Any> EffectScope<R>.bind(
-  maybe: Maybe<B>,
-  shift: () -> R
-): B = maybe.fold({ shift(shift()) }, { it })
+public suspend inline fun <R, reified B> EffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
+  maybe.fold({ shift(shift()) }, { it })
 
 @JvmName("bindMaybe")
-public suspend fun <R, B : Any> EffectScope<R>.bind(
-  maybe: Maybe<Maybe<B>>,
-  shift: () -> R
-): Maybe<B> {
+public suspend fun <R, B> EffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
   // Similar in spirit to EagerEffectScope.bind(shift)
   // We don't want the maybe argument to "hang around" after the suspension point of the shift
   // And so instead we use the maybe argument immediately, get its contents or null, and *then*

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -98,9 +98,8 @@ internal val <A> Maybe<A>.value: A
     when (underlying) {
       is NestedNull -> if (underlying.nesting == 0U) null else NestedNull(underlying.nesting - 1U)
       is NestedNothing ->
-        NestedNothing(underlying.nesting - 1U).also {
-          if (it.nesting < 0U) error("Cannot unpack the value of a Maybe.Nothing")
-        }
+        if (underlying.nesting == 0U) error("Cannot unpack the value of a Maybe.Nothing")
+        else NestedNothing(underlying.nesting - 1U)
       else -> underlying
     }
       as A

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -14,13 +14,16 @@ import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 
-@RequiresOptIn(message = "This declaration is part of the internals of Maybe. Great caution must be taken to avoid ClassCastExceptions")
+@RequiresOptIn(
+  message =
+    "This declaration is part of the internals of Maybe. Great caution must be taken to avoid ClassCastExceptions"
+)
 internal annotation class MaybeInternals
 
 @JvmInline
-public value class Maybe<out A : Any> @MaybeInternals private constructor(
-  @property:MaybeInternals @PublishedApi internal val underlying: Any
-) {
+public value class Maybe<out A : Any>
+@MaybeInternals
+private constructor(@property:MaybeInternals @PublishedApi internal val underlying: Any) {
 
   public companion object {
     // This is simply an alias to constructor-impl
@@ -28,66 +31,58 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
     @MaybeInternals
     internal fun <A : Any> construct(value: Any): Maybe<A> = Maybe(value)
 
-    @OptIn(MaybeInternals::class)
-    public val Nothing: Maybe<Nothing> = construct(NestedNothing(0))
+    @OptIn(MaybeInternals::class) public val Nothing: Maybe<Nothing> = construct(NestedNothing(0))
 
     @JvmStatic
     public inline fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
 
     @JvmStatic
-    public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> = if (a != null) Just(a) else Nothing
+    public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> =
+      if (a != null) Just(a) else Nothing
 
-    @JvmStatic
-    public inline operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
+    @JvmStatic public inline operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
 
     @JvmStatic
     @JvmName("tryCatchOrNothing")
-    /**
-     * Ignores exceptions and returns Nothing if one is thrown
-     */
+    /** Ignores exceptions and returns Nothing if one is thrown */
     public inline fun <A : Any> catch(f: () -> A): Maybe<A> {
       return catch({ Nothing }, f)
     }
 
     @JvmStatic
     @JvmName("tryCatch")
-    public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> = try {
-      Just(f())
-    } catch (t: Throwable) {
-      recover(t.nonFatalOrThrow())
-    }
+    public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> =
+      try {
+        Just(f())
+      } catch (t: Throwable) {
+        recover(t.nonFatalOrThrow())
+      }
 
     @JvmStatic
-    public inline fun <reified A : Any, B : Any> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> = { it.map(f) }
+    public inline fun <reified A : Any, B : Any> lift(
+      crossinline f: (A) -> B
+    ): (Maybe<A>) -> Maybe<B> = { it.map(f) }
   }
 
   public inline fun tapNothing(f: () -> Unit): Maybe<A> = this.also { if (isEmpty()) f() }
 
-  /**
-   * Returns true if the maybe is [Nothing], false otherwise.
-   */
+  /** Returns true if the maybe is [Nothing], false otherwise. */
   public fun isEmpty(): Boolean = fold<Any, Boolean>({ true }, { false })
 
   public fun isNotEmpty(): Boolean = !isEmpty()
 
-  /**
-   * alias for [isDefined]
-   */
-  public val isJust: Boolean get() = isDefined()
+  /** alias for [isDefined] */
+  public val isJust: Boolean
+    get() = isDefined()
 
-  /**
-   * alias for [isEmpty]
-   */
-  public val isNothing: Boolean get() = isEmpty()
+  /** alias for [isEmpty] */
+  public val isNothing: Boolean
+    get() = isEmpty()
 
-  /**
-   * alias for [isDefined]
-   */
+  /** alias for [isDefined] */
   public fun nonEmpty(): Boolean = isDefined()
 
-  /**
-   * Returns true if the maybe is an instance of [Just], false otherwise.
-   */
+  /** Returns true if the maybe is an instance of [Just], false otherwise. */
   public fun isDefined(): Boolean = isNotEmpty()
 
   override fun toString(): String = fold<Any, String>({ "Maybe.Nothing" }, { "Maybe.Just($it)" })
@@ -100,54 +95,145 @@ internal inline fun <reified T> isTypeMaybe(): Boolean =
 @PublishedApi
 @MaybeInternals
 internal val <A : Any> Maybe<A>.value: A
-  get() = when (underlying) {
-    is NestedNothing -> NestedNothing(underlying.nesting - 1).also { if (it.nesting < 0) error("Cannot unpack the value of a Maybe.Nothing") }
-    else -> underlying
-  } as A
+  get() =
+    when (underlying) {
+      is NestedNothing ->
+        NestedNothing(underlying.nesting - 1).also {
+          if (it.nesting < 0) error("Cannot unpack the value of a Maybe.Nothing")
+        }
+      else -> underlying
+    }
+      as A
 
-public inline fun <reified A : Any, reified B : Any> Maybe<A>.zip(other: Maybe<B>): Maybe<Pair<A, B>> =
-  zip(other, ::Pair)
+public inline fun <reified A : Any, reified B : Any> Maybe<A>.zip(
+  other: Maybe<B>
+): Maybe<Pair<A, B>> = zip(other, ::Pair)
 
 public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.zip(
-  b: Maybe<B>, map: (A, B) -> C
-): Maybe<C> = zip(
-  b, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit
-) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+  b: Maybe<B>,
+  map: (A, B) -> C
+): Maybe<C> =
+  zip(b, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit) {
+    b,
+    c,
+    _,
+    _,
+    _,
+    _,
+    _,
+    _,
+    _,
+    _ ->
+    map(b, c)
+  }
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, D : Any> Maybe<A>.zip(
-  b: Maybe<B>, c: Maybe<C>, map: (A, B, C) -> D
-): Maybe<D> = zip(
-  b, c, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit
-) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+  b: Maybe<B>,
+  c: Maybe<C>,
+  map: (A, B, C) -> D
+): Maybe<D> =
+  zip(b, c, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit) {
+    b,
+    c,
+    d,
+    _,
+    _,
+    _,
+    _,
+    _,
+    _,
+    _ ->
+    map(b, c, d)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, E : Any> Maybe<A>.zip(
-  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, map: (A, B, C, D) -> E
-): Maybe<E> = zip(
-  b, c, d, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit
-) { a, b, c, d, _, _, _, _, _, _ -> map(a, b, c, d) }
+public inline fun <
+  reified A : Any, reified B : Any, reified C : Any, reified D : Any, E : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  map: (A, B, C, D) -> E
+): Maybe<E> =
+  zip(b, c, d, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit) {
+    a,
+    b,
+    c,
+    d,
+    _,
+    _,
+    _,
+    _,
+    _,
+    _ ->
+    map(a, b, c, d)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, F : Any> Maybe<A>.zip(
-  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, e: Maybe<E>, map: (A, B, C, D, E) -> F
-): Maybe<F> = zip(b, c, d, e, justUnit, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
-  map(
-    a, b, c, d, e
-  )
-}
+public inline fun <
+  reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, F : Any
+> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  map: (A, B, C, D, E) -> F
+): Maybe<F> =
+  zip(b, c, d, e, justUnit, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _
+    ->
+    map(a, b, c, d, e)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, G : Any> Maybe<A>.zip(
-  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, e: Maybe<E>, f: Maybe<F>, map: (A, B, C, D, E, F) -> G
-): Maybe<G> = zip(b, c, d, e, f, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
-  map(
-    a, b, c, d, e, f
-  )
-}
+public inline fun <
+  reified A : Any,
+  reified B : Any,
+  reified C : Any,
+  reified D : Any,
+  reified E : Any,
+  reified F : Any,
+  G : Any
+> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  map: (A, B, C, D, E, F) -> G
+): Maybe<G> =
+  zip(b, c, d, e, f, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
+    map(a, b, c, d, e, f)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, H : Any> Maybe<A>.zip(
-  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, e: Maybe<E>, f: Maybe<F>, g: Maybe<G>, map: (A, B, C, D, E, F, G) -> H
+public inline fun <
+  reified A : Any,
+  reified B : Any,
+  reified C : Any,
+  reified D : Any,
+  reified E : Any,
+  reified F : Any,
+  reified G : Any,
+  H : Any
+> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  g: Maybe<G>,
+  map: (A, B, C, D, E, F, G) -> H
 ): Maybe<H> =
-  zip(b, c, d, e, f, g, justUnit, justUnit, justUnit) { a, b, c, d, e, f, g, _, _, _ -> map(a, b, c, d, e, f, g) }
+  zip(b, c, d, e, f, g, justUnit, justUnit, justUnit) { a, b, c, d, e, f, g, _, _, _ ->
+    map(a, b, c, d, e, f, g)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, I : Any> Maybe<A>.zip(
+public inline fun <
+  reified A : Any,
+  reified B : Any,
+  reified C : Any,
+  reified D : Any,
+  reified E : Any,
+  reified F : Any,
+  reified G : Any,
+  reified H : Any,
+  I : Any
+> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -157,9 +243,22 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
   h: Maybe<H>,
   map: (A, B, C, D, E, F, G, H) -> I
 ): Maybe<I> =
-  zip(b, c, d, e, f, g, h, justUnit, justUnit) { a, b, c, d, e, f, g, h, _, _ -> map(a, b, c, d, e, f, g, h) }
+  zip(b, c, d, e, f, g, h, justUnit, justUnit) { a, b, c, d, e, f, g, h, _, _ ->
+    map(a, b, c, d, e, f, g, h)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, reified I : Any, J : Any> Maybe<A>.zip(
+public inline fun <
+  reified A : Any,
+  reified B : Any,
+  reified C : Any,
+  reified D : Any,
+  reified E : Any,
+  reified F : Any,
+  reified G : Any,
+  reified H : Any,
+  reified I : Any,
+  J : Any
+> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -169,9 +268,24 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
   h: Maybe<H>,
   i: Maybe<I>,
   map: (A, B, C, D, E, F, G, H, I) -> J
-): Maybe<J> = zip(b, c, d, e, f, g, h, i, justUnit) { a, b, c, d, e, f, g, h, i, _ -> map(a, b, c, d, e, f, g, h, i) }
+): Maybe<J> =
+  zip(b, c, d, e, f, g, h, i, justUnit) { a, b, c, d, e, f, g, h, i, _ ->
+    map(a, b, c, d, e, f, g, h, i)
+  }
 
-public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, reified I : Any, reified J : Any, K : Any> Maybe<A>.zip(
+public inline fun <
+  reified A : Any,
+  reified B : Any,
+  reified C : Any,
+  reified D : Any,
+  reified E : Any,
+  reified F : Any,
+  reified G : Any,
+  reified H : Any,
+  reified I : Any,
+  reified J : Any,
+  K : Any
+> Maybe<A>.zip(
   b: Maybe<B>,
   c: Maybe<C>,
   d: Maybe<D>,
@@ -201,193 +315,262 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
 }
 
 /**
- * Returns the result of applying [f] to this $maybe's value if
- * this $maybe is nonempty.
- * Returns $nothing if this $maybe is empty.
- * Slightly different from `map` in that $f is expected to
- * return a $maybe (which could be $nothing).
+ * Returns the result of applying [f] to this $maybe's value if this $maybe is nonempty. Returns
+ * $nothing if this $maybe is empty. Slightly different from `map` in that $f is expected to return
+ * a $maybe (which could be $nothing).
  *
  * @param f the function to apply
  * @see map
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> = fold({ Nothing }, f)
+public inline fun <reified A : Any, B : Any> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> =
+  fold({ Nothing }, f)
 
 @OptIn(MaybeInternals::class)
-public inline fun <reified A : Any, R> Maybe<A>.fold(ifEmpty: () -> R, ifJust: (A) -> R): R = when (this) {
-  Nothing -> ifEmpty()
-  else -> if (isTypeMaybe<A>()) Maybe.construct<Any>((this as Maybe<Any>).value).invokeBlockOnMaybe(ifJust) else ifJust(
-    value
-  )
-}
+public inline fun <reified A : Any, R> Maybe<A>.fold(ifEmpty: () -> R, ifJust: (A) -> R): R =
+  when (this) {
+    Nothing -> ifEmpty()
+    else ->
+      if (isTypeMaybe<A>())
+        Maybe.construct<Any>((this as Maybe<Any>).value).invokeBlockOnMaybe(ifJust)
+      else ifJust(value)
+  }
 
 @PublishedApi
 internal inline fun <R, A> Maybe<*>.invokeBlockOnMaybe(block: (A) -> R): R {
   return block(this as A)
 }
 
-public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> = this.also { fold({}, f) }
+public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> =
+  this.also { fold({}, f) }
 
-public inline fun <reified A : Any> Maybe<A>.orNull(): A? = fold({ return null }, ::identity)
+public inline fun <reified A : Any> Maybe<A>.orNull(): A? =
+  fold(
+    {
+      return null
+    },
+    ::identity
+  )
 
 @JvmName("orNullMaybe")
-public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = fold({ return null }, ::identity)
+public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? =
+  fold(
+    {
+      return null
+    },
+    ::identity
+  )
 
 /**
- * Returns a [Just<$B>] containing the result of applying $f to this $maybe's
- * value if this $maybe is nonempty. Otherwise return $nothing.
+ * Returns a [Just<$B>] containing the result of applying $f to this $maybe's value if this $maybe
+ * is nonempty. Otherwise return $nothing.
  *
- * @note This is similar to `flatMap` except here,
- * $f does not need to wrap its result in a $maybe.
+ * @note This is similar to `flatMap` except here, $f does not need to wrap its result in a $maybe.
  *
  * @param f the function to apply
  * @see flatMap
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> = flatMap { a -> Just(f(a)) }
+public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> = flatMap { a ->
+  Just(f(a))
+}
 
 /**
- * Returns $nothing if the result of applying $f to this $maybe's value is null.
- * Otherwise returns the result.
+ * Returns $nothing if the result of applying $f to this $maybe's value is null. Otherwise returns
+ * the result.
  *
- * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
- * and primarily for convenience.
+ * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }` and primarily for convenience.
  *
  * @param f the function to apply.
- * */
-public inline fun <reified A : Any, B : Any> Maybe<A>.mapNotNull(f: (A) -> B?): Maybe<B> =
-  flatMap { a -> Maybe.fromNullable(f(a)) }
-
-/**
- * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior].
  */
-public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(b: Maybe<B>): Maybe<Ior<A, B>> = fold({
-  b.fold({ Nothing }, { b -> Just(b.rightIor()) })
-}, { a ->
-  b.fold({ Just(a.leftIor()) }, { b -> Just(Pair(a, b).bothIor()) })
-})
+public inline fun <reified A : Any, B : Any> Maybe<A>.mapNotNull(f: (A) -> B?): Maybe<B> =
+  flatMap { a ->
+    Maybe.fromNullable(f(a))
+  }
 
+/** Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior]. */
+public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(
+  b: Maybe<B>
+): Maybe<Ior<A, B>> =
+  fold(
+    { b.fold({ Nothing }, { b -> Just(b.rightIor()) }) },
+    { a -> b.fold({ Just(a.leftIor()) }, { b -> Just(Pair(a, b).bothIor()) }) }
+  )
 
 /**
- * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior], and then, if it's not [Nothing], map it using [f].
+ * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior], and then, if
+ * it's not [Nothing], map it using [f].
  *
- * @note This function works like a regular `align` function, but is then mapped by the `map` function.
+ * @note This function works like a regular `align` function, but is then mapped by the `map`
+ * function.
  */
 public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.align(
-  b: Maybe<B>, f: (Ior<A, B>) -> C
+  b: Maybe<B>,
+  f: (Ior<A, B>) -> C
 ): Maybe<C> = align(b).map(f)
 
 /**
- * Returns true if this maybe is empty '''or''' the predicate
- * $predicate returns true when applied to this $maybe's value.
+ * Returns true if this maybe is empty '''or''' the predicate $predicate returns true when applied
+ * to this $maybe's value.
  *
  * @param predicate the predicate to test
  */
-public inline fun <reified A : Any> Maybe<A>.all(predicate: (A) -> Boolean): Boolean = fold({ true }, predicate)
+public inline fun <reified A : Any> Maybe<A>.all(predicate: (A) -> Boolean): Boolean =
+  fold({ true }, predicate)
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalk(f: (A) -> Maybe<B>): Maybe<Maybe<B>> =
+public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalk(
+  f: (A) -> Maybe<B>
+): Maybe<Maybe<B>> =
   fold({ Nothing }, { value -> f(value).map<Any, Maybe<B>> { Just(it) as Maybe<B> } })
 
-public inline fun <reified A : Any, K, V : Any> Maybe<A>.crosswalkMap(f: (A) -> Map<K, V>): Map<K, Maybe<V>> =
-  fold({ emptyMap() }, { value -> f(value).mapValues { Just(it.value) } })
+public inline fun <reified A : Any, K, V : Any> Maybe<A>.crosswalkMap(
+  f: (A) -> Map<K, V>
+): Map<K, Maybe<V>> = fold({ emptyMap() }, { value -> f(value).mapValues { Just(it.value) } })
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNull(f: (A) -> B?): Maybe<B>? =
-  fold({ return null }, { value -> return f(value)?.let { Just(it) } })
+  fold(
+    {
+      return null
+    },
+    { value ->
+      return f(value)?.let { Just(it) }
+    }
+  )
 
 /**
- * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
- * this $maybe's value returns true. Otherwise, return $nothing.
+ * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to this $maybe's value
+ * returns true. Otherwise, return $nothing.
  *
- *  @param predicate the predicate used for testing.
+ * @param predicate the predicate used for testing.
  */
 public inline fun <reified A : Any> Maybe<A>.filter(predicate: (A) -> Boolean): Maybe<A> =
-  flatMap { a -> if (predicate(a)) Just(a) else Nothing }
+  flatMap { a ->
+    if (predicate(a)) Just(a) else Nothing
+  }
 
 /**
- * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
- * this $maybe's value returns false. Otherwise, return $nothing.
+ * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to this $maybe's value
+ * returns false. Otherwise, return $nothing.
  *
  * @param predicate the predicate used for testing.
  */
 public inline fun <reified A : Any> Maybe<A>.filterNot(predicate: (A) -> Boolean): Maybe<A> =
-  flatMap { a -> if (!predicate(a)) Just(a) else Nothing }
+  flatMap { a ->
+    if (!predicate(a)) Just(a) else Nothing
+  }
 
-public inline fun <reified A : Any> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean = fold({ false }, predicate)
+public inline fun <reified A : Any> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean =
+  fold({ false }, predicate)
 
 public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolean): A? =
-  fold({ return null }, { return if (predicate(it)) it else null })
-
+  fold(
+    {
+      return null
+    },
+    {
+      return if (predicate(it)) it else null
+    }
+  )
 
 @JvmName("maybeFindOrNull")
-public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(predicate: (Maybe<A>) -> Boolean): Maybe<A>? =
-  fold({ return null }, { return if (predicate(it)) it else null })
+public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(
+  predicate: (Maybe<A>) -> Boolean
+): Maybe<A>? =
+  fold(
+    {
+      return null
+    },
+    {
+      return if (predicate(it)) it else null
+    }
+  )
 
-public inline fun <reified A : Any, B> Maybe<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
-  foldLeft(empty()) { b, a -> b.combine(f(a)) }
-}
+public inline fun <reified A : Any, B> Maybe<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B =
+  MB.run { foldLeft(empty()) { b, a -> b.combine(f(a)) } }
 
 @JvmName("foldMapMaybe")
-public inline fun <reified A : Any, B : Any> Maybe<A>.foldMap(MB: Monoid<Maybe<B>>, f: (A) -> Maybe<B>): Maybe<B> =
-  MB.run {
-    foldLeft(emptyMaybe()) { b, a -> combineToMaybe(b, f(a)).flatten() }
-  }
+public inline fun <reified A : Any, B : Any> Maybe<A>.foldMap(
+  MB: Monoid<Maybe<B>>,
+  f: (A) -> Maybe<B>
+): Maybe<B> = MB.run { foldLeft(emptyMaybe()) { b, a -> combineToMaybe(b, f(a)).flatten() } }
 
 public inline fun <reified A : Any, B> Maybe<A>.foldLeft(initial: B, operation: (B, A) -> B): B =
   fold({ initial }, { operation(initial, it) })
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.foldLeft(
-  initial: Maybe<B>, operation: (Maybe<B>, A) -> Maybe<B>
+  initial: Maybe<B>,
+  operation: (Maybe<B>, A) -> Maybe<B>
 ): Maybe<B> = fold({ initial }, { operation(initial, it) })
 
-public inline fun <reified A : Any, reified B : Any> Maybe<A>.padZip(other: Maybe<B>): Maybe<Pair<A?, B?>> =
-  padZip(other, ::Pair)
+public inline fun <reified A : Any, reified B : Any> Maybe<A>.padZip(
+  other: Maybe<B>
+): Maybe<Pair<A?, B?>> = padZip(other, ::Pair)
 
 public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZip(
-  other: Maybe<B>, f: (A?, B?) -> C
-): Maybe<C> = fold({
-  other.fold({
-    Nothing
-  }, { b ->
-    Just(f(null, b))
-  })
-}, { a ->
-  other.fold({
-    Just(f(a, null))
-  }, { b ->
-    Just(f(a, b))
-  })
-})
+  other: Maybe<B>,
+  f: (A?, B?) -> C
+): Maybe<C> =
+  fold(
+    { other.fold({ Nothing }, { b -> Just(f(null, b)) }) },
+    { a -> other.fold({ Just(f(a, null)) }, { b -> Just(f(a, b)) }) }
+  )
 
-public inline fun <reified A : Any, B> Maybe<A>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A) -> B): B? =
-  fold({ return null }, { operation(initial(it), it) })
+public inline fun <reified A : Any, B> Maybe<A>.reduceOrNull(
+  initial: (A) -> B,
+  operation: (acc: B, A) -> B
+): B? =
+  fold(
+    {
+      return null
+    },
+    { operation(initial(it), it) }
+  )
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.reduceOrNullMaybe(
-  initial: (A) -> Maybe<B>, operation: (acc: Maybe<B>, A) -> Maybe<B>
-): Maybe<B>? = fold({ return null }, { operation(initial(it), it) })
+  initial: (A) -> Maybe<B>,
+  operation: (acc: Maybe<B>, A) -> Maybe<B>
+): Maybe<B>? =
+  fold(
+    {
+      return null
+    },
+    { operation(initial(it), it) }
+  )
 
 public inline fun <reified A : Any> Maybe<A>.replicate(n: Int): Maybe<List<A>> =
   if (n <= 0) Just(emptyList()) else map { a -> List(n) { a } }
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <reified A : Any, B : Any> Maybe<A>.traverse(fa: (A) -> Iterable<B>): List<Maybe<B>> =
-  fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
+public inline fun <reified A : Any, B : Any> Maybe<A>.traverse(
+  fa: (A) -> Iterable<B>
+): List<Maybe<B>> = fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(fa: (A) -> Either<AA, B>): Either<AA, Maybe<B>> =
-  fold({ Right(Nothing) }, { value -> fa(value).map { Just(it) } })
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(
+  fa: (A) -> Either<AA, B>
+): Either<AA, Maybe<B>> = fold({ Right(Nothing) }, { value -> fa(value).map { Just(it) } })
 
-@Deprecated("traverseEither is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseEither(fa: (A) -> Either<AA, B>): Either<AA, Maybe<B>> =
-  traverse(fa)
+@Deprecated(
+  "traverseEither is being renamed to traverse to simplify the Arrow API",
+  ReplaceWith("traverse(fa)")
+)
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseEither(
+  fa: (A) -> Either<AA, B>
+): Either<AA, Maybe<B>> = traverse(fa)
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(fa: (A) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
-  fold({ Valid(Nothing) }, { value -> fa(value).map { Just(it) } })
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(
+  fa: (A) -> Validated<AA, B>
+): Validated<AA, Maybe<B>> = fold({ Valid(Nothing) }, { value -> fa(value).map { Just(it) } })
 
-@Deprecated("traverseValidated is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
-public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseValidated(fa: (A) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
-  traverse(fa)
+@Deprecated(
+  "traverseValidated is being renamed to traverse to simplify the Arrow API",
+  ReplaceWith("traverse(fa)")
+)
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseValidated(
+  fa: (A) -> Validated<AA, B>
+): Validated<AA, Maybe<B>> = traverse(fa)
 
 public inline fun <reified A : Any, L> Maybe<A>.toEither(ifEmpty: () -> L): Either<L, A> =
   fold({ ifEmpty().left() }, { it.right() })
@@ -396,15 +579,18 @@ public inline fun <reified A : Any> Maybe<A>.toList(): List<A> = fold(::emptyLis
 
 public fun Maybe<*>.void(): Maybe<Unit> = justUnit
 
-public inline fun <reified A : Any, L> Maybe<A>.pairLeft(left: L): Maybe<Pair<L, A>> = this.map { left to it }
+public inline fun <reified A : Any, L> Maybe<A>.pairLeft(left: L): Maybe<Pair<L, A>> =
+  this.map { left to it }
 
-public inline fun <reified A : Any, R> Maybe<A>.pairRight(right: R): Maybe<Pair<A, R>> = this.map { it to right }
+public inline fun <reified A : Any, R> Maybe<A>.pairRight(right: R): Maybe<Pair<A, R>> =
+  this.map { it to right }
 
-public infix fun <A : Any, X : Any> Maybe<A>.and(value: Maybe<X>): Maybe<X> = if (isEmpty()) {
-  Nothing
-} else {
-  value
-}
+public infix fun <A : Any, X : Any> Maybe<A>.and(value: Maybe<X>): Maybe<X> =
+  if (isEmpty()) {
+    Nothing
+  } else {
+    value
+  }
 
 @PublishedApi
 internal data class NestedNothing private constructor(val nesting: Int) {
@@ -413,11 +599,12 @@ internal data class NestedNothing private constructor(val nesting: Int) {
     operator fun invoke(nesting: Int) = cache.getOrElse(nesting, ::NestedNothing)
   }
 
-  override fun toString(): String = buildString("Maybe.Just()".length * nesting + "Maybe.Nothing".length) {
-    repeat(nesting) { this.append("Maybe.Just(") }
-    append("Maybe.Nothing")
-    repeat(nesting) { this.append(")") }
-  }
+  override fun toString(): String =
+    buildString("Maybe.Just()".length * nesting + "Maybe.Nothing".length) {
+      repeat(nesting) { this.append("Maybe.Just(") }
+      append("Maybe.Nothing")
+      repeat(nesting) { this.append(")") }
+    }
 }
 
 @OptIn(MaybeInternals::class)
@@ -429,25 +616,26 @@ public inline fun <T : Any> Just(value: T): Maybe<T> {
 @MaybeInternals
 @PublishedApi
 internal fun <T : Any> _Just(trueValue: Any): Maybe<T> =
-  Maybe.construct(if (trueValue is NestedNothing) NestedNothing(trueValue.nesting + 1) else trueValue)
+  Maybe.construct(
+    if (trueValue is NestedNothing) NestedNothing(trueValue.nesting + 1) else trueValue
+  )
 
-@PublishedApi
-internal val justUnit: Maybe<Unit> = Just(Unit)
+@PublishedApi internal val justUnit: Maybe<Unit> = Just(Unit)
 
-@PublishedApi
-internal val boxedJustUnit: Any = justUnit
+@PublishedApi internal val boxedJustUnit: Any = justUnit
 
 /**
- * Returns the maybe's value if the maybe is nonempty, otherwise
- * return the result of evaluating `default`.
+ * Returns the maybe's value if the maybe is nonempty, otherwise return the result of evaluating
+ * `default`.
  *
  * @param default the default expression.
  */
-public inline fun <reified T : Any> Maybe<T>.getOrElse(default: () -> T): T = fold({ default() }, ::identity)
+public inline fun <reified T : Any> Maybe<T>.getOrElse(default: () -> T): T =
+  fold({ default() }, ::identity)
 
 /**
- * Returns the maybe's value if the maybe is nonempty, otherwise
- * return the result of evaluating `default`.
+ * Returns the maybe's value if the maybe is nonempty, otherwise return the result of evaluating
+ * `default`.
  *
  * @param default the default expression.
  */
@@ -456,46 +644,50 @@ public inline fun <T : Any> Maybe<Maybe<T>>.getOrElse(default: () -> Maybe<T>): 
   fold({ default() }, ::identity)
 
 /**
- * Returns this maybe's if the maybe is nonempty, otherwise
- * returns another maybe provided lazily by `default`.
+ * Returns this maybe's if the maybe is nonempty, otherwise returns another maybe provided lazily by
+ * `default`.
  *
  * @param alternative the default maybe if this is empty.
  */
 public inline fun <A : Any> Maybe<A>.orElse(alternative: () -> Maybe<A>): Maybe<A> =
   if (isEmpty()) alternative() else this
 
-public infix fun <T : Any> Maybe<T>.or(value: Maybe<T>): Maybe<T> = if (isEmpty()) {
-  value
-} else {
-  this
-}
+public infix fun <T : Any> Maybe<T>.or(value: Maybe<T>): Maybe<T> =
+  if (isEmpty()) {
+    value
+  } else {
+    this
+  }
 
 public inline fun <T : Any> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
+
 public fun <T : Any> Maybe<T>?.toMaybe(): Maybe<Maybe<T>> = this?.let { Just(it) } ?: Nothing
 
-public inline fun <A : Any> Boolean.maybe2(f: () -> A): Maybe<A> = if (this) {
-  Just(f())
-} else {
-  Nothing
-}
+public inline fun <A : Any> Boolean.maybe2(f: () -> A): Maybe<A> =
+  if (this) {
+    Just(f())
+  } else {
+    Nothing
+  }
 
 public inline fun <A : Any> A.just(): Maybe<A> = Just(this)
 
 public fun <A : Any> nothing(): Maybe<A> = Nothing
 
 public inline fun <reified A : Any> Monoid.Companion.maybe(MA: Semigroup<A>): Monoid<Maybe<A>> =
-  if (isTypeMaybe<A>()) MaybeMonoidNested(MA as Semigroup<Maybe<A>>) as Monoid<Maybe<A>> else MaybeMonoid(MA)
+  if (isTypeMaybe<A>()) MaybeMonoidNested(MA as Semigroup<Maybe<A>>) as Monoid<Maybe<A>>
+  else MaybeMonoid(MA)
 
 @JvmName("maybeMaybe")
-public inline fun <A : Any> Monoid.Companion.maybe(MA: Semigroup<Maybe<A>>): Monoid<Maybe<Maybe<A>>> =
-  MaybeMonoidNested(MA)
+public inline fun <A : Any> Monoid.Companion.maybe(
+  MA: Semigroup<Maybe<A>>
+): Monoid<Maybe<Maybe<A>>> = MaybeMonoidNested(MA)
 
 @PublishedApi
-internal open class MaybeMonoid<A : Any>(
-  protected val MA: Semigroup<A>
-) : Monoid<Maybe<A>> {
+internal open class MaybeMonoid<A : Any>(protected val MA: Semigroup<A>) : Monoid<Maybe<A>> {
 
-  override fun Maybe<A>.combine(b: Maybe<A>): Maybe<A> = combine(MA as Semigroup<Any>, b) as Maybe<A>
+  override fun Maybe<A>.combine(b: Maybe<A>): Maybe<A> =
+    combine(MA as Semigroup<Any>, b) as Maybe<A>
 
   override fun Maybe<A>.maybeCombine(b: Maybe<A>?): Maybe<A> =
     b?.let { combine(MA as Semigroup<Any>, it) as Maybe<A> } ?: this
@@ -504,39 +696,48 @@ internal open class MaybeMonoid<A : Any>(
 }
 
 @PublishedApi
-internal class MaybeMonoidNested<A : Any>(
-  MA: Semigroup<Maybe<A>>
-) : MaybeMonoid<Maybe<A>>(MA) {
+internal class MaybeMonoidNested<A : Any>(MA: Semigroup<Maybe<A>>) : MaybeMonoid<Maybe<A>>(MA) {
 
   override fun Maybe<Maybe<A>>.combine(b: Maybe<Maybe<A>>): Maybe<Maybe<A>> = combine(MA, b)
 
-  override fun Maybe<Maybe<A>>.maybeCombine(b: Maybe<Maybe<A>>?): Maybe<Maybe<A>> = b?.let { combine(MA, it) } ?: this
+  override fun Maybe<Maybe<A>>.maybeCombine(b: Maybe<Maybe<A>>?): Maybe<Maybe<A>> =
+    b?.let { combine(MA, it) } ?: this
 
   override fun empty(): Maybe<Maybe<A>> = Nothing
 }
 
-@Deprecated("use fold instead", ReplaceWith("fold(Monoid.maybe(MA))", "arrow.core.fold", "arrow.typeclasses.Monoid"))
-public inline fun <reified A : Any> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> = fold(Monoid.maybe(MA))
+@Deprecated(
+  "use fold instead",
+  ReplaceWith("fold(Monoid.maybe(MA))", "arrow.core.fold", "arrow.typeclasses.Monoid")
+)
+public inline fun <reified A : Any> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> =
+  fold(Monoid.maybe(MA))
 
 @Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
 public inline fun <reified A : Any> Maybe<A>.combineAll(MA: Monoid<A>): A = getOrElse { MA.empty() }
 
 @JvmName("maybeCombineAll")
 @Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
-public fun <A : Any> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> = getOrElse { MA.emptyMaybe() }
+public fun <A : Any> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> = getOrElse {
+  MA.emptyMaybe()
+}
 
-public inline fun <reified A : Any> Maybe<A>.ensure(error: () -> Unit, predicate: (A) -> Boolean): Maybe<A> =
-  fold({ this }, {
-    if (predicate(it)) this
-    else {
-      error()
-      Nothing
+public inline fun <reified A : Any> Maybe<A>.ensure(
+  error: () -> Unit,
+  predicate: (A) -> Boolean
+): Maybe<A> =
+  fold(
+    { this },
+    {
+      if (predicate(it)) this
+      else {
+        error()
+        Nothing
+      }
     }
-  })
+  )
 
-/**
- * Returns a Maybe containing all elements that are instances of specified type parameter [B].
- */
+/** Returns a Maybe containing all elements that are instances of specified type parameter [B]. */
 public inline fun <reified B : Any> Maybe<*>.filterIsInstance(): Maybe<B> = flatMap {
   when (it) {
     is B -> Just(it)
@@ -552,54 +753,65 @@ public inline fun <reified B : Any> Maybe<Maybe<*>>.filterIsInstance(): Maybe<B>
   }
 }
 
-public inline fun <A : Any> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> = handleErrorWith { Just(f(Unit)) }
+public inline fun <A : Any> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> = handleErrorWith {
+  Just(f(Unit))
+}
 
-public inline fun <A : Any> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> = if (isEmpty()) f(Unit) else this
+public inline fun <A : Any> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> =
+  if (isEmpty()) f(Unit) else this
 
 public fun <A : Any> Maybe<Maybe<A>>.flatten(): Maybe<A> = flatMap(::identity)
 
-public inline fun <reified A : Any, B : Any> Maybe<A>.redeem(fe: (Unit) -> B, fb: (A) -> B): Maybe<B> =
-  map(fb).handleError(fe)
+public inline fun <reified A : Any, B : Any> Maybe<A>.redeem(
+  fe: (Unit) -> B,
+  fb: (A) -> B
+): Maybe<B> = map(fb).handleError(fe)
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.redeemWith(
-  fe: (Unit) -> Maybe<B>, fb: (A) -> Maybe<B>
+  fe: (Unit) -> Maybe<B>,
+  fb: (A) -> Maybe<B>
 ): Maybe<B> = flatMap(fb).handleErrorWith(fe)
 
-public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): Maybe<A> = MA.run {
-  if (n <= 0) Just(empty())
-  else map { a ->
-    var result = empty()
-    repeat(n) {
-      result += a
-    }
-    result
+public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): Maybe<A> =
+  MA.run {
+    if (n <= 0) Just(empty())
+    else
+      map { a ->
+        var result = empty()
+        repeat(n) { result += a }
+        result
+      }
   }
-}
 
 @JvmName("replicateMaybe")
-public fun <A : Any> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Maybe<Maybe<A>> = MA.run {
-  if (n <= 0) Just(emptyMaybe())
-  else map { a ->
-    var result = emptyMaybe()
-    repeat(n) {
-      result = MA.combineToMaybe(result, a).flatten()
-    }
-    result
+public fun <A : Any> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Maybe<Maybe<A>> =
+  MA.run {
+    if (n <= 0) Just(emptyMaybe())
+    else
+      map { a ->
+        var result = emptyMaybe()
+        repeat(n) { result = MA.combineToMaybe(result, a).flatten() }
+        result
+      }
   }
-}
 
 @PublishedApi
-internal inline fun <A : Any> Monoid<Maybe<A>>.emptyMaybe(): Maybe<A> = when (this) {
-  is MaybeMonoid<*> -> (this as MaybeMonoid<*>).empty()
-  else -> this.empty()
-} as Maybe<A>
+internal inline fun <A : Any> Monoid<Maybe<A>>.emptyMaybe(): Maybe<A> =
+  when (this) {
+    is MaybeMonoid<*> -> (this as MaybeMonoid<*>).empty()
+    else -> this.empty()
+  }
+    as Maybe<A>
 
-
-public fun <A : Any> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> = flatMap { it.fold({ Nothing }, { a -> Just(a) }) }
+public fun <A : Any> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> = flatMap {
+  it.fold({ Nothing }, { a -> Just(a) })
+}
 
 public inline fun <reified A : Any> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A>): Maybe<A> {
   map { a ->
-    b.map { b -> return SA.combineToMaybe(a, b) }
+    b.map { b ->
+      return SA.combineToMaybe(a, b)
+    }
   }
   return this or b
 }
@@ -620,7 +832,8 @@ public fun <A : Any, B : Any> Maybe<Either<A, B>>.separateEither(): Pair<Maybe<A
  * Separate the inner [Validated] value into the [Validated.Invalid] and [Validated.Valid].
  *
  * @receiver Maybe of Either
- * @return a tuple containing Maybe of [Validated.Invalid] and another Maybe of its [Validated.Valid] value.
+ * @return a tuple containing Maybe of [Validated.Invalid] and another Maybe of its
+ * [Validated.Valid] value.
  */
 public fun <A : Any, B : Any> Maybe<Validated<A, B>>.separateValidated(): Pair<Maybe<A>, Maybe<B>> {
   val asep = flatMap { gab -> gab.fold({ Just(it) }, { Nothing }) }
@@ -642,20 +855,29 @@ public fun <A, B : Any> Maybe<Either<A, B>>.sequence(): Either<A, Maybe<B>> = tr
   "sequenceValidated is being renamed to sequence to simplify the Arrow API",
   ReplaceWith("sequence()", "arrow.core.sequence")
 )
-public fun <A, B : Any> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> = sequence()
+public fun <A, B : Any> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> =
+  sequence()
 
-public fun <A, B : Any> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> = traverse(::identity)
+public fun <A, B : Any> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> =
+  traverse(::identity)
 
-public fun <A : Any, B : Any> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> = unalign(::identity)
+public fun <A : Any, B : Any> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> =
+  unalign(::identity)
 
-public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unalign(f: (C) -> Ior<A, B>): Pair<Maybe<A>, Maybe<B>> =
-  this.map(f).fold({ Nothing to Nothing }, {
-    when (it) {
-      is Ior.Left -> Just(it.value) to Nothing
-      is Ior.Right -> Nothing to Just(it.value)
-      is Ior.Both -> Just(it.leftValue) to Just(it.rightValue)
-    }
-  })
+public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unalign(
+  f: (C) -> Ior<A, B>
+): Pair<Maybe<A>, Maybe<B>> =
+  this.map(f)
+    .fold(
+      { Nothing to Nothing },
+      {
+        when (it) {
+          is Ior.Left -> Just(it.value) to Nothing
+          is Ior.Right -> Nothing to Just(it.value)
+          is Ior.Both -> Just(it.leftValue) to Just(it.rightValue)
+        }
+      }
+    )
 
 public fun <A : Any> Maybe<Iterable<A>>.unite(MA: Monoid<A>): Maybe<A> = map { iterable ->
   iterable.fold(MA)
@@ -669,116 +891,136 @@ public fun <A, B : Any> Maybe<Validated<A, B>>.uniteValidated(): Maybe<B> = flat
   validated.fold({ Nothing }, { b -> Just(b) })
 }
 
-public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> = unzip(::identity)
+public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> =
+  unzip(::identity)
 
-public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unzip(f: (C) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
+public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unzip(
+  f: (C) -> Pair<A, B>
+): Pair<Maybe<A>, Maybe<B>> =
   fold({ Nothing to Nothing }, { f(it).let { pair -> Just(pair.first) to Just(pair.second) } })
 
 public fun <B : Any, A : B> Maybe<A>.widen(): Maybe<B> = this
 
 public fun <K, V> Maybe<Pair<K, V>>.toMap(): Map<K, V> = this.toList().toMap()
 
-public inline fun <reified A : Any> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> = fold({ b }, { first ->
-  b.fold({ this }, { second ->
-    SGA.combineToMaybe(first, second)
-  })
-})
+public inline fun <reified A : Any> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
+  fold({ b }, { first -> b.fold({ this }, { second -> SGA.combineToMaybe(first, second) }) })
 
 @Suppress("UNCHECKED_CAST")
 @PublishedApi
-internal inline fun <A : Any> Semigroup<A>.combineToMaybe(
-  first: A, second: A
-): Maybe<A> = when {
-  this is MaybeMonoid<*> -> (this as MaybeMonoid<Any>).run {
-    Just((first as Maybe<*>).combine(second as Maybe<*>)) as Maybe<A>
+internal inline fun <A : Any> Semigroup<A>.combineToMaybe(first: A, second: A): Maybe<A> =
+  when {
+    this is MaybeMonoid<*> ->
+      (this as MaybeMonoid<Any>).run {
+        Just((first as Maybe<*>).combine(second as Maybe<*>)) as Maybe<A>
+      }
+    first is Maybe<*> || second is Maybe<*> ->
+      (this as Semigroup<Maybe<*>>).run {
+        Just((first as Maybe<*>).rebox().combine((second as Maybe<*>).rebox()) as A)
+      }
+    else -> Just(first.combine(second))
   }
-
-  first is Maybe<*> || second is Maybe<*> -> (this as Semigroup<Maybe<*>>).run {
-    Just((first as Maybe<*>).rebox().combine((second as Maybe<*>).rebox()) as A)
-  }
-
-  else -> Just(first.combine(second))
-}
 
 /**
- * Purposefully NOT inline because, as the name suggests, this will cause the [this]
- * to be reboxed, which convinces the compiler that [this] Maybe is not being used in an Any or generic context
+ * Purposefully NOT inline because, as the name suggests, this will cause the [this] to be reboxed,
+ * which convinces the compiler that [this] Maybe is not being used in an Any or generic context
  */
-@PublishedApi
-internal fun <A : Any> Maybe<A>.rebox(): Maybe<A> = this
+@PublishedApi internal fun <A : Any> Maybe<A>.rebox(): Maybe<A> = this
 
 public inline operator fun <reified A : Comparable<A>> Maybe<A>.compareTo(other: Maybe<A>): Int =
-  fold({ other.fold({ 0 }, { -1 }) }, { a1 ->
-    other.fold({ 1 }, { a2 -> a1.compareTo(a2) })
-  })
+  fold({ other.fold({ 0 }, { -1 }) }, { a1 -> other.fold({ 1 }, { a2 -> a1.compareTo(a2) }) })
 
 public fun <A, B : Any> Either<A, B>.orNothing(): Maybe<B> = fold({ Nothing }, { Just(it) })
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, B, reified C : Any> Either<A, B>.traverse(fa: (B) -> Maybe<C>): Maybe<Either<A, C>> =
-  fold({ Nothing }, { right -> fa(right).map(::Right) })
+public inline fun <A, B, reified C : Any> Either<A, B>.traverse(
+  fa: (B) -> Maybe<C>
+): Maybe<Either<A, C>> = fold({ Nothing }, { right -> fa(right).map(::Right) })
 
 public inline fun <A, B, reified AA : Any, reified C : Any> Either<A, B>.bitraverseMaybe(
-  fl: (A) -> Maybe<AA>, fr: (B) -> Maybe<C>
+  fl: (A) -> Maybe<AA>,
+  fr: (B) -> Maybe<C>
 ): Maybe<Either<AA, C>> = fold({ fl(it).map(::Left) }, { fr(it).map(::Right) })
 
-public inline fun <A, reified B : Any> Either<A, Maybe<B>>.sequence(): Maybe<Either<A, B>> = traverse(::identity)
+public inline fun <A, reified B : Any> Either<A, Maybe<B>>.sequence(): Maybe<Either<A, B>> =
+  traverse(::identity)
 
-public inline fun <reified A : Any, reified B : Any> Either<Maybe<A>, Maybe<B>>.bisequenceMaybe(): Maybe<Either<A, B>> =
-  bitraverseMaybe(::identity, ::identity)
+public inline fun <reified A : Any, reified B : Any> Either<Maybe<A>, Maybe<B>>.bisequenceMaybe():
+  Maybe<Either<A, B>> = bitraverseMaybe(::identity, ::identity)
 
 public inline fun <A, B, reified C : Any, reified D : Any> Ior<A, B>.bitraverseMaybe(
-  fa: (A) -> Maybe<C>, fb: (B) -> Maybe<D>
-): Maybe<Ior<C, D>> = fold({ fa(it).map { Ior.Left(it) } },
-  { fb(it).map { Ior.Right(it) } },
-  { a, b -> fa(a).flatMap { aa -> fb(b).map { c -> Ior.Both(aa, c) } } })
+  fa: (A) -> Maybe<C>,
+  fb: (B) -> Maybe<D>
+): Maybe<Ior<C, D>> =
+  fold(
+    { fa(it).map { Ior.Left(it) } },
+    { fb(it).map { Ior.Right(it) } },
+    { a, b -> fa(a).flatMap { aa -> fb(b).map { c -> Ior.Both(aa, c) } } }
+  )
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, B, reified C : Any> Ior<A, B>.traverse(fa: (B) -> Maybe<C>): Maybe<Ior<A, C>> =
-  fold({ a -> Just(Ior.Left(a)) }, { b -> fa(b).map { Ior.Right(it) } }, { a, b -> fa(b).map { Ior.Both(a, it) } })
+public inline fun <A, B, reified C : Any> Ior<A, B>.traverse(
+  fa: (B) -> Maybe<C>
+): Maybe<Ior<A, C>> =
+  fold(
+    { a -> Just(Ior.Left(a)) },
+    { b -> fa(b).map { Ior.Right(it) } },
+    { a, b -> fa(b).map { Ior.Both(a, it) } }
+  )
 
-public inline fun <reified B : Any, reified C : Any> Ior<Maybe<B>, Maybe<C>>.bisequenceMaybe(): Maybe<Ior<B, C>> =
-  bitraverseMaybe(::identity, ::identity)
+public inline fun <reified B : Any, reified C : Any> Ior<Maybe<B>, Maybe<C>>.bisequenceMaybe():
+  Maybe<Ior<B, C>> = bitraverseMaybe(::identity, ::identity)
 
-public inline fun <A, reified B : Any> Ior<A, Maybe<B>>.sequence(): Maybe<Ior<A, B>> = traverse(::identity)
+public inline fun <A, reified B : Any> Ior<A, Maybe<B>>.sequence(): Maybe<Ior<A, B>> =
+  traverse(::identity)
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
 public inline fun <A, reified B : Any> Iterable<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
   val destination = ArrayList<B>(collectionSizeOrDefault(10))
   for (item in this) {
-    f(item).fold({ return Nothing }, { destination.add(it) })
+    f(item)
+      .fold(
+        {
+          return Nothing
+        },
+        { destination.add(it) }
+      )
   }
   return destination.just()
 }
 
-public inline fun <reified A : Any> Iterable<Maybe<A>>.sequence(): Maybe<List<A>> = traverse(::identity)
+public inline fun <reified A : Any> Iterable<Maybe<A>>.sequence(): Maybe<List<A>> =
+  traverse(::identity)
 
 /**
  * Returns the first element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty.
  */
-public fun <T : Any> Iterable<T>.firstOrNothing(): Maybe<T> = when (this) {
-  is Collection -> if (!isEmpty()) {
-    Just(first())
+public fun <T : Any> Iterable<T>.firstOrNothing(): Maybe<T> =
+  when (this) {
+    is Collection ->
+      if (!isEmpty()) {
+        Just(first())
+      } else {
+        Nothing
+      }
+    else -> {
+      iterator().nextOrNothing()
+    }
+  }
+
+private fun <T : Any> Iterator<T>.nextOrNothing(): Maybe<T> =
+  if (hasNext()) {
+    Just(next())
   } else {
     Nothing
   }
 
-  else -> {
-    iterator().nextOrNothing()
-  }
-}
-
-private fun <T : Any> Iterator<T>.nextOrNothing(): Maybe<T> = if (hasNext()) {
-  Just(next())
-} else {
-  Nothing
-}
-
 /**
- * Returns the first element as [Just(element)][Just] matching the given [predicate], or [Maybe.Nothing] if element was not found.
+ * Returns the first element as [Just(element)][Just] matching the given [predicate], or
+ * [Maybe.Nothing] if element was not found.
  */
 public inline fun <T : Any> Iterable<T>.firstOrNothing(predicate: (T) -> Boolean): Maybe<T> {
   for (element in this) {
@@ -790,21 +1032,24 @@ public inline fun <T : Any> Iterable<T>.firstOrNothing(predicate: (T) -> Boolean
 }
 
 /**
- * Returns single element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty or has more than one element.
+ * Returns single element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty or
+ * has more than one element.
  */
-public fun <T : Any> Iterable<T>.singleOrNothing(): Maybe<T> = when (this) {
-  is Collection -> when (size) {
-    1 -> firstOrNothing()
-    else -> Nothing
+public fun <T : Any> Iterable<T>.singleOrNothing(): Maybe<T> =
+  when (this) {
+    is Collection ->
+      when (size) {
+        1 -> firstOrNothing()
+        else -> Nothing
+      }
+    else -> {
+      iterator().run { nextOrNothing().filter<Any> { !hasNext() } as Maybe<T> }
+    }
   }
-
-  else -> {
-    iterator().run { nextOrNothing().filter<Any> { !hasNext() } as Maybe<T> }
-  }
-}
 
 /**
- * Returns the single element as [Just(element)][Just] matching the given [predicate], or [Maybe.Nothing] if element was not found or more than one element was found.
+ * Returns the single element as [Just(element)][Just] matching the given [predicate], or
+ * [Maybe.Nothing] if element was not found or more than one element was found.
  */
 public inline fun <T : Any> Iterable<T>.singleOrNothing(predicate: (T) -> Boolean): Maybe<T> {
   var result: Maybe<T> = Nothing
@@ -822,26 +1067,29 @@ public inline fun <T : Any> Iterable<T>.singleOrNothing(predicate: (T) -> Boolea
 /**
  * Returns the last element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty.
  */
-public fun <T : Any> Iterable<T>.lastOrNothing(): Maybe<T> = when (this) {
-  is Collection -> if (!isEmpty()) {
-    Just(last())
-  } else {
-    Nothing
+public fun <T : Any> Iterable<T>.lastOrNothing(): Maybe<T> =
+  when (this) {
+    is Collection ->
+      if (!isEmpty()) {
+        Just(last())
+      } else {
+        Nothing
+      }
+    else ->
+      iterator().run {
+        if (hasNext()) {
+          var last: T
+          do last = next() while (hasNext())
+          Just(last)
+        } else {
+          Nothing
+        }
+      }
   }
-
-  else -> iterator().run {
-    if (hasNext()) {
-      var last: T
-      do last = next() while (hasNext())
-      Just(last)
-    } else {
-      Nothing
-    }
-  }
-}
 
 /**
- * Returns the last element as [Just(element)][Just] matching the given [predicate], or [Maybe.Nothing] if no such element was found.
+ * Returns the last element as [Just(element)][Just] matching the given [predicate], or
+ * [Maybe.Nothing] if no such element was found.
  */
 public inline fun <T : Any> Iterable<T>.lastOrNothing(predicate: (T) -> Boolean): Maybe<T> {
   var value: Maybe<T> = Nothing
@@ -854,28 +1102,31 @@ public inline fun <T : Any> Iterable<T>.lastOrNothing(predicate: (T) -> Boolean)
 }
 
 /**
- * Returns an element as [Just(element)][Just] at the given [index] or [Maybe.Nothing] if the [index] is out of bounds of this iterable.
+ * Returns an element as [Just(element)][Just] at the given [index] or [Maybe.Nothing] if the
+ * [index] is out of bounds of this iterable.
  */
-public fun <T : Any> Iterable<T>.elementAtOrNothing(index: Int): Maybe<T> = when {
-  index < 0 -> Nothing
-  this is Collection -> when (index) {
-    in indices -> Just(elementAt(index))
-    else -> Nothing
+public fun <T : Any> Iterable<T>.elementAtOrNothing(index: Int): Maybe<T> =
+  when {
+    index < 0 -> Nothing
+    this is Collection ->
+      when (index) {
+        in indices -> Just(elementAt(index))
+        else -> Nothing
+      }
+    else -> iterator().skip(index).nextOrNothing()
   }
 
-  else -> iterator().skip(index).nextOrNothing()
-}
-
-private tailrec fun <T> Iterator<T>.skip(count: Int): Iterator<T> = when {
-  count > 0 && hasNext() -> {
-    next()
-    skip(count - 1)
+private tailrec fun <T> Iterator<T>.skip(count: Int): Iterator<T> =
+  when {
+    count > 0 && hasNext() -> {
+      next()
+      skip(count - 1)
+    }
+    else -> this
   }
 
-  else -> this
-}
-
-public inline fun <reified T : Any> Iterable<Maybe<T>>.filterMaybe(): List<T> = mapNotNull(Maybe<T>::orNull)
+public inline fun <reified T : Any> Iterable<Maybe<T>>.filterMaybe(): List<T> =
+  mapNotNull(Maybe<T>::orNull)
 
 public inline fun <reified T : Any> Iterable<Maybe<T>>.flattenMaybe(): List<T> = filterMaybe()
 
@@ -884,75 +1135,106 @@ public inline fun <reified T : Any> Iterable<Maybe<T>>.flattenMaybe(): List<T> =
 public inline fun <K, A, reified B : Any> Map<K, A>.traverse(f: (A) -> Maybe<B>): Maybe<Map<K, B>> {
   val acc = mutableMapOf<K, B>()
   forEach { (k, v) ->
-    f(v).fold({ return@traverse Nothing }, { acc[k] = it })
+    f(v)
+      .fold(
+        {
+          return@traverse Nothing
+        },
+        { acc[k] = it }
+      )
   }
   return acc.just()
 }
 
-public inline fun <K, reified V : Any> Map<K, Maybe<V>>.sequence(): Maybe<Map<K, V>> = traverse(::identity)
+public inline fun <K, reified V : Any> Map<K, Maybe<V>>.sequence(): Maybe<Map<K, V>> =
+  traverse(::identity)
 
-public inline fun <K, reified A : Any> Map<K, Maybe<A>>.filterOption(): Map<K, A> = filterMap { it.orNull() }
+public inline fun <K, reified A : Any> Map<K, Maybe<A>>.filterOption(): Map<K, A> = filterMap {
+  it.orNull()
+}
 
 public fun <K, V : Any> Map<K, V>.getOrNothing(key: K): Maybe<V> = this[key].toMaybe()
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <A, reified B : Any> NonEmptyList<A>.traverse(f: (A) -> Maybe<B>): Maybe<NonEmptyList<B>> =
+public inline fun <A, reified B : Any> NonEmptyList<A>.traverse(
+  f: (A) -> Maybe<B>
+): Maybe<NonEmptyList<B>> =
   f(head).map { newHead ->
     val acc = mutableListOf<B>()
     tail.forEach { a ->
-      f(a).fold({ return@traverse Nothing }, { acc.add(it) })
+      f(a)
+        .fold(
+          {
+            return@traverse Nothing
+          },
+          { acc.add(it) }
+        )
     }
     NonEmptyList(newHead, acc)
   }
 
-public inline fun <reified A : Any> NonEmptyList<Maybe<A>>.sequence(): Maybe<NonEmptyList<A>> = traverse(::identity)
+public inline fun <reified A : Any> NonEmptyList<Maybe<A>>.sequence(): Maybe<NonEmptyList<A>> =
+  traverse(::identity)
 
-public inline fun <reified A : Any> Sequence<Maybe<A>>.sequence(): Maybe<List<A>> = traverse(::identity)
+public inline fun <reified A : Any> Sequence<Maybe<A>>.sequence(): Maybe<List<A>> =
+  traverse(::identity)
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
 public inline fun <A, reified B : Any> Sequence<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
-  // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
+  // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when
+  // using
   //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
   //  forcing too much of the sequence to be evaluated.
   val acc = mutableListOf<B>()
   forEach { a ->
-    f(a).fold({ return@traverse Nothing }, { acc.add(it) })
+    f(a)
+      .fold(
+        {
+          return@traverse Nothing
+        },
+        { acc.add(it) }
+      )
   }
   return Just(acc)
 }
 
-public inline fun <reified A : Any> Sequence<Maybe<A>>.filterMaybe(): Sequence<A> = mapNotNull(Maybe<A>::orNull)
+public inline fun <reified A : Any> Sequence<Maybe<A>>.filterMaybe(): Sequence<A> =
+  mapNotNull(Maybe<A>::orNull)
 
 /**
- * Converts an `Maybe<A>` to a `Validated<E, A>`, where the provided `ifNothing` output value is returned as [Invalid]
- * when the specified `Maybe` is `Nothing`.
+ * Converts an `Maybe<A>` to a `Validated<E, A>`, where the provided `ifNothing` output value is
+ * returned as [Invalid] when the specified `Maybe` is `Nothing`.
  */
-public inline fun <E, reified A : Any> Validated.Companion.fromMaybe(o: Maybe<A>, ifNothing: () -> E): Validated<E, A> =
-  o.fold({ Validated.Invalid(ifNothing()) }, { Validated.Valid(it) })
+public inline fun <E, reified A : Any> Validated.Companion.fromMaybe(
+  o: Maybe<A>,
+  ifNothing: () -> E
+): Validated<E, A> = o.fold({ Validated.Invalid(ifNothing()) }, { Validated.Valid(it) })
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-public inline fun <E, A, reified B : Any> Validated<E, A>.traverse(fa: (A) -> Maybe<B>): Maybe<Validated<E, B>> =
+public inline fun <E, A, reified B : Any> Validated<E, A>.traverse(
+  fa: (A) -> Maybe<B>
+): Maybe<Validated<E, B>> =
   when (this) {
     is Validated.Valid -> fa(this.value).map { Validated.Valid(it) }
     is Validated.Invalid -> Nothing
   }
 
 public inline fun <E, A, reified B : Any, reified C : Any> Validated<E, A>.bitraverseMaybe(
-  fe: (E) -> Maybe<B>, fa: (A) -> Maybe<C>
+  fe: (E) -> Maybe<B>,
+  fa: (A) -> Maybe<C>
 ): Maybe<Validated<B, C>> = fold({ fe(it).map(::Invalid) }, { fa(it).map(::Valid) })
 
-/**
- * Returns Valid values wrapped in Just, and Nothing for Invalid values
- */
+/** Returns Valid values wrapped in Just, and Nothing for Invalid values */
 public fun <E, A : Any> Validated<E, A>.toMaybe(): Maybe<A> = fold({ Nothing }, ::Just)
 
-public inline fun <reified A : Any, reified B : Any> Validated<Maybe<A>, Maybe<B>>.bisequenceMaybe(): Maybe<Validated<A, B>> =
-  bitraverseMaybe(::identity, ::identity)
+public inline fun <reified A : Any, reified B : Any> Validated<Maybe<A>, Maybe<B>>
+  .bisequenceMaybe(): Maybe<Validated<A, B>> = bitraverseMaybe(::identity, ::identity)
 
-public inline fun <A, reified B : Any> Validated<A, Maybe<B>>.sequence(): Maybe<Validated<A, B>> = traverse(::identity)
+public inline fun <A, reified B : Any> Validated<A, Maybe<B>>.sequence(): Maybe<Validated<A, B>> =
+  traverse(::identity)
 
 public fun <E, A : Any> Validated<E, A>.orNothing(): Maybe<A> = fold({ Nothing }, { Just(it) })
 
@@ -961,7 +1243,9 @@ public fun <E, A : Any> Validated<E, A>.orNothing(): Maybe<A> = fold({ Nothing }
  * provided function [orElse], and result value [A] is mapped to [Just].
  */
 @OptIn(MaybeInternals::class)
-public inline fun <R, A : Any> EagerEffect<R, A>.toMaybe(crossinline orElse: (R) -> Maybe<A>): Maybe<A> {
+public inline fun <R, A : Any> EagerEffect<R, A>.toMaybe(
+  crossinline orElse: (R) -> Maybe<A>
+): Maybe<A> {
   // An effect's fold is not inline, so it will box the maybe.
   // That is, unless we pass the underlying values instead and construct the maybe on the outside
   // Also, orElse is crossinline because a normal function would just box
@@ -973,18 +1257,25 @@ public inline fun <R, A : Any> EagerEffect<R, A>.toMaybe(crossinline orElse: (R)
  * provided function [orElse], and result value [A] is mapped to [Just].
  */
 @OptIn(MaybeInternals::class)
-public suspend inline fun <R, A : Any> Effect<R, A>.toMaybe(crossinline orElse: (R) -> Maybe<A>): Maybe<A> {
+public suspend inline fun <R, A : Any> Effect<R, A>.toMaybe(
+  crossinline orElse: (R) -> Maybe<A>
+): Maybe<A> {
   // An effect's fold is not inline, so it will box the maybe.
   // That is, unless we pass the underlying values instead and construct the maybe on the outside
   // Also, orElse is crossinline because a normal function would just box
   return Maybe.construct(fold({ orElse(it).underlying }, { Just(it).underlying }))
 }
 
-public suspend inline fun <R, reified B : Any> EagerEffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
-  maybe.fold({ shift(shift()) }, { it })
+public suspend inline fun <R, reified B : Any> EagerEffectScope<R>.bind(
+  maybe: Maybe<B>,
+  shift: () -> R
+): B = maybe.fold({ shift(shift()) }, { it })
 
 @JvmName("bindMaybe")
-public suspend fun <R, B : Any> EagerEffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
+public suspend fun <R, B : Any> EagerEffectScope<R>.bind(
+  maybe: Maybe<Maybe<B>>,
+  shift: () -> R
+): Maybe<B> {
   // Similar in spirit to EagerEffectScope.bind(shift)
   // We don't want the maybe argument to "hang around" after the suspension point of the shift
   // And so instead we use the maybe argument immediately, get its contents or null, and *then*
@@ -992,11 +1283,16 @@ public suspend fun <R, B : Any> EagerEffectScope<R>.bind(maybe: Maybe<Maybe<B>>,
   return maybe.orNull() ?: shift(shift())
 }
 
-public suspend inline fun <R, reified B : Any> EffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
-  maybe.fold({ shift(shift()) }, { it })
+public suspend inline fun <R, reified B : Any> EffectScope<R>.bind(
+  maybe: Maybe<B>,
+  shift: () -> R
+): B = maybe.fold({ shift(shift()) }, { it })
 
 @JvmName("bindMaybe")
-public suspend fun <R, B : Any> EffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
+public suspend fun <R, B : Any> EffectScope<R>.bind(
+  maybe: Maybe<Maybe<B>>,
+  shift: () -> R
+): Maybe<B> {
   // Similar in spirit to EagerEffectScope.bind(shift)
   // We don't want the maybe argument to "hang around" after the suspension point of the shift
   // And so instead we use the maybe argument immediately, get its contents or null, and *then*

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -35,7 +35,7 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
     public inline fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
 
     @JvmStatic
-    public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> = fromNullable<Maybe<A>>(a)
+    public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> = if (a != null) Just(a) else Nothing
 
     @JvmStatic
     public inline operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
@@ -50,27 +50,12 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
     }
 
     @JvmStatic
-    @JvmName("tryCatchOrNothingMaybe")
-    /**
-     * Ignores exceptions and returns Nothing if one is thrown
-     */
-    public inline fun <A : Any> catchMaybe(f: () -> Maybe<A>): Maybe<Maybe<A>> {
-      return catch(f)
-    }
-
-    @JvmStatic
     @JvmName("tryCatch")
     public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> = try {
       Just(f())
     } catch (t: Throwable) {
       recover(t.nonFatalOrThrow())
     }
-
-    @JvmStatic
-    @JvmName("tryCatchMaybe")
-    public inline fun <A : Any> catchMaybe(
-      recover: (Throwable) -> Maybe<Maybe<A>>, f: () -> Maybe<A>
-    ): Maybe<Maybe<A>> = catch(recover, f)
 
     @JvmStatic
     public inline fun <reified A : Any, B : Any> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> = { it.map(f) }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -1,7 +1,12 @@
 package arrow.core
 
+import arrow.core.Either.Left
 import arrow.core.Either.Right
 import arrow.core.Maybe.Companion.Nothing
+import arrow.core.continuations.EagerEffect
+import arrow.core.continuations.EagerEffectScope
+import arrow.core.continuations.Effect
+import arrow.core.continuations.EffectScope
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import kotlin.experimental.ExperimentalTypeInference
@@ -356,8 +361,7 @@ internal annotation class MaybeInternals
 
 @JvmInline
 public value class Maybe<out A : Any> @MaybeInternals private constructor(
-  @property:MaybeInternals
-  @PublishedApi internal val underlying: Any
+  @property:MaybeInternals @PublishedApi internal val underlying: Any
 ) {
 
   public companion object {
@@ -370,16 +374,13 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
     public val Nothing: Maybe<Nothing> = construct(Nil(0))
 
     @JvmStatic
-    public fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
+    public inline fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
 
     @JvmStatic
-    public fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> = if (a != null) Just(a) else Nothing
+    public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> = fromNullable<Maybe<A>>(a)
 
     @JvmStatic
-    public operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
-
-    @JvmStatic
-    public operator fun <A : Any> invoke(a: Maybe<A>): Maybe<Maybe<A>> = Just(a)
+    public inline operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
 
     @JvmStatic
     @JvmName("tryCatchOrNothing")
@@ -387,8 +388,7 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
      * Ignores exceptions and returns Nothing if one is thrown
      */
     public inline fun <A : Any> catch(f: () -> A): Maybe<A> {
-      val recover: (Throwable) -> Maybe<A> = { Nothing }
-      return catch(recover, f)
+      return catch({ Nothing }, f)
     }
 
     @JvmStatic
@@ -397,34 +397,25 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
      * Ignores exceptions and returns Nothing if one is thrown
      */
     public inline fun <A : Any> catchMaybe(f: () -> Maybe<A>): Maybe<Maybe<A>> {
-      val recover: (Throwable) -> Maybe<Maybe<A>> = { Nothing }
-      return catchMaybe(recover, f)
+      return catch(f)
     }
 
     @JvmStatic
     @JvmName("tryCatch")
-    public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> =
-      try {
-        Just(f())
-      } catch (t: Throwable) {
-        recover(t.nonFatalOrThrow())
-      }
+    public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> = try {
+      Just(f())
+    } catch (t: Throwable) {
+      recover(t.nonFatalOrThrow())
+    }
 
     @JvmStatic
     @JvmName("tryCatchMaybe")
     public inline fun <A : Any> catchMaybe(
-      recover: (Throwable) -> Maybe<Maybe<A>>,
-      f: () -> Maybe<A>
-    ): Maybe<Maybe<A>> =
-      try {
-        Just(f())
-      } catch (t: Throwable) {
-        recover(t.nonFatalOrThrow())
-      }
+      recover: (Throwable) -> Maybe<Maybe<A>>, f: () -> Maybe<A>
+    ): Maybe<Maybe<A>> = catch(recover, f)
 
     @JvmStatic
-    public inline fun <reified A : Any, B : Any> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> =
-      { it.map(f) }
+    public inline fun <reified A : Any, B : Any> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> = { it.map(f) }
   }
 
   /**
@@ -449,7 +440,6 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
 
   /**
    * Returns true if the maybe is [Nothing], false otherwise.
-   * @note Used only for performance instead of fold.
    */
   public fun isEmpty(): Boolean = fold<Any, Boolean>({ true }, { false })
 
@@ -476,10 +466,7 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
    */
   public fun isDefined(): Boolean = isNotEmpty()
 
-  override fun toString(): String = fold<Any, String>(
-    { "Maybe.Nil" },
-    { "Maybe.Just($it)" }
-  )
+  override fun toString(): String = fold<Any, String>({ "Maybe.Nothing" }, { "Maybe.Just($it)" })
 }
 
 @PublishedApi
@@ -488,120 +475,51 @@ internal inline fun <reified T> isTypeMaybe(): Boolean =
 
 @PublishedApi
 @MaybeInternals
-internal inline val <reified A : Any> Maybe<A>.value: A
-  get() {
-    val trueValue = when (underlying) {
-      is Nil -> Nil(underlying.nesting - 1).also { if (it.nesting < 0) error("Unexpected nesting value for Nil") }
-      else -> underlying
-    }
-    return (if (isTypeMaybe<A>()) Maybe.construct<Any>(trueValue) else trueValue) as A
-  }
-
-@get:JvmName("getMaybeValue")
-@PublishedApi
-@MaybeInternals
-internal inline val <A : Any> Maybe<Maybe<A>>.value: Maybe<A>
-  get() =
-    Maybe.construct((this as Maybe<*>).value) // Should not box since its return type is Maybe
+internal val <A : Any> Maybe<A>.value: A
+  get() = when (underlying) {
+    is Nil -> Nil(underlying.nesting - 1).also { if (it.nesting < 0) error("Unexpected nesting value for Nil") }
+    else -> underlying
+  } as A
 
 public inline fun <reified A : Any, reified B : Any> Maybe<A>.zip(other: Maybe<B>): Maybe<Pair<A, B>> =
   zip(other, ::Pair)
 
 public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  map: (A, B) -> C
-): Maybe<C> =
-  zip(
-    b,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit
-  ) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+  b: Maybe<B>, map: (A, B) -> C
+): Maybe<C> = zip(
+  b, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit
+) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, D : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  c: Maybe<C>,
-  map: (A, B, C) -> D
-): Maybe<D> =
-  zip(
-    b,
-    c,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit
-  ) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+  b: Maybe<B>, c: Maybe<C>, map: (A, B, C) -> D
+): Maybe<D> = zip(
+  b, c, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit
+) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, E : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  c: Maybe<C>,
-  d: Maybe<D>,
-  map: (A, B, C, D) -> E
-): Maybe<E> =
-  zip(
-    b,
-    c,
-    d,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit,
-    justUnit
-  ) { a, b, c, d, _, _, _, _, _, _ -> map(a, b, c, d) }
+  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, map: (A, B, C, D) -> E
+): Maybe<E> = zip(
+  b, c, d, justUnit, justUnit, justUnit, justUnit, justUnit, justUnit
+) { a, b, c, d, _, _, _, _, _, _ -> map(a, b, c, d) }
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, F : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  c: Maybe<C>,
-  d: Maybe<D>,
-  e: Maybe<E>,
-  map: (A, B, C, D, E) -> F
-): Maybe<F> =
-  zip(b, c, d, e, justUnit, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
-    map(
-      a,
-      b,
-      c,
-      d,
-      e
-    )
-  }
+  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, e: Maybe<E>, map: (A, B, C, D, E) -> F
+): Maybe<F> = zip(b, c, d, e, justUnit, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
+  map(
+    a, b, c, d, e
+  )
+}
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, G : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  c: Maybe<C>,
-  d: Maybe<D>,
-  e: Maybe<E>,
-  f: Maybe<F>,
-  map: (A, B, C, D, E, F) -> G
-): Maybe<G> =
-  zip(b, c, d, e, f, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
-    map(
-      a,
-      b,
-      c,
-      d,
-      e,
-      f
-    )
-  }
+  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, e: Maybe<E>, f: Maybe<F>, map: (A, B, C, D, E, F) -> G
+): Maybe<G> = zip(b, c, d, e, f, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
+  map(
+    a, b, c, d, e, f
+  )
+}
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, H : Any> Maybe<A>.zip(
-  b: Maybe<B>,
-  c: Maybe<C>,
-  d: Maybe<D>,
-  e: Maybe<E>,
-  f: Maybe<F>,
-  g: Maybe<G>,
-  map: (A, B, C, D, E, F, G) -> H
+  b: Maybe<B>, c: Maybe<C>, d: Maybe<D>, e: Maybe<E>, f: Maybe<F>, g: Maybe<G>, map: (A, B, C, D, E, F, G) -> H
 ): Maybe<H> =
   zip(b, c, d, e, f, g, justUnit, justUnit, justUnit) { a, b, c, d, e, f, g, _, _, _ -> map(a, b, c, d, e, f, g) }
 
@@ -627,8 +545,7 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
   h: Maybe<H>,
   i: Maybe<I>,
   map: (A, B, C, D, E, F, G, H, I) -> J
-): Maybe<J> =
-  zip(b, c, d, e, f, g, h, i, justUnit) { a, b, c, d, e, f, g, h, i, _ -> map(a, b, c, d, e, f, g, h, i) }
+): Maybe<J> = zip(b, c, d, e, f, g, h, i, justUnit) { a, b, c, d, e, f, g, h, i, _ -> map(a, b, c, d, e, f, g, h, i) }
 
 public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, reified I : Any, reified J : Any, K : Any> Maybe<A>.zip(
   b: Maybe<B>,
@@ -641,13 +558,23 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
   i: Maybe<I>,
   j: Maybe<J>,
   map: (A, B, C, D, E, F, G, H, I, J) -> K
-): Maybe<K> =
-  @OptIn(MaybeInternals::class) // For simplicity of implementation
-  if (this.isJust && b.isJust && c.isJust && d.isJust && e.isJust && f.isJust && g.isJust && h.isJust && i.isJust && j.isJust) {
-    Just(map(this.value, b.value, c.value, d.value, e.value, f.value, g.value, h.value, i.value, j.value))
-  } else {
-    Nothing
+): Maybe<K> {
+  Nullable.zip(
+    this.orNull(),
+    b.orNull(),
+    c.orNull(),
+    d.orNull(),
+    e.orNull(),
+    f.orNull(),
+    g.orNull(),
+    h.orNull(),
+    i.orNull(),
+    j.orNull()
+  ) { a, b, c, d, e, f, g, h, i, j ->
+    return Just(map(a, b, c, d, e, f, g, h, i, j))
   }
+  return Nothing
+}
 
 /**
  * Returns the result of applying $f to this $maybe's value if
@@ -659,52 +586,24 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
  * @param f the function to apply
  * @see map
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> =
-  fold({ Nothing }, f)
-
-/**
- * Returns the result of applying $f to this $maybe's value if
- * this $maybe is nonempty.
- * Returns $nil if this $maybe is empty.
- * Slightly different from `map` in that $f is expected to
- * return an $maybe (which could be $nil).
- *
- * @param f the function to apply
- * @see map
- */
-@JvmName("maybeFlatMap")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.flatMap(f: (Maybe<A>) -> Maybe<B>): Maybe<B> =
-  fold({ Nothing }, f)
+public inline fun <reified A : Any, B : Any> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> = fold({ Nothing }, f)
 
 @OptIn(MaybeInternals::class)
 public inline fun <reified A : Any, R> Maybe<A>.fold(ifEmpty: () -> R, ifJust: (A) -> R): R = when (this) {
   Nothing -> ifEmpty()
-  else -> ifJust(value)
+  else -> if (isTypeMaybe<A>()) Maybe.construct<Any>((this as Maybe<Any>).value).invokeBlockOnMaybe(ifJust) else ifJust(
+    value
+  )
 }
 
-@OptIn(MaybeInternals::class)
-@JvmName("maybeFold")
-public inline fun <A : Any, R> Maybe<Maybe<A>>.fold(ifEmpty: () -> R, ifJust: (Maybe<A>) -> R): R = when (this) {
-  Nothing -> ifEmpty()
-  else -> ifJust(value)
-}
-@OptIn(MaybeInternals::class)
-public inline fun <reified A : Any, R : Any> Maybe<A>.foldMaybe(
-  ifEmpty: () -> Maybe<R>,
-  ifJust: (A) -> Maybe<R>
-): Maybe<R> = when (this) {
-  Nothing -> ifEmpty()
-  else -> ifJust(value)
+@PublishedApi
+internal inline fun <T, R, A> T.invokeBlock(block: (A) -> R): R {
+  return block(this as A)
 }
 
-@OptIn(MaybeInternals::class)
-@JvmName("maybeFoldMaybe")
-public inline fun <A : Any, R : Any> Maybe<Maybe<A>>.foldMaybe(
-  ifEmpty: () -> Maybe<R>,
-  ifJust: (Maybe<A>) -> Maybe<R>
-): Maybe<R> = when (this) {
-  Nothing -> ifEmpty()
-  else -> ifJust(value)
+@PublishedApi
+internal inline fun <R, A> Maybe<*>.invokeBlockOnMaybe(block: (A) -> R): R {
+  return block(this as A)
 }
 
 /**
@@ -725,17 +624,12 @@ public inline fun <A : Any, R : Any> Maybe<Maybe<A>>.foldMaybe(
  * ```
  * <!--- KNIT example-maybe-20.kt -->
  */
-public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> =
-  this.also { fold({}, f) }
+public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> = this.also { fold({}, f) }
 
-@JvmName("maybeTap")
-public inline fun <A : Any> Maybe<Maybe<A>>.tap(f: (Maybe<A>) -> Unit): Maybe<Maybe<A>> =
-  this.also { fold({}, f) }
-
-public inline fun <reified A : Any> Maybe<A>.orNull(): A? = fold({ null }, ::identity)
+public inline fun <reified A : Any> Maybe<A>.orNull(): A? = fold({ return null }, ::identity)
 
 @JvmName("orNullMaybe")
-public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = foldMaybe({ return null }, ::identity)
+public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = fold({ return null }, ::identity)
 
 /**
  * Returns a [Just<$B>] containing the result of applying $f to this $maybe's
@@ -747,19 +641,7 @@ public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = foldMaybe({ return nu
  * @param f the function to apply
  * @see flatMap
  */
-public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> =
-  flatMap { a -> Just(f(a)) }
-
-@JvmName("maybeMap")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.map(f: (Maybe<A>) -> B): Maybe<B> =
-  flatMap { a -> Just(f(a)) }
-
-public inline fun <reified A : Any, B : Any> Maybe<A>.mapMaybe(f: (A) -> Maybe<B>): Maybe<Maybe<B>> =
-  flatMap { a -> Just(f(a)) }
-
-@JvmName("maybeMapMaybe")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.mapMaybe(f: (Maybe<A>) -> Maybe<B>): Maybe<Maybe<B>> =
-  flatMap { a -> Just(f(a)) }
+public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> = flatMap { a -> Just(f(a)) }
 
 /**
  * Returns $nil if the result of applying $f to this $maybe's value is null.
@@ -774,61 +656,13 @@ public inline fun <reified A : Any, B : Any> Maybe<A>.mapNotNull(f: (A) -> B?): 
   flatMap { a -> Maybe.fromNullable(f(a)) }
 
 /**
- * Returns $nil if the result of applying $f to this $maybe's value is null.
- * Otherwise returns the result.
- *
- * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
- * and primarily for convenience.
- *
- * @param f the function to apply.
- * */
-
-@JvmName("maybeMapNotNull")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.mapNotNull(f: (Maybe<A>) -> B?): Maybe<B> =
-  flatMap { a -> Maybe.fromNullable(f(a)) }
-
-/**
- * Returns $nil if the result of applying $f to this $maybe's value is null.
- * Otherwise returns the result.
- *
- * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
- * and primarily for convenience.
- *
- * @param f the function to apply.
- * */
-public inline fun <reified A : Any, B : Any> Maybe<A>.mapMaybeNotNull(f: (A) -> Maybe<B>?): Maybe<Maybe<B>> =
-  flatMap { a -> Maybe.fromNullable(f(a)) }
-
-/**
- * Returns $nil if the result of applying $f to this $maybe's value is null.
- * Otherwise returns the result.
- *
- * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
- * and primarily for convenience.
- *
- * @param f the function to apply.
- * */
-
-@JvmName("maybeMapMaybeNotNull")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.mapMaybeNotNull(f: (Maybe<A>) -> Maybe<B>?): Maybe<Maybe<B>> =
-  flatMap { a -> Maybe.fromNullable(f(a)) }
-
-
-/**
  * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior].
  */
-public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(b: Maybe<B>): Maybe<Ior<A, B>> =
-  fold({
-    b.fold(
-      { Nothing },
-      { b -> Just(b.rightIor()) })
-  },
-    { a ->
-      b.fold(
-        { Just(a.leftIor()) },
-        { b -> Just(Pair(a, b).bothIor()) })
-    }
-  )
+public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(b: Maybe<B>): Maybe<Ior<A, B>> = fold({
+  b.fold({ Nothing }, { b -> Just(b.rightIor()) })
+}, { a ->
+  b.fold({ Just(a.leftIor()) }, { b -> Just(Pair(a, b).bothIor()) })
+})
 
 
 /**
@@ -837,21 +671,8 @@ public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(b: May
  * @note This function works like a regular `align` function, but is then mapped by the `map` function.
  */
 public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.align(
-  b: Maybe<B>,
-  f: (Ior<A, B>) -> C
-): Maybe<C> =
-  align(b).map(f)
-
-/**
- * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior], and then, if it's not [Nothing], map it using [f].
- *
- * @note This function works like a regular `align` function, but is then mapped by the `map` function.
- */
-public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.alignMaybe(
-  b: Maybe<B>,
-  f: (Ior<A, B>) -> Maybe<C>
-): Maybe<Maybe<C>> =
-  align(b).mapMaybe(f)
+  b: Maybe<B>, f: (Ior<A, B>) -> C
+): Maybe<C> = align(b).map(f)
 
 /**
  * Returns true if this maybe is empty '''or''' the predicate
@@ -859,68 +680,16 @@ public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.alignMayb
  *
  * @param predicate the predicate to test
  */
-public inline fun <reified A : Any> Maybe<A>.all(predicate: (A) -> Boolean): Boolean =
-  fold({ true }, predicate)
-
-/**
- * Returns true if this maybe is empty '''or''' the predicate
- * $predicate returns true when applied to this $maybe's value.
- *
- * @param predicate the predicate to test
- */
-@JvmName("maybeAll")
-public inline fun <A : Any> Maybe<Maybe<A>>.all(predicate: (Maybe<A>) -> Boolean): Boolean =
-  fold({ true }, predicate)
+public inline fun <reified A : Any> Maybe<A>.all(predicate: (A) -> Boolean): Boolean = fold({ true }, predicate)
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalk(f: (A) -> Maybe<B>): Maybe<Maybe<B>> =
-  fold(
-    { Nothing },
-    { value -> f(value).mapMaybe<Any, B> { Just(it) as Maybe<B> } })
-
-@JvmName("maybeCrosswalk")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.crosswalk(f: (Maybe<A>) -> Maybe<B>): Maybe<Maybe<B>> =
-  fold(
-    { Nothing },
-    { value -> f(value).mapMaybe<Any, B> { Just(it) as Maybe<B> } })
+  fold({ Nothing }, { value -> f(value).map<Any, Maybe<B>> { Just(it) as Maybe<B> } })
 
 public inline fun <reified A : Any, K, V : Any> Maybe<A>.crosswalkMap(f: (A) -> Map<K, V>): Map<K, Maybe<V>> =
-  fold(
-    { emptyMap() },
-    { value -> f(value).mapValues { Just(it.value) } }
-  )
-
-@JvmName("maybeCrosswalkMap")
-public inline fun <A : Any, K, V : Any> Maybe<Maybe<A>>.crosswalkMap(f: (Maybe<A>) -> Map<K, V>): Map<K, Maybe<V>> =
-  fold(
-    { emptyMap() },
-    { value -> f(value).mapValues { Just(it.value) } }
-  )
+  fold({ emptyMap() }, { value -> f(value).mapValues { Just(it.value) } })
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNull(f: (A) -> B?): Maybe<B>? =
-  fold(
-    { null },
-    { value -> f(value)?.let { Just(it) } }
-  )
-
-@JvmName("maybeCrosswalkNull")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.crosswalkNull(f: (Maybe<A>) -> B?): Maybe<B>? =
-  fold(
-    { null },
-    { value -> f(value)?.let { Just(it) } }
-  )
-
-public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNullMaybe(f: (A) -> Maybe<B>?): Maybe<Maybe<B>>? =
-  fold(
-    { null },
-    { value -> f(value)?.let { Just(it) } }
-  )
-
-@JvmName("maybeCrosswalkNullMaybe")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.crosswalkNullMaybe(f: (Maybe<A>) -> Maybe<B>?): Maybe<Maybe<B>>? =
-  fold(
-    { null },
-    { value -> f(value)?.let { Just(it) } }
-  )
+  fold({ return null }, { value -> return f(value)?.let { Just(it) } })
 
 /**
  * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
@@ -933,31 +702,11 @@ public inline fun <reified A : Any> Maybe<A>.filter(predicate: (A) -> Boolean): 
 
 /**
  * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
- * this $maybe's value returns true. Otherwise, return $nil.
- *
- *  @param predicate the predicate used for testing.
- */
-@JvmName("maybeFilter")
-public inline fun <A : Any> Maybe<Maybe<A>>.filter(predicate: (Maybe<A>) -> Boolean): Maybe<Maybe<A>> =
-  flatMap { a -> if (predicate(a)) Just(a) else Nothing }
-
-/**
- * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
  * this $maybe's value returns false. Otherwise, return $nil.
  *
  * @param predicate the predicate used for testing.
  */
 public inline fun <reified A : Any> Maybe<A>.filterNot(predicate: (A) -> Boolean): Maybe<A> =
-  flatMap { a -> if (!predicate(a)) Just(a) else Nothing }
-
-/**
- * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
- * this $maybe's value returns false. Otherwise, return $nil.
- *
- * @param predicate the predicate used for testing.
- */
-@JvmName("maybeFilterNot")
-public inline fun <A : Any> Maybe<Maybe<A>>.filterNot(predicate: (Maybe<A>) -> Boolean): Maybe<Maybe<A>> =
   flatMap { a -> if (!predicate(a)) Just(a) else Nothing }
 
 /**
@@ -986,33 +735,6 @@ public inline fun <A : Any> Maybe<Maybe<A>>.filterNot(predicate: (Maybe<A>) -> B
 public inline fun <reified A : Any> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean = fold({ false }, predicate)
 
 /**
- * Returns true if this maybe is nonempty '''and''' the predicate
- * $p returns true when applied to this $maybe's value.
- * Otherwise, returns false.
- *
- * Example:
- * ```kotlin
- * import arrow.core.Just
- * import arrow.core.Nil
- * import arrow.core.Maybe
- *
- * fun main() {
- *   Just(12).exists { it > 10 } // Result: true
- *   Just(7).exists { it > 10 }  // Result: false
- *
- *   val nil: Maybe<Int> = Nil
- *   nil.exists { it > 10 }      // Result: false
- * }
- * ```
- * <!--- KNIT example-maybe-21.kt -->
- *
- * @param predicate the predicate to test
- */
-@JvmName("maybeExists")
-public inline fun <A : Any> Maybe<Maybe<A>>.exists(predicate: (Maybe<A>) -> Boolean): Boolean =
-  fold({ false }, predicate)
-
-/**
  * Returns the $maybe's value if this maybe is nonempty '''and''' the predicate
  * $p returns true when applied to this $maybe's value.
  * Otherwise, returns null.
@@ -1034,10 +756,7 @@ public inline fun <A : Any> Maybe<Maybe<A>>.exists(predicate: (Maybe<A>) -> Bool
  * <!--- KNIT example-maybe-22.kt -->
  */
 public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolean): A? =
-  fold(
-    { null },
-    { if (predicate(it)) it else null }
-  )
+  fold({ return null }, { return if (predicate(it)) it else null })
 
 /**
  * Returns the $maybe's value if this maybe is nonempty '''and''' the predicate
@@ -1063,290 +782,48 @@ public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolea
 
 @JvmName("maybeFindOrNull")
 public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(predicate: (Maybe<A>) -> Boolean): Maybe<A>? =
-  fold(
-    { null },
-    { if (predicate(it)) it else null }
-  )
+  fold({ return null }, { return if (predicate(it)) it else null })
 
 public inline fun <reified A : Any, B> Maybe<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
   foldLeft(empty()) { b, a -> b.combine(f(a)) }
 }
-
-@JvmName("maybeFoldMap")
-public inline fun <A : Any, B> Maybe<Maybe<A>>.foldMap(MB: Monoid<B>, f: (Maybe<A>) -> B): B = MB.run {
-  foldLeft(empty()) { b, a -> b.combine(f(a)) }
-}
-
-public inline fun <reified A : Any, B : Any> Maybe<A>.foldMapMaybe(MB: Monoid<Maybe<B>>, f: (A) -> Maybe<B>): Maybe<B> =
-  MB.run {
-    foldLeftMaybe(empty()) { b, a -> b.combine(f(a)) }
-  }
-
-@JvmName("maybeFoldMapMaybe")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.foldMapMaybe(
-  MB: Monoid<Maybe<B>>,
-  f: (Maybe<A>) -> Maybe<B>
-): Maybe<B> = MB.run {
-  foldLeftMaybe(empty()) { b, a -> b.combine(f(a)) }
+@JvmName("foldMapMaybe")
+public inline fun <reified A : Any, B: Any> Maybe<A>.foldMap(MB: Monoid<Maybe<B>>, f: (A) -> Maybe<B>): Maybe<B> = MB.run {
+  foldLeft(emptyMaybe()) { b, a -> combineToMaybe(b, f(a)).flatten() }
 }
 
 public inline fun <reified A : Any, B> Maybe<A>.foldLeft(initial: B, operation: (B, A) -> B): B =
-  fold(
-    { initial },
-    { operation(initial, it) }
-  )
+  fold({ initial }, { operation(initial, it) })
 
-@JvmName("maybeFoldLeft")
-public inline fun <A : Any, B> Maybe<Maybe<A>>.foldLeft(initial: B, operation: (B, Maybe<A>) -> B): B =
-  fold(
-    { initial },
-    { operation(initial, it) }
-  )
-
-public inline fun <reified A : Any, B : Any> Maybe<A>.foldLeftMaybe(
-  initial: Maybe<B>,
-  operation: (Maybe<B>, A) -> Maybe<B>
-): Maybe<B> =
-  fold(
-    { initial },
-    { operation(initial, it) }
-  )
-
-@JvmName("maybeFoldLeftMaybe")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.foldLeftMaybe(
-  initial: Maybe<B>,
-  operation: (Maybe<B>, Maybe<A>) -> Maybe<B>
-): Maybe<B> =
-  fold(
-    { initial },
-    { operation(initial, it) }
-  )
+public inline fun <reified A : Any, B : Any> Maybe<A>.foldLeft(
+  initial: Maybe<B>, operation: (Maybe<B>, A) -> Maybe<B>
+): Maybe<B> = fold({ initial }, { operation(initial, it) })
 
 public inline fun <reified A : Any, reified B : Any> Maybe<A>.padZip(other: Maybe<B>): Maybe<Pair<A?, B?>> =
   padZip(other, ::Pair)
 
 public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZip(
-  other: Maybe<B>,
-  f: (A?, B?) -> C
-): Maybe<C> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
+  other: Maybe<B>, f: (A?, B?) -> C
+): Maybe<C> = fold({
+  other.fold({
+    Nothing
+  }, { b ->
+    Just(f(null, b))
   })
-
-@JvmName("maybeNormalPadZip")
-public inline fun <A : Any, reified B : Any, C : Any> Maybe<Maybe<A>>.padZip(
-  other: Maybe<B>,
-  f: (Maybe<A>?, B?) -> C
-): Maybe<C> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
+}, { a ->
+  other.fold({
+    Just(f(a, null))
+  }, { b ->
+    Just(f(a, b))
   })
-
-@JvmName("normalMaybePadZip")
-public inline fun <reified A : Any, B : Any, C : Any> Maybe<A>.padZip(
-  other: Maybe<Maybe<B>>,
-  f: (A?, Maybe<B>?) -> C
-): Maybe<C> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
-
-@JvmName("maybeMaybePadZip")
-public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<A>>.padZip(
-  other: Maybe<Maybe<B>>,
-  f: (Maybe<A>?, Maybe<B>?) -> C
-): Maybe<C> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
-
-@JvmName("maybeMaybePadZip2")
-public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<A>>.padZip2(
-  other: Maybe<Maybe<B>>,
-  f: (Maybe<A>?, Maybe<B>?) -> C
-): Maybe<C> =
-  fold({
-    other.fold({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.fold({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
-
-public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZipMaybe(
-  other: Maybe<B>,
-  f: (A?, B?) -> Maybe<C>
-): Maybe<Maybe<C>> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
-
-@JvmName("maybeNormalPadZipMaybe")
-public inline fun <A : Any, reified B : Any, C : Any> Maybe<Maybe<A>>.padZipMaybe(
-  other: Maybe<B>,
-  f: (Maybe<A>?, B?) -> Maybe<C>
-): Maybe<Maybe<C>> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
-
-@JvmName("normalMaybePadZipMaybe")
-public inline fun <reified A : Any, B : Any, C : Any> Maybe<A>.padZipMaybe(
-  other: Maybe<Maybe<B>>,
-  f: (A?, Maybe<B>?) -> Maybe<C>
-): Maybe<Maybe<C>> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
-
-@JvmName("maybeMaybePadZipMaybe")
-public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<A>>.padZipMaybe(
-  other: Maybe<Maybe<B>>,
-  f: (Maybe<A>?, Maybe<B>?) -> Maybe<C>
-): Maybe<Maybe<C>> =
-  foldMaybe({
-    other.foldMaybe({
-      Nothing
-    }, { b ->
-      Just(f(null, b))
-    })
-  }, { a ->
-    other.foldMaybe({
-      Just(f(a, null))
-    }, { b ->
-      Just(f(a, b))
-    })
-  })
+})
 
 public inline fun <reified A : Any, B> Maybe<A>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A) -> B): B? =
-  fold(
-    { null },
-    { operation(initial(it), it) }
-  )
-
-@JvmName("maybeReduceOrNull")
-public inline fun <A : Any, B> Maybe<Maybe<A>>.reduceOrNull(
-  initial: (Maybe<A>) -> B,
-  operation: (acc: B, Maybe<A>) -> B
-): B? =
-  fold(
-    { null },
-    { operation(initial(it), it) }
-  )
+  fold({ return null }, { operation(initial(it), it) })
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.reduceOrNullMaybe(
-  initial: (A) -> Maybe<B>,
-  operation: (acc: Maybe<B>, A) -> Maybe<B>
-): Maybe<B>? =
-  fold(
-    { null },
-    { operation(initial(it), it) }
-  )
-
-@JvmName("maybeReduceOrNullMaybe")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.reduceOrNullMaybe(
-  initial: (Maybe<A>) -> Maybe<B>,
-  operation: (acc: Maybe<B>, Maybe<A>) -> Maybe<B>
-): Maybe<B>? =
-  fold(
-    { null },
-    { operation(initial(it), it) }
-  )
-
-public inline fun <reified A : Any, B> Maybe<A>.reduceRightEvalOrNull(
-  initial: (A) -> B,
-  operation: (A, acc: Eval<B>) -> Eval<B>
-): Eval<B?> =
-  fold(
-    { Eval.now(null) },
-    { operation(it, Eval.now(initial(it))) }
-  )
-
-@JvmName("maybeReduceRightEvalOrNull")
-public inline fun <A : Any, B> Maybe<Maybe<A>>.reduceRightEvalOrNull(
-  initial: (Maybe<A>) -> B,
-  operation: (Maybe<A>, acc: Eval<B>) -> Eval<B>
-): Eval<B?> =
-  fold(
-    { Eval.now(null) },
-    { operation(it, Eval.now(initial(it))) }
-  )
+  initial: (A) -> Maybe<B>, operation: (acc: Maybe<B>, A) -> Maybe<B>
+): Maybe<B>? = fold({ return null }, { operation(initial(it), it) })
 
 public inline fun <reified A : Any> Maybe<A>.replicate(n: Int): Maybe<List<A>> =
   if (n <= 0) Just(emptyList()) else map { a -> List(n) { a } }
@@ -1358,60 +835,20 @@ public inline fun <reified A : Any, B : Any> Maybe<A>.traverse(fa: (A) -> Iterab
 
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
-@JvmName("maybeTraverse")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.traverse(fa: (Maybe<A>) -> Iterable<B>): List<Maybe<B>> =
-  fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
-
-@OptIn(ExperimentalTypeInference::class)
-@OverloadResolutionByLambdaReturnType
 public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(fa: (A) -> Either<AA, B>): Either<AA, Maybe<B>> =
-  fold(
-    { Right(Nothing) },
-    { value -> fa(value).map { Just(it) } }
-  )
-
-@OptIn(ExperimentalTypeInference::class)
-@OverloadResolutionByLambdaReturnType
-@JvmName("maybeTraverse")
-public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverse(fa: (Maybe<A>) -> Either<AA, B>): Either<AA, Maybe<B>> =
-  fold(
-    { Right(Nothing) },
-    { value -> fa(value).map { Just(it) } }
-  )
+  fold({ Right(Nothing) }, { value -> fa(value).map { Just(it) } })
 
 @Deprecated("traverseEither is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
 public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseEither(fa: (A) -> Either<AA, B>): Either<AA, Maybe<B>> =
   traverse(fa)
 
-@JvmName("maybeTraverseEither")
-@Deprecated("traverseEither is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
-public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverseEither(fa: (Maybe<A>) -> Either<AA, B>): Either<AA, Maybe<B>> =
-  traverse(fa)
-
 @OptIn(ExperimentalTypeInference::class)
 @OverloadResolutionByLambdaReturnType
 public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(fa: (A) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
-  fold(
-    { Valid(Nothing) },
-    { value -> fa(value).map { Just(it) } }
-  )
-
-@OptIn(ExperimentalTypeInference::class)
-@OverloadResolutionByLambdaReturnType
-@JvmName("maybeTraverse")
-public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverse(fa: (Maybe<A>) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
-  fold(
-    { Valid(Nothing) },
-    { value -> fa(value).map { Just(it) } }
-  )
+  fold({ Valid(Nothing) }, { value -> fa(value).map { Just(it) } })
 
 @Deprecated("traverseValidated is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
 public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseValidated(fa: (A) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
-  traverse(fa)
-
-@JvmName("maybeTraverseValidated")
-@Deprecated("traverseValidated is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
-public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverseValidated(fa: (Maybe<A>) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
   traverse(fa)
 
 public inline fun <reified A : Any, L> Maybe<A>.toEither(ifEmpty: () -> L): Either<L, A> =
@@ -1438,7 +875,7 @@ internal data class Nil private constructor(val nesting: Int) {
     operator fun invoke(nesting: Int) = cache.getOrElse(nesting, ::Nil)
   }
 
-  override fun toString(): String = buildString("Maybe.Just()".length + "Maybe.Nothing".length) {
+  override fun toString(): String = buildString("Maybe.Just()".length * nesting + "Maybe.Nothing".length) {
     repeat(nesting) { this.append("Maybe.Just(") }
     append("Maybe.Nothing")
     repeat(nesting) { this.append(")") }
@@ -1446,20 +883,19 @@ internal data class Nil private constructor(val nesting: Int) {
 }
 
 @OptIn(MaybeInternals::class)
-public inline fun <T : Any> Just(value: T): Maybe<T> =
-  if (value is Maybe<*>) {
-    Just(value) as Maybe<T> // Should rarely ever happen, but just in case this ensures that there *never* is a boxed Maybe inside a Maybe
-  } else
-    Maybe.construct(if (value is Nil) Nil(value.nesting + 1) else value)
-
-@OptIn(MaybeInternals::class)
-public inline fun <T : Any> Just(value: Maybe<T>): Maybe<Maybe<T>> = (value as Maybe<*>).underlying.let {
-  // .value will remove 1 level of nesting, but we're inside 2 levels here, so we use underlying instead to get the raw value, and then we add 1 level of nesting
-  Maybe.construct(if (it is Nil) Nil(it.nesting + 1) else it)
+public inline fun <T : Any> Just(value: T): Maybe<T> {
+  // This `is` check gets inlined by the compiler if `value` is statically known to be Maybe
+  return _Just(if (value is Maybe<*>) value.underlying else value)
 }
+
+@MaybeInternals
+@PublishedApi
+internal fun <T : Any> _Just(trueValue: Any): Maybe<T> =
+  Maybe.construct(if (trueValue is Nil) Nil(trueValue.nesting + 1) else trueValue)
 
 @PublishedApi
 internal val justUnit: Maybe<Unit> = Just(Unit)
+
 @PublishedApi
 internal val boxedJustUnit: Any = justUnit
 
@@ -1479,7 +915,7 @@ public inline fun <reified T : Any> Maybe<T>.getOrElse(default: () -> T): T = fo
  */
 @JvmName("maybeGetOrElse")
 public inline fun <T : Any> Maybe<Maybe<T>>.getOrElse(default: () -> Maybe<T>): Maybe<T> =
-  foldMaybe({ default() }, ::identity)
+  fold({ default() }, ::identity)
 
 /**
  * Returns this maybe's if the maybe is nonempty, otherwise
@@ -1496,18 +932,16 @@ public infix fun <T : Any> Maybe<T>.or(value: Maybe<T>): Maybe<T> = if (isEmpty(
   this
 }
 
-public fun <T : Any> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
+public inline fun <T : Any> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
 public fun <T : Any> Maybe<T>?.toMaybe(): Maybe<Maybe<T>> = this?.let { Just(it) } ?: Nothing
 
-public inline fun <A : Any> Boolean.maybe2(f: () -> A): Maybe<A> =
-  if (this) {
-    Just(f())
-  } else {
-    Nothing
-  }
+public inline fun <A : Any> Boolean.maybe2(f: () -> A): Maybe<A> = if (this) {
+  Just(f())
+} else {
+  Nothing
+}
 
-public fun <A : Any> A.just(): Maybe<A> = Just(this)
-public fun <A : Any> Maybe<A>.just(): Maybe<Maybe<A>> = Just(this)
+public inline fun <A : Any> A.just(): Maybe<A> = Just(this)
 
 public fun <A : Any> nothing(): Maybe<A> = Nothing
 
@@ -1519,12 +953,11 @@ public inline fun <A : Any> Monoid.Companion.maybe(MA: Semigroup<Maybe<A>>): Mon
   MaybeMonoidNested(MA)
 
 @PublishedApi
-internal class MaybeMonoid<A : Any>(
-  private val MA: Semigroup<A>
+internal open class MaybeMonoid<A : Any>(
+  protected val MA: Semigroup<A>
 ) : Monoid<Maybe<A>> {
 
-  override fun Maybe<A>.combine(b: Maybe<A>): Maybe<A> =
-    combine(MA as Semigroup<Any>, b) as Maybe<A>
+  override fun Maybe<A>.combine(b: Maybe<A>): Maybe<A> = combine(MA as Semigroup<Any>, b) as Maybe<A>
 
   override fun Maybe<A>.maybeCombine(b: Maybe<A>?): Maybe<A> =
     b?.let { combine(MA as Semigroup<Any>, it) as Maybe<A> } ?: this
@@ -1534,126 +967,66 @@ internal class MaybeMonoid<A : Any>(
 
 @PublishedApi
 internal class MaybeMonoidNested<A : Any>(
-  private val MA: Semigroup<Maybe<A>>
-) : Monoid<Maybe<Maybe<A>>> {
+  MA: Semigroup<Maybe<A>>
+) : MaybeMonoid<Maybe<A>>(MA) {
 
-  override fun Maybe<Maybe<A>>.combine(b: Maybe<Maybe<A>>): Maybe<Maybe<A>> =
-    combine(MA, b)
+  override fun Maybe<Maybe<A>>.combine(b: Maybe<Maybe<A>>): Maybe<Maybe<A>> = combine(MA, b)
 
-  override fun Maybe<Maybe<A>>.maybeCombine(b: Maybe<Maybe<A>>?): Maybe<Maybe<A>> =
-    b?.let { combine(MA, it) } ?: this
+  override fun Maybe<Maybe<A>>.maybeCombine(b: Maybe<Maybe<A>>?): Maybe<Maybe<A>> = b?.let { combine(MA, it) } ?: this
 
   override fun empty(): Maybe<Maybe<A>> = Nothing
 }
 
 @Deprecated("use fold instead", ReplaceWith("fold(Monoid.maybe(MA))", "arrow.core.fold", "arrow.typeclasses.Monoid"))
-public inline fun <reified A : Any> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> =
-  fold(Monoid.maybe(MA))
+public inline fun <reified A : Any> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> = fold(Monoid.maybe(MA))
 
 @Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
-public inline fun <reified A : Any> Maybe<A>.combineAll(MA: Monoid<A>): A =
-  getOrElse { MA.empty() }
+public inline fun <reified A : Any> Maybe<A>.combineAll(MA: Monoid<A>): A = getOrElse { MA.empty() }
 
+@Suppress("UNCHECKED_CAST")
 @JvmName("maybeCombineAll")
 @Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
-public fun <A : Any> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> =
-  getOrElse { MA.empty() }
+public fun <A : Any> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> = getOrElse { MA.emptyMaybe() }
 
 public inline fun <reified A : Any> Maybe<A>.ensure(error: () -> Unit, predicate: (A) -> Boolean): Maybe<A> =
-  fold(
-    { this },
-    {
-      if (predicate(it))
-        this
-      else {
-        error()
-        Nothing
-      }
+  fold({ this }, {
+    if (predicate(it)) this
+    else {
+      error()
+      Nothing
     }
-  )
-
-@JvmName("maybeEnsure")
-public inline fun <A : Any> Maybe<Maybe<A>>.ensure(
-  error: () -> Unit,
-  predicate: (Maybe<A>) -> Boolean
-): Maybe<Maybe<A>> =
-  fold(
-    { this },
-    {
-      if (predicate(it))
-        this
-      else {
-        error()
-        Nothing
-      }
-    }
-  )
+  })
 
 /**
  * Returns a Maybe containing all elements that are instances of specified type parameter [B].
  */
-public inline fun <reified B : Any> Maybe<*>.filterIsInstance(): Maybe<B> =
-  flatMap {
-    when (it) {
-      is B -> Just(it)
-      else -> Nothing
-    }
+public inline fun <reified B : Any> Maybe<*>.filterIsInstance(): Maybe<B> = flatMap {
+  when (it) {
+    is B -> Just(it)
+    else -> Nothing
   }
+}
 
 @JvmName("maybeFilterIsInstance")
-public inline fun <reified B : Any> Maybe<Maybe<*>>.filterIsInstance(): Maybe<B> =
-  flatMap {
-    when (it) {
-      is B -> Just(it) as Maybe<B>
-      else -> Nothing
-    }
+public inline fun <reified B : Any> Maybe<Maybe<*>>.filterIsInstance(): Maybe<B> = flatMap {
+  when (it) {
+    is B -> Just(it)
+    else -> Nothing
   }
+}
 
-public inline fun <A : Any> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> =
-  handleErrorWith { Just(f(Unit)) }
+public inline fun <A : Any> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> = handleErrorWith { Just(f(Unit)) }
 
-@JvmName("maybeHandleError")
-public inline fun <A : Any> Maybe<Maybe<A>>.handleError(f: (Unit) -> Maybe<A>): Maybe<Maybe<A>> =
-  handleErrorWith { Just(f(Unit)) }
+public inline fun <A : Any> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> = if (isEmpty()) f(Unit) else this
 
-public inline fun <A : Any> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> =
-  if (isEmpty()) f(Unit) else this
-
-public fun <A : Any> Maybe<Maybe<A>>.flatten(): Maybe<A> =
-  flatMap(::identity)
+public fun <A : Any> Maybe<Maybe<A>>.flatten(): Maybe<A> = flatMap(::identity)
 
 public inline fun <reified A : Any, B : Any> Maybe<A>.redeem(fe: (Unit) -> B, fb: (A) -> B): Maybe<B> =
   map(fb).handleError(fe)
 
-@JvmName("maybeRedeem")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.redeem(fe: (Unit) -> B, fb: (Maybe<A>) -> B): Maybe<B> =
-  map(fb).handleError(fe)
-
-public inline fun <reified A : Any, B : Any> Maybe<A>.redeemMaybe(
-  fe: (Unit) -> Maybe<B>,
-  fb: (A) -> Maybe<B>
-): Maybe<Maybe<B>> =
-  mapMaybe(fb).handleError(fe)
-
-@JvmName("maybeRedeemMaybe")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.redeemMaybe(
-  fe: (Unit) -> Maybe<B>,
-  fb: (Maybe<A>) -> Maybe<B>
-): Maybe<Maybe<B>> =
-  mapMaybe(fb).handleError(fe)
-
 public inline fun <reified A : Any, B : Any> Maybe<A>.redeemWith(
-  fe: (Unit) -> Maybe<B>,
-  fb: (A) -> Maybe<B>
-): Maybe<B> =
-  flatMap(fb).handleErrorWith(fe)
-
-@JvmName("maybeRedeemWith")
-public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.redeemWith(
-  fe: (Unit) -> Maybe<B>,
-  fb: (Maybe<A>) -> Maybe<B>
-): Maybe<B> =
-  flatMap(fb).handleErrorWith(fe)
+  fe: (Unit) -> Maybe<B>, fb: (A) -> Maybe<B>
+): Maybe<B> = flatMap(fb).handleErrorWith(fe)
 
 public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): Maybe<A> = MA.run {
   if (n <= 0) Just(empty())
@@ -1665,37 +1038,34 @@ public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): M
     result
   }
 }
-
-@JvmName("maybeReplicate")
+@JvmName("replicateMaybe")
 public fun <A : Any> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Maybe<Maybe<A>> = MA.run {
-  if (n <= 0) Just(empty())
+  if (n <= 0) Just(emptyMaybe())
   else map { a ->
-    var result = empty()
+    var result = emptyMaybe()
     repeat(n) {
-      result += a
+      result = MA.combineToMaybe(result, a).flatten()
     }
     result
   }
 }
 
+@PublishedApi
+internal inline fun <A: Any> Monoid<Maybe<A>>.emptyMaybe(): Maybe<A> =
+  when(this){
+    is MaybeMonoid<*> -> (this as MaybeMonoid<*>).empty()
+    else -> this.empty()
+  } as Maybe<A>
 
-public fun <A : Any> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> =
-  flatMap { it.fold({ Nothing }, { a -> Just(a) }) }
 
-public inline fun <reified A : Any> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
-  align(b) {
-    it.fold(::identity, ::identity) { a, b ->
-      SA.run { a.combine(b) }
-    }
+public fun <A : Any> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> = flatMap { it.fold({ Nothing }, { a -> Just(a) }) }
+
+public inline fun <reified A : Any> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A>): Maybe<A> {
+  map { a ->
+    b.map { b -> return SA.combineToMaybe(a, b) }
   }
-
-@JvmName("maybeSalign")
-public fun <A : Any> Maybe<Maybe<A>>.salign(SA: Semigroup<Maybe<A>>, b: Maybe<Maybe<A>>): Maybe<Maybe<A>> =
-  align(b) {
-    it.fold(::identity, ::identity) { a, b ->
-      SA.run { a.combine(b) }
-    }
-  }
+  return this or b
+}
 
 /**
  * Separate the inner [Either] value into the [Either.Left] and [Either.Right].
@@ -1721,78 +1091,51 @@ public fun <A : Any, B : Any> Maybe<Validated<A, B>>.separateValidated(): Pair<M
   return asep to bsep
 }
 
-public fun <A : Any> Maybe<Iterable<A>>.sequence(): List<Maybe<A>> =
-  traverse(::identity)
+public fun <A : Any> Maybe<Iterable<A>>.sequence(): List<Maybe<A>> = traverse(::identity)
 
 @Deprecated(
   "sequenceEither is being renamed to sequence to simplify the Arrow API",
   ReplaceWith("sequence()", "arrow.core.sequence")
 )
-public fun <A, B : Any> Maybe<Either<A, B>>.sequenceEither(): Either<A, Maybe<B>> =
-  sequence()
+public fun <A, B : Any> Maybe<Either<A, B>>.sequenceEither(): Either<A, Maybe<B>> = sequence()
 
-public fun <A, B : Any> Maybe<Either<A, B>>.sequence(): Either<A, Maybe<B>> =
-  traverse(::identity)
+public fun <A, B : Any> Maybe<Either<A, B>>.sequence(): Either<A, Maybe<B>> = traverse(::identity)
 
 @Deprecated(
   "sequenceValidated is being renamed to sequence to simplify the Arrow API",
   ReplaceWith("sequence()", "arrow.core.sequence")
 )
-public fun <A, B : Any> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> =
-  sequence()
+public fun <A, B : Any> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> = sequence()
 
-public fun <A, B : Any> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> =
-  traverse(::identity)
+public fun <A, B : Any> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> = traverse(::identity)
 
-public fun <A : Any, B : Any> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> =
-  unalign(::identity)
+public fun <A : Any, B : Any> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> = unalign(::identity)
 
 public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unalign(f: (C) -> Ior<A, B>): Pair<Maybe<A>, Maybe<B>> =
-  this.map(f).fold(
-    { Nothing to Nothing },
-    {
-      when (it) {
-        is Ior.Left -> Just(it.value) to Nothing
-        is Ior.Right -> Nothing to Just(it.value)
-        is Ior.Both -> Just(it.leftValue) to Just(it.rightValue)
-      }
+  this.map(f).fold({ Nothing to Nothing }, {
+    when (it) {
+      is Ior.Left -> Just(it.value) to Nothing
+      is Ior.Right -> Nothing to Just(it.value)
+      is Ior.Both -> Just(it.leftValue) to Just(it.rightValue)
     }
-  )
+  })
 
-@JvmName("maybeUnalign")
-public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<C>>.unalign(f: (Maybe<C>) -> Ior<A, B>): Pair<Maybe<A>, Maybe<B>> =
-  this.map(f).unalign()
+public fun <A : Any> Maybe<Iterable<A>>.unite(MA: Monoid<A>): Maybe<A> = map { iterable ->
+  iterable.fold(MA)
+}
 
-public fun <A : Any> Maybe<Iterable<A>>.unite(MA: Monoid<A>): Maybe<A> =
-  map { iterable ->
-    iterable.fold(MA)
-  }
+public fun <A, B : Any> Maybe<Either<A, B>>.uniteEither(): Maybe<B> = flatMap { either ->
+  either.fold({ Nothing }, { b -> Just(b) })
+}
 
-public fun <A, B : Any> Maybe<Either<A, B>>.uniteEither(): Maybe<B> =
-  flatMap { either ->
-    either.fold({ Nothing }, { b -> Just(b) })
-  }
+public fun <A, B : Any> Maybe<Validated<A, B>>.uniteValidated(): Maybe<B> = flatMap { validated ->
+  validated.fold({ Nothing }, { b -> Just(b) })
+}
 
-public fun <A, B : Any> Maybe<Validated<A, B>>.uniteValidated(): Maybe<B> =
-  flatMap { validated ->
-    validated.fold({ Nothing }, { b -> Just(b) })
-  }
-
-public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> =
-  unzip(::identity)
+public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> = unzip(::identity)
 
 public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unzip(f: (C) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
-  fold(
-    { Nothing to Nothing },
-    { f(it).let { pair -> Just(pair.first) to Just(pair.second) } }
-  )
-
-@JvmName("maybeUnzip")
-public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<C>>.unzip(f: (Maybe<C>) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
-  fold(
-    { Nothing to Nothing },
-    { f(it).let { pair -> Just(pair.first) to Just(pair.second) } }
-  )
+  fold({ Nothing to Nothing }, { f(it).let { pair -> Just(pair.first) to Just(pair.second) } })
 
 /**
  *  Given [A] is a sub type of [B], re-type this value from Maybe<A> to Maybe<B>
@@ -1814,41 +1157,410 @@ public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<C>>.unzip(f: (Maybe<C>
  *  ```
  * <!--- KNIT example-maybe-23.kt -->
  */
-public fun <B : Any, A : B> Maybe<A>.widen(): Maybe<B> =
-  this
+public fun <B : Any, A : B> Maybe<A>.widen(): Maybe<B> = this
 
 public fun <K, V> Maybe<Pair<K, V>>.toMap(): Map<K, V> = this.toList().toMap()
 
-public inline fun <reified A : Any> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
-  fold(
-    { b },
-    { first ->
-      b.fold(
-        { this },
-        { second ->
-          Just(SGA.run { first.combine(second) })
-        }
-      )
-    }
-  )
+public inline fun <reified A : Any> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> = fold({ b }, { first ->
+  b.fold({ this }, { second ->
+    SGA.combineToMaybe(first, second)
+  })
+})
 
-@JvmName("maybeCombine")
-public fun <A : Any> Maybe<Maybe<A>>.combine(SGA: Semigroup<Maybe<A>>, b: Maybe<Maybe<A>>): Maybe<Maybe<A>> =
-  fold(
-    { b },
-    { first ->
-      b.fold(
-        { this },
-        { second ->
-          Just(SGA.run { first.combine(second) })
-        }
-      )
+@Suppress("UNCHECKED_CAST")
+@PublishedApi
+internal inline fun <A : Any> Semigroup<A>.combineToMaybe(
+  first: A,
+  second: A
+): Maybe<A> = //TODO: This is sometimes unoptimized
+  when (this) {
+    is MaybeMonoid<*> -> (this as MaybeMonoid<Any>).run {
+      Just((first as Maybe<*>).combine(second as Maybe<*>)) as Maybe<A>
     }
-  )
-
-public inline operator fun <reified A : Comparable<A>> Maybe<A>.compareTo(other: Maybe<A>): Int = fold(
-  { other.fold({ 0 }, { -1 }) },
-  { a1 ->
-    other.fold({ 1 }, { a2 -> a1.compareTo(a2) })
+    else -> Just(first.combine(second))
   }
-)
+
+public inline operator fun <reified A : Comparable<A>> Maybe<A>.compareTo(other: Maybe<A>): Int =
+  fold({ other.fold({ 0 }, { -1 }) }, { a1 ->
+    other.fold({ 1 }, { a2 -> a1.compareTo(a2) })
+  })
+
+public fun <A, B : Any> Either<A, B>.orNothing(): Maybe<B> = fold({ Nothing }, { Just(it) })
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <A, B, reified C : Any> Either<A, B>.traverse(fa: (B) -> Maybe<C>): Maybe<Either<A, C>> =
+  fold({ Nothing }, { right -> fa(right).map(::Right) })
+
+public inline fun <A, B, reified AA : Any, reified C : Any> Either<A, B>.bitraverseMaybe(
+  fl: (A) -> Maybe<AA>, fr: (B) -> Maybe<C>
+): Maybe<Either<AA, C>> = fold({ fl(it).map(::Left) }, { fr(it).map(::Right) })
+
+public inline fun <A, reified B : Any> Either<A, Maybe<B>>.sequence(): Maybe<Either<A, B>> = traverse(::identity)
+
+public inline fun <reified A : Any, reified B : Any> Either<Maybe<A>, Maybe<B>>.bisequenceMaybe(): Maybe<Either<A, B>> =
+  bitraverseMaybe(::identity, ::identity)
+
+public inline fun <A, B, reified C : Any, reified D : Any> Ior<A, B>.bitraverseMaybe(
+  fa: (A) -> Maybe<C>, fb: (B) -> Maybe<D>
+): Maybe<Ior<C, D>> = fold({ fa(it).map { Ior.Left(it) } },
+  { fb(it).map { Ior.Right(it) } },
+  { a, b -> fa(a).flatMap { aa -> fb(b).map { c -> Ior.Both(aa, c) } } })
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <A, B, reified C : Any> Ior<A, B>.traverse(fa: (B) -> Maybe<C>): Maybe<Ior<A, C>> =
+  fold({ a -> Just(Ior.Left(a)) }, { b -> fa(b).map { Ior.Right(it) } }, { a, b -> fa(b).map { Ior.Both(a, it) } })
+
+public inline fun <reified B : Any, reified C : Any> Ior<Maybe<B>, Maybe<C>>.bisequenceMaybe(): Maybe<Ior<B, C>> =
+  bitraverseMaybe(::identity, ::identity)
+
+public inline fun <A, reified B : Any> Ior<A, Maybe<B>>.sequence(): Maybe<Ior<A, B>> = traverse(::identity)
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <A, reified B : Any> Iterable<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
+  val destination = ArrayList<B>(collectionSizeOrDefault(10))
+  for (item in this) {
+    f(item).fold({ return Nothing }, { destination.add(it) })
+  }
+  return destination.just()
+}
+
+public inline fun <reified A : Any> Iterable<Maybe<A>>.sequence(): Maybe<List<A>> = traverse(::identity)
+
+/**
+ * Returns the first element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty.
+ */
+public fun <T : Any> Iterable<T>.firstOrNothing(): Maybe<T> = when (this) {
+  is Collection -> if (!isEmpty()) {
+    Just(first())
+  } else {
+    Nothing
+  }
+  else -> {
+    iterator().nextOrNothing()
+  }
+}
+
+private fun <T : Any> Iterator<T>.nextOrNothing(): Maybe<T> = if (hasNext()) {
+  Just(next())
+} else {
+  Nothing
+}
+
+/**
+ * Returns the first element as [Just(element)][Just] matching the given [predicate], or [Maybe.Nothing] if element was not found.
+ */
+public inline fun <T : Any> Iterable<T>.firstOrNothing(predicate: (T) -> Boolean): Maybe<T> {
+  for (element in this) {
+    if (predicate(element)) {
+      return Just(element)
+    }
+  }
+  return Nothing
+}
+
+/**
+ * Returns single element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty or has more than one element.
+ */
+public fun <T : Any> Iterable<T>.singleOrNothing(): Maybe<T> = when (this) {
+  is Collection -> when (size) {
+    1 -> firstOrNothing()
+    else -> Nothing
+  }
+  else -> {
+    iterator().run { nextOrNothing().filter<Any> { !hasNext() } as Maybe<T> }
+  }
+}
+
+/**
+ * Returns the single element as [Just(element)][Just] matching the given [predicate], or [Maybe.Nothing] if element was not found or more than one element was found.
+ */
+public inline fun <T : Any> Iterable<T>.singleOrNothing(predicate: (T) -> Boolean): Maybe<T> {
+  var result: Maybe<T> = Nothing
+  for (element in this) {
+    if (predicate(element)) {
+      if (result.isNotEmpty()) {
+        return Nothing
+      }
+      result = Just(element)
+    }
+  }
+  return result
+}
+
+/**
+ * Returns the last element as [Just(element)][Just], or [Maybe.Nothing] if the iterable is empty.
+ */
+public fun <T : Any> Iterable<T>.lastOrNothing(): Maybe<T> = when (this) {
+  is Collection -> if (!isEmpty()) {
+    Just(last())
+  } else {
+    Nothing
+  }
+  else -> iterator().run {
+    if (hasNext()) {
+      var last: T
+      do last = next() while (hasNext())
+      Just(last)
+    } else {
+      Nothing
+    }
+  }
+}
+
+/**
+ * Returns the last element as [Just(element)][Just] matching the given [predicate], or [Maybe.Nothing] if no such element was found.
+ */
+public inline fun <T : Any> Iterable<T>.lastOrNothing(predicate: (T) -> Boolean): Maybe<T> {
+  var value: Maybe<T> = Nothing
+  for (element in this) {
+    if (predicate(element)) {
+      value = Just(element)
+    }
+  }
+  return value
+}
+
+/**
+ * Returns an element as [Just(element)][Just] at the given [index] or [Maybe.Nothing] if the [index] is out of bounds of this iterable.
+ */
+public fun <T : Any> Iterable<T>.elementAtOrNothing(index: Int): Maybe<T> = when {
+  index < 0 -> Nothing
+  this is Collection -> when (index) {
+    in indices -> Just(elementAt(index))
+    else -> Nothing
+  }
+  else -> iterator().skip(index).nextOrNothing()
+}
+
+private tailrec fun <T> Iterator<T>.skip(count: Int): Iterator<T> = when {
+  count > 0 && hasNext() -> {
+    next()
+    skip(count - 1)
+  }
+  else -> this
+}
+
+public inline fun <reified T : Any> Iterable<Maybe<T>>.filterMaybe(): List<T> = mapNotNull(Maybe<T>::orNull)
+
+public inline fun <reified T : Any> Iterable<Maybe<T>>.flattenMaybe(): List<T> = filterMaybe()
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <K, A, reified B : Any> Map<K, A>.traverse(f: (A) -> Maybe<B>): Maybe<Map<K, B>> {
+  val acc = mutableMapOf<K, B>()
+  forEach { (k, v) ->
+    f(v).fold({ return@traverse Nothing }, { acc[k] = it })
+  }
+  return acc.just()
+}
+
+public inline fun <K, reified V : Any> Map<K, Maybe<V>>.sequence(): Maybe<Map<K, V>> = traverse(::identity)
+
+public inline fun <K, reified A : Any> Map<K, Maybe<A>>.filterOption(): Map<K, A> = filterMap { it.orNull() }
+
+public fun <K, V : Any> Map<K, V>.getOrNothing(key: K): Maybe<V> = this[key].toMaybe()
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <A, reified B : Any> NonEmptyList<A>.traverse(f: (A) -> Maybe<B>): Maybe<NonEmptyList<B>> =
+  f(head).map { newHead ->
+    val acc = mutableListOf<B>()
+    tail.forEach { a ->
+      f(a).fold({ return@traverse Nothing }, { acc.add(it) })
+    }
+    NonEmptyList(newHead, acc)
+  }
+
+public inline fun <reified A : Any> NonEmptyList<Maybe<A>>.sequence(): Maybe<NonEmptyList<A>> = traverse(::identity)
+
+public inline fun <reified A : Any> Sequence<Maybe<A>>.sequence(): Maybe<List<A>> = traverse(::identity)
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <A, reified B : Any> Sequence<A>.traverse(f: (A) -> Maybe<B>): Maybe<List<B>> {
+  // Note: Using a mutable list here avoids the stackoverflows one can accidentally create when using
+  //  Sequence.plus instead. But we don't convert the sequence to a list beforehand to avoid
+  //  forcing too much of the sequence to be evaluated.
+  val acc = mutableListOf<B>()
+  forEach { a ->
+    f(a).fold({ return@traverse Nothing }, { acc.add(it) })
+  }
+  return Just(acc)
+}
+
+public inline fun <reified A : Any> Sequence<Maybe<A>>.filterMaybe(): Sequence<A> = mapNotNull(Maybe<A>::orNull)
+
+/**
+ * Converts an `Maybe<A>` to a `Validated<E, A>`, where the provided `ifNothing` output value is returned as [Invalid]
+ * when the specified `Maybe` is `Nothing`.
+ */
+public inline fun <E, reified A : Any> Validated.Companion.fromMaybe(o: Maybe<A>, ifNothing: () -> E): Validated<E, A> =
+  o.fold({ Validated.Invalid(ifNothing()) }, { Validated.Valid(it) })
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <E, A, reified B : Any> Validated<E, A>.traverse(fa: (A) -> Maybe<B>): Maybe<Validated<E, B>> =
+  when (this) {
+    is Validated.Valid -> fa(this.value).map { Validated.Valid(it) }
+    is Validated.Invalid -> Nothing
+  }
+
+public inline fun <E, A, reified B : Any, reified C : Any> Validated<E, A>.bitraverseMaybe(
+  fe: (E) -> Maybe<B>, fa: (A) -> Maybe<C>
+): Maybe<Validated<B, C>> = fold({ fe(it).map(::Invalid) }, { fa(it).map(::Valid) })
+
+/**
+ * Returns Valid values wrapped in Just, and Nothing for Invalid values
+ */
+public fun <E, A : Any> Validated<E, A>.toMaybe(): Maybe<A> = fold({ Nothing }, ::Just)
+
+public inline fun <reified A : Any, reified B : Any> Validated<Maybe<A>, Maybe<B>>.bisequenceMaybe(): Maybe<Validated<A, B>> =
+  bitraverseMaybe(::identity, ::identity)
+
+public inline fun <A, reified B : Any> Validated<A, Maybe<B>>.sequence(): Maybe<Validated<A, B>> = traverse(::identity)
+
+public fun <E, A : Any> Validated<E, A>.orNothing(): Maybe<A> = fold({ Nothing }, { Just(it) })
+
+/**
+ * [fold] the [EagerEffect] into a [Maybe]. Where the shifted value [R] is mapped to [Maybe] by the
+ * provided function [orElse], and result value [A] is mapped to [Just].
+ */
+@OptIn(MaybeInternals::class)
+public inline fun <R, A : Any> EagerEffect<R, A>.toMaybe(crossinline orElse: (R) -> Maybe<A>): Maybe<A> {
+  // An effect's fold is not inline, so it will box the maybe.
+  // That is, unless we pass the underlying values instead and construct the maybe on the outside
+  // Also, orElse is crossinline because a normal function would just box
+  return Maybe.construct(fold({ orElse(it).underlying }, { Just(it).underlying }))
+}
+
+/**
+ * [fold] the [Effect] into an [Maybe]. Where the shifted value [R] is mapped to [Maybe] by the
+ * provided function [orElse], and result value [A] is mapped to [Just].
+ */
+@OptIn(MaybeInternals::class)
+public suspend inline fun <R, A : Any> Effect<R, A>.toMaybe(crossinline orElse: (R) -> Maybe<A>): Maybe<A> {
+  // An effect's fold is not inline, so it will box the maybe.
+  // That is, unless we pass the underlying values instead and construct the maybe on the outside
+  // Also, orElse is crossinline because a normal function would just box
+  return Maybe.construct(fold({ orElse(it).underlying }, { Just(it).underlying }))
+}
+
+/**
+ * Folds [Option] into [EagerEffect], by returning [B] or a transforming [None] into [R] and shifting the
+ * result.
+ *
+ * ```kotlin
+ * import arrow.core.None
+ * import arrow.core.Option
+ * import arrow.core.continuations.eagerEffect
+ * import arrow.core.getOrElse
+ * import arrow.core.identity
+ * import io.kotest.matchers.shouldBe
+ *
+ * private val default = "failed"
+ * fun main() {
+ *   val option: Option<Int> = None
+ *   eagerEffect<String, Int> {
+ *     val x: Int = option.bind { default }
+ *     x
+ *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
+ * }
+ * ```
+ * <!--- KNIT example-eager-effect-scope-06.kt -->
+ */
+public suspend inline fun <R, reified B : Any> EagerEffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
+  maybe.fold({ shift(shift()) }, { it })
+
+/**
+ * Folds [Option] into [EagerEffect], by returning [B] or a transforming [None] into [R] and shifting the
+ * result.
+ *
+ * ```kotlin
+ * import arrow.core.None
+ * import arrow.core.Option
+ * import arrow.core.continuations.eagerEffect
+ * import arrow.core.getOrElse
+ * import arrow.core.identity
+ * import io.kotest.matchers.shouldBe
+ *
+ * private val default = "failed"
+ * fun main() {
+ *   val option: Option<Int> = None
+ *   eagerEffect<String, Int> {
+ *     val x: Int = option.bind { default }
+ *     x
+ *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
+ * }
+ * ```
+ * <!--- KNIT example-eager-effect-scope-06.kt -->
+ */
+@JvmName("bindMaybe")
+public suspend fun <R, B : Any> EagerEffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
+  // Similar in spirit to EagerEffectScope.bind(shift)
+  // We don't want the maybe argument to "hang around" after the suspension point of the shift
+  // And so instead we use the maybe argument immediately, get its contents or null, and *then*
+  // if those contents are null, we shift.
+  return maybe.orNull() ?: shift(shift())
+}
+
+
+/**
+ * Folds [Option] into [Effect], by returning [B] or a transforming [None] into [R] and shifting the
+ * result.
+ *
+ * ```kotlin
+ * import arrow.core.None
+ * import arrow.core.Option
+ * import arrow.core.continuations.effect
+ * import arrow.core.getOrElse
+ * import arrow.core.identity
+ * import io.kotest.matchers.shouldBe
+ *
+ * private val default = "failed"
+ * suspend fun main() {
+ *   val option: Option<Int> = None
+ *   effect<String, Int> {
+ *     val x: Int = option.bind { default }
+ *     x
+ *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
+ * }
+ * ```
+ * <!--- KNIT example-effect-scope-07.kt -->
+ */
+public suspend inline fun <R, reified B : Any> EffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
+  maybe.fold({ shift(shift()) }, { it })
+
+/**
+ * Folds [Option] into [Effect], by returning [B] or a transforming [None] into [R] and shifting the
+ * result.
+ *
+ * ```kotlin
+ * import arrow.core.None
+ * import arrow.core.Option
+ * import arrow.core.continuations.effect
+ * import arrow.core.getOrElse
+ * import arrow.core.identity
+ * import io.kotest.matchers.shouldBe
+ *
+ * private val default = "failed"
+ * suspend fun main() {
+ *   val option: Option<Int> = None
+ *   effect<String, Int> {
+ *     val x: Int = option.bind { default }
+ *     x
+ *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
+ * }
+ * ```
+ * <!--- KNIT example-effect-scope-07.kt -->
+ */
+@JvmName("bindMaybe")
+public suspend fun <R, B : Any> EffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
+  // Similar in spirit to EagerEffectScope.bind(shift)
+  // We don't want the maybe argument to "hang around" after the suspension point of the shift
+  // And so instead we use the maybe argument immediately, get its contents or null, and *then*
+  // if those contents are null, we shift.
+  return maybe.orNull() ?: shift(shift())
+}

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -14,348 +14,6 @@ import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 
-/**
- *
- *
- * If you have worked with Java at all in the past, it is very likely that you have come across a `NullPointerException` at some time (other languages will throw similarly named errors in such a case). Usually this happens because some method returns `null` when you weren't expecting it and, thus, isn't dealing with that possibility in your client code. A value of `null` is often abused to represent an absent optional value.
- * Kotlin tries to solve the problem by getting rid of `null` values altogether, and providing its own special syntax [Null-safety machinery based on `?`](https://kotlinlang.org/docs/reference/null-safety.html).
- *
- * Arrow models the absence of values through the `Maybe` datatype similar to how Scala, Haskell, and other FP languages handle optional values.
- *
- * `Maybe<A>` is a container for an optional value of type `A`. If the value of type `A` is present, the `Maybe<A>` is an instance of `Just<A>`, containing the present value of type `A`. If the value is absent, the `Maybe<A>` is the object `Nil`.
- *
- * ```kotlin
- * import arrow.core.Maybe
- * import arrow.core.Just
- * import arrow.core.nil
- *
- * //sampleStart
- * val someValue: Maybe<String> = Just("I am wrapped in something")
- * val emptyValue: Maybe<String> = nil()
- * //sampleEnd
- * fun main() {
- *  println("value = $someValue")
- *  println("emptyValue = $emptyValue")
- * }
- * ```
- * <!--- KNIT example-maybe-01.kt -->
- *
- * Let's write a function that may or may not give us a string, thus returning `Maybe<String>`:
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- *
- * //sampleStart
- * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
- *  if (flag) Just("Found value") else Nil
- * //sampleEnd
- * ```
- * <!--- KNIT example-maybe-02.kt -->
- *
- * Using `getOrElse`, we can provide a default value `"No value"` when the optional argument `Nil` does not exist:
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- * import arrow.core.getOrElse
- *
- * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
- *  if (flag) Just("Found value") else Nil
- *
- * val value1 =
- * //sampleStart
- *  maybeItWillReturnSomething(true)
- *     .getOrElse { "No value" }
- * //sampleEnd
- * fun main() {
- *  println(value1)
- * }
- * ```
- * <!--- KNIT example-maybe-03.kt -->
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- * import arrow.core.getOrElse
- *
- * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
- *  if (flag) Just("Found value") else Nil
- *
- * val value2 =
- * //sampleStart
- *  maybeItWillReturnSomething(false)
- *   .getOrElse { "No value" }
- * //sampleEnd
- * fun main() {
- *  println(value2)
- * }
- * ```
- * <!--- KNIT example-maybe-04.kt -->
- *
- * Checking whether maybe has value:
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- *
- * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
- *  if (flag) Just("Found value") else Nil
- *
- *  //sampleStart
- * val valueJust = maybeItWillReturnSomething(true) is Nil
- * val valueNil = maybeItWillReturnSomething(false) is Nil
- * //sampleEnd
- * fun main() {
- *  println("valueJust = $valueJust")
- *  println("valueNil = $valueNil")
- * }
- * ```
- * <!--- KNIT example-maybe-05.kt -->
- * Creating a `Maybe<T>` of a `T?`. Useful for working with values that can be nullable:
- *
- * ```kotlin
- * import arrow.core.Maybe
- *
- * //sampleStart
- * val myString: String? = "Nullable string"
- * val maybe: Maybe<String> = Maybe.fromNullable(myString)
- * //sampleEnd
- * fun main () {
- *  println("maybe = $maybe")
- * }
- * ```
- * <!--- KNIT example-maybe-06.kt -->
- *
- * Maybe can also be used with when statements:
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- *
- * //sampleStart
- * val justValue: Maybe<Double> = Just(20.0)
- * val value = when(justValue) {
- *  isJust -> justValue.value
- *  is Nil -> 0.0
- * }
- * //sampleEnd
- * fun main () {
- *  println("value = $value")
- * }
- * ```
- * <!--- KNIT example-maybe-07.kt -->
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- *
- * //sampleStart
- * val noValue: Maybe<Double> = Nil
- * val value = when(noValue) {
- *  isJust -> noValue.value
- *  is Nil -> 0.0
- * }
- * //sampleEnd
- * fun main () {
- *  println("value = $value")
- * }
- * ```
- * <!--- KNIT example-maybe-08.kt -->
- *
- * An alternative for pattern matching is folding. This is possible because an maybe could be looked at as a collection or foldable structure with either one or zero elements.
- *
- * One of these operations is `map`. This operation allows us to map the inner value to a different type while preserving the maybe:
- *
- * ```kotlin
- * import arrow.core.Nil
- * import arrow.core.Maybe
- * import arrow.core.Just
- *
- * //sampleStart
- * val number: Maybe<Int> = Just(3)
- * val noNumber: Maybe<Int> = Nil
- * val mappedResult1 = number.map { it * 1.5 }
- * val mappedResult2 = noNumber.map { it * 1.5 }
- * //sampleEnd
- * fun main () {
- *  println("number = $number")
- *  println("noNumber = $noNumber")
- *  println("mappedResult1 = $mappedResult1")
- *  println("mappedResult2 = $mappedResult2")
- * }
- * ```
- * <!--- KNIT example-maybe-09.kt -->
- * Another operation is `fold`. This operation will extract the value from the maybe, or provide a default if the value is `Nil`
- *
- * ```kotlin
- * import arrow.core.Maybe
- * import arrow.core.Just
- *
- * val fold =
- * //sampleStart
- *  Just(3).fold({ 1 }, { it * 3 })
- * //sampleEnd
- * fun main () {
- *  println(fold)
- * }
- * ```
- * <!--- KNIT example-maybe-10.kt -->
- *
- * ```kotlin
- * import arrow.core.Maybe
- * import arrow.core.nil
- *
- * val fold =
- * //sampleStart
- *  nil<Int>().fold({ 1 }, { it * 3 })
- * //sampleEnd
- * fun main () {
- *  println(fold)
- * }
- * ```
- * <!--- KNIT example-maybe-11.kt -->
- *
- * Arrow also adds syntax to all datatypes so you can easily lift them into the context of `Maybe` where needed.
- *
- * ```kotlin
- * import arrow.core.just
- * import arrow.core.nil
- *
- * //sampleStart
- *  val just = 1.just()
- *  val nil = nil<String>()
- * //sampleEnd
- * fun main () {
- *  println("just = $just")
- *  println("nil = $nil")
- * }
- * ```
- * <!--- KNIT example-maybe-12.kt -->
- *
- * ```kotlin
- * import arrow.core.toMaybe
- *
- * //sampleStart
- * val nullString: String? = null
- * val valueFromNull = nullString.toMaybe()
- *
- * val helloString: String? = "Hello"
- * val valueFromStr = helloString.toMaybe()
- * //sampleEnd
- * fun main () {
- *  println("valueFromNull = $valueFromNull")
- *  println("valueFromStr = $valueFromStr")
- * }
- * ```
- * <!--- KNIT example-maybe-13.kt -->
- *
- * You can easily convert between `A?` and `Maybe<A>` by using the `toMaybe()` extension or `Maybe.fromNullable` constructor.
- *
- * ```kotlin
- * import arrow.core.firstOrNil
- * import arrow.core.toMaybe
- * import arrow.core.Maybe
- *
- * //sampleStart
- * val foxMap = mapOf(1 to "The", 2 to "Quick", 3 to "Brown", 4 to "Fox")
- *
- * val empty = foxMap.entries.firstOrNull { it.key == 5 }?.value.let { it?.toCharArray() }.toMaybe()
- * val filled = Maybe.fromNullable(foxMap.entries.firstOrNull { it.key == 5 }?.value.let { it?.toCharArray() })
- *
- * //sampleEnd
- * fun main() {
- *  println("empty = $empty")
- *  println("filled = $filled")
- * }
- * ```
- * <!--- KNIT example-maybe-14.kt -->
- *
- * ### Transforming the inner contents
- *
- * ```kotlin
- * import arrow.core.Just
- *
- * fun main() {
- * val value =
- *  //sampleStart
- *    Just(1).map { it + 1 }
- *  //sampleEnd
- *  println(value)
- * }
- * ```
- * <!--- KNIT example-maybe-15.kt -->
- *
- * ### Computing over independent values
- *
- * ```kotlin
- * import arrow.core.Just
- *
- *  val value =
- * //sampleStart
- *  Just(1).zip(Just("Hello"), Just(20.0), ::Triple)
- * //sampleEnd
- * fun main() {
- *  println(value)
- * }
- * ```
- * <!--- KNIT example-maybe-16.kt -->
- *
- * ### Computing over dependent values ignoring absence
- *
- * ```kotlin
- * import arrow.core.computations.maybe
- * import arrow.core.Just
- * import arrow.core.Maybe
- *
- * suspend fun value(): Maybe<Int> =
- * //sampleStart
- *  maybe {
- *    val a = Just(1).bind()
- *    val b = Just(1 + a).bind()
- *    val c = Just(1 + b).bind()
- *    a + b + c
- * }
- * //sampleEnd
- * suspend fun main() {
- *  println(value())
- * }
- * ```
- * <!--- KNIT example-maybe-17.kt -->
- *
- * ```kotlin
- * import arrow.core.computations.maybe
- * import arrow.core.Just
- * import arrow.core.nil
- * import arrow.core.Maybe
- *
- * suspend fun value(): Maybe<Int> =
- * //sampleStart
- *  maybe {
- *    val x = nil<Int>().bind()
- *    val y = Just(1 + x).bind()
- *    val z = Just(1 + y).bind()
- *    x + y + z
- *  }
- * //sampleEnd
- * suspend fun main() {
- *  println(value())
- * }
- * ```
- * <!--- KNIT example-maybe-18.kt -->
- *
- * ## Credits
- *
- * Contents partially adapted from [Scala Exercises Option Tutorial](https://www.scala-exercises.org/std_lib/options)
- * Originally based on the Scala Koans.
- */
-
 @RequiresOptIn(message = "This declaration is part of the internals of Maybe. Great caution must be taken to avoid ClassCastExceptions")
 internal annotation class MaybeInternals
 
@@ -418,24 +76,6 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
     public inline fun <reified A : Any, B : Any> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> = { it.map(f) }
   }
 
-  /**
-   * The given function is applied as a fire and forget effect
-   * if this is a `Nil`.
-   * When applied the result is ignored and the original
-   * Nil value is returned
-   *
-   * Example:
-   * ```kotlin
-   * import arrow.core.Just
-   * import arrow.core.nil
-   *
-   * fun main() {
-   *   Just(12).tapNil { println("flower") } // Result: Just(12)
-   *   nil<Int>().tapNil { println("flower") }  // Result: prints "flower" and returns: Nil
-   * }
-   * ```
-   * <!--- KNIT example-maybe-19.kt -->
-   */
   public inline fun tapNothing(f: () -> Unit): Maybe<A> = this.also { if (isEmpty()) f() }
 
   /**
@@ -462,7 +102,6 @@ public value class Maybe<out A : Any> @MaybeInternals private constructor(
 
   /**
    * Returns true if the maybe is an instance of [Just], false otherwise.
-   * @note Used only for performance instead of fold.
    */
   public fun isDefined(): Boolean = isNotEmpty()
 
@@ -577,11 +216,11 @@ public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D 
 }
 
 /**
- * Returns the result of applying $f to this $maybe's value if
+ * Returns the result of applying [f] to this $maybe's value if
  * this $maybe is nonempty.
- * Returns $nil if this $maybe is empty.
+ * Returns $nothing if this $maybe is empty.
  * Slightly different from `map` in that $f is expected to
- * return an $maybe (which could be $nil).
+ * return a $maybe (which could be $nothing).
  *
  * @param f the function to apply
  * @see map
@@ -601,24 +240,6 @@ internal inline fun <R, A> Maybe<*>.invokeBlockOnMaybe(block: (A) -> R): R {
   return block(this as A)
 }
 
-/**
- * The given function is applied as a fire and forget effect
- * if this is a `just`.
- * When applied the result is ignored and the original
- * Just value is returned
- *
- * Example:
- * ```kotlin
- * import arrow.core.Just
- * import arrow.core.nil
- *
- * fun main() {
- *   Just(12).tap { println("flower") } // Result: prints "flower" and returns: Just(12)
- *   nil<Int>().tap { println("flower") }  // Result: Nil
- * }
- * ```
- * <!--- KNIT example-maybe-20.kt -->
- */
 public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> = this.also { fold({}, f) }
 
 public inline fun <reified A : Any> Maybe<A>.orNull(): A? = fold({ return null }, ::identity)
@@ -628,7 +249,7 @@ public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = fold({ return null },
 
 /**
  * Returns a [Just<$B>] containing the result of applying $f to this $maybe's
- * value if this $maybe is nonempty. Otherwise return $nil.
+ * value if this $maybe is nonempty. Otherwise return $nothing.
  *
  * @note This is similar to `flatMap` except here,
  * $f does not need to wrap its result in a $maybe.
@@ -639,7 +260,7 @@ public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = fold({ return null },
 public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> = flatMap { a -> Just(f(a)) }
 
 /**
- * Returns $nil if the result of applying $f to this $maybe's value is null.
+ * Returns $nothing if the result of applying $f to this $maybe's value is null.
  * Otherwise returns the result.
  *
  * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
@@ -704,76 +325,11 @@ public inline fun <reified A : Any> Maybe<A>.filter(predicate: (A) -> Boolean): 
 public inline fun <reified A : Any> Maybe<A>.filterNot(predicate: (A) -> Boolean): Maybe<A> =
   flatMap { a -> if (!predicate(a)) Just(a) else Nothing }
 
-/**
- * Returns true if this maybe is nonempty '''and''' the predicate
- * $p returns true when applied to this $maybe's value.
- * Otherwise, returns false.
- *
- * Example:
- * ```kotlin
- * import arrow.core.Just
- * import arrow.core.Nil
- * import arrow.core.Maybe
- *
- * fun main() {
- *   Just(12).exists { it > 10 } // Result: true
- *   Just(7).exists { it > 10 }  // Result: false
- *
- *   val nil: Maybe<Int> = Nil
- *   nil.exists { it > 10 }      // Result: false
- * }
- * ```
- * <!--- KNIT example-maybe-21.kt -->
- *
- * @param predicate the predicate to test
- */
 public inline fun <reified A : Any> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean = fold({ false }, predicate)
 
-/**
- * Returns the $maybe's value if this maybe is nonempty '''and''' the predicate
- * $p returns true when applied to this $maybe's value.
- * Otherwise, returns null.
- *
- * Example:
- * ```kotlin
- * import arrow.core.Just
- * import arrow.core.Nil
- * import arrow.core.Maybe
- *
- * fun main() {
- *   Just(12).exists { it > 10 } // Result: 12
- *   Just(7).exists { it > 10 }  // Result: null
- *
- *   val nil: Maybe<Int> = Nil
- *   nil.exists { it > 10 }      // Result: null
- * }
- * ```
- * <!--- KNIT example-maybe-22.kt -->
- */
 public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolean): A? =
   fold({ return null }, { return if (predicate(it)) it else null })
 
-/**
- * Returns the $maybe's value if this maybe is nonempty '''and''' the predicate
- * $p returns true when applied to this $maybe's value.
- * Otherwise, returns null.
- *
- * Example:
- * ```kotlin
- * import arrow.core.Just
- * import arrow.core.Nil
- * import arrow.core.Maybe
- *
- * fun main() {
- *   Just(12).exists { it > 10 } // Result: 12
- *   Just(7).exists { it > 10 }  // Result: null
- *
- *   val nil: Maybe<Int> = Nil
- *   nil.exists { it > 10 }      // Result: null
- * }
- * ```
- * <!--- KNIT example-maybe-22.kt -->
- */
 
 @JvmName("maybeFindOrNull")
 public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(predicate: (Maybe<A>) -> Boolean): Maybe<A>? =
@@ -1131,26 +687,6 @@ public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>
 public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unzip(f: (C) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
   fold({ Nothing to Nothing }, { f(it).let { pair -> Just(pair.first) to Just(pair.second) } })
 
-/**
- *  Given [A] is a sub type of [B], re-type this value from Maybe<A> to Maybe<B>
- *
- *  Maybe<A> -> Maybe<B>
- *
- *  ```kotlin
- *  import arrow.core.Maybe
- *  import arrow.core.just
- *  import arrow.core.widen
- *
- *  fun main(args: Array<String>) {
- *   val result: Maybe<CharSequence> =
- *   //sampleStart
- *   "Hello".just().map({ "$it World" }).widen()
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- * <!--- KNIT example-maybe-23.kt -->
- */
 public fun <B : Any, A : B> Maybe<A>.widen(): Maybe<B> = this
 
 public fun <K, V> Maybe<Pair<K, V>>.toMap(): Map<K, V> = this.toList().toMap()
@@ -1452,55 +988,9 @@ public suspend inline fun <R, A : Any> Effect<R, A>.toMaybe(crossinline orElse: 
   return Maybe.construct(fold({ orElse(it).underlying }, { Just(it).underlying }))
 }
 
-/**
- * Folds [Option] into [EagerEffect], by returning [B] or a transforming [None] into [R] and shifting the
- * result.
- *
- * ```kotlin
- * import arrow.core.None
- * import arrow.core.Option
- * import arrow.core.continuations.eagerEffect
- * import arrow.core.getOrElse
- * import arrow.core.identity
- * import io.kotest.matchers.shouldBe
- *
- * private val default = "failed"
- * fun main() {
- *   val option: Option<Int> = None
- *   eagerEffect<String, Int> {
- *     val x: Int = option.bind { default }
- *     x
- *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
- * }
- * ```
- * <!--- KNIT example-eager-effect-scope-06.kt -->
- */
 public suspend inline fun <R, reified B : Any> EagerEffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
   maybe.fold({ shift(shift()) }, { it })
 
-/**
- * Folds [Option] into [EagerEffect], by returning [B] or a transforming [None] into [R] and shifting the
- * result.
- *
- * ```kotlin
- * import arrow.core.None
- * import arrow.core.Option
- * import arrow.core.continuations.eagerEffect
- * import arrow.core.getOrElse
- * import arrow.core.identity
- * import io.kotest.matchers.shouldBe
- *
- * private val default = "failed"
- * fun main() {
- *   val option: Option<Int> = None
- *   eagerEffect<String, Int> {
- *     val x: Int = option.bind { default }
- *     x
- *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
- * }
- * ```
- * <!--- KNIT example-eager-effect-scope-06.kt -->
- */
 @JvmName("bindMaybe")
 public suspend fun <R, B : Any> EagerEffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
   // Similar in spirit to EagerEffectScope.bind(shift)
@@ -1510,56 +1000,9 @@ public suspend fun <R, B : Any> EagerEffectScope<R>.bind(maybe: Maybe<Maybe<B>>,
   return maybe.orNull() ?: shift(shift())
 }
 
-
-/**
- * Folds [Option] into [Effect], by returning [B] or a transforming [None] into [R] and shifting the
- * result.
- *
- * ```kotlin
- * import arrow.core.None
- * import arrow.core.Option
- * import arrow.core.continuations.effect
- * import arrow.core.getOrElse
- * import arrow.core.identity
- * import io.kotest.matchers.shouldBe
- *
- * private val default = "failed"
- * suspend fun main() {
- *   val option: Option<Int> = None
- *   effect<String, Int> {
- *     val x: Int = option.bind { default }
- *     x
- *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
- * }
- * ```
- * <!--- KNIT example-effect-scope-07.kt -->
- */
 public suspend inline fun <R, reified B : Any> EffectScope<R>.bind(maybe: Maybe<B>, shift: () -> R): B =
   maybe.fold({ shift(shift()) }, { it })
 
-/**
- * Folds [Option] into [Effect], by returning [B] or a transforming [None] into [R] and shifting the
- * result.
- *
- * ```kotlin
- * import arrow.core.None
- * import arrow.core.Option
- * import arrow.core.continuations.effect
- * import arrow.core.getOrElse
- * import arrow.core.identity
- * import io.kotest.matchers.shouldBe
- *
- * private val default = "failed"
- * suspend fun main() {
- *   val option: Option<Int> = None
- *   effect<String, Int> {
- *     val x: Int = option.bind { default }
- *     x
- *   }.fold({ default }, ::identity) shouldBe option.getOrElse { default }
- * }
- * ```
- * <!--- KNIT example-effect-scope-07.kt -->
- */
 @JvmName("bindMaybe")
 public suspend fun <R, B : Any> EffectScope<R>.bind(maybe: Maybe<Maybe<B>>, shift: () -> R): Maybe<B> {
   // Similar in spirit to EagerEffectScope.bind(shift)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -1,0 +1,1854 @@
+package arrow.core
+
+import arrow.core.Either.Right
+import arrow.core.Maybe.Companion.Nothing
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Semigroup
+import kotlin.experimental.ExperimentalTypeInference
+import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmStatic
+
+/**
+ *
+ *
+ * If you have worked with Java at all in the past, it is very likely that you have come across a `NullPointerException` at some time (other languages will throw similarly named errors in such a case). Usually this happens because some method returns `null` when you weren't expecting it and, thus, isn't dealing with that possibility in your client code. A value of `null` is often abused to represent an absent optional value.
+ * Kotlin tries to solve the problem by getting rid of `null` values altogether, and providing its own special syntax [Null-safety machinery based on `?`](https://kotlinlang.org/docs/reference/null-safety.html).
+ *
+ * Arrow models the absence of values through the `Maybe` datatype similar to how Scala, Haskell, and other FP languages handle optional values.
+ *
+ * `Maybe<A>` is a container for an optional value of type `A`. If the value of type `A` is present, the `Maybe<A>` is an instance of `Just<A>`, containing the present value of type `A`. If the value is absent, the `Maybe<A>` is the object `Nil`.
+ *
+ * ```kotlin
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ * import arrow.core.nil
+ *
+ * //sampleStart
+ * val someValue: Maybe<String> = Just("I am wrapped in something")
+ * val emptyValue: Maybe<String> = nil()
+ * //sampleEnd
+ * fun main() {
+ *  println("value = $someValue")
+ *  println("emptyValue = $emptyValue")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-01.kt -->
+ *
+ * Let's write a function that may or may not give us a string, thus returning `Maybe<String>`:
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ *
+ * //sampleStart
+ * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
+ *  if (flag) Just("Found value") else Nil
+ * //sampleEnd
+ * ```
+ * <!--- KNIT example-maybe-02.kt -->
+ *
+ * Using `getOrElse`, we can provide a default value `"No value"` when the optional argument `Nil` does not exist:
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ * import arrow.core.getOrElse
+ *
+ * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
+ *  if (flag) Just("Found value") else Nil
+ *
+ * val value1 =
+ * //sampleStart
+ *  maybeItWillReturnSomething(true)
+ *     .getOrElse { "No value" }
+ * //sampleEnd
+ * fun main() {
+ *  println(value1)
+ * }
+ * ```
+ * <!--- KNIT example-maybe-03.kt -->
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ * import arrow.core.getOrElse
+ *
+ * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
+ *  if (flag) Just("Found value") else Nil
+ *
+ * val value2 =
+ * //sampleStart
+ *  maybeItWillReturnSomething(false)
+ *   .getOrElse { "No value" }
+ * //sampleEnd
+ * fun main() {
+ *  println(value2)
+ * }
+ * ```
+ * <!--- KNIT example-maybe-04.kt -->
+ *
+ * Checking whether maybe has value:
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ *
+ * fun maybeItWillReturnSomething(flag: Boolean): Maybe<String> =
+ *  if (flag) Just("Found value") else Nil
+ *
+ *  //sampleStart
+ * val valueJust = maybeItWillReturnSomething(true) is Nil
+ * val valueNil = maybeItWillReturnSomething(false) is Nil
+ * //sampleEnd
+ * fun main() {
+ *  println("valueJust = $valueJust")
+ *  println("valueNil = $valueNil")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-05.kt -->
+ * Creating a `Maybe<T>` of a `T?`. Useful for working with values that can be nullable:
+ *
+ * ```kotlin
+ * import arrow.core.Maybe
+ *
+ * //sampleStart
+ * val myString: String? = "Nullable string"
+ * val maybe: Maybe<String> = Maybe.fromNullable(myString)
+ * //sampleEnd
+ * fun main () {
+ *  println("maybe = $maybe")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-06.kt -->
+ *
+ * Maybe can also be used with when statements:
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ *
+ * //sampleStart
+ * val justValue: Maybe<Double> = Just(20.0)
+ * val value = when(justValue) {
+ *  isJust -> justValue.value
+ *  is Nil -> 0.0
+ * }
+ * //sampleEnd
+ * fun main () {
+ *  println("value = $value")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-07.kt -->
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ *
+ * //sampleStart
+ * val noValue: Maybe<Double> = Nil
+ * val value = when(noValue) {
+ *  isJust -> noValue.value
+ *  is Nil -> 0.0
+ * }
+ * //sampleEnd
+ * fun main () {
+ *  println("value = $value")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-08.kt -->
+ *
+ * An alternative for pattern matching is folding. This is possible because an maybe could be looked at as a collection or foldable structure with either one or zero elements.
+ *
+ * One of these operations is `map`. This operation allows us to map the inner value to a different type while preserving the maybe:
+ *
+ * ```kotlin
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ *
+ * //sampleStart
+ * val number: Maybe<Int> = Just(3)
+ * val noNumber: Maybe<Int> = Nil
+ * val mappedResult1 = number.map { it * 1.5 }
+ * val mappedResult2 = noNumber.map { it * 1.5 }
+ * //sampleEnd
+ * fun main () {
+ *  println("number = $number")
+ *  println("noNumber = $noNumber")
+ *  println("mappedResult1 = $mappedResult1")
+ *  println("mappedResult2 = $mappedResult2")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-09.kt -->
+ * Another operation is `fold`. This operation will extract the value from the maybe, or provide a default if the value is `Nil`
+ *
+ * ```kotlin
+ * import arrow.core.Maybe
+ * import arrow.core.Just
+ *
+ * val fold =
+ * //sampleStart
+ *  Just(3).fold({ 1 }, { it * 3 })
+ * //sampleEnd
+ * fun main () {
+ *  println(fold)
+ * }
+ * ```
+ * <!--- KNIT example-maybe-10.kt -->
+ *
+ * ```kotlin
+ * import arrow.core.Maybe
+ * import arrow.core.nil
+ *
+ * val fold =
+ * //sampleStart
+ *  nil<Int>().fold({ 1 }, { it * 3 })
+ * //sampleEnd
+ * fun main () {
+ *  println(fold)
+ * }
+ * ```
+ * <!--- KNIT example-maybe-11.kt -->
+ *
+ * Arrow also adds syntax to all datatypes so you can easily lift them into the context of `Maybe` where needed.
+ *
+ * ```kotlin
+ * import arrow.core.just
+ * import arrow.core.nil
+ *
+ * //sampleStart
+ *  val just = 1.just()
+ *  val nil = nil<String>()
+ * //sampleEnd
+ * fun main () {
+ *  println("just = $just")
+ *  println("nil = $nil")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-12.kt -->
+ *
+ * ```kotlin
+ * import arrow.core.toMaybe
+ *
+ * //sampleStart
+ * val nullString: String? = null
+ * val valueFromNull = nullString.toMaybe()
+ *
+ * val helloString: String? = "Hello"
+ * val valueFromStr = helloString.toMaybe()
+ * //sampleEnd
+ * fun main () {
+ *  println("valueFromNull = $valueFromNull")
+ *  println("valueFromStr = $valueFromStr")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-13.kt -->
+ *
+ * You can easily convert between `A?` and `Maybe<A>` by using the `toMaybe()` extension or `Maybe.fromNullable` constructor.
+ *
+ * ```kotlin
+ * import arrow.core.firstOrNil
+ * import arrow.core.toMaybe
+ * import arrow.core.Maybe
+ *
+ * //sampleStart
+ * val foxMap = mapOf(1 to "The", 2 to "Quick", 3 to "Brown", 4 to "Fox")
+ *
+ * val empty = foxMap.entries.firstOrNull { it.key == 5 }?.value.let { it?.toCharArray() }.toMaybe()
+ * val filled = Maybe.fromNullable(foxMap.entries.firstOrNull { it.key == 5 }?.value.let { it?.toCharArray() })
+ *
+ * //sampleEnd
+ * fun main() {
+ *  println("empty = $empty")
+ *  println("filled = $filled")
+ * }
+ * ```
+ * <!--- KNIT example-maybe-14.kt -->
+ *
+ * ### Transforming the inner contents
+ *
+ * ```kotlin
+ * import arrow.core.Just
+ *
+ * fun main() {
+ * val value =
+ *  //sampleStart
+ *    Just(1).map { it + 1 }
+ *  //sampleEnd
+ *  println(value)
+ * }
+ * ```
+ * <!--- KNIT example-maybe-15.kt -->
+ *
+ * ### Computing over independent values
+ *
+ * ```kotlin
+ * import arrow.core.Just
+ *
+ *  val value =
+ * //sampleStart
+ *  Just(1).zip(Just("Hello"), Just(20.0), ::Triple)
+ * //sampleEnd
+ * fun main() {
+ *  println(value)
+ * }
+ * ```
+ * <!--- KNIT example-maybe-16.kt -->
+ *
+ * ### Computing over dependent values ignoring absence
+ *
+ * ```kotlin
+ * import arrow.core.computations.maybe
+ * import arrow.core.Just
+ * import arrow.core.Maybe
+ *
+ * suspend fun value(): Maybe<Int> =
+ * //sampleStart
+ *  maybe {
+ *    val a = Just(1).bind()
+ *    val b = Just(1 + a).bind()
+ *    val c = Just(1 + b).bind()
+ *    a + b + c
+ * }
+ * //sampleEnd
+ * suspend fun main() {
+ *  println(value())
+ * }
+ * ```
+ * <!--- KNIT example-maybe-17.kt -->
+ *
+ * ```kotlin
+ * import arrow.core.computations.maybe
+ * import arrow.core.Just
+ * import arrow.core.nil
+ * import arrow.core.Maybe
+ *
+ * suspend fun value(): Maybe<Int> =
+ * //sampleStart
+ *  maybe {
+ *    val x = nil<Int>().bind()
+ *    val y = Just(1 + x).bind()
+ *    val z = Just(1 + y).bind()
+ *    x + y + z
+ *  }
+ * //sampleEnd
+ * suspend fun main() {
+ *  println(value())
+ * }
+ * ```
+ * <!--- KNIT example-maybe-18.kt -->
+ *
+ * ## Credits
+ *
+ * Contents partially adapted from [Scala Exercises Option Tutorial](https://www.scala-exercises.org/std_lib/options)
+ * Originally based on the Scala Koans.
+ */
+
+@RequiresOptIn(message = "This declaration is part of the internals of Maybe. Great caution must be taken to avoid ClassCastExceptions")
+internal annotation class MaybeInternals
+
+@JvmInline
+public value class Maybe<out A : Any> @MaybeInternals private constructor(
+  @property:MaybeInternals
+  @PublishedApi internal val underlying: Any
+) {
+
+  public companion object {
+    // This is simply an alias to constructor-impl
+    @PublishedApi
+    @MaybeInternals
+    internal fun <A : Any> construct(value: Any): Maybe<A> = Maybe(value)
+
+    @OptIn(MaybeInternals::class)
+    public val Nothing: Maybe<Nothing> = construct(Nil(0))
+
+    @JvmStatic
+    public fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
+
+    @JvmStatic
+    public fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> = if (a != null) Just(a) else Nothing
+
+    @JvmStatic
+    public operator fun <A : Any> invoke(a: A): Maybe<A> = Just(a)
+
+    @JvmStatic
+    public operator fun <A : Any> invoke(a: Maybe<A>): Maybe<Maybe<A>> = Just(a)
+
+    @JvmStatic
+    @JvmName("tryCatchOrNothing")
+    /**
+     * Ignores exceptions and returns Nothing if one is thrown
+     */
+    public inline fun <A : Any> catch(f: () -> A): Maybe<A> {
+      val recover: (Throwable) -> Maybe<A> = { Nothing }
+      return catch(recover, f)
+    }
+
+    @JvmStatic
+    @JvmName("tryCatchOrNothingMaybe")
+    /**
+     * Ignores exceptions and returns Nothing if one is thrown
+     */
+    public inline fun <A : Any> catchMaybe(f: () -> Maybe<A>): Maybe<Maybe<A>> {
+      val recover: (Throwable) -> Maybe<Maybe<A>> = { Nothing }
+      return catchMaybe(recover, f)
+    }
+
+    @JvmStatic
+    @JvmName("tryCatch")
+    public inline fun <A : Any> catch(recover: (Throwable) -> Maybe<A>, f: () -> A): Maybe<A> =
+      try {
+        Just(f())
+      } catch (t: Throwable) {
+        recover(t.nonFatalOrThrow())
+      }
+
+    @JvmStatic
+    @JvmName("tryCatchMaybe")
+    public inline fun <A : Any> catchMaybe(
+      recover: (Throwable) -> Maybe<Maybe<A>>,
+      f: () -> Maybe<A>
+    ): Maybe<Maybe<A>> =
+      try {
+        Just(f())
+      } catch (t: Throwable) {
+        recover(t.nonFatalOrThrow())
+      }
+
+    @JvmStatic
+    public inline fun <reified A : Any, B : Any> lift(crossinline f: (A) -> B): (Maybe<A>) -> Maybe<B> =
+      { it.map(f) }
+  }
+
+  /**
+   * The given function is applied as a fire and forget effect
+   * if this is a `Nil`.
+   * When applied the result is ignored and the original
+   * Nil value is returned
+   *
+   * Example:
+   * ```kotlin
+   * import arrow.core.Just
+   * import arrow.core.nil
+   *
+   * fun main() {
+   *   Just(12).tapNil { println("flower") } // Result: Just(12)
+   *   nil<Int>().tapNil { println("flower") }  // Result: prints "flower" and returns: Nil
+   * }
+   * ```
+   * <!--- KNIT example-maybe-19.kt -->
+   */
+  public inline fun tapNothing(f: () -> Unit): Maybe<A> = this.also { if (isEmpty()) f() }
+
+  /**
+   * Returns true if the maybe is [Nothing], false otherwise.
+   * @note Used only for performance instead of fold.
+   */
+  public fun isEmpty(): Boolean = fold<Any, Boolean>({ true }, { false })
+
+  public fun isNotEmpty(): Boolean = !isEmpty()
+
+  /**
+   * alias for [isDefined]
+   */
+  public val isJust: Boolean get() = isDefined()
+
+  /**
+   * alias for [isEmpty]
+   */
+  public val isNil: Boolean get() = isEmpty()
+
+  /**
+   * alias for [isDefined]
+   */
+  public fun nonEmpty(): Boolean = isDefined()
+
+  /**
+   * Returns true if the maybe is an instance of [Just], false otherwise.
+   * @note Used only for performance instead of fold.
+   */
+  public fun isDefined(): Boolean = isNotEmpty()
+
+  override fun toString(): String = fold<Any, String>(
+    { "Maybe.Nil" },
+    { "Maybe.Just($it)" }
+  )
+}
+
+@PublishedApi
+internal inline fun <reified T> isTypeMaybe(): Boolean =
+  boxedJustUnit is T && Unit !is T // Checks that type is not Any but is Maybe
+
+@PublishedApi
+@MaybeInternals
+internal inline val <reified A : Any> Maybe<A>.value: A
+  get() {
+    val trueValue = when (underlying) {
+      is Nil -> Nil(underlying.nesting - 1).also { if (it.nesting < 0) error("Unexpected nesting value for Nil") }
+      else -> underlying
+    }
+    return (if (isTypeMaybe<A>()) Maybe.construct<Any>(trueValue) else trueValue) as A
+  }
+
+@get:JvmName("getMaybeValue")
+@PublishedApi
+@MaybeInternals
+internal inline val <A : Any> Maybe<Maybe<A>>.value: Maybe<A>
+  get() =
+    Maybe.construct((this as Maybe<*>).value) // Should not box since its return type is Maybe
+
+public inline fun <reified A : Any, reified B : Any> Maybe<A>.zip(other: Maybe<B>): Maybe<Pair<A, B>> =
+  zip(other, ::Pair)
+
+public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  map: (A, B) -> C
+): Maybe<C> =
+  zip(
+    b,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit
+  ) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, D : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  map: (A, B, C) -> D
+): Maybe<D> =
+  zip(
+    b,
+    c,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit
+  ) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, E : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  map: (A, B, C, D) -> E
+): Maybe<E> =
+  zip(
+    b,
+    c,
+    d,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit,
+    justUnit
+  ) { a, b, c, d, _, _, _, _, _, _ -> map(a, b, c, d) }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, F : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  map: (A, B, C, D, E) -> F
+): Maybe<F> =
+  zip(b, c, d, e, justUnit, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
+    map(
+      a,
+      b,
+      c,
+      d,
+      e
+    )
+  }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, G : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  map: (A, B, C, D, E, F) -> G
+): Maybe<G> =
+  zip(b, c, d, e, f, justUnit, justUnit, justUnit, justUnit) { a, b, c, d, e, f, _, _, _, _ ->
+    map(
+      a,
+      b,
+      c,
+      d,
+      e,
+      f
+    )
+  }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, H : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  g: Maybe<G>,
+  map: (A, B, C, D, E, F, G) -> H
+): Maybe<H> =
+  zip(b, c, d, e, f, g, justUnit, justUnit, justUnit) { a, b, c, d, e, f, g, _, _, _ -> map(a, b, c, d, e, f, g) }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, I : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  g: Maybe<G>,
+  h: Maybe<H>,
+  map: (A, B, C, D, E, F, G, H) -> I
+): Maybe<I> =
+  zip(b, c, d, e, f, g, h, justUnit, justUnit) { a, b, c, d, e, f, g, h, _, _ -> map(a, b, c, d, e, f, g, h) }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, reified I : Any, J : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  g: Maybe<G>,
+  h: Maybe<H>,
+  i: Maybe<I>,
+  map: (A, B, C, D, E, F, G, H, I) -> J
+): Maybe<J> =
+  zip(b, c, d, e, f, g, h, i, justUnit) { a, b, c, d, e, f, g, h, i, _ -> map(a, b, c, d, e, f, g, h, i) }
+
+public inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any, reified E : Any, reified F : Any, reified G : Any, reified H : Any, reified I : Any, reified J : Any, K : Any> Maybe<A>.zip(
+  b: Maybe<B>,
+  c: Maybe<C>,
+  d: Maybe<D>,
+  e: Maybe<E>,
+  f: Maybe<F>,
+  g: Maybe<G>,
+  h: Maybe<H>,
+  i: Maybe<I>,
+  j: Maybe<J>,
+  map: (A, B, C, D, E, F, G, H, I, J) -> K
+): Maybe<K> =
+  @OptIn(MaybeInternals::class) // For simplicity of implementation
+  if (this.isJust && b.isJust && c.isJust && d.isJust && e.isJust && f.isJust && g.isJust && h.isJust && i.isJust && j.isJust) {
+    Just(map(this.value, b.value, c.value, d.value, e.value, f.value, g.value, h.value, i.value, j.value))
+  } else {
+    Nothing
+  }
+
+/**
+ * Returns the result of applying $f to this $maybe's value if
+ * this $maybe is nonempty.
+ * Returns $nil if this $maybe is empty.
+ * Slightly different from `map` in that $f is expected to
+ * return an $maybe (which could be $nil).
+ *
+ * @param f the function to apply
+ * @see map
+ */
+public inline fun <reified A : Any, B : Any> Maybe<A>.flatMap(f: (A) -> Maybe<B>): Maybe<B> =
+  fold({ Nothing }, f)
+
+/**
+ * Returns the result of applying $f to this $maybe's value if
+ * this $maybe is nonempty.
+ * Returns $nil if this $maybe is empty.
+ * Slightly different from `map` in that $f is expected to
+ * return an $maybe (which could be $nil).
+ *
+ * @param f the function to apply
+ * @see map
+ */
+@JvmName("maybeFlatMap")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.flatMap(f: (Maybe<A>) -> Maybe<B>): Maybe<B> =
+  fold({ Nothing }, f)
+
+@OptIn(MaybeInternals::class)
+public inline fun <reified A : Any, R> Maybe<A>.fold(ifEmpty: () -> R, ifJust: (A) -> R): R = when (this) {
+  Nothing -> ifEmpty()
+  else -> ifJust(value)
+}
+
+@OptIn(MaybeInternals::class)
+@JvmName("maybeFold")
+public inline fun <A : Any, R> Maybe<Maybe<A>>.fold(ifEmpty: () -> R, ifJust: (Maybe<A>) -> R): R = when (this) {
+  Nothing -> ifEmpty()
+  else -> ifJust(value)
+}
+@OptIn(MaybeInternals::class)
+public inline fun <reified A : Any, R : Any> Maybe<A>.foldMaybe(
+  ifEmpty: () -> Maybe<R>,
+  ifJust: (A) -> Maybe<R>
+): Maybe<R> = when (this) {
+  Nothing -> ifEmpty()
+  else -> ifJust(value)
+}
+
+@OptIn(MaybeInternals::class)
+@JvmName("maybeFoldMaybe")
+public inline fun <A : Any, R : Any> Maybe<Maybe<A>>.foldMaybe(
+  ifEmpty: () -> Maybe<R>,
+  ifJust: (Maybe<A>) -> Maybe<R>
+): Maybe<R> = when (this) {
+  Nothing -> ifEmpty()
+  else -> ifJust(value)
+}
+
+/**
+ * The given function is applied as a fire and forget effect
+ * if this is a `just`.
+ * When applied the result is ignored and the original
+ * Just value is returned
+ *
+ * Example:
+ * ```kotlin
+ * import arrow.core.Just
+ * import arrow.core.nil
+ *
+ * fun main() {
+ *   Just(12).tap { println("flower") } // Result: prints "flower" and returns: Just(12)
+ *   nil<Int>().tap { println("flower") }  // Result: Nil
+ * }
+ * ```
+ * <!--- KNIT example-maybe-20.kt -->
+ */
+public inline fun <reified A : Any> Maybe<A>.tap(f: (A) -> Unit): Maybe<A> =
+  this.also { fold({}, f) }
+
+@JvmName("maybeTap")
+public inline fun <A : Any> Maybe<Maybe<A>>.tap(f: (Maybe<A>) -> Unit): Maybe<Maybe<A>> =
+  this.also { fold({}, f) }
+
+public inline fun <reified A : Any> Maybe<A>.orNull(): A? = fold({ null }, ::identity)
+
+@JvmName("orNullMaybe")
+public fun <A : Any> Maybe<Maybe<A>>.orNull(): Maybe<A>? = foldMaybe({ return null }, ::identity)
+
+/**
+ * Returns a [Just<$B>] containing the result of applying $f to this $maybe's
+ * value if this $maybe is nonempty. Otherwise return $nil.
+ *
+ * @note This is similar to `flatMap` except here,
+ * $f does not need to wrap its result in a $maybe.
+ *
+ * @param f the function to apply
+ * @see flatMap
+ */
+public inline fun <reified A : Any, B : Any> Maybe<A>.map(f: (A) -> B): Maybe<B> =
+  flatMap { a -> Just(f(a)) }
+
+@JvmName("maybeMap")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.map(f: (Maybe<A>) -> B): Maybe<B> =
+  flatMap { a -> Just(f(a)) }
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.mapMaybe(f: (A) -> Maybe<B>): Maybe<Maybe<B>> =
+  flatMap { a -> Just(f(a)) }
+
+@JvmName("maybeMapMaybe")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.mapMaybe(f: (Maybe<A>) -> Maybe<B>): Maybe<Maybe<B>> =
+  flatMap { a -> Just(f(a)) }
+
+/**
+ * Returns $nil if the result of applying $f to this $maybe's value is null.
+ * Otherwise returns the result.
+ *
+ * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
+ * and primarily for convenience.
+ *
+ * @param f the function to apply.
+ * */
+public inline fun <reified A : Any, B : Any> Maybe<A>.mapNotNull(f: (A) -> B?): Maybe<B> =
+  flatMap { a -> Maybe.fromNullable(f(a)) }
+
+/**
+ * Returns $nil if the result of applying $f to this $maybe's value is null.
+ * Otherwise returns the result.
+ *
+ * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
+ * and primarily for convenience.
+ *
+ * @param f the function to apply.
+ * */
+
+@JvmName("maybeMapNotNull")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.mapNotNull(f: (Maybe<A>) -> B?): Maybe<B> =
+  flatMap { a -> Maybe.fromNullable(f(a)) }
+
+/**
+ * Returns $nil if the result of applying $f to this $maybe's value is null.
+ * Otherwise returns the result.
+ *
+ * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
+ * and primarily for convenience.
+ *
+ * @param f the function to apply.
+ * */
+public inline fun <reified A : Any, B : Any> Maybe<A>.mapMaybeNotNull(f: (A) -> Maybe<B>?): Maybe<Maybe<B>> =
+  flatMap { a -> Maybe.fromNullable(f(a)) }
+
+/**
+ * Returns $nil if the result of applying $f to this $maybe's value is null.
+ * Otherwise returns the result.
+ *
+ * @note This is similar to `.flatMap { Maybe.fromNullable(null)) }`
+ * and primarily for convenience.
+ *
+ * @param f the function to apply.
+ * */
+
+@JvmName("maybeMapMaybeNotNull")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.mapMaybeNotNull(f: (Maybe<A>) -> Maybe<B>?): Maybe<Maybe<B>> =
+  flatMap { a -> Maybe.fromNullable(f(a)) }
+
+
+/**
+ * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior].
+ */
+public inline infix fun <reified A : Any, reified B : Any> Maybe<A>.align(b: Maybe<B>): Maybe<Ior<A, B>> =
+  fold({
+    b.fold(
+      { Nothing },
+      { b -> Just(b.rightIor()) })
+  },
+    { a ->
+      b.fold(
+        { Just(a.leftIor()) },
+        { b -> Just(Pair(a, b).bothIor()) })
+    }
+  )
+
+
+/**
+ * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior], and then, if it's not [Nothing], map it using [f].
+ *
+ * @note This function works like a regular `align` function, but is then mapped by the `map` function.
+ */
+public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.align(
+  b: Maybe<B>,
+  f: (Ior<A, B>) -> C
+): Maybe<C> =
+  align(b).map(f)
+
+/**
+ * Align two maybes (`this` on the left and [b] on the right) as one Maybe of [Ior], and then, if it's not [Nothing], map it using [f].
+ *
+ * @note This function works like a regular `align` function, but is then mapped by the `map` function.
+ */
+public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.alignMaybe(
+  b: Maybe<B>,
+  f: (Ior<A, B>) -> Maybe<C>
+): Maybe<Maybe<C>> =
+  align(b).mapMaybe(f)
+
+/**
+ * Returns true if this maybe is empty '''or''' the predicate
+ * $predicate returns true when applied to this $maybe's value.
+ *
+ * @param predicate the predicate to test
+ */
+public inline fun <reified A : Any> Maybe<A>.all(predicate: (A) -> Boolean): Boolean =
+  fold({ true }, predicate)
+
+/**
+ * Returns true if this maybe is empty '''or''' the predicate
+ * $predicate returns true when applied to this $maybe's value.
+ *
+ * @param predicate the predicate to test
+ */
+@JvmName("maybeAll")
+public inline fun <A : Any> Maybe<Maybe<A>>.all(predicate: (Maybe<A>) -> Boolean): Boolean =
+  fold({ true }, predicate)
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalk(f: (A) -> Maybe<B>): Maybe<Maybe<B>> =
+  fold(
+    { Nothing },
+    { value -> f(value).mapMaybe<Any, B> { Just(it) as Maybe<B> } })
+
+@JvmName("maybeCrosswalk")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.crosswalk(f: (Maybe<A>) -> Maybe<B>): Maybe<Maybe<B>> =
+  fold(
+    { Nothing },
+    { value -> f(value).mapMaybe<Any, B> { Just(it) as Maybe<B> } })
+
+public inline fun <reified A : Any, K, V : Any> Maybe<A>.crosswalkMap(f: (A) -> Map<K, V>): Map<K, Maybe<V>> =
+  fold(
+    { emptyMap() },
+    { value -> f(value).mapValues { Just(it.value) } }
+  )
+
+@JvmName("maybeCrosswalkMap")
+public inline fun <A : Any, K, V : Any> Maybe<Maybe<A>>.crosswalkMap(f: (Maybe<A>) -> Map<K, V>): Map<K, Maybe<V>> =
+  fold(
+    { emptyMap() },
+    { value -> f(value).mapValues { Just(it.value) } }
+  )
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNull(f: (A) -> B?): Maybe<B>? =
+  fold(
+    { null },
+    { value -> f(value)?.let { Just(it) } }
+  )
+
+@JvmName("maybeCrosswalkNull")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.crosswalkNull(f: (Maybe<A>) -> B?): Maybe<B>? =
+  fold(
+    { null },
+    { value -> f(value)?.let { Just(it) } }
+  )
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.crosswalkNullMaybe(f: (A) -> Maybe<B>?): Maybe<Maybe<B>>? =
+  fold(
+    { null },
+    { value -> f(value)?.let { Just(it) } }
+  )
+
+@JvmName("maybeCrosswalkNullMaybe")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.crosswalkNullMaybe(f: (Maybe<A>) -> Maybe<B>?): Maybe<Maybe<B>>? =
+  fold(
+    { null },
+    { value -> f(value)?.let { Just(it) } }
+  )
+
+/**
+ * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
+ * this $maybe's value returns true. Otherwise, return $nil.
+ *
+ *  @param predicate the predicate used for testing.
+ */
+public inline fun <reified A : Any> Maybe<A>.filter(predicate: (A) -> Boolean): Maybe<A> =
+  flatMap { a -> if (predicate(a)) Just(a) else Nothing }
+
+/**
+ * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
+ * this $maybe's value returns true. Otherwise, return $nil.
+ *
+ *  @param predicate the predicate used for testing.
+ */
+@JvmName("maybeFilter")
+public inline fun <A : Any> Maybe<Maybe<A>>.filter(predicate: (Maybe<A>) -> Boolean): Maybe<Maybe<A>> =
+  flatMap { a -> if (predicate(a)) Just(a) else Nothing }
+
+/**
+ * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
+ * this $maybe's value returns false. Otherwise, return $nil.
+ *
+ * @param predicate the predicate used for testing.
+ */
+public inline fun <reified A : Any> Maybe<A>.filterNot(predicate: (A) -> Boolean): Maybe<A> =
+  flatMap { a -> if (!predicate(a)) Just(a) else Nothing }
+
+/**
+ * Returns this $maybe if it is nonempty '''and''' applying the predicate $p to
+ * this $maybe's value returns false. Otherwise, return $nil.
+ *
+ * @param predicate the predicate used for testing.
+ */
+@JvmName("maybeFilterNot")
+public inline fun <A : Any> Maybe<Maybe<A>>.filterNot(predicate: (Maybe<A>) -> Boolean): Maybe<Maybe<A>> =
+  flatMap { a -> if (!predicate(a)) Just(a) else Nothing }
+
+/**
+ * Returns true if this maybe is nonempty '''and''' the predicate
+ * $p returns true when applied to this $maybe's value.
+ * Otherwise, returns false.
+ *
+ * Example:
+ * ```kotlin
+ * import arrow.core.Just
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ *
+ * fun main() {
+ *   Just(12).exists { it > 10 } // Result: true
+ *   Just(7).exists { it > 10 }  // Result: false
+ *
+ *   val nil: Maybe<Int> = Nil
+ *   nil.exists { it > 10 }      // Result: false
+ * }
+ * ```
+ * <!--- KNIT example-maybe-21.kt -->
+ *
+ * @param predicate the predicate to test
+ */
+public inline fun <reified A : Any> Maybe<A>.exists(predicate: (A) -> Boolean): Boolean = fold({ false }, predicate)
+
+/**
+ * Returns true if this maybe is nonempty '''and''' the predicate
+ * $p returns true when applied to this $maybe's value.
+ * Otherwise, returns false.
+ *
+ * Example:
+ * ```kotlin
+ * import arrow.core.Just
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ *
+ * fun main() {
+ *   Just(12).exists { it > 10 } // Result: true
+ *   Just(7).exists { it > 10 }  // Result: false
+ *
+ *   val nil: Maybe<Int> = Nil
+ *   nil.exists { it > 10 }      // Result: false
+ * }
+ * ```
+ * <!--- KNIT example-maybe-21.kt -->
+ *
+ * @param predicate the predicate to test
+ */
+@JvmName("maybeExists")
+public inline fun <A : Any> Maybe<Maybe<A>>.exists(predicate: (Maybe<A>) -> Boolean): Boolean =
+  fold({ false }, predicate)
+
+/**
+ * Returns the $maybe's value if this maybe is nonempty '''and''' the predicate
+ * $p returns true when applied to this $maybe's value.
+ * Otherwise, returns null.
+ *
+ * Example:
+ * ```kotlin
+ * import arrow.core.Just
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ *
+ * fun main() {
+ *   Just(12).exists { it > 10 } // Result: 12
+ *   Just(7).exists { it > 10 }  // Result: null
+ *
+ *   val nil: Maybe<Int> = Nil
+ *   nil.exists { it > 10 }      // Result: null
+ * }
+ * ```
+ * <!--- KNIT example-maybe-22.kt -->
+ */
+public inline fun <reified A : Any> Maybe<A>.findOrNull(predicate: (A) -> Boolean): A? =
+  fold(
+    { null },
+    { if (predicate(it)) it else null }
+  )
+
+/**
+ * Returns the $maybe's value if this maybe is nonempty '''and''' the predicate
+ * $p returns true when applied to this $maybe's value.
+ * Otherwise, returns null.
+ *
+ * Example:
+ * ```kotlin
+ * import arrow.core.Just
+ * import arrow.core.Nil
+ * import arrow.core.Maybe
+ *
+ * fun main() {
+ *   Just(12).exists { it > 10 } // Result: 12
+ *   Just(7).exists { it > 10 }  // Result: null
+ *
+ *   val nil: Maybe<Int> = Nil
+ *   nil.exists { it > 10 }      // Result: null
+ * }
+ * ```
+ * <!--- KNIT example-maybe-22.kt -->
+ */
+
+@JvmName("maybeFindOrNull")
+public inline fun <A : Any> Maybe<Maybe<A>>.findOrNull(predicate: (Maybe<A>) -> Boolean): Maybe<A>? =
+  fold(
+    { null },
+    { if (predicate(it)) it else null }
+  )
+
+public inline fun <reified A : Any, B> Maybe<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
+  foldLeft(empty()) { b, a -> b.combine(f(a)) }
+}
+
+@JvmName("maybeFoldMap")
+public inline fun <A : Any, B> Maybe<Maybe<A>>.foldMap(MB: Monoid<B>, f: (Maybe<A>) -> B): B = MB.run {
+  foldLeft(empty()) { b, a -> b.combine(f(a)) }
+}
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.foldMapMaybe(MB: Monoid<Maybe<B>>, f: (A) -> Maybe<B>): Maybe<B> =
+  MB.run {
+    foldLeftMaybe(empty()) { b, a -> b.combine(f(a)) }
+  }
+
+@JvmName("maybeFoldMapMaybe")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.foldMapMaybe(
+  MB: Monoid<Maybe<B>>,
+  f: (Maybe<A>) -> Maybe<B>
+): Maybe<B> = MB.run {
+  foldLeftMaybe(empty()) { b, a -> b.combine(f(a)) }
+}
+
+public inline fun <reified A : Any, B> Maybe<A>.foldLeft(initial: B, operation: (B, A) -> B): B =
+  fold(
+    { initial },
+    { operation(initial, it) }
+  )
+
+@JvmName("maybeFoldLeft")
+public inline fun <A : Any, B> Maybe<Maybe<A>>.foldLeft(initial: B, operation: (B, Maybe<A>) -> B): B =
+  fold(
+    { initial },
+    { operation(initial, it) }
+  )
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.foldLeftMaybe(
+  initial: Maybe<B>,
+  operation: (Maybe<B>, A) -> Maybe<B>
+): Maybe<B> =
+  fold(
+    { initial },
+    { operation(initial, it) }
+  )
+
+@JvmName("maybeFoldLeftMaybe")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.foldLeftMaybe(
+  initial: Maybe<B>,
+  operation: (Maybe<B>, Maybe<A>) -> Maybe<B>
+): Maybe<B> =
+  fold(
+    { initial },
+    { operation(initial, it) }
+  )
+
+public inline fun <reified A : Any, reified B : Any> Maybe<A>.padZip(other: Maybe<B>): Maybe<Pair<A?, B?>> =
+  padZip(other, ::Pair)
+
+public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZip(
+  other: Maybe<B>,
+  f: (A?, B?) -> C
+): Maybe<C> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("maybeNormalPadZip")
+public inline fun <A : Any, reified B : Any, C : Any> Maybe<Maybe<A>>.padZip(
+  other: Maybe<B>,
+  f: (Maybe<A>?, B?) -> C
+): Maybe<C> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("normalMaybePadZip")
+public inline fun <reified A : Any, B : Any, C : Any> Maybe<A>.padZip(
+  other: Maybe<Maybe<B>>,
+  f: (A?, Maybe<B>?) -> C
+): Maybe<C> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("maybeMaybePadZip")
+public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<A>>.padZip(
+  other: Maybe<Maybe<B>>,
+  f: (Maybe<A>?, Maybe<B>?) -> C
+): Maybe<C> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("maybeMaybePadZip2")
+public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<A>>.padZip2(
+  other: Maybe<Maybe<B>>,
+  f: (Maybe<A>?, Maybe<B>?) -> C
+): Maybe<C> =
+  fold({
+    other.fold({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.fold({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+public inline fun <reified A : Any, reified B : Any, C : Any> Maybe<A>.padZipMaybe(
+  other: Maybe<B>,
+  f: (A?, B?) -> Maybe<C>
+): Maybe<Maybe<C>> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("maybeNormalPadZipMaybe")
+public inline fun <A : Any, reified B : Any, C : Any> Maybe<Maybe<A>>.padZipMaybe(
+  other: Maybe<B>,
+  f: (Maybe<A>?, B?) -> Maybe<C>
+): Maybe<Maybe<C>> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("normalMaybePadZipMaybe")
+public inline fun <reified A : Any, B : Any, C : Any> Maybe<A>.padZipMaybe(
+  other: Maybe<Maybe<B>>,
+  f: (A?, Maybe<B>?) -> Maybe<C>
+): Maybe<Maybe<C>> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+@JvmName("maybeMaybePadZipMaybe")
+public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<A>>.padZipMaybe(
+  other: Maybe<Maybe<B>>,
+  f: (Maybe<A>?, Maybe<B>?) -> Maybe<C>
+): Maybe<Maybe<C>> =
+  foldMaybe({
+    other.foldMaybe({
+      Nothing
+    }, { b ->
+      Just(f(null, b))
+    })
+  }, { a ->
+    other.foldMaybe({
+      Just(f(a, null))
+    }, { b ->
+      Just(f(a, b))
+    })
+  })
+
+public inline fun <reified A : Any, B> Maybe<A>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A) -> B): B? =
+  fold(
+    { null },
+    { operation(initial(it), it) }
+  )
+
+@JvmName("maybeReduceOrNull")
+public inline fun <A : Any, B> Maybe<Maybe<A>>.reduceOrNull(
+  initial: (Maybe<A>) -> B,
+  operation: (acc: B, Maybe<A>) -> B
+): B? =
+  fold(
+    { null },
+    { operation(initial(it), it) }
+  )
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.reduceOrNullMaybe(
+  initial: (A) -> Maybe<B>,
+  operation: (acc: Maybe<B>, A) -> Maybe<B>
+): Maybe<B>? =
+  fold(
+    { null },
+    { operation(initial(it), it) }
+  )
+
+@JvmName("maybeReduceOrNullMaybe")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.reduceOrNullMaybe(
+  initial: (Maybe<A>) -> Maybe<B>,
+  operation: (acc: Maybe<B>, Maybe<A>) -> Maybe<B>
+): Maybe<B>? =
+  fold(
+    { null },
+    { operation(initial(it), it) }
+  )
+
+public inline fun <reified A : Any, B> Maybe<A>.reduceRightEvalOrNull(
+  initial: (A) -> B,
+  operation: (A, acc: Eval<B>) -> Eval<B>
+): Eval<B?> =
+  fold(
+    { Eval.now(null) },
+    { operation(it, Eval.now(initial(it))) }
+  )
+
+@JvmName("maybeReduceRightEvalOrNull")
+public inline fun <A : Any, B> Maybe<Maybe<A>>.reduceRightEvalOrNull(
+  initial: (Maybe<A>) -> B,
+  operation: (Maybe<A>, acc: Eval<B>) -> Eval<B>
+): Eval<B?> =
+  fold(
+    { Eval.now(null) },
+    { operation(it, Eval.now(initial(it))) }
+  )
+
+public inline fun <reified A : Any> Maybe<A>.replicate(n: Int): Maybe<List<A>> =
+  if (n <= 0) Just(emptyList()) else map { a -> List(n) { a } }
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <reified A : Any, B : Any> Maybe<A>.traverse(fa: (A) -> Iterable<B>): List<Maybe<B>> =
+  fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+@JvmName("maybeTraverse")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.traverse(fa: (Maybe<A>) -> Iterable<B>): List<Maybe<B>> =
+  fold({ emptyList() }, { a -> fa(a).map { Just(it) } })
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(fa: (A) -> Either<AA, B>): Either<AA, Maybe<B>> =
+  fold(
+    { Right(Nothing) },
+    { value -> fa(value).map { Just(it) } }
+  )
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+@JvmName("maybeTraverse")
+public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverse(fa: (Maybe<A>) -> Either<AA, B>): Either<AA, Maybe<B>> =
+  fold(
+    { Right(Nothing) },
+    { value -> fa(value).map { Just(it) } }
+  )
+
+@Deprecated("traverseEither is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseEither(fa: (A) -> Either<AA, B>): Either<AA, Maybe<B>> =
+  traverse(fa)
+
+@JvmName("maybeTraverseEither")
+@Deprecated("traverseEither is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
+public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverseEither(fa: (Maybe<A>) -> Either<AA, B>): Either<AA, Maybe<B>> =
+  traverse(fa)
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverse(fa: (A) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
+  fold(
+    { Valid(Nothing) },
+    { value -> fa(value).map { Just(it) } }
+  )
+
+@OptIn(ExperimentalTypeInference::class)
+@OverloadResolutionByLambdaReturnType
+@JvmName("maybeTraverse")
+public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverse(fa: (Maybe<A>) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
+  fold(
+    { Valid(Nothing) },
+    { value -> fa(value).map { Just(it) } }
+  )
+
+@Deprecated("traverseValidated is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
+public inline fun <reified A : Any, AA, B : Any> Maybe<A>.traverseValidated(fa: (A) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
+  traverse(fa)
+
+@JvmName("maybeTraverseValidated")
+@Deprecated("traverseValidated is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
+public inline fun <A : Any, AA, B : Any> Maybe<Maybe<A>>.traverseValidated(fa: (Maybe<A>) -> Validated<AA, B>): Validated<AA, Maybe<B>> =
+  traverse(fa)
+
+public inline fun <reified A : Any, L> Maybe<A>.toEither(ifEmpty: () -> L): Either<L, A> =
+  fold({ ifEmpty().left() }, { it.right() })
+
+public inline fun <reified A : Any> Maybe<A>.toList(): List<A> = fold(::emptyList) { listOf(it) }
+
+public fun Maybe<*>.void(): Maybe<Unit> = justUnit
+
+public inline fun <reified A : Any, L> Maybe<A>.pairLeft(left: L): Maybe<Pair<L, A>> = this.map { left to it }
+
+public inline fun <reified A : Any, R> Maybe<A>.pairRight(right: R): Maybe<Pair<A, R>> = this.map { it to right }
+
+public infix fun <A : Any, X : Any> Maybe<A>.and(value: Maybe<X>): Maybe<X> = if (isEmpty()) {
+  Nothing
+} else {
+  value
+}
+
+@PublishedApi
+internal data class Nil private constructor(val nesting: Int) {
+  companion object {
+    private val cache = Array(22) { Nil(it) }
+    operator fun invoke(nesting: Int) = cache.getOrElse(nesting, ::Nil)
+  }
+
+  override fun toString(): String = buildString("Maybe.Just()".length + "Maybe.Nothing".length) {
+    repeat(nesting) { this.append("Maybe.Just(") }
+    append("Maybe.Nothing")
+    repeat(nesting) { this.append(")") }
+  }
+}
+
+@OptIn(MaybeInternals::class)
+public inline fun <T : Any> Just(value: T): Maybe<T> =
+  if (value is Maybe<*>) {
+    Just(value) as Maybe<T> // Should rarely ever happen, but just in case this ensures that there *never* is a boxed Maybe inside a Maybe
+  } else
+    Maybe.construct(if (value is Nil) Nil(value.nesting + 1) else value)
+
+@OptIn(MaybeInternals::class)
+public inline fun <T : Any> Just(value: Maybe<T>): Maybe<Maybe<T>> = (value as Maybe<*>).underlying.let {
+  // .value will remove 1 level of nesting, but we're inside 2 levels here, so we use underlying instead to get the raw value, and then we add 1 level of nesting
+  Maybe.construct(if (it is Nil) Nil(it.nesting + 1) else it)
+}
+
+@PublishedApi
+internal val justUnit: Maybe<Unit> = Just(Unit)
+@PublishedApi
+internal val boxedJustUnit: Any = justUnit
+
+/**
+ * Returns the maybe's value if the maybe is nonempty, otherwise
+ * return the result of evaluating `default`.
+ *
+ * @param default the default expression.
+ */
+public inline fun <reified T : Any> Maybe<T>.getOrElse(default: () -> T): T = fold({ default() }, ::identity)
+
+/**
+ * Returns the maybe's value if the maybe is nonempty, otherwise
+ * return the result of evaluating `default`.
+ *
+ * @param default the default expression.
+ */
+@JvmName("maybeGetOrElse")
+public inline fun <T : Any> Maybe<Maybe<T>>.getOrElse(default: () -> Maybe<T>): Maybe<T> =
+  foldMaybe({ default() }, ::identity)
+
+/**
+ * Returns this maybe's if the maybe is nonempty, otherwise
+ * returns another maybe provided lazily by `default`.
+ *
+ * @param alternative the default maybe if this is empty.
+ */
+public inline fun <A : Any> Maybe<A>.orElse(alternative: () -> Maybe<A>): Maybe<A> =
+  if (isEmpty()) alternative() else this
+
+public infix fun <T : Any> Maybe<T>.or(value: Maybe<T>): Maybe<T> = if (isEmpty()) {
+  value
+} else {
+  this
+}
+
+public fun <T : Any> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
+public fun <T : Any> Maybe<T>?.toMaybe(): Maybe<Maybe<T>> = this?.let { Just(it) } ?: Nothing
+
+public inline fun <A : Any> Boolean.maybe2(f: () -> A): Maybe<A> =
+  if (this) {
+    Just(f())
+  } else {
+    Nothing
+  }
+
+public fun <A : Any> A.just(): Maybe<A> = Just(this)
+public fun <A : Any> Maybe<A>.just(): Maybe<Maybe<A>> = Just(this)
+
+public fun <A : Any> nothing(): Maybe<A> = Nothing
+
+public inline fun <reified A : Any> Monoid.Companion.maybe(MA: Semigroup<A>): Monoid<Maybe<A>> =
+  if (isTypeMaybe<A>()) MaybeMonoidNested(MA as Semigroup<Maybe<A>>) as Monoid<Maybe<A>> else MaybeMonoid(MA)
+
+@JvmName("maybeMaybe")
+public inline fun <A : Any> Monoid.Companion.maybe(MA: Semigroup<Maybe<A>>): Monoid<Maybe<Maybe<A>>> =
+  MaybeMonoidNested(MA)
+
+@PublishedApi
+internal class MaybeMonoid<A : Any>(
+  private val MA: Semigroup<A>
+) : Monoid<Maybe<A>> {
+
+  override fun Maybe<A>.combine(b: Maybe<A>): Maybe<A> =
+    combine(MA as Semigroup<Any>, b) as Maybe<A>
+
+  override fun Maybe<A>.maybeCombine(b: Maybe<A>?): Maybe<A> =
+    b?.let { combine(MA as Semigroup<Any>, it) as Maybe<A> } ?: this
+
+  override fun empty(): Maybe<A> = Nothing
+}
+
+@PublishedApi
+internal class MaybeMonoidNested<A : Any>(
+  private val MA: Semigroup<Maybe<A>>
+) : Monoid<Maybe<Maybe<A>>> {
+
+  override fun Maybe<Maybe<A>>.combine(b: Maybe<Maybe<A>>): Maybe<Maybe<A>> =
+    combine(MA, b)
+
+  override fun Maybe<Maybe<A>>.maybeCombine(b: Maybe<Maybe<A>>?): Maybe<Maybe<A>> =
+    b?.let { combine(MA, it) } ?: this
+
+  override fun empty(): Maybe<Maybe<A>> = Nothing
+}
+
+@Deprecated("use fold instead", ReplaceWith("fold(Monoid.maybe(MA))", "arrow.core.fold", "arrow.typeclasses.Monoid"))
+public inline fun <reified A : Any> Iterable<Maybe<A>>.combineAll(MA: Monoid<A>): Maybe<A> =
+  fold(Monoid.maybe(MA))
+
+@Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
+public inline fun <reified A : Any> Maybe<A>.combineAll(MA: Monoid<A>): A =
+  getOrElse { MA.empty() }
+
+@JvmName("maybeCombineAll")
+@Deprecated("use getOrElse instead", ReplaceWith("getOrElse { MA.empty() }"))
+public fun <A : Any> Maybe<Maybe<A>>.combineAll(MA: Monoid<Maybe<A>>): Maybe<A> =
+  getOrElse { MA.empty() }
+
+public inline fun <reified A : Any> Maybe<A>.ensure(error: () -> Unit, predicate: (A) -> Boolean): Maybe<A> =
+  fold(
+    { this },
+    {
+      if (predicate(it))
+        this
+      else {
+        error()
+        Nothing
+      }
+    }
+  )
+
+@JvmName("maybeEnsure")
+public inline fun <A : Any> Maybe<Maybe<A>>.ensure(
+  error: () -> Unit,
+  predicate: (Maybe<A>) -> Boolean
+): Maybe<Maybe<A>> =
+  fold(
+    { this },
+    {
+      if (predicate(it))
+        this
+      else {
+        error()
+        Nothing
+      }
+    }
+  )
+
+/**
+ * Returns a Maybe containing all elements that are instances of specified type parameter [B].
+ */
+public inline fun <reified B : Any> Maybe<*>.filterIsInstance(): Maybe<B> =
+  flatMap {
+    when (it) {
+      is B -> Just(it)
+      else -> Nothing
+    }
+  }
+
+@JvmName("maybeFilterIsInstance")
+public inline fun <reified B : Any> Maybe<Maybe<*>>.filterIsInstance(): Maybe<B> =
+  flatMap {
+    when (it) {
+      is B -> Just(it) as Maybe<B>
+      else -> Nothing
+    }
+  }
+
+public inline fun <A : Any> Maybe<A>.handleError(f: (Unit) -> A): Maybe<A> =
+  handleErrorWith { Just(f(Unit)) }
+
+@JvmName("maybeHandleError")
+public inline fun <A : Any> Maybe<Maybe<A>>.handleError(f: (Unit) -> Maybe<A>): Maybe<Maybe<A>> =
+  handleErrorWith { Just(f(Unit)) }
+
+public inline fun <A : Any> Maybe<A>.handleErrorWith(f: (Unit) -> Maybe<A>): Maybe<A> =
+  if (isEmpty()) f(Unit) else this
+
+public fun <A : Any> Maybe<Maybe<A>>.flatten(): Maybe<A> =
+  flatMap(::identity)
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.redeem(fe: (Unit) -> B, fb: (A) -> B): Maybe<B> =
+  map(fb).handleError(fe)
+
+@JvmName("maybeRedeem")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.redeem(fe: (Unit) -> B, fb: (Maybe<A>) -> B): Maybe<B> =
+  map(fb).handleError(fe)
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.redeemMaybe(
+  fe: (Unit) -> Maybe<B>,
+  fb: (A) -> Maybe<B>
+): Maybe<Maybe<B>> =
+  mapMaybe(fb).handleError(fe)
+
+@JvmName("maybeRedeemMaybe")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.redeemMaybe(
+  fe: (Unit) -> Maybe<B>,
+  fb: (Maybe<A>) -> Maybe<B>
+): Maybe<Maybe<B>> =
+  mapMaybe(fb).handleError(fe)
+
+public inline fun <reified A : Any, B : Any> Maybe<A>.redeemWith(
+  fe: (Unit) -> Maybe<B>,
+  fb: (A) -> Maybe<B>
+): Maybe<B> =
+  flatMap(fb).handleErrorWith(fe)
+
+@JvmName("maybeRedeemWith")
+public inline fun <A : Any, B : Any> Maybe<Maybe<A>>.redeemWith(
+  fe: (Unit) -> Maybe<B>,
+  fb: (Maybe<A>) -> Maybe<B>
+): Maybe<B> =
+  flatMap(fb).handleErrorWith(fe)
+
+public inline fun <reified A : Any> Maybe<A>.replicate(n: Int, MA: Monoid<A>): Maybe<A> = MA.run {
+  if (n <= 0) Just(empty())
+  else map { a ->
+    var result = empty()
+    repeat(n) {
+      result += a
+    }
+    result
+  }
+}
+
+@JvmName("maybeReplicate")
+public fun <A : Any> Maybe<Maybe<A>>.replicate(n: Int, MA: Monoid<Maybe<A>>): Maybe<Maybe<A>> = MA.run {
+  if (n <= 0) Just(empty())
+  else map { a ->
+    var result = empty()
+    repeat(n) {
+      result += a
+    }
+    result
+  }
+}
+
+
+public fun <A : Any> Maybe<Either<Unit, A>>.rethrow(): Maybe<A> =
+  flatMap { it.fold({ Nothing }, { a -> Just(a) }) }
+
+public inline fun <reified A : Any> Maybe<A>.salign(SA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
+  align(b) {
+    it.fold(::identity, ::identity) { a, b ->
+      SA.run { a.combine(b) }
+    }
+  }
+
+@JvmName("maybeSalign")
+public fun <A : Any> Maybe<Maybe<A>>.salign(SA: Semigroup<Maybe<A>>, b: Maybe<Maybe<A>>): Maybe<Maybe<A>> =
+  align(b) {
+    it.fold(::identity, ::identity) { a, b ->
+      SA.run { a.combine(b) }
+    }
+  }
+
+/**
+ * Separate the inner [Either] value into the [Either.Left] and [Either.Right].
+ *
+ * @receiver Maybe of Either
+ * @return a tuple containing Maybe of [Either.Left] and another Maybe of its [Either.Right] value.
+ */
+public fun <A : Any, B : Any> Maybe<Either<A, B>>.separateEither(): Pair<Maybe<A>, Maybe<B>> {
+  val asep = flatMap { gab -> gab.fold({ Just(it) }, { Nothing }) }
+  val bsep = flatMap { gab -> gab.fold({ Nothing }, { Just(it) }) }
+  return asep to bsep
+}
+
+/**
+ * Separate the inner [Validated] value into the [Validated.Invalid] and [Validated.Valid].
+ *
+ * @receiver Maybe of Either
+ * @return a tuple containing Maybe of [Validated.Invalid] and another Maybe of its [Validated.Valid] value.
+ */
+public fun <A : Any, B : Any> Maybe<Validated<A, B>>.separateValidated(): Pair<Maybe<A>, Maybe<B>> {
+  val asep = flatMap { gab -> gab.fold({ Just(it) }, { Nothing }) }
+  val bsep = flatMap { gab -> gab.fold({ Nothing }, { Just(it) }) }
+  return asep to bsep
+}
+
+public fun <A : Any> Maybe<Iterable<A>>.sequence(): List<Maybe<A>> =
+  traverse(::identity)
+
+@Deprecated(
+  "sequenceEither is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence()", "arrow.core.sequence")
+)
+public fun <A, B : Any> Maybe<Either<A, B>>.sequenceEither(): Either<A, Maybe<B>> =
+  sequence()
+
+public fun <A, B : Any> Maybe<Either<A, B>>.sequence(): Either<A, Maybe<B>> =
+  traverse(::identity)
+
+@Deprecated(
+  "sequenceValidated is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence()", "arrow.core.sequence")
+)
+public fun <A, B : Any> Maybe<Validated<A, B>>.sequenceValidated(): Validated<A, Maybe<B>> =
+  sequence()
+
+public fun <A, B : Any> Maybe<Validated<A, B>>.sequence(): Validated<A, Maybe<B>> =
+  traverse(::identity)
+
+public fun <A : Any, B : Any> Maybe<Ior<A, B>>.unalign(): Pair<Maybe<A>, Maybe<B>> =
+  unalign(::identity)
+
+public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unalign(f: (C) -> Ior<A, B>): Pair<Maybe<A>, Maybe<B>> =
+  this.map(f).fold(
+    { Nothing to Nothing },
+    {
+      when (it) {
+        is Ior.Left -> Just(it.value) to Nothing
+        is Ior.Right -> Nothing to Just(it.value)
+        is Ior.Both -> Just(it.leftValue) to Just(it.rightValue)
+      }
+    }
+  )
+
+@JvmName("maybeUnalign")
+public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<C>>.unalign(f: (Maybe<C>) -> Ior<A, B>): Pair<Maybe<A>, Maybe<B>> =
+  this.map(f).unalign()
+
+public fun <A : Any> Maybe<Iterable<A>>.unite(MA: Monoid<A>): Maybe<A> =
+  map { iterable ->
+    iterable.fold(MA)
+  }
+
+public fun <A, B : Any> Maybe<Either<A, B>>.uniteEither(): Maybe<B> =
+  flatMap { either ->
+    either.fold({ Nothing }, { b -> Just(b) })
+  }
+
+public fun <A, B : Any> Maybe<Validated<A, B>>.uniteValidated(): Maybe<B> =
+  flatMap { validated ->
+    validated.fold({ Nothing }, { b -> Just(b) })
+  }
+
+public fun <A : Any, B : Any> Maybe<Pair<A, B>>.unzip(): Pair<Maybe<A>, Maybe<B>> =
+  unzip(::identity)
+
+public inline fun <A : Any, B : Any, reified C : Any> Maybe<C>.unzip(f: (C) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
+  fold(
+    { Nothing to Nothing },
+    { f(it).let { pair -> Just(pair.first) to Just(pair.second) } }
+  )
+
+@JvmName("maybeUnzip")
+public inline fun <A : Any, B : Any, C : Any> Maybe<Maybe<C>>.unzip(f: (Maybe<C>) -> Pair<A, B>): Pair<Maybe<A>, Maybe<B>> =
+  fold(
+    { Nothing to Nothing },
+    { f(it).let { pair -> Just(pair.first) to Just(pair.second) } }
+  )
+
+/**
+ *  Given [A] is a sub type of [B], re-type this value from Maybe<A> to Maybe<B>
+ *
+ *  Maybe<A> -> Maybe<B>
+ *
+ *  ```kotlin
+ *  import arrow.core.Maybe
+ *  import arrow.core.just
+ *  import arrow.core.widen
+ *
+ *  fun main(args: Array<String>) {
+ *   val result: Maybe<CharSequence> =
+ *   //sampleStart
+ *   "Hello".just().map({ "$it World" }).widen()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ * <!--- KNIT example-maybe-23.kt -->
+ */
+public fun <B : Any, A : B> Maybe<A>.widen(): Maybe<B> =
+  this
+
+public fun <K, V> Maybe<Pair<K, V>>.toMap(): Map<K, V> = this.toList().toMap()
+
+public inline fun <reified A : Any> Maybe<A>.combine(SGA: Semigroup<A>, b: Maybe<A>): Maybe<A> =
+  fold(
+    { b },
+    { first ->
+      b.fold(
+        { this },
+        { second ->
+          Just(SGA.run { first.combine(second) })
+        }
+      )
+    }
+  )
+
+@JvmName("maybeCombine")
+public fun <A : Any> Maybe<Maybe<A>>.combine(SGA: Semigroup<Maybe<A>>, b: Maybe<Maybe<A>>): Maybe<Maybe<A>> =
+  fold(
+    { b },
+    { first ->
+      b.fold(
+        { this },
+        { second ->
+          Just(SGA.run { first.combine(second) })
+        }
+      )
+    }
+  )
+
+public inline operator fun <reified A : Comparable<A>> Maybe<A>.compareTo(other: Maybe<A>): Int = fold(
+  { other.fold({ 0 }, { -1 }) },
+  { a1 ->
+    other.fold({ 1 }, { a2 -> a1.compareTo(a2) })
+  }
+)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Maybe.kt
@@ -35,6 +35,7 @@ private constructor(@property:MaybeInternals @PublishedApi internal val underlyi
 
     @JvmStatic
     public inline fun <A : Any> fromNullable(a: A?): Maybe<A> = if (a != null) Just(a) else Nothing
+    @JvmStatic public inline fun fromNullable(a: Nothing?): Maybe<Nothing> = Nothing
 
     @JvmStatic
     public inline fun <A : Any> fromNullable(a: Maybe<A>?): Maybe<Maybe<A>> =
@@ -660,6 +661,8 @@ public infix fun <T : Any> Maybe<T>.or(value: Maybe<T>): Maybe<T> =
   }
 
 public inline fun <T : Any> T?.toMaybe(): Maybe<T> = this?.let { Just(it) } ?: Nothing
+
+public inline fun Nothing?.toMaybe(): Maybe<Nothing> = Nothing
 
 public fun <T : Any> Maybe<T>?.toMaybe(): Maybe<Maybe<T>> = this?.let { Just(it) } ?: Nothing
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
@@ -1,0 +1,61 @@
+package arrow.core.continuations
+
+import arrow.core.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import kotlin.jvm.JvmInline
+
+public suspend fun <A: Any> Effect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
+  fold(::identity) { Just(it) }
+
+public fun <A: Any> EagerEffect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
+  fold(::identity) { Just(it) }
+
+@JvmInline
+public value class MaybeEffectScope(private val cont: EffectScope<Maybe<Nothing>>) : EffectScope<Maybe<Nothing>> {
+  override suspend fun <B> shift(r: Maybe<Nothing>): B =
+    cont.shift(r)
+
+  public suspend inline fun <reified B: Any> Maybe<B>.bind(): B =
+    bind(this) { Maybe.Nothing }
+
+  public suspend fun ensure(value: Boolean): Unit =
+    ensure(value) { Maybe.Nothing }
+}
+
+@OptIn(ExperimentalContracts::class)
+public suspend fun <B> MaybeEffectScope.ensureNotNull(value: B?): B {
+  contract { returns() implies (value != null) }
+  return ensureNotNull(value) { Maybe.Nothing }
+}
+
+@OptIn(ExperimentalContracts::class)
+public suspend fun <B> MaybeEagerEffectScope.ensureNotNull(value: B?): B {
+  contract { returns() implies (value != null) }
+  return ensureNotNull(value) { Maybe.Nothing }
+}
+
+@JvmInline
+public value class MaybeEagerEffectScope(private val cont: EagerEffectScope<Maybe<Nothing>>) : EagerEffectScope<Maybe<Nothing>> {
+  @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
+  override suspend fun <B> shift(r: Maybe<Nothing>): B =
+    cont.shift(r)
+
+  public suspend inline fun <reified B: Any> Maybe<B>.bind(): B =
+    bind(this) { Maybe.Nothing }
+
+  public suspend fun ensure(value: Boolean): Unit =
+    ensure(value) { Maybe.Nothing }
+}
+
+@Suppress("ClassName")
+public object maybe {
+  public inline fun <A: Any> eager(crossinline f: suspend MaybeEagerEffectScope.() -> A): Maybe<A> =
+    eagerEffect<Maybe<Nothing>, A> {
+      @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
+      f(MaybeEagerEffectScope(this))
+    }.toMaybe()
+
+  public suspend inline operator fun <A: Any> invoke(crossinline f: suspend MaybeEffectScope.() -> A): Maybe<A> =
+    effect<Maybe<Nothing>, A> { f(MaybeEffectScope(this)) }.toMaybe()
+}

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
@@ -18,6 +18,8 @@ public value class MaybeEffectScope(private val cont: EffectScope<Maybe<Nothing>
 
   public suspend inline fun <reified B: Any> Maybe<B>.bind(): B =
     bind(this) { Maybe.Nothing }
+  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
+    bind(this) { Maybe.Nothing }
 
   public suspend fun ensure(value: Boolean): Unit =
     ensure(value) { Maybe.Nothing }
@@ -42,6 +44,8 @@ public value class MaybeEagerEffectScope(private val cont: EagerEffectScope<Mayb
     cont.shift(r)
 
   public suspend inline fun <reified B: Any> Maybe<B>.bind(): B =
+    bind(this) { Maybe.Nothing }
+  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
     bind(this) { Maybe.Nothing }
 
   public suspend fun ensure(value: Boolean): Unit =

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
@@ -15,18 +15,15 @@ public fun <A : Any> EagerEffect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
   fold(::identity) { Just(it) }
 
 @JvmInline
-public value class MaybeEffectScope(private val cont: EffectScope<Maybe<Nothing>>) : EffectScope<Maybe<Nothing>> {
-  override suspend fun <B> shift(r: Maybe<Nothing>): B =
-    cont.shift(r)
+public value class MaybeEffectScope(private val cont: EffectScope<Maybe<Nothing>>) :
+  EffectScope<Maybe<Nothing>> {
+  override suspend fun <B> shift(r: Maybe<Nothing>): B = cont.shift(r)
 
-  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
-    bind(this) { Maybe.Nothing }
+  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B = bind(this) { Maybe.Nothing }
 
-  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
-    bind(this) { Maybe.Nothing }
+  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> = bind(this) { Maybe.Nothing }
 
-  public suspend fun ensure(value: Boolean): Unit =
-    ensure(value) { Maybe.Nothing }
+  public suspend fun ensure(value: Boolean): Unit = ensure(value) { Maybe.Nothing }
 }
 
 @OptIn(ExperimentalContracts::class)
@@ -45,27 +42,26 @@ public suspend fun <B> MaybeEagerEffectScope.ensureNotNull(value: B?): B {
 public value class MaybeEagerEffectScope(private val cont: EagerEffectScope<Maybe<Nothing>>) :
   EagerEffectScope<Maybe<Nothing>> {
   @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
-  override suspend fun <B> shift(r: Maybe<Nothing>): B =
-    cont.shift(r)
+  override suspend fun <B> shift(r: Maybe<Nothing>): B = cont.shift(r)
 
-  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
-    bind(this) { Maybe.Nothing }
+  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B = bind(this) { Maybe.Nothing }
 
-  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
-    bind(this) { Maybe.Nothing }
+  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> = bind(this) { Maybe.Nothing }
 
-  public suspend fun ensure(value: Boolean): Unit =
-    ensure(value) { Maybe.Nothing }
+  public suspend fun ensure(value: Boolean): Unit = ensure(value) { Maybe.Nothing }
 }
 
 @Suppress("ClassName")
 public object maybe {
-  public inline fun <A : Any> eager(crossinline f: suspend MaybeEagerEffectScope.() -> A): Maybe<A> =
+  public inline fun <A : Any> eager(
+    crossinline f: suspend MaybeEagerEffectScope.() -> A
+  ): Maybe<A> =
     eagerEffect<Maybe<Nothing>, A> {
-      @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
-      f(MaybeEagerEffectScope(this))
-    }.toMaybe()
+        @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL") f(MaybeEagerEffectScope(this))
+      }
+      .toMaybe()
 
-  public suspend inline operator fun <A : Any> invoke(crossinline f: suspend MaybeEffectScope.() -> A): Maybe<A> =
-    effect<Maybe<Nothing>, A> { f(MaybeEffectScope(this)) }.toMaybe()
+  public suspend inline operator fun <A : Any> invoke(
+    crossinline f: suspend MaybeEffectScope.() -> A
+  ): Maybe<A> = effect<Maybe<Nothing>, A> { f(MaybeEffectScope(this)) }.toMaybe()
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/maybe.kt
@@ -1,14 +1,17 @@
 package arrow.core.continuations
 
-import arrow.core.*
+import arrow.core.Just
+import arrow.core.Maybe
+import arrow.core.bind
+import arrow.core.identity
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.jvm.JvmInline
 
-public suspend fun <A: Any> Effect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
+public suspend fun <A : Any> Effect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
   fold(::identity) { Just(it) }
 
-public fun <A: Any> EagerEffect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
+public fun <A : Any> EagerEffect<Maybe<Nothing>, A>.toMaybe(): Maybe<A> =
   fold(::identity) { Just(it) }
 
 @JvmInline
@@ -16,8 +19,9 @@ public value class MaybeEffectScope(private val cont: EffectScope<Maybe<Nothing>
   override suspend fun <B> shift(r: Maybe<Nothing>): B =
     cont.shift(r)
 
-  public suspend inline fun <reified B: Any> Maybe<B>.bind(): B =
+  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
     bind(this) { Maybe.Nothing }
+
   public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
     bind(this) { Maybe.Nothing }
 
@@ -38,13 +42,15 @@ public suspend fun <B> MaybeEagerEffectScope.ensureNotNull(value: B?): B {
 }
 
 @JvmInline
-public value class MaybeEagerEffectScope(private val cont: EagerEffectScope<Maybe<Nothing>>) : EagerEffectScope<Maybe<Nothing>> {
+public value class MaybeEagerEffectScope(private val cont: EagerEffectScope<Maybe<Nothing>>) :
+  EagerEffectScope<Maybe<Nothing>> {
   @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
   override suspend fun <B> shift(r: Maybe<Nothing>): B =
     cont.shift(r)
 
-  public suspend inline fun <reified B: Any> Maybe<B>.bind(): B =
+  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
     bind(this) { Maybe.Nothing }
+
   public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
     bind(this) { Maybe.Nothing }
 
@@ -54,12 +60,12 @@ public value class MaybeEagerEffectScope(private val cont: EagerEffectScope<Mayb
 
 @Suppress("ClassName")
 public object maybe {
-  public inline fun <A: Any> eager(crossinline f: suspend MaybeEagerEffectScope.() -> A): Maybe<A> =
+  public inline fun <A : Any> eager(crossinline f: suspend MaybeEagerEffectScope.() -> A): Maybe<A> =
     eagerEffect<Maybe<Nothing>, A> {
       @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
       f(MaybeEagerEffectScope(this))
     }.toMaybe()
 
-  public suspend inline operator fun <A: Any> invoke(crossinline f: suspend MaybeEffectScope.() -> A): Maybe<A> =
+  public suspend inline operator fun <A : Any> invoke(crossinline f: suspend MaybeEffectScope.() -> A): Maybe<A> =
     effect<Maybe<Nothing>, A> { f(MaybeEffectScope(this)) }.toMaybe()
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/nullable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/nullable.kt
@@ -1,6 +1,8 @@
 package arrow.core.continuations
 
+import arrow.core.Maybe
 import arrow.core.Option
+import arrow.core.bind
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.jvm.JvmInline
@@ -12,6 +14,10 @@ public value class NullableEffectScope(private val cont: EffectScope<Nothing?>) 
 
   public suspend fun <B> Option<B>.bind(): B =
     bind { null }
+  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
+    bind(this) { null }
+  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
+    bind(this) { null }
 
   @OptIn(ExperimentalContracts::class)
   public suspend fun <B> B?.bind(): B {
@@ -31,6 +37,11 @@ public value class NullableEagerEffectScope(private val cont: EagerEffectScope<N
 
   public suspend fun <B> Option<B>.bind(): B =
     bind { null }
+
+  public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
+    bind(this) { null }
+  public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
+    bind(this) { null }
 
   @OptIn(ExperimentalContracts::class)
   public suspend fun <B> B?.bind(): B {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/nullable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/nullable.kt
@@ -14,8 +14,10 @@ public value class NullableEffectScope(private val cont: EffectScope<Nothing?>) 
 
   public suspend fun <B> Option<B>.bind(): B =
     bind { null }
+
   public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
     bind(this) { null }
+
   public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
     bind(this) { null }
 
@@ -40,6 +42,7 @@ public value class NullableEagerEffectScope(private val cont: EagerEffectScope<N
 
   public suspend inline fun <reified B : Any> Maybe<B>.bind(): B =
     bind(this) { null }
+
   public suspend fun <B : Any> Maybe<Maybe<B>>.bind(): Maybe<B> =
     bind(this) { null }
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MaybeTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MaybeTest.kt
@@ -1,0 +1,411 @@
+package arrow.core
+
+import arrow.core.continuations.ensureNotNull
+import arrow.core.continuations.maybe
+import arrow.core.traverse
+import arrow.core.test.UnitSpec
+import arrow.core.test.generators.maybe
+import arrow.core.test.laws.MonoidLaws
+import arrow.typeclasses.Monoid
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.orNull
+
+class MaybeTest : UnitSpec() {
+
+  val just: Maybe<String> = Just("kotlin")
+  val nothing: Maybe<String> = Maybe.Nothing
+
+  init {
+
+    testLaws(MonoidLaws.laws(Monoid.maybe(Monoid.int()), Arb.maybe(Arb.int())))
+
+    "ensure null in maybe computation" {
+      checkAll(Arb.boolean(), Arb.int()) { predicate, i ->
+        maybe {
+          ensure(predicate)
+          i
+        } shouldBe if (predicate) Just(i) else Maybe.Nothing
+      }
+    }
+
+    "ensureNotNull in maybe computation" {
+      fun square(i: Int): Int = i * i
+      checkAll(Arb.int().orNull()) { i: Int? ->
+        maybe {
+          val ii = i
+          ensureNotNull(ii)
+          square(ii) // Smart-cast by contract
+        } shouldBe i.toMaybe().map(::square)
+      }
+    }
+
+    "short circuit null" {
+      maybe {
+        val number: Int = "s".length
+        ensureNotNull(number.takeIf { it > 1 })
+        throw IllegalStateException("This should not be executed")
+      } shouldBe Maybe.Nothing
+    }
+
+    "tap applies effects returning the original value" {
+      checkAll(Arb.long().orNull()) { long ->
+        val maybe = long.toMaybe()
+        var effect = 0
+        val res = maybe.tap { effect += 1 }
+        val expected = maybe.fold({ 0 }, { 1 })
+        effect shouldBe expected
+        res shouldBe maybe
+      }
+    }
+
+    "tapNothing applies effects returning the original value" {
+      checkAll(Arb.long().orNull()) { long ->
+        val maybe = long.toMaybe()
+        var effect = 0
+        val res = maybe.tapNothing { effect += 1 }
+        val expected = maybe.fold({ 1 }, { 0 })
+        effect shouldBe expected
+        res shouldBe maybe
+      }
+    }
+
+    "fromNullable should work for both null and non-null values of nullable types" {
+      checkAll(Arb.int().orNull()) { a: Int? ->
+        // This seems to be generating only non-null values, so it is complemented by the next test
+        val o: Maybe<Int> = Maybe.fromNullable(a)
+        if (a == null) o shouldBe Maybe.Nothing else o shouldBe Just(a)
+      }
+    }
+
+    "fromNullable should return maybe.Nothing for null values of nullable types" {
+      val a: Int? = null
+      Maybe.fromNullable(a) shouldBe Maybe.Nothing
+    }
+
+    "getOrElse" {
+      just.getOrElse { "java" } shouldBe "kotlin"
+      nothing.getOrElse { "java" } shouldBe "java"
+    }
+
+    "orNull" {
+      just.orNull() shouldNotBe null
+      nothing.orNull() shouldBe null
+    }
+
+    "map" {
+      just.map(String::uppercase) shouldBe Just("KOTLIN")
+      nothing.map(String::uppercase) shouldBe Maybe.Nothing
+    }
+
+    "zip" {
+      checkAll(Arb.int()) { a: Int ->
+        val op: Maybe<Int> = a.just()
+        just.zip(op) { a, b -> a + b } shouldBe Just("kotlin$a")
+        nothing.zip(op) { a, b -> a + b } shouldBe Maybe.Nothing
+        just.zip(op) shouldBe Just(Pair("kotlin", a))
+      }
+    }
+
+    "mapNotNull" {
+      just.mapNotNull { it.toIntOrNull() } shouldBe Maybe.Nothing
+      just.mapNotNull { it.uppercase() } shouldBe Just("KOTLIN")
+    }
+
+    "fold" {
+      just.fold({ 0 }) { it.length } shouldBe 6
+      nothing.fold({ 0 }) { it.length } shouldBe 0
+    }
+
+    "flatMap" {
+      just.flatMap { Just(it.uppercase()) } shouldBe Just("KOTLIN")
+      nothing.flatMap { Just(it.uppercase()) } shouldBe Maybe.Nothing
+    }
+
+    "align" {
+      just align just shouldBe Just(Ior.Both("kotlin", "kotlin"))
+      just align nothing shouldBe Just(Ior.Left("kotlin"))
+      nothing align just shouldBe Just(Ior.Right("kotlin"))
+      nothing align nothing shouldBe Maybe.Nothing
+
+      just.align(just) { "$it" } shouldBe Just("Ior.Both(kotlin, kotlin)")
+      just.align(nothing) { "$it" } shouldBe Just("Ior.Left(kotlin)")
+      nothing.align(just) { "$it" } shouldBe Just("Ior.Right(kotlin)")
+      nothing.align(nothing) { "$it" } shouldBe Maybe.Nothing
+
+      val nullable = Just(Maybe.fromNullable(null))
+      just align nullable shouldBe Just(Ior.Both("kotlin", Maybe.Nothing))
+      nullable align just shouldBe Just(Ior.Both(Maybe.Nothing, "kotlin"))
+      nullable align nullable shouldBe Just(Ior.Both(Maybe.Nothing, Maybe.Nothing))
+
+      just.align(nullable) { "$it" } shouldBe Just("Ior.Both(kotlin, Maybe.Nothing)")
+      nullable.align(just) { "$it" } shouldBe Just("Ior.Both(Maybe.Nothing, kotlin)")
+      nullable.align(nullable) { "$it" } shouldBe Just("Ior.Both(Maybe.Nothing, Maybe.Nothing)")
+    }
+
+    "filter" {
+      just.filter { it == "java" } shouldBe Maybe.Nothing
+      nothing.filter { it == "java" } shouldBe Maybe.Nothing
+      just.filter { it.startsWith('k') } shouldBe Just("kotlin")
+    }
+
+    "filterNot" {
+      just.filterNot { it == "java" } shouldBe Just("kotlin")
+      nothing.filterNot { it == "java" } shouldBe Maybe.Nothing
+      just.filterNot { it.startsWith('k') } shouldBe Maybe.Nothing
+    }
+
+    "filterIsInstance" {
+      val justAny: Maybe<Any> = just
+      justAny.filterIsInstance<String>() shouldBe Just("kotlin")
+      justAny.filterIsInstance<Int>() shouldBe Maybe.Nothing
+
+      val nothingAny: Maybe<Any> = nothing
+      nothingAny.filterIsInstance<String>() shouldBe Maybe.Nothing
+      nothingAny.filterIsInstance<Int>() shouldBe Maybe.Nothing
+    }
+
+    "exists" {
+      just.exists { it.startsWith('k') } shouldBe true
+      just.exists { it.startsWith('j') } shouldBe false
+      nothing.exists { it.startsWith('k') } shouldBe false
+    }
+
+    "all" {
+      just.all { it.startsWith('k') } shouldBe true
+      just.all { it.startsWith('j') } shouldBe false
+      nothing.all { it.startsWith('k') } shouldBe true
+    }
+
+    "orElse" {
+      just.orElse { Just("java") } shouldBe Just("kotlin")
+      nothing.orElse { Just("java") } shouldBe Just("java")
+    }
+
+    "toList" {
+      just.toList() shouldBe listOf("kotlin")
+      nothing.toList() shouldBe listOf()
+    }
+
+    "Iterable.firstOrNothing" {
+      val iterable = iterableOf(1, 2, 3, 4, 5, 6)
+      iterable.firstOrNothing() shouldBe Just(1)
+      iterable.firstOrNothing { it > 2 } shouldBe Just(3)
+      iterable.firstOrNothing { it > 7 } shouldBe Maybe.Nothing
+
+      val emptyIterable = iterableOf<Int>()
+      emptyIterable.firstOrNothing() shouldBe Maybe.Nothing
+
+      val nullableIterable1 = iterableOf(null, 2, 3, 4, 5, 6).map { it.toMaybe() }
+      nullableIterable1.firstOrNothing() shouldBe Just(Maybe.Nothing)
+
+      val nullableIterable2 = iterableOf(1, 2, 3, null, 5, null).map { it.toMaybe() }
+      nullableIterable2.firstOrNothing { it == Maybe.Nothing } shouldBe Just(Maybe.Nothing)
+    }
+
+    "Collection.firstOrNothing" {
+      val list = listOf(1, 2, 3, 4, 5, 6)
+      list.firstOrNothing() shouldBe Just(1)
+
+      val emptyList = emptyList<Int>()
+      emptyList.firstOrNothing() shouldBe Maybe.Nothing
+
+      val nullableList = listOf(null, 2, 3, 4, 5, 6).map { it.toMaybe() }
+      nullableList.firstOrNothing() shouldBe Just(Maybe.Nothing)
+    }
+
+    "Iterable.singleOrNothing" {
+      val iterable = iterableOf(1, 2, 3, 4, 5, 6)
+      iterable.singleOrNothing() shouldBe Maybe.Nothing
+      iterable.singleOrNothing { it > 2 } shouldBe Maybe.Nothing
+
+      val singleIterable = iterableOf(3)
+      singleIterable.singleOrNothing() shouldBe Just(3)
+      singleIterable.singleOrNothing { it == 3 } shouldBe Just(3)
+
+      val nullableSingleIterable1 = iterableOf<Int?>(null).map { it.toMaybe() }
+      nullableSingleIterable1.singleOrNothing() shouldBe Just(Maybe.Nothing)
+
+      val nullableSingleIterable2 = iterableOf(1, 2, 3, null, 5, 6).map { it.toMaybe() }
+      nullableSingleIterable2.singleOrNothing { it == Maybe.Nothing } shouldBe Just(Maybe.Nothing)
+
+      val nullableSingleIterable3 = iterableOf(1, 2, 3, null, 5, null).map { it.toMaybe() }
+      nullableSingleIterable3.singleOrNothing { it == Maybe.Nothing } shouldBe Maybe.Nothing
+    }
+
+    "Collection.singleOrNothing" {
+      val list = listOf(1, 2, 3, 4, 5, 6)
+      list.singleOrNothing() shouldBe Maybe.Nothing
+
+      val singleList = listOf(3)
+      singleList.singleOrNothing() shouldBe Just(3)
+
+      val nullableSingleList = listOf(null).map { it.toMaybe() }
+      nullableSingleList.singleOrNothing() shouldBe Just(Maybe.Nothing)
+    }
+
+    "Iterable.lastOrNothing" {
+      val iterable = iterableOf(1, 2, 3, 4, 5, 6)
+      iterable.lastOrNothing() shouldBe Just(6)
+      iterable.lastOrNothing { it < 4 } shouldBe Just(3)
+      iterable.lastOrNothing { it > 7 } shouldBe Maybe.Nothing
+
+      val emptyIterable = iterableOf<Int>()
+      emptyIterable.lastOrNothing() shouldBe Maybe.Nothing
+
+      val nullableIterable1 = iterableOf(1, 2, 3, 4, 5, null).map { it.toMaybe() }
+      nullableIterable1.lastOrNothing() shouldBe Just(Maybe.Nothing)
+
+      val nullableIterable2 = iterableOf(null, 2, 3, null, 5, 6).map { it.toMaybe() }
+      nullableIterable2.lastOrNothing { it == Maybe.Nothing } shouldBe Just(Maybe.Nothing)
+    }
+
+    "Collection.lastOrNothing" {
+      val list = listOf(1, 2, 3, 4, 5, 6)
+      list.lastOrNothing() shouldBe Just(6)
+
+      val emptyList = emptyList<Int>()
+      emptyList.lastOrNothing() shouldBe Maybe.Nothing
+
+      val nullableList = listOf(1, 2, 3, 4, 5, null).map { it.toMaybe() }
+      nullableList.lastOrNothing() shouldBe Just(Maybe.Nothing)
+    }
+
+    "Iterable.elementAtOrNothing" {
+      val iterable = iterableOf(1, 2, 3, 4, 5, 6)
+      iterable.elementAtOrNothing(index = 3 - 1) shouldBe Just(3)
+      iterable.elementAtOrNothing(index = -1) shouldBe Maybe.Nothing
+      iterable.elementAtOrNothing(index = 100) shouldBe Maybe.Nothing
+
+      val nullableIterable = iterableOf(1, 2, null, 4, 5, 6).map { it.toMaybe() }
+      nullableIterable.elementAtOrNothing(index = 3 - 1) shouldBe Just(Maybe.Nothing)
+    }
+
+    "Collection.elementAtOrNothing" {
+      val list = listOf(1, 2, 3, 4, 5, 6)
+      list.elementAtOrNothing(index = 3 - 1) shouldBe Just(3)
+      list.elementAtOrNothing(index = -1) shouldBe Maybe.Nothing
+      list.elementAtOrNothing(index = 100) shouldBe Maybe.Nothing
+
+      val nullableList = listOf(1, 2, null, 4, 5, 6).map { it.toMaybe() }
+      nullableList.elementAtOrNothing(index = 3 - 1) shouldBe Just(Maybe.Nothing)
+    }
+
+    "and" {
+      val x = Just(2)
+      val y = Just("Foo")
+      x and y shouldBe Just("Foo")
+      x and Maybe.Nothing shouldBe Maybe.Nothing
+      Maybe.Nothing and x shouldBe Maybe.Nothing
+      Maybe.Nothing and Maybe.Nothing shouldBe Maybe.Nothing
+    }
+
+    "or" {
+      val x = Just(2)
+      val y = Just(100)
+      x or y shouldBe Just(2)
+      x or Maybe.Nothing shouldBe Just(2)
+      Maybe.Nothing or x shouldBe Just(2)
+      Maybe.Nothing or Maybe.Nothing shouldBe Maybe.Nothing
+    }
+
+    "toLeftMaybe" {
+      1.leftIor().leftOrNull() shouldBe 1
+      2.rightIor().leftOrNull() shouldBe null
+      (1 to 2).bothIor().leftOrNull() shouldBe 1
+    }
+
+    "pairLeft" {
+      val just: Maybe<Int> = Just(2)
+      val nothing: Maybe<Int> = Maybe.Nothing
+      just.pairLeft("key") shouldBe Just("key" to 2)
+      nothing.pairLeft("key") shouldBe Maybe.Nothing
+    }
+
+    "pairRight" {
+      val just: Maybe<Int> = Just(2)
+      val nothing: Maybe<Int> = Maybe.Nothing
+      just.pairRight("right") shouldBe Just(2 to "right")
+      nothing.pairRight("right") shouldBe Maybe.Nothing
+    }
+
+    "Maybe<Pair<L, R>>.toMap()" {
+      val just: Maybe<Pair<String, String>> = Just("key" to "value")
+      val nothing: Maybe<Pair<String, String>> = Maybe.Nothing
+      just.toMap() shouldBe mapOf("key" to "value")
+      nothing.toMap() shouldBe emptyMap()
+    }
+
+    "traverse should yield list of maybe" {
+      val just: Maybe<String> = Just("value")
+      val nothing: Maybe<String> = Maybe.Nothing
+      just.traverse { listOf(it) } shouldBe listOf(Just("value"))
+      nothing.traverse { listOf(it) } shouldBe emptyList()
+    }
+
+    "sequence should be consistent with traverse" {
+      checkAll(Arb.int().orNull()) { int ->
+        val maybe = int.toMaybe()
+        maybe.map { listOf(it) }.sequence() shouldBe maybe.traverse { listOf(it) }
+      }
+    }
+
+    "traverseEither should yield either of maybe" {
+      val just: Maybe<String> = Just("value")
+      val nothing: Maybe<String> = Maybe.Nothing
+      just.traverse { it.right() } shouldBe just.right()
+      nothing.traverse { it.right() } shouldBe nothing.right()
+    }
+
+    "sequenceEither should be consistent with traverseEither" {
+      checkAll(Arb.int().orNull()) { int ->
+        val maybe = int.toMaybe()
+        maybe.map { it.right() }.sequence() shouldBe maybe.traverse { it.right() }
+      }
+    }
+
+    "traverseValidated should yield validated of maybe" {
+      val just: Maybe<String> = Just("value")
+      val nothing: Maybe<String> = Maybe.Nothing
+      just.traverse { it.valid() } shouldBe just.valid()
+      nothing.traverse { it.valid() } shouldBe nothing.valid()
+    }
+
+    "sequenceValidated should be consistent with traverseValidated" {
+      checkAll(Arb.int().orNull()) { int ->
+        val maybe = int.toMaybe()
+        maybe.map { it.valid() }.sequence() shouldBe maybe.traverse { it.valid() }
+      }
+    }
+
+    "catch should return Just(result) when f does not throw" {
+      val recover: (Throwable) -> Maybe<Int> = { _ -> Maybe.Nothing }
+      Maybe.catch(recover) { 1 } shouldBe Just(1)
+    }
+
+    "catch with default recover should return Just(result) when f does not throw" {
+      Maybe.catch { 1 } shouldBe Just(1)
+    }
+
+    "catch should return Just(recoverValue) when f throws" {
+      val exception = Exception("Boom!")
+      val recoverValue = 10
+      val recover: (Throwable) -> Maybe<Int> = { _ -> Just(recoverValue) }
+      Maybe.catch(recover) { throw exception } shouldBe Just(recoverValue)
+    }
+
+    "catch should return Maybe.Nothing when f throws" {
+      val exception = Exception("Boom!")
+      Maybe.catch { throw exception } shouldBe Maybe.Nothing
+    }
+  }
+}
+// Utils
+
+private fun <T> iterableOf(vararg elements: T): Iterable<T> = Iterable {
+  iterator { yieldAll(elements.toList()) }
+}

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/MaybeSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/MaybeSpec.kt
@@ -1,0 +1,52 @@
+package arrow.core.continuations
+
+import arrow.core.Maybe
+import arrow.core.map
+import arrow.core.toMaybe
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.checkAll
+
+class MaybeSpec :
+  StringSpec({
+    "ensureNotNull in maybe computation" {
+      fun square(i: Int): Int = i * i
+      checkAll(Arb.int().orNull()) { i: Int? ->
+        maybe {
+          val ii = i
+          ensureNotNull(ii)
+          square(ii) // Smart-cast by contract
+        } shouldBe i.toMaybe().map(::square)
+      }
+    }
+
+    "short circuit maybe" {
+      maybe {
+        val number: Int = "s".length
+        ensureNotNull(number.takeIf { it > 1 })
+        throw IllegalStateException("This should not be executed")
+      } shouldBe Maybe.Nothing
+    }
+
+    "ensureNotNull in eager maybe computation" {
+      fun square(i: Int): Int = i * i
+      checkAll(Arb.int().orNull()) { i: Int? ->
+        maybe {
+          val ii = i
+          ensureNotNull(ii)
+          square(ii) // Smart-cast by contract
+        } shouldBe i.toMaybe().map(::square)
+      }
+    }
+
+    "eager short circuit null" {
+      maybe.eager {
+        val number: Int = "s".length
+        ensureNotNull(number.takeIf { it > 1 })
+        throw IllegalStateException("This should not be executed")
+      } shouldBe Maybe.Nothing
+    }
+  })


### PR DESCRIPTION
This PR adds a boxing-free version of the Option data type that works performantly for nested Options (technically up to UInt.MAX_VALUE nestings :grin:)

Maybe sadly still boxes if used inside a generic context (i.e. put in a `List` or an `Either` or printed out etc), but it won't box for placing it inside itself.
~Maybe has its type parameter not-nullable on purpose because if `A` could be nullable, `Maybe<A>?` would box. In fact, it doesn't really make sense to have a nullable type inside `Maybe`, since one could just use `Maybe.fromNullable` instead.~ UPDATE: I've implemented support for nullability inside of `Maybe` now. It works in a similar fashion to `NestedNothing` so that we can indicate where exactly the null appeared (i.e. at which nesting level).
The biggest 2 things that we lose with `Maybe` instead of `Option is:

1. We're forced to use `Maybe.fold` instead of pattern-matching over a `Maybe`: This should be fixed when [KT-27576 Support-inline-sealed-classes](https://youtrack.jetbrains.com/issue/KT-27576/Support-inline-sealed-classes) is implemented. This will allow for `is Just` to be a type cast, and therefore granting access to a `.value` property. (Pattern matching in that way will actually result in boxing for nested Maybe due to the peculiar way that allowed me to optimize fold being inherently about inline functions. More on that later!)

2. Any function that wants to `fold` over a Maybe has to do so using a `reified A`. This might seem very weird at first, but the implementation details should make it clear. Basically, whenever `Just(aValueOfTypeMaybe)` is called, `Just` accesses the `underlying` value of `aValueOfTypeMaybe` and wraps that inside Maybe instead. What this means is that, at runtime, we can't distinguish between a `Just(Just(42))` vs a `Just(42)`. Therefore, we rely on compile-time information by using the reified type to check if the function that is passed to `fold` expects a `Maybe` or a different type. This reified requirement propagates through all functions that do an operation on a generic `Maybe`, but seemingly this shouldn't affect normal consumers of Arrow. This reified requirement cannot be remedied for now unless Kotlin eventually provides some feature to declare that a `value class` should *never* box (something like a `@NeverBoxes` annotation).

The way that nested Maybes are handled for `Just` is that the value is represented simply as whatever its true value is, no matter the level of nesting. For `Nothing`, however, it's quite interesting. Basically, and this is the whole point of using `Maybe` and not just nullable types, we want to be able to know at which level of nesting did a `Nothing` occur. Therefore, it uses internally a `NestedNothing` which has its level of nesting in a property (the first 22 nestings of that class is cached as an optimization). Normal `Nothing` is just the value `NestedNothing(0)` inside a maybe. Whenever `Just` is called on a Maybe whose underlying is `NestedNothing(n)`, it returns a Maybe whose underlying is `NestedNothing(n + 1)`. Conversely, whenever `fold(ifEmpty, ifJust)` is called on a Maybe whose underlying is `NestedNothing(n)`, it first checks if the Maybe is equal to `NestedNothing(0)` and if so it calls `ifEmpty`; otherwise, it calls `ifJust` on `NestedNothing(n-1)` inside a maybe.

Some weird implementation details:
At first I thought that, whenever a `Maybe` is used in a generic context (i.e. as a value of a type parameter `A` or as an `Any`) that it will *always* box. You can even see my initial commit has 2x the final code since I duplicated all the functions that access Maybe just to prevent boxing. Turns out, that is not true for `inline` functions. The compiler is surprisingly much smarter than I initially figured, and in fact it will not box if it can determine that inside of the function the `Maybe` is never used generically. In fact, the compiler even evaluates `aValueOfTypeMaybe is Maybe<*>` at *compile-time*, and it performs dead-code elimination which then ensures that the value isn't used in a boxing way. This is how `Just` is implemented:
```
public inline fun <T : Any> Just(value: T): Maybe<T> {
  // This `is` check gets inlined by the compiler if `value` is statically known to be Maybe
  return _Just(if (value is Maybe<*>) value.underlying else value)
}
```
If `Just` is called on a value that is *known* to be a maybe, the code gets inlined into `_Just(value.underlying)`, which is a non-boxing usage of that maybe value.

Additionally, if a lambda parameter of an `inline` function has a generic parameter `T`, and the compiler knows that `T` is provided completely by the caller, it won't box that value of `T` if it turns out to be a `Maybe`. This means that `aValueOfTypeMaybe.let { /* some code */ }` does not box, which is very neat. 

The really odd-yet-powerful thing is that this works even if the value is not provided by the caller, but is instead provided to the lambda directly. So, what I did is that fold checks if the type parameter `A` is `Maybe` (by checking if a normal Maybe is an instance of it (which is true when `A` is `Maybe` or `Any`) and checking that `Unit` is *not* an instance of it (which rules out `Any`). I figured this might be more performant than a class equality check, and such an `instanceOf` check should be easy to optimize by JIT or a minifier) and if `A` is indeed `Maybe`, it calls the provided lambda with the value wrapped inside a `Maybe`. 

Miraculously, the compiler understands that the lambda is called with a `Maybe` directly, and so it doesn't box it! However, the flip side of this is that every call to `fold` will duplicate its `ifJust` lambda. This means that nesting `fold`s inside of each other generates exponentially more bytecode (interestingly as a result I couldn't implement `zip` like that, and so `zip` actually boxes all of its arguments then unboxes them immediately). This code duplication does result in bigger file sizes, so be warned.

When it comes to the `MaybeInternals` opt-in annotation, I added it just to prevent any internal `Maybe` apis from being used literally anywhere in Arrow unless the dev knows exactly what they're doing. For those internal functions, you can see an interesting symmetry:
`fold` is dual to `Just` (since the first ensures a value is a `Maybe` and the second checks that a value is a `Maybe`)
`value` is dual to `_Just` (since the first un-nests a `NestedNohting` and the second nests a `NestedNothing`
`Maybe.Companion.construct` is dual to `Maybe.underlying` (they give access to `constructor-impl` and `box-impl` in the first case and the raw value of a Maybe and `unbox-impl` in the second case)

You'll find that there's very few cases where a function is duplicated with slightly varying type-arguments, a prime example of which is `Maybe<A>.orNull(): A?` and `Maybe<Maybe<A>>.orNull(): Maybe<A>?`. This is because, sadly, functions that return a generic type `A` based on a value inside of a `Maybe` will box whenever that type is substitued for a `Maybe`. This happens unless the return value is uniquely determined by lambdas that that function takes (`fold` is the perfect example of this where it returns some type `R` that is returned by `ifEmpty` and `ifJust`, and as a result `fold` doesn't need a duplicate `foldMaybe`). This is why `zip`, as I mentioned earlier, is not optimized properly: internally it relies on `Maybe<A>.orNull()`, which will box if `A` is a `Maybe`. Writing `zip` differently requires either maintaining 2^10 = 1024 versions of it for all combinations of its ten type parameters being a `Maybe`. Writing `zip` to use fold results in a method that is literally too large it crashes the compiler (I mean you can imagine how big 1024 copies of a method must be). Also there is some weirdness with `fold` for instance if `R` is determined to be `Maybe<A>?` since then it boxes and unboxes for some reason. To combat that, I just `return null` inside of `Maybe.orNull` in the `ifEmpty` case, so that `fold` returns `Maybe<A>` in this case without nullability.

I've checked that all of these functions (except `zip`) does not box unless it absolutely needs to (e.g. if a `Maybe` is going inside an `Either` or a `Pair`).  Even functions for `EffectScope` have been optimized so that it doesn't box even between shifts (only case I haven't checked yet is if there's a suspension inside a shift since that might keep the `Maybe` across suspension points and therefore box it). I did this mainly by decompiling using cfr-0.152 and looking at the decompiled Java code. If you wish to embark upon that same journey, make sure to have some aspirin nearby, oh and keep in mind that sometimes certain inline functions with lambdas *look* like they're boxing, except that whenever they're used with those lambdas actually specified, the boxing goes away (prime example is `flatMap` which looks like it boxes in bytecode but whenever it is used (e.g. inside `map`) it doesn't box at all.

Also, I couldn't add `Maybe<B>.bind(shift: () -> R)` inside `EffectScope` because `EffectScope` is an interface and interfaces aren't allowed to have `inline` functions. This can be solved by using `context` receivers, or maybe by providing an unsafe variant of `Maybe<A>.bind(shift)` that considers the value to be an `Any` and unsafe-casts it alongside a `Maybe<Maybe<A>>.bind(shift)` that considers the value to be a `Maybe`. such usage of `EffectScope` with `bind(shift)` doesn't seem that common though since most would just rely on `maybe { }` and `maybe.eager { }` instead, which do work using the expected `Maybe.bind()` syntax.

Finally, this is a draft PR because it is missing documentation ~and tests~ UPDATE: I've added tests that are based on the `Option` tests already included. I also haven't done benchmarks yet to verify that this is much faster than `Option` or not, and whether this will have performance on par with normal nullable types. I'll port the documentation over from `Option` ASAP. I also didn't dare touch any usage of `Option` in `optics` and just left them as-is since I don't know if they'd benefit from equivalent `Maybe` functions.