### PR TITLE
Do not reuse the name of the file in Optics KSP

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
@@ -8,7 +8,6 @@ import arrow.optics.plugin.internals.noCompanion
 import arrow.optics.plugin.internals.otherClassTypeErrorMessage
 import arrow.optics.plugin.internals.qualifiedNameOrSimpleName
 import arrow.optics.plugin.internals.snippets
-import arrow.optics.plugin.internals.typeParametersErrorMessage
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.KSPLogger
@@ -52,7 +51,7 @@ class OpticsProcessor(private val codegen: CodeGenerator, private val logger: KS
           .createNewFile(
             Dependencies(aggregating = true, *listOfNotNull(klass.containingFile).toTypedArray()),
             it.`package`,
-            it.name
+            it.name + "__Optics"
           )
           .writer()
       writer.write(it.asFileText())

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/Compilation.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/Compilation.kt
@@ -26,6 +26,11 @@ fun String.compilationFails() {
   Assertions.assertThat(compilationResult.exitCode).isNotEqualTo(KotlinCompilation.ExitCode.OK)
 }
 
+fun String.compilationSucceeds() {
+  val compilationResult = compile(this)
+  Assertions.assertThat(compilationResult.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+}
+
 fun String.evals(thing: Pair<String, Any?>) {
   val compilationResult = compile(this)
   Assertions.assertThat(compilationResult.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/DSLTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/DSLTests.kt
@@ -27,5 +27,21 @@ class DSLTests {
       """.evals("r" to "Db(content={Two=two, Three=three, Four=four})")
   }
 
+  @Test
+  fun `DSL works with extensions in the file, issue #2803`() {
+    // it's important to keep the 'Source' name for the class,
+    // because files in the test are named 'Source.kt'
+    """
+      |$imports
+      |
+      |@optics
+      |data class Source(val id: Int) {
+      |  companion object
+      |}
+      |
+      |fun Source.toSomeObject() = 5
+      """.compilationSucceeds()
+  }
+
   // Db.content.at(At.map(), One).set(db, None)
 }


### PR DESCRIPTION
Fixes #2803

The problem is that we were re-using the name of the file. However, if you also define extension functions, or any other tp-level element, two classes with the same JVM name are generated. The solution is to create a weirder name so it doesn't conflict, I chose to add `__Optics` to the current name.