### PR TITLE
Remove all references to shift from new Arrow 2.0 code

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2619,10 +2619,10 @@ public final class arrow/core/continuations/Effect {
 	public static final fun option (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun orNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun orNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun raisedOrRethrow (Ljava/util/concurrent/CancellationException;Larrow/core/continuations/DefaultRaise;)Ljava/lang/Object;
 	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
 	public static final fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
 	public static final fun result (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun shiftedOrRethrow (Ljava/util/concurrent/CancellationException;Larrow/core/continuations/DefaultRaise;)Ljava/lang/Object;
 	public static final fun toEither (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun toEither (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toIor (Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1234,7 +1234,7 @@ public sealed class Either<out A, out B> {
 
 /**
  * Recover from [E] when encountering [Left].
- * You can either return a new value of [A], or short-circuit by shifting with a value of [E2].
+ * You can either return a new value of [A], or short-circuit by raising with a value of [E2].
  *
  * ```kotlin
  * import arrow.core.Either

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EagerEffectSpec.kt
@@ -19,7 +19,7 @@ import io.kotest.property.checkAll
 import kotlinx.coroutines.CompletableDeferred
 
 class EagerEffectSpec : StringSpec({
-  "try/catch - can recover from shift" {
+  "try/catch - can recover from raise" {
     checkAll(Arb.int(), Arb.string()) { i, s ->
       eagerEffect {
         try {
@@ -46,7 +46,7 @@ class EagerEffectSpec : StringSpec({
     }
   }
   
-  "try/catch - First shift is ignored and second is returned" {
+  "try/catch - First raise is ignored and second is returned" {
     checkAll(Arb.int(), Arb.string(), Arb.string()) { i, s, s2 ->
       eagerEffect<String, Int> {
         val x: Int =
@@ -86,7 +86,7 @@ class EagerEffectSpec : StringSpec({
     }
   }
   
-  "attempt - shift from catch" {
+  "attempt - raise from catch" {
     checkAll(Arb.int(), Arb.long(), Arb.string()) { i, l, error ->
       eagerEffect {
         eagerEffect<Long, Int> {
@@ -109,25 +109,25 @@ class EagerEffectSpec : StringSpec({
   }
   
   "ensure null in eager either computation" {
-    checkAll(Arb.boolean(), Arb.int(), Arb.string()) { predicate, success, shift ->
+    checkAll(Arb.boolean(), Arb.int(), Arb.string()) { predicate, success, raise ->
       either<String, Int> {
-        ensure(predicate) { shift }
+        ensure(predicate) { raise }
         success
-      } shouldBe if (predicate) success.right() else shift.left()
+      } shouldBe if (predicate) success.right() else raise.left()
     }
   }
   
   "ensureNotNull in eager either computation" {
     fun square(i: Int): Int = i * i
     
-    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, shift: String ->
+    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, raise: String ->
       val res =
         either<String, Int> {
           val ii = i
-          ensureNotNull(ii) { shift }
+          ensureNotNull(ii) { raise }
           square(ii) // Smart-cast by contract
         }
-      val expected = i?.let(::square)?.right() ?: shift.left()
+      val expected = i?.let(::square)?.right() ?: raise.left()
       res shouldBe expected
     }
   }
@@ -151,7 +151,7 @@ class EagerEffectSpec : StringSpec({
     }
   }
   
-  "catch - error path and re-shift" {
+  "catch - error path and re-raise" {
     checkAll(Arb.int(), Arb.string()) { int, fallback ->
       eagerEffect<Int, Unit> {
         raise<String>(int)
@@ -191,7 +191,7 @@ class EagerEffectSpec : StringSpec({
     }
   }
   
-  "attempt - error path and re-shift" {
+  "attempt - error path and re-raise" {
     checkAll(Arb.string(), Arb.int()) { msg, fallback ->
       eagerEffect<Int, Unit> {
         throw RuntimeException(msg)

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.withContext
 
 class EffectSpec :
   StringSpec({
-    "try/catch - can recover from shift" {
+    "try/catch - can recover from raise" {
       checkAll(Arb.int().suspend(), Arb.string().suspend()) { i, s ->
         effect {
           try {
@@ -57,7 +57,7 @@ class EffectSpec :
       }
     }
     
-    "try/catch - First shift is ignored and second is returned" {
+    "try/catch - First raise is ignored and second is returned" {
       checkAll(Arb.int().suspend(), Arb.string().suspend(), Arb.string().suspend()) { i, s, s2 ->
         effect<String, Int> {
           val x: Int = try {
@@ -110,7 +110,7 @@ class EffectSpec :
       }
     }
     
-    "eagerEffect shift short-circuits effect computation" {
+    "eagerEffect raise short-circuits effect computation" {
       checkAll(Arb.string(), Arb.int().suspend()) { a, b ->
         val eager: EagerEffect<String, Int> =
           eagerEffect { raise(a) }
@@ -174,25 +174,25 @@ class EffectSpec :
         Arb.boolean().suspend(),
         Arb.int().suspend(),
         Arb.string().suspend()
-      ) { predicate, success, shift ->
+      ) { predicate, success, raise ->
         either {
-          ensure(predicate()) { shift() }
+          ensure(predicate()) { raise() }
           success()
-        } shouldBe if (predicate()) success().right() else shift().left()
+        } shouldBe if (predicate()) success().right() else raise().left()
       }
     }
     
     "ensureNotNull in either computation" {
       fun square(i: Int): Int = i * i
       
-      checkAll(Arb.int().orNull().suspend(), Arb.string().suspend()) { i, shift->
+      checkAll(Arb.int().orNull().suspend(), Arb.string().suspend()) { i, raise->
         val res =
           either<String, Int> {
             val ii = i()
-            ensureNotNull(ii) { shift() }
+            ensureNotNull(ii) { raise() }
             square(ii) // Smart-cast by contract
           }
-        val expected = i()?.let(::square)?.right() ?: shift().left()
+        val expected = i()?.let(::square)?.right() ?: raise().left()
         res shouldBe expected
       }
     }
@@ -262,7 +262,7 @@ class EffectSpec :
       }
     }
     
-    "Can shift from thrown exceptions" {
+    "Can raise from thrown exceptions" {
       checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
         effect<String, Int> {
           effect<Int, String> {
@@ -309,7 +309,7 @@ class EffectSpec :
       }
     }
     
-    "catch - error path and re-shift" {
+    "catch - error path and re-raise" {
       checkAll(Arb.int().suspend(), Arb.string().suspend()) { int, fallback ->
         effect<Int, Unit> {
           raise<String>(int())
@@ -349,7 +349,7 @@ class EffectSpec :
       }
     }
     
-    "attempt - error path and re-shift" {
+    "attempt - error path and re-raise" {
       checkAll(Arb.string().suspend(), Arb.int().suspend()) { msg, fallback ->
         effect<Int, Unit> {
           throw RuntimeException(msg())

--- a/arrow-libs/fx/arrow-fx-coroutines-test/src/jvmTest/kotlin/arrow/fx/coroutines/PredefTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines-test/src/jvmTest/kotlin/arrow/fx/coroutines/PredefTest.kt
@@ -30,7 +30,7 @@ class PredefTest : ArrowFxSpec(
       }
     }
     
-    "shift" {
+    "raise" {
       checkAll(Arb.string(), Arb.string()) { a, b ->
         val t0 = Thread.currentThread().name
         


### PR DESCRIPTION
@franciscodr review feedback on #2827.

There were some lingering _shift_ references in the code, and default lambda argument names.
For consistency, and easier understanding the internals, we want to remove all references to `shift` and only have the new `raise` name remain.