### PR TITLE
Refactor - #2812 iterable separate performance

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -999,11 +999,13 @@ public fun <A, B> Iterable<Validated<A, B>>.uniteValidated(): List<B> =
  * @receiver Iterable of Validated
  * @return a tuple containing List with [Either.Left] and another List with its [Either.Right] values.
  */
-public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>> {
-  val asep = flatMap { gab -> gab.fold({ listOf(it) }, { emptyList() }) }
-  val bsep = flatMap { gab -> gab.fold({ emptyList() }, { listOf(it) }) }
-  return asep to bsep
-}
+public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>> =
+  fold(listOf<A>() to listOf<B>()) { (lefts, rights), either ->
+    when (either) {
+      is Left -> lefts + either.value to rights
+      is Right -> lefts to rights + either.value
+    }
+  }
 
 /**
  * Separate the inner [Validated] values into the [Validated.Invalid] and [Validated.Valid].

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -997,13 +997,18 @@ public fun <A, B> Iterable<Validated<A, B>>.uniteValidated(): List<B> =
  * @receiver Iterable of Validated
  * @return a tuple containing List with [Either.Left] and another List with its [Either.Right] values.
  */
-public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>> =
-  fold(listOf<A>() to listOf<B>()) { (lefts, rights), either ->
+public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>> {
+  val left = ArrayList<A>(collectionSizeOrDefault(10))
+  val right = ArrayList<B>(collectionSizeOrDefault(10))
+
+  for (either in this)
     when (either) {
-      is Left -> lefts + either.value to rights
-      is Right -> lefts to rights + either.value
+      is Left -> left.add(either.value)
+      is Right -> right.add(either.value)
     }
-  }
+
+  return Pair(left, right)
+}
 
 /**
  * Separate the inner [Validated] values into the [Validated.Invalid] and [Validated.Valid].
@@ -1011,13 +1016,18 @@ public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>
  * @receiver Iterable of Validated
  * @return a tuple containing List with [Validated.Invalid] and another List with its [Validated.Valid] values.
  */
-public fun <A, B> Iterable<Validated<A, B>>.separateValidated(): Pair<List<A>, List<B>> =
-  fold(listOf<A>() to listOf<B>()) { (invalids, valids), validated ->
+public fun <A, B> Iterable<Validated<A, B>>.separateValidated(): Pair<List<A>, List<B>> {
+  val invalids = ArrayList<A>(collectionSizeOrDefault(10))
+  val valids = ArrayList<B>(collectionSizeOrDefault(10))
+
+  for (validated in this)
     when (validated) {
-      is Valid -> invalids to valids + validated.value
-      is Invalid -> invalids + validated.value to valids
+      is Invalid -> invalids.add(validated.value)
+      is Valid -> valids.add(validated.value)
     }
-  }
+
+  return Pair(invalids, valids)
+}
 
 public fun <A> Iterable<Iterable<A>>.flatten(): List<A> =
   flatMap(::identity)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -1013,11 +1013,13 @@ public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>
  * @receiver Iterable of Validated
  * @return a tuple containing List with [Validated.Invalid] and another List with its [Validated.Valid] values.
  */
-public fun <A, B> Iterable<Validated<A, B>>.separateValidated(): Pair<List<A>, List<B>> {
-  val asep = flatMap { gab -> gab.fold({ listOf(it) }, { emptyList() }) }
-  val bsep = flatMap { gab -> gab.fold({ emptyList() }, { listOf(it) }) }
-  return asep to bsep
-}
+public fun <A, B> Iterable<Validated<A, B>>.separateValidated(): Pair<List<A>, List<B>> =
+  fold(listOf<A>() to listOf<B>()) { (invalids, valids), validated ->
+    when (validated) {
+      is Valid -> invalids to valids + validated.value
+      is Invalid -> invalids + validated.value to valids
+    }
+  }
 
 public fun <A> Iterable<Iterable<A>>.flatten(): List<A> =
   flatMap(::identity)


### PR DESCRIPTION
related to #2812

A single pass is now made over the original `Iterable` instead of 2. I am not sure if using mutable lists and a single pair would offer any significant advantages but I am open to changing it if that is considered better.

I ran the tests introduced in #2814 at my local setup and they seem to pass.