### PR TITLE
Add Resource.allocated() to decompose Resource into it's allocate and…

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/IterableTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/IterableTest.kt
@@ -479,5 +479,25 @@ class IterableTest : UnitSpec() {
         listOfOption.flattenOption() shouldBe listOfOption.mapNotNull { it.orNull() }
       }
     }
+
+    "separateEither" {
+      checkAll(Arb.list(Arb.int())) { ints ->
+        val list = ints.map {
+          if (it % 2 == 0) it.left()
+          else it.right()
+        }
+        list.separateEither() shouldBe ints.partition { it % 2 == 0 }
+      }
+    }
+
+    "separateValidated" {
+      checkAll(Arb.list(Arb.int())) { ints ->
+        val list = ints.map {
+          if (it % 2 == 0) it.invalid()
+          else it.valid()
+        }
+        list.separateValidated() shouldBe ints.partition { it % 2 == 0 }
+      }
+    }
   }
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -94,6 +94,7 @@ public final class arrow/fx/coroutines/CircuitBreaker$State$Open : arrow/fx/coro
 }
 
 public abstract class arrow/fx/coroutines/ExitCase {
+	public static final field Companion Larrow/fx/coroutines/ExitCase$Companion;
 }
 
 public final class arrow/fx/coroutines/ExitCase$Cancelled : arrow/fx/coroutines/ExitCase {
@@ -105,6 +106,10 @@ public final class arrow/fx/coroutines/ExitCase$Cancelled : arrow/fx/coroutines/
 	public final fun getException ()Ljava/util/concurrent/CancellationException;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/fx/coroutines/ExitCase$Companion {
+	public final fun ExitCase (Ljava/lang/Throwable;)Larrow/fx/coroutines/ExitCase;
 }
 
 public final class arrow/fx/coroutines/ExitCase$Completed : arrow/fx/coroutines/ExitCase {

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -303,6 +303,7 @@ public final class arrow/fx/coroutines/Race3Kt {
 
 public abstract class arrow/fx/coroutines/Resource {
 	public static final field Companion Larrow/fx/coroutines/Resource$Companion;
+	public final fun allocated (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ap (Larrow/fx/coroutines/Resource;)Larrow/fx/coroutines/Resource;
 	public final fun flatMap (Lkotlin/jvm/functions/Function1;)Larrow/fx/coroutines/Resource;
 	public final fun map (Lkotlin/jvm/functions/Function2;)Larrow/fx/coroutines/Resource;

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Bracket.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Bracket.kt
@@ -13,6 +13,11 @@ public sealed class ExitCase {
 
   public data class Cancelled(val exception: CancellationException) : ExitCase()
   public data class Failure(val failure: Throwable) : ExitCase()
+
+  public companion object {
+    public fun ExitCase(error: Throwable): ExitCase =
+      if (error is CancellationException) Cancelled(error) else Failure(error)
+  }
 }
 
 /**

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -4,8 +4,8 @@ import arrow.core.continuations.AtomicRef
 import arrow.core.continuations.update
 import arrow.core.identity
 import arrow.core.prependTo
+import arrow.fx.coroutines.ExitCase.Companion.ExitCase
 import arrow.fx.coroutines.continuations.ResourceScope
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -181,9 +181,8 @@ public sealed class Resource<out A> {
           val a = dsl(effect)
           f(a)
         } catch (e: Throwable) {
-          val ex = if (e is CancellationException) ExitCase.Cancelled(e) else ExitCase.Failure(e)
           val ee = withContext(NonCancellable) {
-            effect.finalizers.get().cancelAll(ex, e) ?: e
+            effect.finalizers.get().cancelAll(ExitCase(e), e) ?: e
           }
           throw ee
         }
@@ -497,9 +496,8 @@ public sealed class Resource<out A> {
           }
           allocate to release
         } catch (e: Throwable) {
-          val ex = if (e is CancellationException) ExitCase.Cancelled(e) else ExitCase.Failure(e)
           val ee = withContext(NonCancellable) {
-            effect.finalizers.get().cancelAll(ex, e) ?: e
+            effect.finalizers.get().cancelAll(ExitCase(e), e) ?: e
           }
           throw ee
         }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -6,6 +6,7 @@ import arrow.core.identity
 import arrow.core.prependTo
 import arrow.fx.coroutines.continuations.ResourceScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
@@ -476,6 +477,7 @@ public sealed class Resource<out A> {
    *
    * This can be used to integrate Resources with code which cannot be run within the [use] function.
    */
+  @DelicateCoroutinesApi
   public suspend fun allocated(): Pair<suspend () -> A, suspend (@UnsafeVariance A, ExitCase) -> Unit> =
     when (this) {
       is Bind<*, A> ->

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -478,6 +478,7 @@ public sealed class Resource<out A> {
    *
    * ```kotlin
    * import arrow.fx.coroutines.*
+   * import arrow.fx.coroutines.ExitCase.Companion.ExitCase
    *
    * val resource = Resource({ println("Acquire") }) { _, exitCase ->
    *  println("Release $exitCase")

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -459,11 +459,11 @@ class ResourceTest : ArrowFxSpec(
       val releaseValue = Random.nextInt()
       val seed = Random.nextInt()
 
-      val (allocate, release) = mkResource({ seed }) { _, _ -> released.complete(releaseValue) }.allocated()
+      val (allocate, release) = mkResource({ seed }) { i, _ -> released.complete(i) }.allocated()
 
       allocate() shouldBe seed
 
-      release(1, ExitCase.Completed)
+      release(releaseValue, ExitCase.Completed)
 
       released.getCompleted() shouldBe releaseValue
     }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -460,7 +460,7 @@ class ResourceTest : ArrowFxSpec(
       listOf(
         ExitCase.Completed,
         ExitCase.Failure(Exception()),
-        ExitCase.Cancelled(CancellationException(null))
+        ExitCase.Cancelled(CancellationException(null, null))
       ).forAll { exit ->
         val released = CompletableDeferred<Int>()
         val seed = Random.nextInt()

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import kotlin.random.Random
 
 class ResourceTest : ArrowFxSpec(
   spec = {
@@ -217,15 +218,19 @@ class ResourceTest : ArrowFxSpec(
           val res = if (isLeft) Resource({
             latch.await() shouldBe (1..depth).sum()
             throw cancel
-          }) { _, _ -> }.parZip(resource.flatMap {
-            Resource({ require(latch.complete(it)) }) { _, _ -> }
-          }) { _, _ -> }
+          }) { _, _ -> }.parZip(
+            resource.flatMap {
+              Resource({ require(latch.complete(it)) }) { _, _ -> }
+            }
+          ) { _, _ -> }
           else resource.flatMap {
             Resource({ require(latch.complete(it)) }) { _, _ -> }
-          }.parZip(Resource({
-            latch.await() shouldBe (1..depth).sum()
-            throw cancel
-          }) { _, _ -> }) { _, _ -> }
+          }.parZip(
+            Resource({
+              latch.await() shouldBe (1..depth).sum()
+              throw cancel
+            }) { _, _ -> }
+          ) { _, _ -> }
 
           res.use { fail("It should never reach here") }
         }.shouldBeTypeOf<CancellationException>()
@@ -265,9 +270,11 @@ class ResourceTest : ArrowFxSpec(
             started.await()
             throw cancel
           }) { _, _ -> }
-            .parZip(Resource({ require(started.complete(Unit)); i }, { ii, ex ->
-              require(released.complete(ii to ex))
-            })) { _, _ -> }
+            .parZip(
+              Resource({ require(started.complete(Unit)); i }, { ii, ex ->
+                require(released.complete(ii to ex))
+              })
+            ) { _, _ -> }
             .use { fail("It should never reach here") }
         }.shouldBeTypeOf<CancellationException>()
 
@@ -310,7 +317,8 @@ class ResourceTest : ArrowFxSpec(
               Resource(
                 { require(started.complete(Unit)); i },
                 { ii, ex -> require(released.complete(ii to ex)) }
-              )) { _, _ -> }
+              )
+            ) { _, _ -> }
             .use { fail("It should never reach here") }
         } shouldBe throwable
 
@@ -426,10 +434,12 @@ class ResourceTest : ArrowFxSpec(
           modifyGate.await()
           r.update { i -> "$i$a" }
         }) { _, _ -> }
-          .parZip(Resource({
-            r.set("$b")
-            require(modifyGate.complete(0))
-          }) { _, _ -> }) { _a, _b -> _a to _b }
+          .parZip(
+            Resource({
+              r.set("$b")
+              require(modifyGate.complete(0))
+            }) { _, _ -> }
+          ) { _a, _b -> _a to _b }
           .use {
             r.get() shouldBe "$b$a"
           }
@@ -441,6 +451,44 @@ class ResourceTest : ArrowFxSpec(
         val r = Resource({ n }, { _, _ -> Unit })
 
         r.asFlow().map { it + 1 }.toList() shouldBe listOf(n + 1)
+      }
+    }
+
+    suspend fun checkAllocated(mkResource: (() -> Int, (Int, ExitCase) -> Unit) -> Resource<Int>) {
+      val released = CompletableDeferred<Int>()
+      val releaseValue = Random.nextInt()
+      val seed = Random.nextInt()
+
+      val (allocate, release) = mkResource({ seed }) { _, _ -> released.complete(releaseValue) }.allocated()
+
+      allocate() shouldBe seed
+
+      release(1, ExitCase.Completed)
+
+      released.getCompleted() shouldBe releaseValue
+    }
+
+    "allocated - Allocate" {
+      checkAllocated { allocate, release ->
+        Resource(allocate, release)
+      }
+    }
+
+    "allocated - Defer" {
+      checkAllocated { allocate, release ->
+        Resource.defer { Resource(allocate, release) }
+      }
+    }
+
+    "allocated - Bind" {
+      checkAllocated { allocate, release ->
+        Resource.Bind(Resource(allocate, release)) { Resource.just(it) }
+      }
+    }
+
+    "allocated - Dsl" {
+      checkAllocated { allocate, close ->
+        arrow.fx.coroutines.continuations.resource { allocate() } releaseCase (close)
       }
     }
   }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-08.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-08.kt
@@ -2,6 +2,7 @@
 package arrow.fx.coroutines.examples.exampleResource08
 
 import arrow.fx.coroutines.*
+import arrow.fx.coroutines.ExitCase.Companion.ExitCase
 
 val resource = Resource({ println("Acquire") }) { _, exitCase ->
  println("Release $exitCase")

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-09.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-09.kt
@@ -3,24 +3,12 @@ package arrow.fx.coroutines.examples.exampleResource09
 
 import arrow.fx.coroutines.*
 
-class File(url: String) {
-  suspend fun open(): File = this
-  suspend fun close(): Unit {}
-  override fun toString(): String = "This file contains some interesting content!"
-}
-
-suspend fun openFile(uri: String): File = File(uri).open()
-suspend fun closeFile(file: File): Unit = file.close()
-suspend fun fileToString(file: File): String = file.toString()
+suspend fun acquireResource(): Int = 42.also { println("Getting expensive resource") }
+suspend fun releaseResource(r: Int, exitCase: ExitCase): Unit = println("Releasing expensive resource: $r, exit: $exitCase")
 
 suspend fun main(): Unit {
-  val res = resource {
-    openFile("data.json")
-  } release { file ->
-    closeFile(file)
-  } use { file ->
-    fileToString(file)
+  val resource = Resource(::acquireResource, ::releaseResource)
+  resource.use {
+    println("Expensive resource under use! $it")
   }
-
-  println(res)
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-10.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-10.kt
@@ -14,18 +14,13 @@ suspend fun closeFile(file: File): Unit = file.close()
 suspend fun fileToString(file: File): String = file.toString()
 
 suspend fun main(): Unit {
-  val res: List<String> = listOf(
-    "data.json",
-    "user.json",
-    "resource.json"
-  ).traverse { uri ->
-    resource {
-     openFile(uri)
-    } release { file ->
-      closeFile(file)
-    }
-  }.use { files ->
-    files.map { fileToString(it) }
+  val res = resource {
+    openFile("data.json")
+  } release { file ->
+    closeFile(file)
+  } use { file ->
+    fileToString(file)
   }
-  res.forEach(::println)
+
+  println(res)
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-12.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-12.kt
@@ -1,5 +1,5 @@
 // This file was automatically generated from Resource.kt by Knit tool. Do not edit.
-package arrow.fx.coroutines.examples.exampleResource11
+package arrow.fx.coroutines.examples.exampleResource12
 
 import arrow.fx.coroutines.*
 
@@ -18,13 +18,13 @@ suspend fun main(): Unit {
     "data.json",
     "user.json",
     "resource.json"
-  ).traverse { uri ->
+  ).map { uri ->
     resource {
      openFile(uri)
     } release { file ->
       closeFile(file)
     }
-  }.use { files ->
+  }.sequence().use { files ->
     files.map { fileToString(it) }
   }
   res.forEach(::println)


### PR DESCRIPTION
… release

Decomposes a [Resource]<A> into a Pair<suspend () -> A, suspend (A, ExitCase) -> Unit>, containing the allocation and release functions which make up the [Resource].

This can be used to integrate Resources with code which cannot be run within the [use] function.