### PR TITLE
Property delegation for bind

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2596,8 +2596,11 @@ public final class arrow/core/continuations/DefaultRaise : arrow/core/continuati
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2617,8 +2620,11 @@ public final class arrow/core/continuations/DefaultStateRaise : arrow/atomic/Ato
 	public fun compareAndSet (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public fun getAndSet (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getValue ()Ljava/lang/Object;
+	public fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2684,10 +2690,13 @@ public final class arrow/core/continuations/IorRaise : arrow/core/continuations/
 	public fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun combine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getEffect ()Larrow/core/continuations/StateRaise;
+	public fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun maybeCombine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun plus (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2720,12 +2729,20 @@ public final class arrow/core/continuations/NullableRaise : arrow/core/continuat
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Larrow/core/continuations/Raise;Larrow/core/continuations/Raise;)Z
+	public fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun getValue-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Larrow/core/continuations/Raise;)I
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun invoke-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate-impl (Larrow/core/continuations/Raise;Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static final fun provideDelegate-impl (Larrow/core/continuations/Raise;Larrow/core/Option;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static final fun provideDelegate-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun raise (Ljava/lang/Void;)Ljava/lang/Void;
 	public static fun raise-impl (Larrow/core/continuations/Raise;Ljava/lang/Void;)Ljava/lang/Void;
@@ -2751,6 +2768,7 @@ public final class arrow/core/continuations/OptionRaise : arrow/core/continuatio
 	public static final fun bind-impl (Larrow/core/continuations/Raise;Larrow/core/Option;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/Raise;Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/Raise;Larrow/core/Validated;)Ljava/lang/Object;
+	public static final fun bind-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2765,12 +2783,20 @@ public final class arrow/core/continuations/OptionRaise : arrow/core/continuatio
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Larrow/core/continuations/Raise;Larrow/core/continuations/Raise;)Z
+	public fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun getValue-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Larrow/core/continuations/Raise;)I
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun invoke-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate-impl (Larrow/core/continuations/Raise;Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static final fun provideDelegate-impl (Larrow/core/continuations/Raise;Larrow/core/Option;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static final fun provideDelegate-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun raise (Larrow/core/None;)Ljava/lang/Void;
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public static fun raise-impl (Larrow/core/continuations/Raise;Larrow/core/None;)Ljava/lang/Void;
@@ -2794,8 +2820,11 @@ public abstract interface class arrow/core/continuations/Raise {
 	public abstract fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public abstract fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public abstract fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public abstract fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public abstract fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public abstract fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2811,8 +2840,11 @@ public final class arrow/core/continuations/Raise$DefaultImpls {
 	public static fun bind (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun catch (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun catch (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getValue (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun provideDelegate (Larrow/core/continuations/Raise;Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2849,12 +2881,19 @@ public final class arrow/core/continuations/ResultRaise : arrow/core/continuatio
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Larrow/core/continuations/Raise;Larrow/core/continuations/Raise;)Z
+	public fun getValue (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun getValue-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Larrow/core/continuations/Raise;)I
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun invoke-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun provideDelegate (Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun provideDelegate (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate-impl (Larrow/core/continuations/Raise;Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static final fun provideDelegate-impl (Larrow/core/continuations/Raise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate-impl (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun raise (Ljava/lang/Throwable;)Ljava/lang/Void;
 	public static fun raise-impl (Larrow/core/continuations/Raise;Ljava/lang/Throwable;)Ljava/lang/Void;
@@ -2881,8 +2920,11 @@ public final class arrow/core/continuations/StateRaise$DefaultImpls {
 	public static fun bind (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun catch (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun catch (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getValue (Larrow/core/continuations/StateRaise;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun provideDelegate (Larrow/core/continuations/StateRaise;Larrow/core/Either;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static fun provideDelegate (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/continuations/StateRaise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;


### PR DESCRIPTION
This is a proposal for an alternative syntax for `bind` using [delegated properties](https://kotlinlang.org/docs/delegated-properties.html#property-delegate-requirements). The idea is that instead of writing:

```kotlin
either {
  val x = oneThing().bind()
  val y = anotherThing().bind()
  x + y
}
```

you can use `by` and remove the `bind`

```kotlin
either {
  val x by oneThing()
  val y by anotherThing()
  x + y
}
```

The goal here is to provide a more intuitive syntax for beginners, since `bind` is not a common word outside of Scala/Haskell circles. The idea would be to say that if you want to "execute" an `Either`, `Result`, ... inside the block you can "bridge" it with `by`.

### Some comments about the implementation

The way Kotlin translates these delegated properties is in two steps. Assuming `val x by t`
1. It calls `provideDelegate` over the type of `t`, which returns something of a new type `D`. In our case, `provideDelegate` is exactly `bind`, so the type `D` is the type `A` "contained" in the `Either`, `Result`, ...
2. It calls `getValue` over the type `D`. In our case this is a no-op, since `provideDelegate` has done all the work.

It's also allowed to *not* give a `provideDelegate`. But one should be aware that `getValue` is called every time we access the variable. So if we made `getValue` the one calling `bind`, code like

```kotlin
val x by thing()
x + x
```

would actually be equivalent to

```kotlin
val t = thing()
t.bind() + t.bind()
```

whereas we only want one `bind`!