### PR TITLE
Replace parTraverse with parMap

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -104,6 +104,12 @@ public final class arrow/fx/coroutines/CountDownLatch {
 	public final fun countDown ()V
 }
 
+public final class arrow/fx/coroutines/CyclicBarrier {
+	public fun <init> (I)V
+	public final fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getCapacity ()I
+}
+
 public abstract class arrow/fx/coroutines/ExitCase {
 	public static final field Companion Larrow/fx/coroutines/ExitCase$Companion;
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CountDownLatch.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CountDownLatch.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CompletableDeferred
  * Must be initialised with an [initial] value of 1 or higher,
  * if constructed with 0 or negative value then it throws [IllegalArgumentException].
  */
-public class CountDownLatch @Throws(IllegalArgumentException::class) constructor(private val initial: Long) {
+public class CountDownLatch(private val initial: Long) {
   private val signal = CompletableDeferred<Unit>()
   private val count = AtomicRef(initial)
   

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CyclicBarrier.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CyclicBarrier.kt
@@ -3,6 +3,7 @@ package arrow.fx.coroutines
 import arrow.core.continuations.AtomicRef
 import arrow.core.continuations.loop
 import arrow.core.continuations.update
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 
 /**
@@ -41,8 +42,9 @@ public class CyclicBarrier @Throws(IllegalArgumentException::class) constructor(
       } else if (state.compareAndSet(original, State(awaitingNow, epoch, unblock))) {
         return try {
           unblock.await()
-        } finally {
+        } catch (cancelled: CancellationException) {
           state.update { s -> if (s.epoch == epoch) s.copy(awaiting = s.awaiting + 1) else s }
+          throw cancelled
         }
       }
     }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CyclicBarrier.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CyclicBarrier.kt
@@ -1,0 +1,50 @@
+package arrow.fx.coroutines
+
+import arrow.core.continuations.AtomicRef
+import arrow.core.continuations.loop
+import arrow.core.continuations.update
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * A [CyclicBarrier] is a synchronization mechanism that allows a set of coroutines to wait for each other
+ * to reach a certain point before continuing execution.
+ * It is called a "cyclic" barrier because it can be reused after all coroutines have reached the barrier and released.
+ *
+ * To use a CyclicBarrier, each coroutine must call the [await] method on the barrier object,
+ * which will cause the coroutine to suspend until the required number of coroutines have reached the barrier.
+ * Once all coroutines have reached the barrier they will _resume_ execution.
+ *
+ * Models the behavior of java.util.concurrent.CyclicBarrier in Kotlin with `suspend`.
+ */
+public class CyclicBarrier @Throws(IllegalArgumentException::class) constructor(public val capacity: Int) {
+  init {
+    require(capacity > 0) {
+      "Cyclic barrier must be constructed with positive non-zero capacity $capacity but was $capacity > 0"
+    }
+  }
+  
+  private data class State(val awaiting: Int, val epoch: Long, val unblock: CompletableDeferred<Unit>)
+  
+  private val state: AtomicRef<State> = AtomicRef(State(capacity, 0, CompletableDeferred()))
+  
+  /**
+   * When [await] is called the function will suspend until the required number of coroutines have reached the barrier.
+   * Once the [capacity] of the barrier has been reached, the coroutine will be released and continue execution.
+   */
+  public suspend fun await() {
+    state.loop { original ->
+      val (awaiting, epoch, unblock) = original
+      val awaitingNow = awaiting - 1
+      if (awaitingNow == 0 && state.compareAndSet(original, State(capacity, epoch + 1, CompletableDeferred()))) {
+        unblock.complete(Unit)
+        return
+      } else if (state.compareAndSet(original, State(awaitingNow, epoch, unblock))) {
+        return try {
+          unblock.await()
+        } finally {
+          state.update { s -> if (s.epoch == epoch) s.copy(awaiting = s.awaiting + 1) else s }
+        }
+      }
+    }
+  }
+}

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CyclicBarrier.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/CyclicBarrier.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.CompletableDeferred
  *
  * Models the behavior of java.util.concurrent.CyclicBarrier in Kotlin with `suspend`.
  */
-public class CyclicBarrier @Throws(IllegalArgumentException::class) constructor(public val capacity: Int) {
+public class CyclicBarrier(public val capacity: Int) {
   init {
     require(capacity > 0) {
       "Cyclic barrier must be constructed with positive non-zero capacity $capacity but was $capacity > 0"

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParMap.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParMap.kt
@@ -1,0 +1,106 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.NonEmptyList
+import arrow.core.continuations.EffectScope
+import arrow.core.continuations.either
+import arrow.core.flattenOrAccumulate
+import arrow.typeclasses.Semigroup
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+public suspend fun <A, B> Iterable<A>.parMap(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  concurrency: Int,
+  f: suspend CoroutineScope.(A) -> B
+): List<B> {
+  val semaphore = Semaphore(concurrency)
+  return parMap(ctx) {
+    semaphore.withPermit { f(it) }
+  }
+}
+
+public suspend fun <A, B> Iterable<A>.parMap(
+  context: CoroutineContext = EmptyCoroutineContext,
+  transform: suspend CoroutineScope.(A) -> B
+): List<B> = coroutineScope {
+  map { async(context) { transform.invoke(this, it) } }.awaitAll()
+}
+
+/** Temporary intersection type, until we have context receivers */
+public class ScopedRaise<E>(
+  raise: EffectScope<E>,
+  scope: CoroutineScope
+) : CoroutineScope by scope, EffectScope<E> by raise
+
+public suspend fun <E, A, B> Iterable<A>.parMapOrAccumulate(
+  context: CoroutineContext = EmptyCoroutineContext,
+  concurrency: Int,
+  semigroup: Semigroup<E>,
+  transform: suspend ScopedRaise<E>.(A) -> B
+): Either<E, List<B>> =
+  coroutineScope {
+    val semaphore = Semaphore(concurrency)
+    map {
+      async(context) {
+        either {
+          semaphore.withPermit {
+            transform(ScopedRaise(this, this@coroutineScope), it)
+          }
+        }
+      }
+    }.awaitAll().flattenOrAccumulate(semigroup)
+  }
+
+public suspend fun <E, A, B> Iterable<A>.parMapOrAccumulate(
+  context: CoroutineContext = EmptyCoroutineContext,
+  semigroup: Semigroup<E>,
+  transform: suspend ScopedRaise<E>.(A) -> B
+): Either<E, List<B>> =
+  coroutineScope {
+    map {
+      async(context) {
+        either {
+          transform(ScopedRaise(this, this@coroutineScope), it)
+        }
+      }
+    }.awaitAll().flattenOrAccumulate(semigroup)
+  }
+
+public suspend fun <E, A, B> Iterable<A>.parMapOrAccumulate(
+  context: CoroutineContext = EmptyCoroutineContext,
+  concurrency: Int,
+  transform: suspend ScopedRaise<E>.(A) -> B
+): Either<NonEmptyList<E>, List<B>> =
+  coroutineScope {
+    val semaphore = Semaphore(concurrency)
+    map {
+      async(context) {
+        either {
+          semaphore.withPermit {
+            transform(ScopedRaise(this, this@coroutineScope), it)
+          }
+        }
+      }
+    }.awaitAll().flattenOrAccumulate()
+  }
+
+public suspend fun <E, A, B> Iterable<A>.parMapOrAccumulate(
+  context: CoroutineContext = EmptyCoroutineContext,
+  transform: suspend ScopedRaise<E>.(A) -> B
+): Either<NonEmptyList<E>, List<B>> =
+  coroutineScope {
+    map {
+      async(context) {
+        either {
+          transform(ScopedRaise(this, this@coroutineScope), it)
+        }
+      }
+    }.awaitAll().flattenOrAccumulate()
+  }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -5,35 +5,51 @@ package arrow.fx.coroutines
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(Dispatchers.Default, n) { it() }",
+    "arrow.fx.coroutines.parMap",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(n: Int): List<A> =
-  parSequenceN(Dispatchers.Default, n)
+  parMap(Dispatchers.Default, n) { it() }
 
 /**
  * Sequences all tasks in [n] parallel processes on [Dispatchers.Default] and return the result.
  *
  * Cancelling this operation cancels all running tasks
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(Dispatchers.Default, n) { it() }",
+    "arrow.fx.coroutines.parMap",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceNScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(n: Int): List<A> =
-  parSequenceN(Dispatchers.Default, n)
+  parMap(Dispatchers.Default, n) { it() }
 
-public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineContext = EmptyCoroutineContext, n: Int): List<A> {
-  val s = Semaphore(n)
-  return parTraverse(ctx) {
-    s.withPermit { it.invoke() }
-  }
-}
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(ctx, n) { it() }",
+    "arrow.fx.coroutines.parMap"
+  )
+)
+public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  n: Int
+): List<A> = parMap(ctx, n) { it() }
 
 /**
  * Sequences all tasks in [n] parallel processes and return the result.
@@ -44,16 +60,28 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineCont
  *
  * Cancelling this operation cancels all running tasks
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(ctx, n) { it() }",
+    "arrow.fx.coroutines.parMap"
+  )
+)
 @JvmName("parSequenceNScoped")
-public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(ctx: CoroutineContext = EmptyCoroutineContext, n: Int): List<A> {
-  val s = Semaphore(n)
-  return parTraverse(ctx) {
-    s.withPermit { it.invoke(this) }
-  }
-}
-
+public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequenceN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  n: Int
+): List<A> = parMap(ctx, n) { it() }
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(Dispatchers.Default) { it() }",
+    "arrow.fx.coroutines.parMap",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
-  parSequence(Dispatchers.Default)
+  parMap(Dispatchers.Default) { it() }
 
 /**
  * Sequences all tasks in parallel on [Dispatchers.Default] and return the result
@@ -79,12 +107,27 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
  * ```
  * <!--- KNIT example-partraverse-01.kt -->
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(Dispatchers.Default) { it() }",
+    "arrow.fx.coroutines.parMap",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequence(): List<A> =
-  parSequence(Dispatchers.Default)
+  parMap(Dispatchers.Default) { it() }
 
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(ctx) { it() }",
+    "arrow.fx.coroutines.parMap"
+  )
+)
 public suspend fun <A> Iterable<suspend () -> A>.parSequence(ctx: CoroutineContext = EmptyCoroutineContext): List<A> =
-  parTraverse(ctx) { it.invoke() }
+  parMap(ctx) { it() }
 
 /**
  * Sequences all tasks in parallel and return the result
@@ -115,17 +158,31 @@ public suspend fun <A> Iterable<suspend () -> A>.parSequence(ctx: CoroutineConte
  * ```
  * <!--- KNIT example-partraverse-02.kt -->
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(ctx) { it() }",
+    "arrow.fx.coroutines.parMap"
+  )
+)
 @JvmName("parSequenceScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> A>.parSequence(ctx: CoroutineContext = EmptyCoroutineContext): List<A> =
-  parTraverse(ctx) { it.invoke(this) }
+  parMap(ctx) { it() }
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
  * Cancelling this operation cancels all running tasks.
  */
-
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(Dispatchers.Default, n, f)",
+    "arrow.fx.coroutines.parMap",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverseN(n: Int, f: suspend CoroutineScope.(A) -> B): List<B> =
-  parTraverseN(Dispatchers.Default, n, f)
+  parMap(Dispatchers.Default, n, f)
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [ctx].
@@ -136,16 +193,18 @@ public suspend fun <A, B> Iterable<A>.parTraverseN(n: Int, f: suspend CoroutineS
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(ctx, n, f)",
+    "arrow.fx.coroutines.parMap"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverseN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int,
   f: suspend CoroutineScope.(A) -> B
-): List<B> {
-  val s = Semaphore(n)
-  return parTraverse(ctx) { a ->
-    s.withPermit { f(a) }
-  }
-}
+): List<B> = parMap(ctx, n, f)
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [Dispatchers.Default].
@@ -169,8 +228,16 @@ public suspend fun <A, B> Iterable<A>.parTraverseN(
  * ```
  * <!--- KNIT example-partraverse-03.kt -->
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith(
+    "parMap(Dispatchers.Default, f)",
+    "arrow.fx.coroutines.parMap",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverse(f: suspend CoroutineScope.(A) -> B): List<B> =
-  parTraverse(Dispatchers.Default, f)
+  parMap(Dispatchers.Default, f)
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [CoroutineContext].
@@ -200,9 +267,11 @@ public suspend fun <A, B> Iterable<A>.parTraverse(f: suspend CoroutineScope.(A) 
  * ```
  * <!--- KNIT example-partraverse-04.kt -->
  */
+@Deprecated(
+  "Function is being renamed to parMap in 2.x.x",
+  ReplaceWith("parMap(ctx, f)", "arrow.fx.coroutines.parMap")
+)
 public suspend fun <A, B> Iterable<A>.parTraverse(
   ctx: CoroutineContext = EmptyCoroutineContext,
   f: suspend CoroutineScope.(A) -> B
-): List<B> = coroutineScope {
-  map { async(ctx) { f.invoke(this, it) } }.awaitAll()
-}
+): List<B> = parMap(ctx, f)

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
@@ -1,16 +1,12 @@
 @file:JvmMultifileClass
 @file:JvmName("ParTraverse")
+
 package arrow.fx.coroutines
 
 import arrow.core.Either
-import arrow.core.computations.either
+import arrow.core.continuations.either
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -22,12 +18,30 @@ import kotlin.jvm.JvmName
  *
  * Cancelling this operation cancels all running tasks
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(Dispatchers.Default, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEitherN(n: Int): Either<A, List<B>> =
-  parTraverseEitherN(Dispatchers.Default, n) { it() }
+  either { parMap(Dispatchers.Default, n) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(Dispatchers.Default, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceEitherNScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEitherN(n: Int): Either<A, List<B>> =
-  parTraverseEitherN(Dispatchers.Default, n) { it() }
+  either { parMap(Dispatchers.Default, n) { it().bind() } }
 
 /**
  * Sequences all tasks in [n] parallel processes on [ctx] and return the result.
@@ -38,18 +52,34 @@ public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.pa
  *
  * Cancelling this operation cancels all running tasks
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(ctx, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either"
+  )
+)
 @JvmName("parSequenceEitherNScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEitherN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int
 ): Either<A, List<B>> =
-  parTraverseEitherN(ctx, n) { it() }
+  either { parMap(ctx, n) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(ctx, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either"
+  )
+)
 public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEitherN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int
 ): Either<A, List<B>> =
-  parTraverseEitherN(ctx, n) { it() }
+  either { parMap(ctx, n) { it().bind() } }
 
 /**
  * Sequences all tasks in parallel on [Dispatchers.Default] and return the result.
@@ -58,12 +88,30 @@ public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(Dispatchers.Default) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither(): Either<A, List<B>> =
-  parTraverseEither(Dispatchers.Default) { it() }
+  either { parMap(Dispatchers.Default) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(Dispatchers.Default) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceEitherScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEither(): Either<A, List<B>> =
-  parTraverseEither(Dispatchers.Default) { it() }
+  either { parMap(Dispatchers.Default) { it().bind() } }
 
 /**
  * Sequences all tasks in parallel on [ctx] and return the result.
@@ -98,16 +146,30 @@ public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.pa
  * ```
  * <!--- KNIT example-partraverseeither-01.kt -->
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(ctx) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either"
+  )
+)
 @JvmName("parSequenceEitherScoped")
 public suspend fun <A, B> Iterable<suspend CoroutineScope.() -> Either<A, B>>.parSequenceEither(
   ctx: CoroutineContext = EmptyCoroutineContext
-): Either<A, List<B>> =
-  parTraverseEither(ctx) { it() }
+): Either<A, List<B>> = either { parMap(ctx) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(ctx) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either"
+  )
+)
 public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither(
   ctx: CoroutineContext = EmptyCoroutineContext
-): Either<A, List<B>> =
-  parTraverseEither(ctx) { it() }
+): Either<A, List<B>> = either { parMap(ctx) { it().bind() } }
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
@@ -116,11 +178,19 @@ public suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(Dispatchers.Default, n) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B, E> Iterable<A>.parTraverseEitherN(
   n: Int,
   f: suspend CoroutineScope.(A) -> Either<E, B>
-): Either<E, List<B>> =
-  parTraverseEitherN(Dispatchers.Default, n, f)
+): Either<E, List<B>> = either { parMap(Dispatchers.Default, n) { f(it).bind() } }
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
@@ -133,16 +203,19 @@ public suspend fun <A, B, E> Iterable<A>.parTraverseEitherN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(ctx, n) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either"
+  )
+)
 public suspend fun <A, B, E> Iterable<A>.parTraverseEitherN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int,
   f: suspend CoroutineScope.(A) -> Either<E, B>
-): Either<E, List<B>> {
-  val semaphore = Semaphore(n)
-  return parTraverseEither(ctx) { a ->
-    semaphore.withPermit { f(a) }
-  }
-}
+): Either<E, List<B>> = either { parMap(ctx, n) { f(it).bind() } }
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [Dispatchers.Default].
@@ -151,10 +224,19 @@ public suspend fun <A, B, E> Iterable<A>.parTraverseEitherN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(Dispatchers.Default) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B, E> Iterable<A>.parTraverseEither(
   f: suspend CoroutineScope.(A) -> Either<E, B>
 ): Either<E, List<B>> =
-  parTraverseEither(Dispatchers.Default, f)
+  either { parMap(Dispatchers.Default) { f(it).bind() } }
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [CoroutineContext].
@@ -193,12 +275,16 @@ public suspend fun <A, B, E> Iterable<A>.parTraverseEither(
  * ```
  * <!--- KNIT example-partraverseeither-02.kt -->
  */
+@Deprecated(
+  "Prefer composing parMap with either DSL",
+  ReplaceWith(
+    "either<E, List<B>> { this.parMap(ctx) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.either"
+  )
+)
 public suspend fun <A, B, E> Iterable<A>.parTraverseEither(
   ctx: CoroutineContext = EmptyCoroutineContext,
   f: suspend CoroutineScope.(A) -> Either<E, B>
 ): Either<E, List<B>> =
-  either {
-    coroutineScope {
-      map { async(ctx) { f.invoke(this, it).bind() } }.awaitAll()
-    }
-  }
+  either { parMap(ctx) { f(it).bind() } }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseResult.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseResult.kt
@@ -3,14 +3,9 @@
 
 package arrow.fx.coroutines
 
-import arrow.core.sequence
+import arrow.core.continuations.result
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -23,12 +18,30 @@ import kotlin.jvm.JvmName
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(Dispatchers.Default, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceResultNScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> Result<A>>.parSequenceResultN(n: Int): Result<List<A>> =
-  parTraverseResultN(Dispatchers.Default, n) { it() }
+  result { parMap(Dispatchers.Default, n) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(Dispatchers.Default, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A> Iterable<suspend () -> Result<A>>.parSequenceResultN(n: Int): Result<List<A>> =
-  parTraverseResultN(Dispatchers.Default, n) { it() }
+  result { parMap(Dispatchers.Default, n) { it().bind() } }
 
 /**
  * Traverses this [Iterable] and runs `suspend CoroutineScope.() -> Result<A>` in [n] parallel operations on [CoroutineContext].
@@ -40,18 +53,34 @@ public suspend fun <A> Iterable<suspend () -> Result<A>>.parSequenceResultN(n: I
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(ctx, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result"
+  )
+)
 @JvmName("parSequenceResultNScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> Result<A>>.parSequenceResultN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int
 ): Result<List<A>> =
-  parTraverseResultN(ctx, n) { it() }
+  result { parMap(ctx, n) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(ctx, n) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result"
+  )
+)
 public suspend fun <A> Iterable<suspend () -> Result<A>>.parSequenceResultN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int
 ): Result<List<A>> =
-  parTraverseResultN(ctx, n) { it() }
+  result { parMap(ctx, n) { it().bind() } }
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
@@ -59,11 +88,20 @@ public suspend fun <A> Iterable<suspend () -> Result<A>>.parSequenceResultN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(Dispatchers.Default, n) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverseResultN(
   n: Int,
   f: suspend CoroutineScope.(A) -> Result<B>
 ): Result<List<B>> =
-  parTraverseResultN(Dispatchers.Default, n, f)
+  result { parMap(Dispatchers.Default, n) { f(it).bind() } }
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [CoroutineContext].
@@ -75,16 +113,19 @@ public suspend fun <A, B> Iterable<A>.parTraverseResultN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(ctx, n) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverseResultN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   n: Int,
   f: suspend CoroutineScope.(A) -> Result<B>
-): Result<List<B>> {
-  val semaphore = Semaphore(n)
-  return parTraverseResult(ctx) { a ->
-    semaphore.withPermit { f(a) }
-  }
-}
+): Result<List<B>> = result { parMap(ctx, n) { f(it).bind() } }
 
 /**
  * Sequences all tasks in parallel on [ctx] and returns the result.
@@ -98,14 +139,31 @@ public suspend fun <A, B> Iterable<A>.parTraverseResultN(
  *
  *
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(ctx) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result"
+  )
+)
 @JvmName("parSequenceResultScoped")
 public suspend fun <A> Iterable<suspend CoroutineScope.() -> Result<A>>.parSequenceResult(
   ctx: CoroutineContext = EmptyCoroutineContext
-): Result<List<A>> = parTraverseResult(ctx) { it() }
+): Result<List<A>> = result { parMap(ctx) { it().bind() } }
 
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(ctx) { it().bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result"
+  )
+)
 public suspend fun <A> Iterable<suspend () -> Result<A>>.parSequenceResult(
   ctx: CoroutineContext = EmptyCoroutineContext
-): Result<List<A>> = parTraverseResult(ctx) { it() }
+): Result<List<A>> =
+  result { parMap(ctx) { it().bind() } }
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [Dispatchers.Default].
@@ -113,8 +171,17 @@ public suspend fun <A> Iterable<suspend () -> Result<A>>.parSequenceResult(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(Dispatchers.Default) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverseResult(f: suspend CoroutineScope.(A) -> Result<B>): Result<List<B>> =
-  parTraverseResult(Dispatchers.Default, f)
+  result { parMap(Dispatchers.Default) { f(it).bind() } }
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [CoroutineContext].
@@ -127,10 +194,16 @@ public suspend fun <A, B> Iterable<A>.parTraverseResult(f: suspend CoroutineScop
  * Cancelling this operation cancels all running tasks.
  *
  */
+@Deprecated(
+  "Prefer composing parMap with result DSL",
+  ReplaceWith(
+    "result<List<B>> { this.parMap(ctx) { f(it).bind() } }",
+    "arrow.fx.coroutines.parMap",
+    "arrow.core.continuations.result"
+  )
+)
 public suspend fun <A, B> Iterable<A>.parTraverseResult(
   ctx: CoroutineContext = EmptyCoroutineContext,
   f: suspend CoroutineScope.(A) -> Result<B>
 ): Result<List<B>> =
-  coroutineScope {
-    map { async(ctx) { f.invoke(this, it) } }.awaitAll().sequence()
-  }
+  result { parMap(ctx) { f(it).bind() } }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
@@ -4,15 +4,9 @@
 package arrow.fx.coroutines
 
 import arrow.core.Validated
-import arrow.core.sequence
 import arrow.typeclasses.Semigroup
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -25,12 +19,34 @@ import kotlin.jvm.JvmName
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, n, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceValidatedNScoped")
-public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidatedN(semigroup: Semigroup<E>, n: Int): Validated<E, List<A>> =
-  parTraverseValidatedN(Dispatchers.Default, semigroup, n) { it() }
+public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidatedN(
+  semigroup: Semigroup<E>,
+  n: Int
+): Validated<E, List<A>> =
+  parMapOrAccumulate(Dispatchers.Default, n, semigroup) { it().bind() }.toValidated()
 
-public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidatedN(semigroup: Semigroup<E>, n: Int): Validated<E, List<A>> =
-  parTraverseValidatedN(Dispatchers.Default, semigroup, n) { it() }
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, n, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
+public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidatedN(
+  semigroup: Semigroup<E>,
+  n: Int
+): Validated<E, List<A>> =
+  parMapOrAccumulate(Dispatchers.Default, n, semigroup) { it().bind() }.toValidated()
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [CoroutineContext].
@@ -42,20 +58,34 @@ public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceVal
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(ctx, n, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate"
+  )
+)
 @JvmName("parSequenceValidatedNScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidatedN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>,
   n: Int
 ): Validated<E, List<A>> =
-  parTraverseValidatedN(ctx, semigroup, n) { it() }
+  parMapOrAccumulate(ctx, n, semigroup) { it().bind() }.toValidated()
 
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(ctx, n, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate"
+  )
+)
 public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidatedN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>,
   n: Int
 ): Validated<E, List<A>> =
-  parTraverseValidatedN(ctx, semigroup, n) { it() }
+  parMapOrAccumulate(ctx, n, semigroup) { it().bind() }.toValidated()
 
 /**
  * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
@@ -63,6 +93,14 @@ public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceVal
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, n, semigroup) { f(it).bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
   semigroup: Semigroup<E>,
   n: Int,
@@ -80,17 +118,21 @@ public suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, n, semigroup) { f(it).bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>,
   n: Int,
   f: suspend CoroutineScope.(A) -> Validated<E, B>
-): Validated<E, List<B>> {
-  val semaphore = Semaphore(n)
-  return parTraverseValidated(ctx, semigroup) { a ->
-    semaphore.withPermit { f(a) }
-  }
-}
+): Validated<E, List<B>> =
+  parMapOrAccumulate(ctx, n, semigroup) { f(it).bind() }.toValidated()
 
 /**
  * Sequences all tasks in parallel on [Dispatchers.Default] and returns the result.
@@ -98,12 +140,28 @@ public suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 @JvmName("parSequenceValidatedScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidated(semigroup: Semigroup<E>): Validated<E, List<A>> =
-  parTraverseValidated(Dispatchers.Default, semigroup) { it() }
+  parMapOrAccumulate(Dispatchers.Default, semigroup) { it().bind() }.toValidated()
 
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidated(semigroup: Semigroup<E>): Validated<E, List<A>> =
-  parTraverseValidated(Dispatchers.Default, semigroup) { it() }
+  parMapOrAccumulate(Dispatchers.Default, semigroup) { it().bind() }.toValidated()
 
 /**
  * Sequences all tasks in parallel on [ctx] and returns the result.
@@ -137,18 +195,32 @@ public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceVal
  * ```
  * <!--- KNIT example-partraversevalidated-01.kt -->
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(ctx, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate"
+  )
+)
 @JvmName("parSequenceValidatedScoped")
 public suspend fun <E, A> Iterable<suspend CoroutineScope.() -> Validated<E, A>>.parSequenceValidated(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>
 ): Validated<E, List<A>> =
-  parTraverseValidated(ctx, semigroup) { it() }
+  parMapOrAccumulate(ctx, semigroup) { it().bind() }.toValidated()
 
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(ctx, semigroup) { it().bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate"
+  )
+)
 public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidated(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>
 ): Validated<E, List<A>> =
-  parTraverseValidated(ctx, semigroup) { it() }
+  parMapOrAccumulate(ctx, semigroup) { it().bind() }.toValidated()
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [Dispatchers.Default].
@@ -156,11 +228,19 @@ public suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceVal
  *
  * Cancelling this operation cancels all running tasks.
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(Dispatchers.Default, semigroup) { f(it).bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate",
+    "kotlinx.coroutines.Dispatchers"
+  )
+)
 public suspend fun <E, A, B> Iterable<A>.parTraverseValidated(
   semigroup: Semigroup<E>,
   f: suspend CoroutineScope.(A) -> Validated<E, B>
 ): Validated<E, List<B>> =
-  parTraverseValidated(Dispatchers.Default, semigroup, f)
+  parMapOrAccumulate(Dispatchers.Default, semigroup) { f(it).bind() }.toValidated()
 
 /**
  * Traverses this [Iterable] and runs all mappers [f] on [CoroutineContext].
@@ -199,12 +279,16 @@ public suspend fun <E, A, B> Iterable<A>.parTraverseValidated(
  * ```
  * <!--- KNIT example-partraversevalidated-02.kt -->
  */
+@Deprecated(
+  "Prefer using more generic parMapOrAccumulate",
+  ReplaceWith(
+    "parMapOrAccumulate(ctx, semigroup) { f(it).bind() }.toValidated()",
+    "arrow.fx.coroutines.parMapOrAccumulate"
+  )
+)
 public suspend fun <E, A, B> Iterable<A>.parTraverseValidated(
   ctx: CoroutineContext = EmptyCoroutineContext,
   semigroup: Semigroup<E>,
   f: suspend CoroutineScope.(A) -> Validated<E, B>
 ): Validated<E, List<B>> =
-  coroutineScope {
-    map { async(ctx) { f.invoke(this, it) } }.awaitAll()
-      .sequence(semigroup)
-  }
+  parMapOrAccumulate(ctx, semigroup) { f(it).bind() }.toValidated()

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CyclicBarrierSpec.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CyclicBarrierSpec.kt
@@ -1,0 +1,84 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.constant
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+
+class CyclicBarrierSpec : StringSpec({
+  "should raise an exception when constructed with a negative or zero capacity" {
+    checkAll(Arb.int(Int.MIN_VALUE, 0)) { i ->
+      shouldThrow<IllegalArgumentException> { CyclicBarrier(i) }.message shouldBe
+        "Cyclic barrier must be constructed with positive non-zero capacity $i but was $i > 0"
+    }
+  }
+  
+  "barrier of capacity 1 is a no op" {
+    checkAll(Arb.constant(Unit)) {
+      val barrier = CyclicBarrier(1)
+      barrier.await()
+    }
+  }
+  
+  "awaiting all in parallel resumes all coroutines" {
+    checkAll(Arb.int(1, 100)) { i ->
+      val barrier = CyclicBarrier(i)
+      (0 until i).parTraverse { barrier.await() }
+    }
+  }
+  
+  "should reset once full" {
+    checkAll(Arb.constant(Unit)) {
+      val barrier = CyclicBarrier(2)
+      parZip({ barrier.await() }, { barrier.await() }) { _, _ -> }
+      barrier.capacity shouldBe 2
+    }
+  }
+  
+  "await is cancelable" {
+    checkAll(Arb.int(2, Int.MAX_VALUE)) { i ->
+      val barrier = CyclicBarrier(i)
+      val exitCase = CompletableDeferred<ExitCase>()
+      
+      val job =
+        launch(start = CoroutineStart.UNDISPATCHED) {
+          guaranteeCase({ barrier.await() }, exitCase::complete)
+        }
+      
+      job.cancelAndJoin()
+      exitCase.isCompleted shouldBe true
+      exitCase.await().shouldBeTypeOf<ExitCase.Cancelled>()
+    }
+  }
+  
+  "should clean up upon cancelation of await" {
+    checkAll(Arb.constant(Unit)) {
+      val barrier = CyclicBarrier(2)
+      launch(start = CoroutineStart.UNDISPATCHED) { barrier.await() }.cancelAndJoin()
+      
+      barrier.capacity shouldBe 2
+    }
+  }
+  
+  "race fiber cancel and barrier full" {
+    checkAll(Arb.constant(Unit)) {
+      val barrier = CyclicBarrier(2)
+      val job = launch(start = CoroutineStart.UNDISPATCHED) { barrier.await() }
+      when (raceN({ barrier.await() }, { job.cancelAndJoin() })) {
+        // without the epoch check in CyclicBarrier, a late cancellation would increment the count
+        // after the barrier has already reset, causing this code to never terminate (test times out)
+        is Either.Left -> parZip({ barrier.await() }, { barrier.await() }) { _, _ -> }
+        is Either.Right -> Unit
+      }
+    }
+  }
+})


### PR DESCRIPTION
Closes #2788, introduces one of the signatures up for discussion in #2861.

This PR deprecates 46 APIs, and proposes to replace them by 6.

- `parTraverse(N)` is proposed to be replaced by `parMap`
- `parTraverseEither(N)` is proposed to be replaced by `either` + `parMap`
- `parTraverseResult(N)` is proposed to be replaced by `result` + `parMap`
- `parTraverseValidated(N)` is proposed to be replaced by `parMapOrAccumulate` in line with newly proposed `mapOrAccumulate`.