### PR TITLE
Update NonEmptyList.fromList deprecation to suggest `toOption()` instead

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -237,10 +237,9 @@ public class NonEmptyList<out A>(
     @Deprecated(
       "Use toNonEmptyListOrNull instead",
       ReplaceWith(
-        "Option.fromNullable<NonEmptyList<A>>(l.toNonEmptyListOrNull())",
+        "l.toNonEmptyListOrNull().toOption()",
         "import arrow.core.toNonEmptyListOrNull",
-        "import arrow.core.Option",
-        "import arrow.core.NonEmptyList"
+        "import arrow.core.toOption"
       )
     )
     @JvmStatic


### PR DESCRIPTION
Suggest .toOption() instead of Option.fromNullable(). Coming from a discussion in StackOverFlow here https://stackoverflow.com/a/73893138/9440211. Thought I'd contribute it myself since it seemed quite straightforward and Simon seemed positive to this change.

Feel free to edit or discuss if you want me to edit something else too.