### PR TITLE
Correct `addressStrees` -> `addressStreet` in optics documentation

### DIFF
--- a/arrow-site/docs/docs/lens/README.md
+++ b/arrow-site/docs/docs/lens/README.md
@@ -91,7 +91,7 @@ val companyAddress: Lens<Company, Address> = Lens(
         set = { company, address -> company.copy(address = address) }
 )
 
-val addressStrees: Lens<Address, Street> = Lens(
+val addressStreet: Lens<Address, Street> = Lens(
         get = { it.street },
         set = { address, street -> address.copy(street = street) }
 )
@@ -101,7 +101,7 @@ val streetName: Lens<Street, String> = Lens(
         set = { street, name -> street.copy(name = name) }
 )
 
-val employeeStreetName: Lens<Employee, String> = employeeCompany compose companyAddress compose addressStrees compose streetName
+val employeeStreetName: Lens<Employee, String> = employeeCompany compose companyAddress compose addressStreet compose streetName
 
 employeeStreetName.modify(employee, String::capitalize)
 ```


### PR DESCRIPTION
Corrects the value of `Lens<Address, Street>` from `addressStrees` to `addressStreet` as probably intended, in the optics documentation.