### PR TITLE
Improve Either.getOrHandle() docs

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1291,7 +1291,7 @@ public fun <B> Either<*, B>.orNull(): B? =
  * import arrow.core.getOrHandle
  *
  * fun main() {
- *   Right("ok").getOrHandle { 17 } // Result: "ok"
+ *   Right(12).getOrHandle { it + 5 } // Result: 12
  *   Left(12).getOrHandle { it + 5 } // Result: 17
  * }
  * ```

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1282,8 +1282,7 @@ public fun <B> Either<*, B>.orNull(): B? =
   orNull()
 
 /**
- * Returns the value from this [Right] or allows clients to transform [Left] to [Right] while providing access to
- * the value of [Left].
+ * Returns the value from this [Right] or allows clients to transform the value from [Left] with the [default] lambda.
  *
  * Example:
  * ```kotlin
@@ -1292,7 +1291,7 @@ public fun <B> Either<*, B>.orNull(): B? =
  * import arrow.core.getOrHandle
  *
  * fun main() {
- *   Right(12).getOrHandle { 17 } // Result: 12
+ *   Right("ok").getOrHandle { 17 } // Result: "ok"
  *   Left(12).getOrHandle { it + 5 } // Result: 17
  * }
  * ```

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1291,7 +1291,7 @@ public fun <B> Either<*, B>.orNull(): B? =
  * import arrow.core.getOrHandle
  *
  * fun main() {
- *   Right(12).getOrHandle { it + 5 } // Result: 12
+ *   Right(12).getOrHandle { 17 } // Result: 12
  *   Left(12).getOrHandle { it + 5 } // Result: 17
  * }
  * ```

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -998,9 +998,16 @@ public fun <A, B> Iterable<Validated<A, B>>.uniteValidated(): List<B> =
  * @return a tuple containing List with [Either.Left] and another List with its [Either.Right] values.
  */
 public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>> {
-  val asep = flatMap { gab -> gab.fold({ listOf(it) }, { emptyList() }) }
-  val bsep = flatMap { gab -> gab.fold({ emptyList() }, { listOf(it) }) }
-  return asep to bsep
+  val left = ArrayList<A>(collectionSizeOrDefault(10))
+  val right = ArrayList<B>(collectionSizeOrDefault(10))
+
+  for (either in this)
+    when (either) {
+      is Left -> left.add(either.value)
+      is Right -> right.add(either.value)
+    }
+
+  return Pair(left, right)
 }
 
 /**
@@ -1010,9 +1017,16 @@ public fun <A, B> Iterable<Either<A, B>>.separateEither(): Pair<List<A>, List<B>
  * @return a tuple containing List with [Validated.Invalid] and another List with its [Validated.Valid] values.
  */
 public fun <A, B> Iterable<Validated<A, B>>.separateValidated(): Pair<List<A>, List<B>> {
-  val asep = flatMap { gab -> gab.fold({ listOf(it) }, { emptyList() }) }
-  val bsep = flatMap { gab -> gab.fold({ emptyList() }, { listOf(it) }) }
-  return asep to bsep
+  val invalids = ArrayList<A>(collectionSizeOrDefault(10))
+  val valids = ArrayList<B>(collectionSizeOrDefault(10))
+
+  for (validated in this)
+    when (validated) {
+      is Invalid -> invalids.add(validated.value)
+      is Valid -> valids.add(validated.value)
+    }
+
+  return Pair(invalids, valids)
 }
 
 public fun <A> Iterable<Iterable<A>>.flatten(): List<A> =


### PR DESCRIPTION
This fixes the `getOrHandle()` doc - there was incorrect information that the function somehow returns `Right`, whereas it always unwraps the value.