### PR TITLE
`Accumulate` DSL for `Raise` (open for discussion)

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -2334,6 +2334,28 @@ public final class arrow/core/computations/option {
 	public final fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class arrow/core/continuations/Accumulate {
+	public abstract fun accumulate (Lkotlin/jvm/functions/Function1;)Larrow/core/continuations/Accumulate$Value;
+}
+
+public abstract interface class arrow/core/continuations/Accumulate$Value {
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun isFailure ()Z
+	public abstract fun isSuccess ()Z
+}
+
+public final class arrow/core/continuations/Accumulate$Value$DefaultImpls {
+	public static fun isFailure (Larrow/core/continuations/Accumulate$Value;)Z
+}
+
+public abstract interface annotation class arrow/core/continuations/AccumulateDSL : java/lang/annotation/Annotation {
+}
+
+public final class arrow/core/continuations/AccumulateKt {
+	public static final fun accumulateErrors (Larrow/core/continuations/Raise;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun accumulateErrors (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public final class arrow/core/continuations/DefaultRaise : arrow/core/continuations/Raise {
 	public fun <init> ()V
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
@@ -2572,6 +2594,7 @@ public final class arrow/core/continuations/RaiseKt {
 	public static final fun mapOrAccumulate (Larrow/core/continuations/Raise;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun recover (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static final fun recover (Larrow/core/continuations/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun zip (Larrow/core/continuations/Raise;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 
 public final class arrow/core/continuations/ResultRaise : arrow/core/continuations/Raise {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Accumulate.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Accumulate.kt
@@ -1,0 +1,140 @@
+package arrow.core.continuations
+
+import arrow.core.EmptyValue
+import arrow.core.NonEmptyList
+import arrow.core.emptyCombine
+import arrow.core.identity
+import arrow.core.nel
+import arrow.typeclasses.Semigroup
+
+@DslMarker
+public annotation class AccumulateDSL
+
+/**
+ * The [Accumulate] DSL allows to carve out a scope in which
+ * errors coming from different validations are _accumulated_,
+ * instead of bailing out on the first error. Each call which
+ * may [Raise] a potential problem must be _protected_ using
+ * [accumulate].
+ *
+ * The accumulation of errors stops at the first moment in which
+ * there's a data dependency on a previous computation which
+ * returned with error. To make those dependencies explicit,
+ * the result of [accumulate] is a [Value], which you need to
+ * unwrap.
+ *
+ * ```kotlin
+ * data class Name(val first: String, val last: String)
+ *
+ * fun Raise<String>.validFirstName(s: String): String = TODO()
+ * fun Raise<String>.validLastName(s: String): String = TODO()
+ *
+ * fun Raise<NonEmptyList<String>>.validName(
+ *   first: String, last: String
+ * ): Name = accumulateErrors {
+ *   val f = accumulate { validFirstname(first) }
+ *   val l = accumulate { validLastName(last) }
+ *   Name(f.value, l.value)
+ * }
+ * ```
+ *
+ * You need to be careful to ensure that you only access `value`
+ * after all the necessary calls to [accumulate].
+ */
+public interface Accumulate<R> {
+  /**
+   * Represents a potential value of type [A]. This is used in
+   * combination with [Accumulate] to track data dependencies.
+   */
+  public interface Value<out A> {
+    public val value: A
+    public val isSuccess: Boolean
+    public val isFailure: Boolean
+      get() = !isSuccess
+  }
+  @AccumulateDSL
+  public fun <B> accumulate(action: Raise<R>.() -> B): Value<B>
+}
+
+/**
+ * Accumulates the errors in [block] as a [NonEmptyList].
+ *
+ * See the documentation for [Accumulate] for a description of the
+ * methods available inside the block.
+ */
+@EffectDSL
+public fun <R, A> Raise<NonEmptyList<R>>.accumulateErrors(
+  block: Accumulate<R>.() -> A
+): A = accumulateErrors(Semigroup.nonEmptyList(), { it.nel() }, block)
+
+/**
+ * Accumulates the errors in [block] using the given [semigroup].
+ *
+ * See the documentation for [Accumulate] for a description of the
+ * methods available inside the block.
+ */
+@EffectDSL
+public fun <R, A> Raise<R>.accumulateErrors(
+  semigroup: Semigroup<R>,
+  block: Accumulate<R>.() -> A
+): A = accumulateErrors(semigroup, ::identity, block)
+
+/**
+ * Used to track nested [accumulateErrors].
+ */
+private class AccumulatorToken()
+
+/**
+ * This exception is thrown by [Accumulate.Value] to indicate
+ * that accessing a missing value was attempted, and thus the
+ * accumulation of errors must finish.
+ */
+private class DataDependencyException(val token: AccumulatorToken): Exception()
+
+private fun <E, R, A> Raise<E>.accumulateErrors(
+  semigroup: Semigroup<E>,
+  inject: (R) -> E,
+  block: Accumulate<R>.() -> A
+): A {
+  val token = AccumulatorToken() // create a new token to distinguish nested accumulate
+  val accumulator = AccumulateImpl(semigroup, inject, token)
+  return try {
+    val result = block(accumulator)
+    when (val e = accumulator.error) {
+      is EmptyValue -> result
+      else -> raise(EmptyValue.unbox<E>(e))
+    }
+  } catch (e: DataDependencyException) {
+    if (e.token == token)
+      raise(EmptyValue.unbox<E>(accumulator.error))
+    else
+      throw e
+  }
+}
+
+private class AccumulateImpl<E, R>(
+  val semigroup: Semigroup<E>,
+  val inject: (R) -> E,
+  val token: AccumulatorToken
+): Accumulate<R> {
+  data class OkValue<out A>(override val value: A): Accumulate.Value<A> {
+    override val isSuccess: Boolean = true
+  }
+  data class NoValue(val token: AccumulatorToken): Accumulate.Value<Nothing> {
+    override val isSuccess: Boolean = false
+    override val value: Nothing
+      get() = throw DataDependencyException(token)
+  }
+
+  var error: Any? = EmptyValue
+
+  override fun <B> accumulate(action: Raise<R>.() -> B): Accumulate.Value<B> =
+    fold(
+      action,
+      { newError ->
+        error = semigroup.emptyCombine(error, inject(newError))
+        NoValue(token)
+      },
+      { OkValue(it) }
+    )
+}

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/continuations/EffectSpec.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.identity
 import arrow.core.left
+import arrow.core.nel
 import arrow.core.right
 import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
@@ -382,11 +383,32 @@ class EffectSpec :
       }
     }
 
+    "accumulate, returns one error" {
+      either<NonEmptyList<Int>, List<Int>> {
+        mapOrAccumulate((0 .. 100).toList()) {
+          ensure(it != 1) { it }
+          it
+        }
+      } shouldBe 1.nel().left()
+    }
+
     "accumulate, returns no error" {
       checkAll(Arb.list(Arb.string())) { elements ->
         either<NonEmptyList<Int>, List<String>> {
           mapOrAccumulate(elements) { it }
         } shouldBe elements.right()
+      }
+    }
+
+    "accumulate DSL" {
+      checkAll(Arb.int(), Arb.int()) { x, y ->
+        either<NonEmptyList<Int>, Int> {
+          accumulateErrors {
+            val a = accumulate<Int> { raise(x) }
+            val b = accumulate { y }
+            a.value + b.value
+          }
+        } shouldBe x.nel().left()
       }
     }
   })


### PR DESCRIPTION
This creates a "sub-DSL" within `Raise` to express scopes in which errors should be accumulated, instead of the regular fail-first approach. The idea is that inside `accumulateErrors` you "protect" each potentially-failing computation with `accumulate`.

```kotlin
data class Name(val first: String, val last: String)

fun Raise<String>.validFirstName(s: String): String = TODO()
fun Raise<String>.validLastName(s: String): String = TODO()

fun Raise<NonEmptyList<String>>.validName(
  first: String, last: String
): Name = accumulateErrors {
  val f = accumulate { validFirstname(first) }
  val l = accumulate { validLastName(last) }
  Name(f.value, l.value)
}
```

The problem here is potential data dependencies. To fight these, the result of `accumulate` is not directly `A`, but `Accumulate.Value<A>`, a "box" which remembers whether the computation it comes from failed or not. If at some point we try to unwrap a failed computation, that means we cannot proceed further with accumulation, and we just return whatever errors we had found.

As a comparison with other FP abstractions, `Accumulate` implements [selective functors](https://eprints.ncl.ac.uk/file_store/production/258640/4FF2555F-0AEC-4876-9701-C83A3E5FFF52.pdf), because it's allowed to choose how to continue based on _whether a computation failed or not_, but not based on the _data_ you obtained (that requires monads).