### PR TITLE
Use `super` equals and hashCode overrides for NonEmptyList

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -205,18 +205,11 @@ public class NonEmptyList<out A>(
   public fun extract(): A =
     this.head
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    other?.let {
-      if (it::class != this::class) return false
-      (other as NonEmptyList<*>)
-      if (all != other.all) return false
-      return true
-    } ?: return false
-  }
+  override fun equals(other: Any?): Boolean =
+    super.equals(other)
 
   override fun hashCode(): Int =
-    all.hashCode()
+    super.hashCode()
 
   override fun toString(): String =
     "NonEmptyList(${all.joinToString()})"

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/NonEmptyListTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/NonEmptyListTest.kt
@@ -3,6 +3,8 @@ package arrow.core
 import arrow.core.test.UnitSpec
 import arrow.core.test.laws.SemigroupLaws
 import arrow.typeclasses.Semigroup
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.property.Arb
 import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.boolean
@@ -298,7 +300,6 @@ class NonEmptyListTest : UnitSpec() {
       }
     }
 
-
     "minBy element" {
       checkAll(
         Arb.nonEmptyList(Arb.int())
@@ -306,6 +307,17 @@ class NonEmptyListTest : UnitSpec() {
         val result = a.minBy(::identity)
         val expected = a.minByOrNull(::identity)
         result shouldBe expected
+      }
+    }
+
+    "NonEmptyList equals List" {
+      checkAll(
+        Arb.nonEmptyList(Arb.int())
+      ) { a ->
+        withClue("$a should be equal to ${a.all}") {
+          // `shouldBe` doesn't use the `equals` methods on `Iterable`
+          (a == a.all).shouldBeTrue()
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/arrow-kt/arrow/issues/2807 by removing the overrides of `equals` and `hashCode` in `NonEmptyList`, so that we use the implementations in `AbstractList`.

One thing to note is that Kotest's `shouldBe` doesn't use the `equals` function for `Iterable`, so I've tested the result of `==` explicitly (and left a comment to that effect).

(This is my first PR here 👋 so let me know if I've missed anything)