### PR TITLE
Backport flattening token/shift into Cont

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2722,6 +2722,7 @@ public final class arrow/core/continuations/EffectScopeKt {
 
 public final class arrow/core/continuations/FoldContinuation : kotlin/coroutines/Continuation {
 	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)V
+	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)V
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun resumeWith (Ljava/lang/Object;)V
 }

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2720,11 +2720,25 @@ public final class arrow/core/continuations/EffectScopeKt {
 	public static final fun ensureNotNull (Larrow/core/continuations/EffectScope;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class arrow/core/continuations/FoldContinuation : kotlin/coroutines/Continuation {
+public final class arrow/core/continuations/FoldContinuation : arrow/core/continuations/Token, arrow/core/continuations/EffectScope, kotlin/coroutines/Continuation {
+	public field recover Lkotlin/jvm/functions/Function2;
 	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/Continuation;)V
 	public fun <init> (Larrow/core/continuations/Token;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)V
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)V
+	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Either;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Validated;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun ensure (ZLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getRecover ()Lkotlin/jvm/functions/Function2;
 	public fun resumeWith (Ljava/lang/Object;)V
+	public final fun setRecover (Lkotlin/jvm/functions/Function2;)V
+	public fun shift (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/core/continuations/IorEagerEffectScope : arrow/core/continuations/EagerEffectScope, arrow/typeclasses/Semigroup {
@@ -3004,7 +3018,7 @@ public final class arrow/core/continuations/Suspend : arrow/core/continuations/S
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class arrow/core/continuations/Token {
+public class arrow/core/continuations/Token {
 	public fun <init> ()V
 	public fun toString ()Ljava/lang/String;
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -11,10 +11,11 @@ import arrow.core.nonFatalOrThrow
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * [Effect] represents a function of `suspend () -> A`, that short-circuit with a value of [R] (and [Throwable]),
@@ -711,14 +712,34 @@ internal class Token {
 internal class FoldContinuation<B>(
   private val token: Token,
   override val context: CoroutineContext,
+  private val error: suspend (Throwable) -> B,
   private val parent: Continuation<B>
 ) : Continuation<B> {
+  
+  constructor(token: Token, context: CoroutineContext, parent: Continuation<B>) : this(token, context, { throw it  }, parent)
+  
+  // In contrast to `createCoroutineUnintercepted this doesn't create a new ContinuationImpl
+  private fun <A> (suspend () -> A).startCoroutineUnintercepted(cont: Continuation<A>): Unit {
+    try {
+      when (val res = startCoroutineUninterceptedOrReturn(cont)) {
+        COROUTINE_SUSPENDED -> Unit
+        else -> cont.resume(res as A)
+      }
+      // We need to wire all immediately throw exceptions to the parent Continuation
+    } catch (e: Throwable) {
+      cont.resumeWithException(e)
+    }
+  }
+  
   override fun resumeWith(result: Result<B>) {
     result.fold(parent::resume) { throwable ->
-      if (throwable is Suspend && token == throwable.token) {
-        val f: suspend () -> B = { throwable.recover(throwable.shifted) as B }
-        f.createCoroutineUnintercepted(parent).resume(Unit)
-      } else parent.resumeWith(result)
+      when {
+        throwable is Suspend && token == throwable.token ->
+          suspend { throwable.recover(throwable.shifted) as B }.startCoroutineUnintercepted(parent)
+        
+        throwable !is Suspend -> suspend { error(throwable.nonFatalOrThrow()) }.startCoroutineUnintercepted(parent)
+        else -> parent.resumeWith(result)
+      }
     }
   }
 }
@@ -756,9 +777,18 @@ internal class FoldContinuation<B>(
 public fun <R, A> effect(f: suspend EffectScope<R>.() -> A): Effect<R, A> = DefaultEffect(f)
 
 private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effect<R, A> {
-  // We create a `Token` for fold Continuation, so we can properly differentiate between nested
-  // folds
-  override suspend fun <B> fold(recover: suspend (R) -> B, transform: suspend (A) -> B): B =
+  
+  override suspend fun <B> fold(
+    recover: suspend (shifted: R) -> B,
+    transform: suspend (value: A) -> B,
+  ): B = fold({ throw it }, recover, transform)
+  
+  // We create a `Token` for fold Continuation, so we can properly differentiate between nested folds
+  override suspend fun <B> fold(
+    error: suspend (error: Throwable) -> B,
+    recover: suspend (shifted: R) -> B,
+    transform: suspend (value: A) -> B,
+  ): B =
     suspendCoroutineUninterceptedOrReturn { cont ->
       val token = Token()
       val effectScope =
@@ -780,12 +810,15 @@ private class DefaultEffect<R, A>(val f: suspend EffectScope<R>.() -> A) : Effec
 
       try {
         suspend { transform(f(effectScope)) }
-          .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, cont))
+          .startCoroutineUninterceptedOrReturn(FoldContinuation(token, cont.context, error, cont))
       } catch (e: Suspend) {
         if (token == e.token) {
           val f: suspend () -> B = { e.recover(e.shifted) as B }
           f.startCoroutineUninterceptedOrReturn(cont)
         } else throw e
+      } catch (e: Throwable) {
+        val f: suspend () -> B = { error(e.nonFatalOrThrow()) }
+        f.startCoroutineUninterceptedOrReturn(cont)
       }
     }
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -758,8 +758,8 @@ internal class FoldContinuation<R, B>(
         throwable is Suspend && this === throwable.token ->
           suspend { throwable.recover(throwable.shifted) as B }.startCoroutineUnintercepted()
         
-        throwable !is Suspend -> suspend { error(throwable.nonFatalOrThrow()) }.startCoroutineUnintercepted()
-        else -> parent.resumeWith(result)
+        throwable is Suspend -> parent.resumeWith(result)
+        else -> suspend { error(throwable.nonFatalOrThrow()) }.startCoroutineUnintercepted()
       }
     }
   }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -25,21 +25,21 @@ import kotlin.coroutines.resumeWithException
  * to map both values of [R] and [A] to a value of `B`.
  *
  * <!--- TOC -->
- 
- * [Writing a program with Effect<R, A>](#writing-a-program-with-effect<r-a>)
- * [Handling errors](#handling-errors)
- * [Structured Concurrency](#structured-concurrency)
- * [Arrow Fx Coroutines](#arrow-fx-coroutines)
- * [parZip](#parzip)
- * [parTraverse](#partraverse)
- * [raceN](#racen)
- * [bracketCase / Resource](#bracketcase--resource)
- * [KotlinX](#kotlinx)
- * [withContext](#withcontext)
- * [async](#async)
- * [launch](#launch)
- * [Strange edge cases](#strange-edge-cases)
- 
+
+      * [Writing a program with Effect<R, A>](#writing-a-program-with-effect<r-a>)
+      * [Handling errors](#handling-errors)
+      * [Structured Concurrency](#structured-concurrency)
+        * [Arrow Fx Coroutines](#arrow-fx-coroutines)
+          * [parZip](#parzip)
+          * [parTraverse](#partraverse)
+          * [raceN](#racen)
+          * [bracketCase / Resource](#bracketcase--resource)
+        * [KotlinX](#kotlinx)
+          * [withContext](#withcontext)
+          * [async](#async)
+          * [launch](#launch)
+          * [Strange edge cases](#strange-edge-cases)
+
  * <!--- END -->
  *
  *
@@ -597,9 +597,9 @@ public interface Effect<out R, out A> {
    */
   public suspend fun <B> fold(
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B,
+    transform: suspend (value: A) -> B
   ): B
-  
+
   /**
    * Like [fold] but also allows folding over any unexpected [Throwable] that might have occurred.
    * @see fold
@@ -607,45 +607,45 @@ public interface Effect<out R, out A> {
   public suspend fun <B> fold(
     error: suspend (error: Throwable) -> B,
     recover: suspend (shifted: R) -> B,
-    transform: suspend (value: A) -> B,
+    transform: suspend (value: A) -> B
   ): B =
     try {
       fold(recover, transform)
     } catch (e: Throwable) {
       error(e.nonFatalOrThrow())
     }
-  
+
   /**
    * [fold] the [Effect] into an [Either]. Where the shifted value [R] is mapped to [Either.Left], and
    * result value [A] is mapped to [Either.Right].
    */
   public suspend fun toEither(): Either<R, A> = fold({ Either.Left(it) }) { Either.Right(it) }
-  
+
   /**
    * [fold] the [Effect] into an [Ior]. Where the shifted value [R] is mapped to [Ior.Left], and
    * result value [A] is mapped to [Ior.Right].
    */
   public suspend fun toIor(): Ior<R, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
-  
+
   /**
    * [fold] the [Effect] into an [Validated]. Where the shifted value [R] is mapped to
    * [Validated.Invalid], and result value [A] is mapped to [Validated.Valid].
    */
   public suspend fun toValidated(): Validated<R, A> =
     fold({ Validated.Invalid(it) }) { Validated.Valid(it) }
-  
+
   /**
    * [fold] the [Effect] into an [Option]. Where the shifted value [R] is mapped to [Option] by the
    * provided function [orElse], and result value [A] is mapped to [Some].
    */
   public suspend fun toOption(orElse: suspend (R) -> Option<@UnsafeVariance A>): Option<A> = fold(orElse, ::Some)
-  
+
   /**
    * [fold] the [Effect] into an [A?]. Where the shifted value [R] is mapped to
    * [null], and result value [A].
    */
   public suspend fun orNull(): A? = fold({ null }, ::identity)
-  
+
   /** Runs the [Effect] and captures any [NonFatal] exception into [Result]. */
   public fun attempt(): Effect<R, Result<A>> = effect {
     try {
@@ -654,23 +654,23 @@ public interface Effect<out R, out A> {
       Result.failure(e.nonFatalOrThrow())
     }
   }
-  
+
   public fun handleError(recover: suspend (R) -> @UnsafeVariance A): Effect<Nothing, A> = effect {
     fold(recover, ::identity)
   }
-  
+
   public fun <R2> handleErrorWith(recover: suspend (R) -> Effect<R2, @UnsafeVariance A>): Effect<R2, A> = effect {
     fold({ recover(it).bind() }, ::identity)
   }
-  
+
   public fun <B> redeem(recover: suspend (R) -> B, transform: suspend (A) -> B): Effect<Nothing, B> =
     effect {
       fold(recover, transform)
     }
-  
+
   public fun <R2, B> redeemWith(
     recover: suspend (R) -> Effect<R2, B>,
-    transform: suspend (A) -> Effect<R2, B>,
+    transform: suspend (A) -> Effect<R2, B>
   ): Effect<R2, B> = effect { fold(recover, transform).bind() }
 }
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -5,11 +5,13 @@ import arrow.core.identity
 import arrow.core.left
 import arrow.core.right
 import io.kotest.assertions.fail
-import io.kotest.common.runBlocking
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.orNull
@@ -323,11 +325,60 @@ class EffectSpec :
         newError.toEither() shouldBe Either.Left(error.reversed().toList())
       }
     }
+    
+    "Can handle thrown exceptions" {
+      checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+        effect<Int, String> {
+          throw RuntimeException(msg())
+        }.fold(
+          { fallback() },
+          ::identity,
+          ::identity
+        ) shouldBe fallback()
+      }
+    }
+    
+    "Can shift from thrown exceptions" {
+      checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+        effect<String, Int> {
+          effect<Int, String> {
+            throw RuntimeException(msg())
+          }.fold(
+            { shift(fallback()) },
+            ::identity,
+            { it.length }
+          )
+        }.runCont() shouldBe fallback()
+      }
+    }
+  
+    "Can throw from thrown exceptions" {
+      checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+        shouldThrow<IllegalStateException> {
+          effect<Int, String> {
+            throw RuntimeException(msg())
+          }.fold(
+            { throw IllegalStateException(fallback()) },
+            ::identity,
+            { it.length }
+          )
+        }.message shouldBe fallback()
+      }
+    }
   })
 
 private data class Failure(val msg: String)
 
 suspend fun currentContext(): CoroutineContext = kotlin.coroutines.coroutineContext
+
+// Turn `A` into `suspend () -> A` which tests both the `immediate` and `COROUTINE_SUSPENDED` path.
+private fun <A> Arb<A>.suspend(): Arb<suspend () -> A> =
+  flatMap { a ->
+    arbitrary(listOf(
+      { a },
+      suspend { a.suspend() }
+    )) { suspend { a.suspend() } }
+  }
 
 internal suspend fun Throwable.suspend(): Nothing = suspendCoroutineUninterceptedOrReturn { cont ->
   suspend { throw this }


### PR DESCRIPTION
In exploration of Effect for Arrow 2.0 I discovered that we can flatten the `Token`, `Continuation` and `EffectScope` types into a single type, and thus reduce `fold` from 3 allocations to 1.

This improvement is back-portable to `1.1.x` in a binary compatible way.
It increases the public API binary of `internal Fold` a bit but entirety of `Effect` will be binary breaking in 2.0 anyway.