### PR TITLE
Fix #2779

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -12,6 +12,7 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resume
@@ -24,21 +25,21 @@ import kotlin.coroutines.resume
  * to map both values of [R] and [A] to a value of `B`.
  *
  * <!--- TOC -->
-
-      * [Writing a program with Effect<R, A>](#writing-a-program-with-effect<r-a>)
-      * [Handling errors](#handling-errors)
-      * [Structured Concurrency](#structured-concurrency)
-        * [Arrow Fx Coroutines](#arrow-fx-coroutines)
-          * [parZip](#parzip)
-          * [parTraverse](#partraverse)
-          * [raceN](#racen)
-          * [bracketCase / Resource](#bracketcase--resource)
-        * [KotlinX](#kotlinx)
-          * [withContext](#withcontext)
-          * [async](#async)
-          * [launch](#launch)
-          * [Strange edge cases](#strange-edge-cases)
-
+ 
+ * [Writing a program with Effect<R, A>](#writing-a-program-with-effect<r-a>)
+ * [Handling errors](#handling-errors)
+ * [Structured Concurrency](#structured-concurrency)
+ * [Arrow Fx Coroutines](#arrow-fx-coroutines)
+ * [parZip](#parzip)
+ * [parTraverse](#partraverse)
+ * [raceN](#racen)
+ * [bracketCase / Resource](#bracketcase--resource)
+ * [KotlinX](#kotlinx)
+ * [withContext](#withcontext)
+ * [async](#async)
+ * [launch](#launch)
+ * [Strange edge cases](#strange-edge-cases)
+ 
  * <!--- END -->
  *
  *
@@ -568,7 +569,7 @@ import kotlin.coroutines.resume
  * ```
  * <!--- KNIT example-effect-guide-13.kt -->
  */
-public sealed interface Effect<out R, out A> {
+public interface Effect<out R, out A> {
   /**
    * Runs the suspending computation by creating a [Continuation], and running the `fold` function
    * over the computation.
@@ -596,9 +597,9 @@ public sealed interface Effect<out R, out A> {
    */
   public suspend fun <B> fold(
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B
+    transform: suspend (value: A) -> B,
   ): B
-
+  
   /**
    * Like [fold] but also allows folding over any unexpected [Throwable] that might have occurred.
    * @see fold
@@ -606,45 +607,45 @@ public sealed interface Effect<out R, out A> {
   public suspend fun <B> fold(
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B
+    transform: suspend (value: A) -> B,
   ): B =
     try {
       fold(recover, transform)
     } catch (e: Throwable) {
       error(e.nonFatalOrThrow())
     }
-
+  
   /**
    * [fold] the [Effect] into an [Either]. Where the shifted value [R] is mapped to [Either.Left], and
    * result value [A] is mapped to [Either.Right].
    */
   public suspend fun toEither(): Either<R, A> = fold({ Either.Left(it) }) { Either.Right(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Ior]. Where the shifted value [R] is mapped to [Ior.Left], and
    * result value [A] is mapped to [Ior.Right].
    */
   public suspend fun toIor(): Ior<R, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Validated]. Where the shifted value [R] is mapped to
    * [Validated.Invalid], and result value [A] is mapped to [Validated.Valid].
    */
   public suspend fun toValidated(): Validated<R, A> =
     fold({ Validated.Invalid(it) }) { Validated.Valid(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Option]. Where the shifted value [R] is mapped to [Option] by the
    * provided function [orElse], and result value [A] is mapped to [Some].
    */
   public suspend fun toOption(orElse: suspend (R) -> Option<@UnsafeVariance A>): Option<A> = fold(orElse, ::Some)
-
+  
   /**
    * [fold] the [Effect] into an [A?]. Where the shifted value [R] is mapped to
    * [null], and result value [A].
    */
   public suspend fun orNull(): A? = fold({ null }, ::identity)
-
+  
   /** Runs the [Effect] and captures any [NonFatal] exception into [Result]. */
   public fun attempt(): Effect<R, Result<A>> = effect {
     try {
@@ -653,23 +654,23 @@ public sealed interface Effect<out R, out A> {
       Result.failure(e.nonFatalOrThrow())
     }
   }
-
+  
   public fun handleError(recover: suspend (R) -> @UnsafeVariance A): Effect<Nothing, A> = effect {
     fold(recover, ::identity)
   }
-
+  
   public fun <R2> handleErrorWith(recover: suspend (R) -> Effect<R2, @UnsafeVariance A>): Effect<R2, A> = effect {
     fold({ recover(it).bind() }, ::identity)
   }
-
+  
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =
     effect {
       fold(recover, transform)
     }
-
+  
   public fun <R2, B> redeemWith(
     recover: suspend (R) -> Effect<R2, B>,
-    transform: suspend (A) -> Effect<R2, B>
+    transform: suspend (A) -> Effect<R2, B>,
   ): Effect<R2, B> = effect { fold(recover, transform).bind() }
 }
 
@@ -711,16 +712,13 @@ internal class Token {
 internal class FoldContinuation<B>(
   private val token: Token,
   override val context: CoroutineContext,
-  private val parent: Continuation<B>
+  private val parent: Continuation<B>,
 ) : Continuation<B> {
   override fun resumeWith(result: Result<B>) {
     result.fold(parent::resume) { throwable ->
       if (throwable is Suspend && token == throwable.token) {
         val f: suspend () -> B = { throwable.recover(throwable.shifted) as B }
-        when (val res = f.startCoroutineUninterceptedOrReturn(parent)) {
-          COROUTINE_SUSPENDED -> Unit
-          else -> parent.resume(res as B)
-        }
+        f.createCoroutineUnintercepted(parent).resume(Unit)
       } else parent.resumeWith(result)
     }
   }
@@ -758,11 +756,7 @@ internal class FoldContinuation<B>(
  */
 public fun <R, A> effect(f: suspend EffectScope<R>.() -> A): Effect<R, A> = DefaultEffect(f)
 
-@Deprecated(
-  "This will be removed in Arrow 2.0",
-  level = DeprecationLevel.WARNING
-)
-internal class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effect<R, A> {
+private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effect<R, A> {
   // We create a `Token` for fold Continuation, so we can properly differentiate between nested
   // folds
   override suspend fun <B> fold(recover: suspend (R) -> B, transform: suspend (A) -> B): B =
@@ -784,7 +778,7 @@ internal class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effe
             // See: EffectSpec - try/catch tests
             throw Suspend(token, r, recover as suspend (Any?) -> Any?)
         }
-
+      
       try {
         suspend { transform(f(effectScope)) }
           .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, cont))

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EffectScope.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/EffectScope.kt
@@ -56,10 +56,7 @@ public interface EffectScope<in R> {
    * ```
    * <!--- KNIT example-effect-scope-02.kt -->
    */
-  public suspend fun <B> Effect<R, B>.bind(): B =
-    when (this) {
-      is DefaultEffect -> f(this@EffectScope)
-    }
+  public suspend fun <B> Effect<R, B>.bind(): B = fold(this@EffectScope::shift, ::identity)
 
   /**
    * Runs the [EagerEffect] to finish, returning [B] or [shift] in case of [R],


### PR DESCRIPTION
This PR fixes the actual cause of #2764 & #2760, and replaces the usage of `startCoroutineUninterceptedOrReturn` with `createCoroutineUnintercepted` and then manually starting it with `resume(Unit)`.

The usage of `startCoroutineUninterceptedOrReturn` was correct AFAIK, so the issue would still be with the compiler but it's hard to verify since both `startCoroutineUninterceptedOrReturn` and `createCoroutineUnintercepted` are compiler generated methods. So we can not easily inspect the code, or the resulting code since the bytecode. (The bytecode viewer crashes when trying to inspect the code in IDEA).

More details on the [YouTrack ticket](https://youtrack.jetbrains.com/issue/KT-53424/Exception-escapes-trycatch-and-ends-up-in-DispatchedTaskhandleFatalException-making-the-code-hang-forever).