### PR TITLE
Enable builder inference for optics `copy`

### DIFF
--- a/arrow-libs/optics/arrow-optics/api/arrow-optics.api
+++ b/arrow-libs/optics/arrow-optics/api/arrow-optics.api
@@ -151,6 +151,9 @@ public final class arrow/optics/ListKt {
 	public static final fun unsnoc (Ljava/util/List;)Lkotlin/Pair;
 }
 
+public abstract interface annotation class arrow/optics/OpticsCopyMarker : java/lang/annotation/Annotation {
+}
+
 public final class arrow/optics/OptionalGetterKt {
 	public static final fun OptionalGetter (Lkotlin/jvm/functions/Function1;)Larrow/optics/POptionalGetter;
 }

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -20,6 +20,10 @@ if (enableCompatibilityMetadataVariant) {
   }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  kotlinOptions.freeCompilerArgs += listOf("-Xenable-builder-inference", "-opt-in=kotlin.RequiresOptIn")
+}
+
 kotlin {
   sourceSets {
     commonMain {

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -21,7 +21,7 @@ if (enableCompatibilityMetadataVariant) {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  kotlinOptions.freeCompilerArgs += listOf("-Xenable-builder-inference", "-opt-in=kotlin.RequiresOptIn")
+  kotlinOptions.freeCompilerArgs += listOf("-Xenable-builder-inference")
 }
 
 kotlin {

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -20,10 +20,6 @@ if (enableCompatibilityMetadataVariant) {
   }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  kotlinOptions.freeCompilerArgs += listOf("-Xenable-builder-inference")
-}
-
 kotlin {
   sourceSets {
     commonMain {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Copy.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Copy.kt
@@ -1,5 +1,11 @@
 package arrow.optics
 
+import kotlin.experimental.ExperimentalTypeInference
+
+@DslMarker
+public annotation class OpticsCopyMarker
+
+@OpticsCopyMarker
 public interface Copy<A> {
   /**
    * Changes the value of the element(s) pointed by the [Setter].
@@ -33,7 +39,8 @@ public interface Copy<A> {
    * }
    * ```
    */
-  public fun <B> inside(field: Traversal<A, B>, f: Copy<B>.() -> Unit): Unit =
+  @OptIn(ExperimentalTypeInference::class)
+  public fun <B> inside(field: Traversal<A, B>, @BuilderInference f: Copy<B>.() -> Unit): Unit =
     field.transform { it.copy(f) }
 }
 
@@ -67,5 +74,6 @@ private class CopyImpl<A>(var current: A): Copy<A> {
  * }
  * ```
  */
-public fun <A> A.copy(f: Copy<A>.() -> Unit): A =
+@OptIn(ExperimentalTypeInference::class)
+public fun <A> A.copy(@BuilderInference f: Copy<A>.() -> Unit): A =
   CopyImpl(this).also(f).current


### PR DESCRIPTION
This should help type inference and show nicer in the IDE