### PR TITLE
Make the server disconnect test more general

### DIFF
--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt
@@ -20,7 +20,7 @@ import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
-import java.net.ConnectException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 
 @ExperimentalSerializationApi
@@ -96,7 +96,7 @@ private fun networkEitherCallAdapterTests(
 
     body.shouldBeInstanceOf<Left<*>>()
       .value.shouldBeInstanceOf<IOError>()
-      .cause.shouldBeInstanceOf<ConnectException>()
+      .cause.shouldBeInstanceOf<SocketException>()
   }
 
   "should return IOError when no response" {


### PR DESCRIPTION
In the `NetworkEitherCallAdapterTest`, it turns out on some host OS/JVM combinations a more general exception (SocketException) is thrown when the server disconnects.
Original problem report: https://kotlinlang.slack.com/archives/C5UPMM0A0/p1663048397387609

As the SocketException is parent of ConnectException, it should be enough to make the test a bit more general. Anyway the main point of the test is that the error is wrapped into a `Left<IoError>`.