### PR TITLE
Backport Optics KSP plugin NPE on multiplatform fix

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/processor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/processor.kt
@@ -48,7 +48,7 @@ internal fun KSClassDeclaration.targetsFromOpticsAnnotation(): List<OpticsTarget
   annotations
     .find { it.annotationType.resolve().declaration.qualifiedName?.asString() == "arrow.optics.optics" }
     ?.arguments
-    ?.flatMap { it.value as ArrayList<KSType> }
+    ?.flatMap { (it.value as? ArrayList<*>).orEmpty().mapNotNull { it as? KSType } }
     ?.mapNotNull {
       when (it.qualifiedString() ) {
         "arrow.optics.OpticsTarget.ISO" -> OpticsTarget.ISO


### PR DESCRIPTION
Should fix the error from #2725.
Backported from https://github.com/arrow-kt/arrow/commit/62044120c483b01304819900a5e4cd8b4f1e8ece