### PR TITLE
Fix knitCheck & re-add check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -87,7 +87,7 @@ jobs:
           name: 'reports-windows'
           path: '**/build/reports/**'
 
-  jvm:
+  check:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -115,7 +115,7 @@ jobs:
       - name: check
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check
+          arguments: check -x linuxX64Test -x jsTest
 
       - name: Create code coverage report
         if: "! github.event.pull_request.head.repo.fork "
@@ -137,7 +137,34 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: 'reports'
+          name: 'reports-jvm'
+          path: '**/build/reports/**'
+
+  js:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: jsTest
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jsTest
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'reports-js'
           path: '**/build/reports/**'
 
   linux:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -112,10 +112,10 @@ jobs:
         with:
           arguments: compileTestKotlin
 
-      - name: jvmTest
+      - name: check
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jvmTest
+          arguments: check
 
       - name: Create code coverage report
         if: "! github.event.pull_request.head.repo.fork "
@@ -137,34 +137,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: 'reports-jvm'
-          path: '**/build/reports/**'
-
-  js:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 11
-
-      - name: jsTest
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jsTest --info
-
-      - name: Upload reports
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: 'reports-js'
+          name: 'reports'
           path: '**/build/reports/**'
 
   linux:

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/continuations/Effect.kt
@@ -26,19 +26,19 @@ import kotlin.coroutines.resumeWithException
  *
  * <!--- TOC -->
 
- * [Writing a program with Effect<R, A>](#writing-a-program-with-effect<r-a>)
- * [Handling errors](#handling-errors)
- * [Structured Concurrency](#structured-concurrency)
- * [Arrow Fx Coroutines](#arrow-fx-coroutines)
- * [parZip](#parzip)
- * [parTraverse](#partraverse)
- * [raceN](#racen)
- * [bracketCase / Resource](#bracketcase--resource)
- * [KotlinX](#kotlinx)
- * [withContext](#withcontext)
- * [async](#async)
- * [launch](#launch)
- * [Leaking `shift`](#leaking-shift)
+      * [Writing a program with Effect<R, A>](#writing-a-program-with-effect<r-a>)
+      * [Handling errors](#handling-errors)
+      * [Structured Concurrency](#structured-concurrency)
+        * [Arrow Fx Coroutines](#arrow-fx-coroutines)
+          * [parZip](#parzip)
+          * [parTraverse](#partraverse)
+          * [raceN](#racen)
+          * [bracketCase / Resource](#bracketcase--resource)
+        * [KotlinX](#kotlinx)
+          * [withContext](#withcontext)
+          * [async](#async)
+          * [launch](#launch)
+          * [Leaking `shift`](#leaking-shift)
 
  * <!--- END -->
  *


### PR DESCRIPTION
@serras in [2874](https://github.com/arrow-kt/arrow/pull/2874/files#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4c) you removed `check` and split into `jvmTest` and `jsTest`.

Was this because you were experiencing flakiness on CI again? This has resulted in a couple of false negatives on main since only `check` guarantees that all tasks to verify the project are ran.