### PR TITLE
'accumulate' for Raise

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -1,6 +1,7 @@
 package arrow.core.continuations
 
 import arrow.core.Either
+import arrow.core.NonEmptyList
 import arrow.core.identity
 import arrow.core.left
 import arrow.core.right
@@ -14,6 +15,7 @@ import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
@@ -369,6 +371,22 @@ class EffectSpec :
           }.catch { throw RuntimeException(msg2()) }
             .runCont()
         }.message.shouldNotBeNull() shouldBe msg2()
+      }
+    }
+
+    "accumulate, returns every error" {
+      checkAll(Arb.list(Arb.int(), range = 2 .. 100)) { errors ->
+        either<NonEmptyList<Int>, List<String>> {
+          accumulate(errors) { raise(it) }
+        } shouldBe NonEmptyList.fromListUnsafe(errors).left()
+      }
+    }
+
+    "accumulate, returns no error" {
+      checkAll(Arb.list(Arb.string())) { elements ->
+        either<NonEmptyList<Int>, List<String>> {
+          accumulate(elements) { it }
+        } shouldBe elements.right()
       }
     }
   })


### PR DESCRIPTION
This PR proposed a one-for-all accumulating map for `Raise`. The signature is not the greatest at this moment, because `Raise` needs to appear in receiver position, so the `list` goes as first argument.

```kotlin
public fun <R, A, B> Raise<NonEmptyList<R>>.accumulate(
  list: Iterable<A>,
  block: Raise<R>.(A) -> B
): List<B>
```

Interestingly, this function is actually generic over the way we run the `Raise`.