### PR TITLE
Use major versions in GitHub Actions

### DIFF
--- a/.github/workflows/generate-alpha-tag.yaml
+++ b/.github/workflows/generate-alpha-tag.yaml
@@ -19,13 +19,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Gradle build
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --full-stacktrace build "-Psemver.stage=alpha"
 
@@ -46,13 +46,13 @@ jobs:
           token: ${{ secrets.TOKEN_GITHUB_ACTION }}
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Generate Tag
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --full-stacktrace createSemverTag "-Psemver.stage=alpha"
 

--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -39,13 +39,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Gradle build
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --full-stacktrace build "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
 
@@ -66,13 +66,13 @@ jobs:
           token: ${{ secrets.TOKEN_GITHUB_ACTION }}
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Generate Tag
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --full-stacktrace createSemverTag "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,13 +38,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Build
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: assemble -Pkotlin.mpp.enableCompatibilityMetadataVariant=true --full-stacktrace
 
@@ -53,13 +53,13 @@ jobs:
         run: echo "::set-output name=arrow::$(head -n 1 build/semver/version.txt)"
 
       - name: Upload reports
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: 'reports-${{ matrix.os }}'
           path: '**/build/reports/**'
 
       - name: Publish alpha/beta/rc version
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         if: |
           contains(steps.version.outputs.arrow, 'alpha') ||
           contains(steps.version.outputs.arrow, 'beta') ||
@@ -68,7 +68,7 @@ jobs:
           arguments: --full-stacktrace -Pkotlin.mpp.enableCompatibilityMetadataVariant=true publishToSonatype closeAndReleaseSonatypeStagingRepository
 
       - name: Publish final version
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         if: |
           !contains(steps.version.outputs.arrow, 'alpha') &&
           !contains(steps.version.outputs.arrow, 'beta') &&
@@ -85,7 +85,7 @@ jobs:
           bundle install --gemfile Gemfile
 
       - name: Create API doc
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --full-stacktrace -Pkotlin.mpp.enableCompatibilityMetadataVariant=true dokkaGfm
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
@@ -32,19 +32,19 @@ jobs:
           xcode-version: '13.4.1'
 
       - name: build
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         if: matrix.os != 'windows-latest'
         with:
           arguments: --full-stacktrace build
 
       - name: mingwX64Test
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         if: matrix.os == 'windows-latest'
         with:
           arguments: --full-stacktrace mingwX64Test
 
       - name: Upload reports
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: 'reports-${{ matrix.os }}'
           path: '**/build/reports/**'
@@ -62,13 +62,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.4.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Build
-        uses: gradle/gradle-build-action@v2.2.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: apiDump
 
@@ -76,7 +76,7 @@ jobs:
         run: ./gradlew --stop
 
       - name: "Commit new API files"
-        uses: stefanzweifel/git-auto-commit-action@v4.14.1
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update API files
           file_pattern: arrow-libs/**/api/*.api


### PR DESCRIPTION
This removes the minor versions from the workflow files, which according to the [documentation](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md) means the Actions use the latest minor in that major series.