### PR TITLE
Arrow Fx: deprecate Platform#composeError, never and unit()

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Platform.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Platform.kt
@@ -3,17 +3,19 @@ package arrow.fx.coroutines
 import arrow.core.NonEmptyList
 import kotlin.jvm.JvmName
 
+@Deprecated("Unused, will be removed from binary in 2.x.x")
 internal const val ArrowExceptionMessage =
   "Arrow-kt internal error. Please let us know and create a ticket at https://github.com/arrow-kt/arrow/issues/new/choose"
 
+@Deprecated("Unused, will be removed from binary in 2.x.x")
 internal class ArrowInternalException(override val message: String = ArrowExceptionMessage) : RuntimeException(message)
 
+@Deprecated(NicheApi)
 public object Platform {
-
-  public fun composeErrors(first: Throwable, res: Result<Any?>): Throwable {
-    res.fold({ first }, { e -> first.addSuppressed(e) })
-    return first
-  }
+  
+  @Deprecated(NicheApi, ReplaceWith("res.fold({ first }, { e -> first.apply { addSuppressed(e) } })"))
+  public fun composeErrors(first: Throwable, res: Result<Any?>): Throwable =
+    res.fold({ first }, { e -> first.apply { addSuppressed(e) } })
 
   /**
    * Composes multiple errors together, meant for those cases in which error suppression, due to a second error being
@@ -22,6 +24,7 @@ public object Platform {
    * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
    * function would return a CompositeException.
    */
+  @Deprecated(NicheApi, ReplaceWith("first.apply { rest.forEach(::addSuppressed) }"))
   public fun composeErrors(first: Throwable, vararg rest: Throwable): Throwable {
     rest.forEach { if (it != first) first.addSuppressed(it) }
     return first
@@ -34,6 +37,7 @@ public object Platform {
    * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
    * function would return a CompositeException.
    */
+  @Deprecated(NicheApi, ReplaceWith("first.apply { rest.forEach(::addSuppressed) }"))
   public fun composeErrors(first: Throwable, rest: List<Throwable>): Throwable {
     rest.forEach { if (it != first) first.addSuppressed(it) }
     return first
@@ -47,6 +51,7 @@ public object Platform {
    * function would return a CompositeException.
    */
   @JvmName("composeErrorsNullable")
+  @Deprecated(NicheApi, ReplaceWith("first?.apply { other?.let(::addSuppressed) } ?: other"))
   public fun composeErrors(first: Throwable?, other: Throwable?): Throwable? =
     first?.let { a ->
       other?.let { b ->
@@ -61,6 +66,7 @@ public object Platform {
    * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
    * function would return a CompositeException.
    */
+  @Deprecated(NicheApi, ReplaceWith("other?.apply { addSuppressed(first) } ?: first"))
   public fun composeErrors(first: Throwable, other: Throwable?): Throwable =
     other?.let { a ->
       a.apply { addSuppressed(first) }
@@ -73,11 +79,16 @@ public object Platform {
    * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
    * function would return a CompositeException.
    */
+  @Deprecated(NicheApi, ReplaceWith("all.head.apply { all.tail.forEach(::addSuppressed) }"))
   public fun composeErrors(all: List<Throwable>): Throwable? =
     all.firstOrNull()?.let { first ->
       composeErrors(first, all.drop(1))
     }
 
+  @Deprecated(NicheApi, ReplaceWith("all.head.apply { all.tail.forEach(::addSuppressed) }"))
   public fun composeErrors(all: NonEmptyList<Throwable>): Throwable =
-      composeErrors(all.head, all.tail)
+    composeErrors(all.head, all.tail)
 }
+
+private const val  NicheApi: String =
+  "Niche use-case, prefer using higher level operators or addSuppressed from Kotlin Std"

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Race3.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Race3.kt
@@ -77,11 +77,17 @@ public suspend inline fun <A, B, C> raceN(
 
 @PublishedApi
 internal suspend fun cancelAndCompose(first: Deferred<*>, second: Deferred<*>): Unit {
-  val e1 = runCatching {
+  val e1 = try {
     first.cancelAndJoin()
-  }.exceptionOrNull()?.nonFatalOrThrow()
-  val e2 = runCatching {
+    null
+  } catch (e: Throwable) {
+    e.nonFatalOrThrow()
+  }
+  val e2 = try {
     second.cancelAndJoin()
-  }.exceptionOrNull()?.nonFatalOrThrow()
+    null
+  } catch (e: Throwable) {
+    e.nonFatalOrThrow()
+  }
   (e1?.apply { e2?.let(::addSuppressed) } ?: e2)?.let { throw it }
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -4,6 +4,7 @@ import arrow.core.continuations.AtomicRef
 import arrow.core.continuations.update
 import arrow.core.identity
 import arrow.core.prependTo
+import arrow.core.zip
 import arrow.fx.coroutines.ExitCase.Companion.ExitCase
 import arrow.fx.coroutines.continuations.ResourceScope
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -818,7 +819,7 @@ private class ResourceScopeImpl : ResourceScope {
         if (ex != ExitCase.Completed) {
           val e = finalizers.get().cancelAll(ex)
           val e2 = runCatching { release(a, ex) }.exceptionOrNull()
-          Platform.composeErrors(e, e2)?.let { throw it }
+          (e?.apply { e2?.let(::addSuppressed) } ?: e2)?.let { throw it }
         }
       })
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/builders.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/builders.kt
@@ -2,9 +2,15 @@ package arrow.fx.coroutines
 
 import kotlinx.coroutines.awaitCancellation
 
-// TODO deprecate?
+@Deprecated(
+  "Prefer using awaitCancellation from KotlinX",
+  ReplaceWith("awaitCancellation()", "kotlinx.coroutines.awaitCancellation")
+)
 public suspend fun <A> never(): A =
   awaitCancellation()
 
-// TODO deprecate?
+@Deprecated(
+  "Prefer simply using Unit, or empty lambda when needed",
+  ReplaceWith("Unit")
+)
 public suspend fun unit(): Unit = Unit

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/predef.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/predef.kt
@@ -1,3 +1,11 @@
 package arrow.fx.coroutines
 
+/**
+ * Gets current system time in milliseconds since certain moment in the past,
+ * only delta between two subsequent calls makes sense.
+ *
+ * For the JVM target this delegates to `java.lang.System.currentTimeMillis()`
+ * For the native targets this delegates to `kotlin.system.getTimeMillis`
+ * For Javascript it relies on `new Date().getTime()`
+ */
 public expect fun timeInMillis(): Long

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
@@ -190,6 +190,9 @@ class BracketCaseTest : ArrowFxSpec(
         } should leftException(e)
       }
     }
+  
+    operator fun Throwable.plus(other: Throwable): Throwable =
+      apply { addSuppressed(other) }
 
     "bracketCase must compose immediate use & immediate release error" {
       checkAll(Arb.int(), Arb.throwable(), Arb.throwable()) { n, e, e2 ->
@@ -199,7 +202,7 @@ class BracketCaseTest : ArrowFxSpec(
             use = { throw e },
             release = { _, _ -> throw e2 }
           )
-        } shouldBe Either.Left(Platform.composeErrors(e, e2))
+        } shouldBe Either.Left(e + e2)
       }
     }
 
@@ -211,7 +214,7 @@ class BracketCaseTest : ArrowFxSpec(
             use = { e.suspend() },
             release = { _, _ -> throw e2 }
           )
-        } shouldBe Either.Left(Platform.composeErrors(e, e2))
+        } shouldBe Either.Left(e + e2)
       }
     }
 
@@ -223,7 +226,7 @@ class BracketCaseTest : ArrowFxSpec(
             use = { throw e },
             release = { _, _ -> e2.suspend() }
           )
-        } shouldBe Either.Left(Platform.composeErrors(e, e2))
+        } shouldBe Either.Left(e + e2)
       }
     }
 
@@ -235,7 +238,7 @@ class BracketCaseTest : ArrowFxSpec(
             use = { e.suspend() },
             release = { _, _ -> e2.suspend() }
           )
-        } shouldBe Either.Left(Platform.composeErrors(e, e2))
+        } shouldBe Either.Left(e + e2)
       }
     }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ParTraverseTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ParTraverseTest.kt
@@ -52,7 +52,7 @@ class ParTraverseTest : ArrowFxSpec(
       ) { n, killOn, e ->
         Either.catch {
           (0 until n).parTraverse { i ->
-            if (i == killOn) throw e else unit()
+            if (i == killOn) throw e else Unit
           }
         } should leftException(e)
       }
@@ -136,7 +136,7 @@ class ParTraverseTest : ArrowFxSpec(
       ) { n, killOn, e ->
         Either.catch {
           (0 until n).parTraverseN(3) { i ->
-            if (i == killOn) throw e else unit()
+            if (i == killOn) throw e else Unit
           }
         } should leftException(e)
       }


### PR DESCRIPTION
Arrow Fx exposes a couple APIs that are unnecessary low-level, and don't really have a use in mainstream code.
All operators in Arrow Fx properly compose errors under the hood, and thus there should never be a need to use these APIs.

Historically we've had this need because there was no MPP solution for composing errors in Kotlin, but since then they've added it to the Kotlin Std. So the recommendation is to use that instead.

I've added `ReplaceWith` deprecations in case anyone was relying on these APIs, and this should help them transition to the Kotlin Std API.

This PR also deprecates `never` which overlaps with KotlinX `awaitCancellation` which is also much more descriptive and better understood. And `suspend fun unit()` which was the old equivalent of `IO.unit` but is not useful in the context of `suspend`.