### PR TITLE
introduce iterable.toNonEmptyListOrNone()

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -761,6 +761,7 @@ public final class arrow/core/NonEmptyListKt {
 	public static final fun sequenceEither (Larrow/core/NonEmptyList;)Larrow/core/Either;
 	public static final fun sequenceOption (Larrow/core/NonEmptyList;)Larrow/core/Option;
 	public static final fun sequenceValidated (Larrow/core/NonEmptyList;Larrow/typeclasses/Semigroup;)Larrow/core/Validated;
+	public static final fun toNonEmptyListOrNone (Ljava/lang/Iterable;)Larrow/core/Option;
 	public static final fun toNonEmptyListOrNull (Ljava/lang/Iterable;)Larrow/core/NonEmptyList;
 	public static final fun traverse (Larrow/core/NonEmptyList;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
 	public static final fun traverse (Larrow/core/NonEmptyList;Lkotlin/jvm/functions/Function1;)Larrow/core/Either;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -505,3 +505,6 @@ public fun <A> NonEmptyList<Option<A>>.sequence(): Option<NonEmptyList<A>> =
 
 public fun <A> Iterable<A>.toNonEmptyListOrNull(): NonEmptyList<A>? =
   firstOrNull()?.let { NonEmptyList(it, drop(1)) }
+
+public fun <A> Iterable<A>.toNonEmptyListOrNone(): Option<NonEmptyList<A>> =
+  toNonEmptyListOrNull().toOption()

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/NonEmptyListTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/NonEmptyListTest.kt
@@ -5,6 +5,7 @@ import arrow.core.test.laws.SemigroupLaws
 import arrow.typeclasses.Semigroup
 import io.kotest.assertions.withClue
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.property.Arb
 import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.boolean
@@ -16,6 +17,18 @@ class NonEmptyListTest : UnitSpec() {
   init {
 
     testLaws(SemigroupLaws.laws(Semigroup.nonEmptyList(), Arb.nonEmptyList(Arb.int())))
+
+    "iterable.toNonEmptyListOrNull should round trip" {
+      checkAll(Arb.nonEmptyList(Arb.int())) { nonEmptyList ->
+        nonEmptyList.all.toNonEmptyListOrNull().shouldNotBeNull() shouldBe nonEmptyList
+      }
+    }
+
+    "iterable.toNonEmptyListOrNone should round trip" {
+      checkAll(Arb.nonEmptyList(Arb.int())) { nonEmptyList ->
+        nonEmptyList.all.toNonEmptyListOrNone() shouldBe nonEmptyList.some()
+      }
+    }
 
     "traverse for Either stack-safe" {
       // also verifies result order and execution order (l to r)


### PR DESCRIPTION
# In this PR
- introduce iterable.toNonEmptyListOrNone() (fixes #2842)