### PR TITLE
Fix usage of startCoroutineUninterceptedOrReturn

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2674,7 +2674,7 @@ public abstract interface class arrow/core/continuations/Effect {
 
 public final class arrow/core/continuations/Effect$DefaultImpls {
 	public static fun attempt (Larrow/core/continuations/Effect;)Larrow/core/continuations/Effect;
-	public static fun fold (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fold (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun handleError (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public static fun handleErrorWith (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public static fun orNull (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2721,6 +2721,7 @@ public final class arrow/core/continuations/EffectScopeKt {
 }
 
 public final class arrow/core/continuations/FoldContinuation : kotlin/coroutines/Continuation {
+	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)V
 	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)V
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun resumeWith (Ljava/lang/Object;)V

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2674,7 +2674,7 @@ public abstract interface class arrow/core/continuations/Effect {
 
 public final class arrow/core/continuations/Effect$DefaultImpls {
 	public static fun attempt (Larrow/core/continuations/Effect;)Larrow/core/continuations/Effect;
-	public static fun fold (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fold (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun handleError (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public static fun handleErrorWith (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function2;)Larrow/core/continuations/Effect;
 	public static fun orNull (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2721,7 +2721,7 @@ public final class arrow/core/continuations/EffectScopeKt {
 }
 
 public final class arrow/core/continuations/FoldContinuation : kotlin/coroutines/Continuation {
-	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)V
+	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)V
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun resumeWith (Ljava/lang/Object;)V
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -11,10 +11,11 @@ import arrow.core.nonFatalOrThrow
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * [Effect] represents a function of `suspend () -> A`, that short-circuit with a value of [R] (and [Throwable]),
@@ -596,9 +597,9 @@ public interface Effect<out R, out A> {
    */
   public suspend fun <B> fold(
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B
+    transform: suspend (value: A) -> B,
   ): B
-
+  
   /**
    * Like [fold] but also allows folding over any unexpected [Throwable] that might have occurred.
    * @see fold
@@ -606,45 +607,45 @@ public interface Effect<out R, out A> {
   public suspend fun <B> fold(
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B
+    transform: suspend (value: A) -> B,
   ): B =
     try {
       fold(recover, transform)
     } catch (e: Throwable) {
       error(e.nonFatalOrThrow())
     }
-
+  
   /**
    * [fold] the [Effect] into an [Either]. Where the shifted value [R] is mapped to [Either.Left], and
    * result value [A] is mapped to [Either.Right].
    */
   public suspend fun toEither(): Either<R, A> = fold({ Either.Left(it) }) { Either.Right(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Ior]. Where the shifted value [R] is mapped to [Ior.Left], and
    * result value [A] is mapped to [Ior.Right].
    */
   public suspend fun toIor(): Ior<R, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Validated]. Where the shifted value [R] is mapped to
    * [Validated.Invalid], and result value [A] is mapped to [Validated.Valid].
    */
   public suspend fun toValidated(): Validated<R, A> =
     fold({ Validated.Invalid(it) }) { Validated.Valid(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Option]. Where the shifted value [R] is mapped to [Option] by the
    * provided function [orElse], and result value [A] is mapped to [Some].
    */
   public suspend fun toOption(orElse: suspend (R) -> Option<@UnsafeVariance A>): Option<A> = fold(orElse, ::Some)
-
+  
   /**
    * [fold] the [Effect] into an [A?]. Where the shifted value [R] is mapped to
    * [null], and result value [A].
    */
   public suspend fun orNull(): A? = fold({ null }, ::identity)
-
+  
   /** Runs the [Effect] and captures any [NonFatal] exception into [Result]. */
   public fun attempt(): Effect<R, Result<A>> = effect {
     try {
@@ -653,23 +654,23 @@ public interface Effect<out R, out A> {
       Result.failure(e.nonFatalOrThrow())
     }
   }
-
+  
   public fun handleError(recover: suspend (R) -> @UnsafeVariance A): Effect<Nothing, A> = effect {
     fold(recover, ::identity)
   }
-
+  
   public fun <R2> handleErrorWith(recover: suspend (R) -> Effect<R2, @UnsafeVariance A>): Effect<R2, A> = effect {
     fold({ recover(it).bind() }, ::identity)
   }
-
+  
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =
     effect {
       fold(recover, transform)
     }
-
+  
   public fun <R2, B> redeemWith(
     recover: suspend (R) -> Effect<R2, B>,
-    transform: suspend (A) -> Effect<R2, B>
+    transform: suspend (A) -> Effect<R2, B>,
   ): Effect<R2, B> = effect { fold(recover, transform).bind() }
 }
 
@@ -717,7 +718,14 @@ internal class FoldContinuation<B>(
     result.fold(parent::resume) { throwable ->
       if (throwable is Suspend && token == throwable.token) {
         val f: suspend () -> B = { throwable.recover(throwable.shifted) as B }
-        f.createCoroutineUnintercepted(parent).resume(Unit)
+        try {
+          when (val res = f.startCoroutineUninterceptedOrReturn(parent)) {
+            COROUTINE_SUSPENDED -> Unit
+            else -> parent.resume(res as B)
+          }
+        } catch (e: Throwable) {
+          parent.resumeWithException(e)
+        }
       } else parent.resumeWith(result)
     }
   }
@@ -777,7 +785,7 @@ private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effec
             // See: EffectSpec - try/catch tests
             throw Suspend(token, r, recover as suspend (Any?) -> Any?)
         }
-
+      
       try {
         suspend { transform(f(effectScope)) }
           .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, cont))

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -598,7 +598,7 @@ public interface Effect<out R, out A> {
   public suspend fun <B> fold(
     recover: suspend (shifted: R) -> B,
     transform: suspend (value: A) -> B
-  ): B
+  ): B = fold({ throw it }, recover, transform)
 
   /**
    * Like [fold] but also allows folding over any unexpected [Throwable] that might have occurred.
@@ -607,14 +607,9 @@ public interface Effect<out R, out A> {
   public suspend fun <B> fold(
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B
-  ): B =
-    try {
-      fold(recover, transform)
-    } catch (e: Throwable) {
-      error(e.nonFatalOrThrow())
-    }
-
+    transform: suspend (value: A) -> B,
+  ): B
+  
   /**
    * [fold] the [Effect] into an [Either]. Where the shifted value [R] is mapped to [Either.Left], and
    * result value [A] is mapped to [Either.Right].
@@ -712,21 +707,31 @@ internal class Token {
 internal class FoldContinuation<B>(
   private val token: Token,
   override val context: CoroutineContext,
-  private val parent: Continuation<B>
+  private val error: suspend (Throwable) -> B,
+  private val parent: Continuation<B>,
 ) : Continuation<B> {
+  // In contrast to `createCoroutineUnintercepted this doesn't create a new ContinuationImpl
+  private fun <A> (suspend () -> A).startCoroutineUnintercepted(cont: Continuation<A>): Unit {
+    try {
+      when (val res = startCoroutineUninterceptedOrReturn(cont)) {
+        COROUTINE_SUSPENDED -> Unit
+        else -> cont.resume(res as A)
+      }
+      // We need to wire all immediately throw exceptions to the parent Continuation
+    } catch (e: Throwable) {
+      cont.resumeWithException(e)
+    }
+  }
+  
   override fun resumeWith(result: Result<B>) {
     result.fold(parent::resume) { throwable ->
-      if (throwable is Suspend && token == throwable.token) {
-        val f: suspend () -> B = { throwable.recover(throwable.shifted) as B }
-        try {
-          when (val res = f.startCoroutineUninterceptedOrReturn(parent)) {
-            COROUTINE_SUSPENDED -> Unit
-            else -> parent.resume(res as B)
-          }
-        } catch (e: Throwable) {
-          parent.resumeWithException(e)
-        }
-      } else parent.resumeWith(result)
+      when {
+        throwable is Suspend && token == throwable.token ->
+          suspend { throwable.recover(throwable.shifted) as B }.startCoroutineUnintercepted(parent)
+        
+        throwable !is Suspend -> suspend { error(throwable) }.startCoroutineUnintercepted(parent)
+        else -> parent.resumeWith(result)
+      }
     }
   }
 }
@@ -766,7 +771,11 @@ public fun <R, A> effect(f: suspend EffectScope<R>.() -> A): Effect<R, A> = Defa
 private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effect<R, A> {
   // We create a `Token` for fold Continuation, so we can properly differentiate between nested
   // folds
-  override suspend fun <B> fold(recover: suspend (R) -> B, transform: suspend (A) -> B): B =
+  override suspend fun <B> fold(
+    error: suspend (error: Throwable) -> B,
+    recover: suspend (shifted: R) -> B,
+    transform: suspend (value: A) -> B,
+  ): B =
     suspendCoroutineUninterceptedOrReturn { cont ->
       val token = Token()
       val effectScope =
@@ -788,12 +797,15 @@ private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effec
 
       try {
         suspend { transform(f(effectScope)) }
-          .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, cont))
+          .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, error, cont))
       } catch (e: Suspend) {
         if (token == e.token) {
           val f: suspend () -> B = { e.recover(e.shifted) as B }
           f.startCoroutineUninterceptedOrReturn(cont)
         } else throw e
+      } catch (e: Throwable) {
+        val f: suspend () -> B = { error(e.nonFatalOrThrow()) }
+        f.startCoroutineUninterceptedOrReturn(cont)
       }
     }
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -597,9 +597,9 @@ public interface Effect<out R, out A> {
    */
   public suspend fun <B> fold(
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B
-  ): B = fold({ throw it }, recover, transform)
-
+    transform: suspend (value: A) -> B,
+  ): B
+  
   /**
    * Like [fold] but also allows folding over any unexpected [Throwable] that might have occurred.
    * @see fold
@@ -608,39 +608,44 @@ public interface Effect<out R, out A> {
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
     transform: suspend (value: A) -> B,
-  ): B
+  ): B =
+    try {
+      fold(recover, transform)
+    } catch (e: Throwable) {
+      error(e.nonFatalOrThrow())
+    }
   
   /**
    * [fold] the [Effect] into an [Either]. Where the shifted value [R] is mapped to [Either.Left], and
    * result value [A] is mapped to [Either.Right].
    */
   public suspend fun toEither(): Either<R, A> = fold({ Either.Left(it) }) { Either.Right(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Ior]. Where the shifted value [R] is mapped to [Ior.Left], and
    * result value [A] is mapped to [Ior.Right].
    */
   public suspend fun toIor(): Ior<R, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Validated]. Where the shifted value [R] is mapped to
    * [Validated.Invalid], and result value [A] is mapped to [Validated.Valid].
    */
   public suspend fun toValidated(): Validated<R, A> =
     fold({ Validated.Invalid(it) }) { Validated.Valid(it) }
-
+  
   /**
    * [fold] the [Effect] into an [Option]. Where the shifted value [R] is mapped to [Option] by the
    * provided function [orElse], and result value [A] is mapped to [Some].
    */
   public suspend fun toOption(orElse: suspend (R) -> Option<@UnsafeVariance A>): Option<A> = fold(orElse, ::Some)
-
+  
   /**
    * [fold] the [Effect] into an [A?]. Where the shifted value [R] is mapped to
    * [null], and result value [A].
    */
   public suspend fun orNull(): A? = fold({ null }, ::identity)
-
+  
   /** Runs the [Effect] and captures any [NonFatal] exception into [Result]. */
   public fun attempt(): Effect<R, Result<A>> = effect {
     try {
@@ -649,23 +654,23 @@ public interface Effect<out R, out A> {
       Result.failure(e.nonFatalOrThrow())
     }
   }
-
+  
   public fun handleError(recover: suspend (R) -> @UnsafeVariance A): Effect<Nothing, A> = effect {
     fold(recover, ::identity)
   }
-
+  
   public fun <R2> handleErrorWith(recover: suspend (R) -> Effect<R2, @UnsafeVariance A>): Effect<R2, A> = effect {
     fold({ recover(it).bind() }, ::identity)
   }
-
+  
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =
     effect {
       fold(recover, transform)
     }
-
+  
   public fun <R2, B> redeemWith(
     recover: suspend (R) -> Effect<R2, B>,
-    transform: suspend (A) -> Effect<R2, B>
+    transform: suspend (A) -> Effect<R2, B>,
   ): Effect<R2, B> = effect { fold(recover, transform).bind() }
 }
 
@@ -707,9 +712,12 @@ internal class Token {
 internal class FoldContinuation<B>(
   private val token: Token,
   override val context: CoroutineContext,
-  private val error: suspend (Throwable) -> B,
+  private val error: (suspend (Throwable) -> B),
   private val parent: Continuation<B>,
 ) : Continuation<B> {
+  
+  constructor(token: Token, context: CoroutineContext, parent: Continuation<B>) : this(token, context, { throw it  }, parent)
+  
   // In contrast to `createCoroutineUnintercepted this doesn't create a new ContinuationImpl
   private fun <A> (suspend () -> A).startCoroutineUnintercepted(cont: Continuation<A>): Unit {
     try {
@@ -769,8 +777,13 @@ internal class FoldContinuation<B>(
 public fun <R, A> effect(f: suspend EffectScope<R>.() -> A): Effect<R, A> = DefaultEffect(f)
 
 private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effect<R, A> {
-  // We create a `Token` for fold Continuation, so we can properly differentiate between nested
-  // folds
+  
+  override suspend fun <B> fold(
+    recover: suspend (shifted: R) -> B,
+    transform: suspend (value: A) -> B,
+  ): B = fold({ throw it }, recover, transform)
+  
+  // We create a `Token` for fold Continuation, so we can properly differentiate between nested folds
   override suspend fun <B> fold(
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
@@ -794,7 +807,7 @@ private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effec
             // See: EffectSpec - try/catch tests
             throw Suspend(token, r, recover as suspend (Any?) -> Any?)
         }
-
+      
       try {
         suspend { transform(f(effectScope)) }
           .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, error, cont))

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -597,9 +597,9 @@ public interface Effect<out R, out A> {
    */
   public suspend fun <B> fold(
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B,
+    transform: suspend (value: A) -> B
   ): B
-  
+
   /**
    * Like [fold] but also allows folding over any unexpected [Throwable] that might have occurred.
    * @see fold
@@ -607,45 +607,45 @@ public interface Effect<out R, out A> {
   public suspend fun <B> fold(
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B,
+    transform: suspend (value: A) -> B
   ): B =
     try {
       fold(recover, transform)
     } catch (e: Throwable) {
       error(e.nonFatalOrThrow())
     }
-  
+
   /**
    * [fold] the [Effect] into an [Either]. Where the shifted value [R] is mapped to [Either.Left], and
    * result value [A] is mapped to [Either.Right].
    */
   public suspend fun toEither(): Either<R, A> = fold({ Either.Left(it) }) { Either.Right(it) }
-  
+
   /**
    * [fold] the [Effect] into an [Ior]. Where the shifted value [R] is mapped to [Ior.Left], and
    * result value [A] is mapped to [Ior.Right].
    */
   public suspend fun toIor(): Ior<R, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
-  
+
   /**
    * [fold] the [Effect] into an [Validated]. Where the shifted value [R] is mapped to
    * [Validated.Invalid], and result value [A] is mapped to [Validated.Valid].
    */
   public suspend fun toValidated(): Validated<R, A> =
     fold({ Validated.Invalid(it) }) { Validated.Valid(it) }
-  
+
   /**
    * [fold] the [Effect] into an [Option]. Where the shifted value [R] is mapped to [Option] by the
    * provided function [orElse], and result value [A] is mapped to [Some].
    */
   public suspend fun toOption(orElse: suspend (R) -> Option<@UnsafeVariance A>): Option<A> = fold(orElse, ::Some)
-  
+
   /**
    * [fold] the [Effect] into an [A?]. Where the shifted value [R] is mapped to
    * [null], and result value [A].
    */
   public suspend fun orNull(): A? = fold({ null }, ::identity)
-  
+
   /** Runs the [Effect] and captures any [NonFatal] exception into [Result]. */
   public fun attempt(): Effect<R, Result<A>> = effect {
     try {
@@ -654,23 +654,23 @@ public interface Effect<out R, out A> {
       Result.failure(e.nonFatalOrThrow())
     }
   }
-  
+
   public fun handleError(recover: suspend (R) -> @UnsafeVariance A): Effect<Nothing, A> = effect {
     fold(recover, ::identity)
   }
-  
+
   public fun <R2> handleErrorWith(recover: suspend (R) -> Effect<R2, @UnsafeVariance A>): Effect<R2, A> = effect {
     fold({ recover(it).bind() }, ::identity)
   }
-  
+
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =
     effect {
       fold(recover, transform)
     }
-  
+
   public fun <R2, B> redeemWith(
     recover: suspend (R) -> Effect<R2, B>,
-    transform: suspend (A) -> Effect<R2, B>,
+    transform: suspend (A) -> Effect<R2, B>
   ): Effect<R2, B> = effect { fold(recover, transform).bind() }
 }
 
@@ -785,7 +785,7 @@ private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effec
             // See: EffectSpec - try/catch tests
             throw Suspend(token, r, recover as suspend (Any?) -> Any?)
         }
-      
+
       try {
         suspend { transform(f(effectScope)) }
           .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, cont))

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -5,11 +5,12 @@ import arrow.core.identity
 import arrow.core.left
 import arrow.core.right
 import io.kotest.assertions.fail
-import io.kotest.common.runBlocking
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.orNull
@@ -323,11 +324,32 @@ class EffectSpec :
         newError.toEither() shouldBe Either.Left(error.reversed().toList())
       }
     }
+    
+    "Can handle thrown exceptions" {
+      checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+        effect<Int, String> {
+          throw RuntimeException(msg())
+        }.fold(
+          { fallback() },
+          ::identity,
+          ::identity
+        ) shouldBe fallback()
+      }
+    }
   })
 
 private data class Failure(val msg: String)
 
 suspend fun currentContext(): CoroutineContext = kotlin.coroutines.coroutineContext
+
+// Turn `A` into `suspend () -> A` which tests both the `immediate` and `COROUTINE_SUSPENDED` path.
+private fun <A> Arb<A>.suspend(): Arb<suspend () -> A> =
+  flatMap { a ->
+    arbitrary(listOf(
+      { a },
+      suspend { a.suspend() }
+    )) { suspend { a.suspend() } }
+  }
 
 internal suspend fun Throwable.suspend(): Nothing = suspendCoroutineUninterceptedOrReturn { cont ->
   suspend { throw this }


### PR DESCRIPTION
In #2783 we replaced `startCoroutineUninterceptedOrReturn` to `createCoroutineUnintercepted` + `resume(Unit)` but this [creates an additional `Continuation` state-machine](https://github.com/JetBrains/kotlin/blob/85800b4f9f078859b3919d34e2108bfba32ebf4c/libraries/stdlib/jvm/src/kotlin/coroutines/intrinsics/IntrinsicsJvm.kt#L186) nested inside the existing state-machine and thus causing a lot of overhead. This overhead is occurring potentially on every `fold`, so not ideal.

While investigating if the issue of `startCoroutineUninterceptedOrReturn` was in our code, or in the compiler I discovered that it was indeed a mistake in our code.

The problem happens in following sequencing where we run the `Effect<R, A>`.

```kotlin
suspendCoroutineUninterceptedOrReturn { cont ->
  val token = Token()
  val effectScope: EffectScope<R> = ...
  
  try {
    suspend { transform(f(effectScope)) }
      .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, cont))
  } catch (e: Suspend) {
    if (token == e.token) {
      val f: suspend () -> B = { e.recover(e.shifted) as B }
      f.startCoroutineUninterceptedOrReturn(cont)
    } else throw e
  }
}
```

1. We create the `EffectScope` and the `Token`
2.  We create the program `suspend { transform(f(effectScope)) }`
3. We start the computation with `startCoroutineUninterceptedOrReturn`.

`startCoroutineUninterceptedOrReturn` immediately returns `COROUTINE_SUSPENDED`, `B` or throws an exception.
*If* `COROUTINE_SUSPENDED` is returned then we **have to** complete the `cont` using `resume`. *If* `COROUTINE_SUSPENDED` is returned it also means we'll go inside the `FoldContinuation` path.

In the original code we *did not* catch any immediate exceptions, meaning we were throwing an exception within `suspendCoroutineUninterceptedOrReturn` where we already returned `COROUTINE_SUSPENDED` earlier. Instead we need to capture the exception, and pass it to `cont#resume` or the exception will get lost in the Coroutine state machine.

```kotlin
when (val res = f.startCoroutineUninterceptedOrReturn(parent)) {
        COROUTINE_SUSPENDED -> Unit
        else -> parent.resume(res as B)
}
```