### PR TITLE
Use Duration in Schedule

### DIFF
--- a/arrow-libs/fx/arrow-fx-resilience/api/arrow-fx-resilience.api
+++ b/arrow-libs/fx/arrow-fx-resilience/api/arrow-fx-resilience.api
@@ -174,6 +174,7 @@ public final class arrow/fx/resilience/Schedule$Decision$Companion {
 }
 
 public final class arrow/fx/resilience/ScheduleKt {
+	public static final field NanosDeprecation Ljava/lang/String;
 	public static final fun retry (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retryOrElse (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retryOrElseEither (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/arrow-libs/fx/arrow-fx-resilience/api/arrow-fx-resilience.api
+++ b/arrow-libs/fx/arrow-fx-resilience/api/arrow-fx-resilience.api
@@ -68,8 +68,8 @@ public abstract class arrow/fx/resilience/Schedule {
 	public abstract fun check (Lkotlin/jvm/functions/Function3;)Larrow/fx/resilience/Schedule;
 	public abstract fun choose (Larrow/fx/resilience/Schedule;)Larrow/fx/resilience/Schedule;
 	public final fun collect ()Larrow/fx/resilience/Schedule;
-	public final fun combine (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
-	public abstract fun combineNanos (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
+	public abstract fun combine (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
+	public final fun combineNanos (Larrow/fx/resilience/Schedule;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
 	public final fun compose (Larrow/fx/resilience/Schedule;)Larrow/fx/resilience/Schedule;
 	public final fun const (Ljava/lang/Object;)Larrow/fx/resilience/Schedule;
 	public abstract fun contramap (Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
@@ -86,8 +86,8 @@ public abstract class arrow/fx/resilience/Schedule {
 	public abstract fun logInput (Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
 	public abstract fun logOutput (Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule;
 	public abstract fun map (Lkotlin/jvm/functions/Function1;)Larrow/fx/resilience/Schedule;
-	public final fun modify (Lkotlin/jvm/functions/Function3;)Larrow/fx/resilience/Schedule;
-	public abstract fun modifyNanos (Lkotlin/jvm/functions/Function3;)Larrow/fx/resilience/Schedule;
+	public abstract fun modify (Lkotlin/jvm/functions/Function3;)Larrow/fx/resilience/Schedule;
+	public final fun modifyNanos (Lkotlin/jvm/functions/Function3;)Larrow/fx/resilience/Schedule;
 	public abstract fun not ()Larrow/fx/resilience/Schedule;
 	public final fun or (Larrow/fx/resilience/Schedule;)Larrow/fx/resilience/Schedule;
 	public abstract fun pipe (Larrow/fx/resilience/Schedule;)Larrow/fx/resilience/Schedule;
@@ -143,15 +143,16 @@ public final class arrow/fx/resilience/Schedule$Companion {
 public final class arrow/fx/resilience/Schedule$Decision {
 	public static final field Companion Larrow/fx/resilience/Schedule$Decision$Companion;
 	public fun <init> (ZDLjava/lang/Object;Larrow/core/Eval;)V
+	public synthetic fun <init> (ZJLjava/lang/Object;Larrow/core/Eval;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun bimap (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/fx/resilience/Schedule$Decision;
 	public final fun combine (Larrow/fx/resilience/Schedule$Decision;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule$Decision;
 	public final fun combineNanos (Larrow/fx/resilience/Schedule$Decision;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Larrow/fx/resilience/Schedule$Decision;
 	public final fun component1 ()Z
-	public final fun component2 ()D
+	public final fun component2-UwyO8pc ()J
 	public final fun component3 ()Ljava/lang/Object;
 	public final fun component4 ()Larrow/core/Eval;
-	public final fun copy (ZDLjava/lang/Object;Larrow/core/Eval;)Larrow/fx/resilience/Schedule$Decision;
-	public static synthetic fun copy$default (Larrow/fx/resilience/Schedule$Decision;ZDLjava/lang/Object;Larrow/core/Eval;ILjava/lang/Object;)Larrow/fx/resilience/Schedule$Decision;
+	public final fun copy-dWUq8MI (ZJLjava/lang/Object;Larrow/core/Eval;)Larrow/fx/resilience/Schedule$Decision;
+	public static synthetic fun copy-dWUq8MI$default (Larrow/fx/resilience/Schedule$Decision;ZJLjava/lang/Object;Larrow/core/Eval;ILjava/lang/Object;)Larrow/fx/resilience/Schedule$Decision;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCont ()Z
 	public final fun getDelayInNanos ()D

--- a/arrow-libs/fx/arrow-fx-resilience/src/commonMain/kotlin/arrow/fx/resilience/Schedule.kt
+++ b/arrow-libs/fx/arrow-fx-resilience/src/commonMain/kotlin/arrow/fx/resilience/Schedule.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlin.coroutines.coroutineContext
 import kotlin.jvm.JvmName
-import kotlin.math.max
-import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.random.Random
@@ -23,6 +21,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retry
+import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.DurationUnit.NANOSECONDS
 
@@ -268,24 +267,24 @@ public sealed class Schedule<Input, Output> {
   /**
    * Combines with another schedule by combining the result and the delay of the [Decision] with the [zipContinue], [zipDuration] and a [zip] functions
    */
-  @ExperimentalTime
-  public fun <A : Input, B, C> combine(
+  public abstract fun <A : Input, B, C> combine(
     other: Schedule<A, B>,
     zipContinue: (cont: Boolean, otherCont: Boolean) -> Boolean,
     zipDuration: (duration: Duration, otherDuration: Duration) -> Duration,
     zip: (Output, B) -> C
-  ): Schedule<A, C> =
-    combineNanos(other, zipContinue, { a, b -> zipDuration(a.nanoseconds, b.nanoseconds).toDouble(NANOSECONDS) }, zip)
+  ): Schedule<A, C>
 
   /**
    * Combines with another schedule by combining the result and the delay of the [Decision] with the functions [zipContinue], [zipDuration] and a [zip] function
    */
-  public abstract fun <A : Input, B, C> combineNanos(
+  @ExperimentalTime
+  public fun <A : Input, B, C> combineNanos(
     other: Schedule<A, B>,
     zipContinue: (cont: Boolean, otherCont: Boolean) -> Boolean,
     zipDuration: (duration: Double, otherDuration: Double) -> Double,
     zip: (Output, B) -> C
-  ): Schedule<A, C>
+  ): Schedule<A, C> =
+    combine(other, zipContinue, { a, b -> zipDuration(a.toDouble(NANOSECONDS), b.toDouble(NANOSECONDS)).nanoseconds }, zip)
 
   /**
    * Always retries a schedule regardless of the decision made prior to invoking this method.
@@ -301,11 +300,11 @@ public sealed class Schedule<Input, Output> {
    * Changes the delay of a resulting [Decision] based on the [Output] and the produced delay.
    *
    */
-  @ExperimentalTime
-  public fun modify(f: suspend (Output, Duration) -> Duration): Schedule<Input, Output> =
-    modifyNanos { output, d -> f(output, d.nanoseconds).toDouble(NANOSECONDS) }
+  public abstract fun modify(f: suspend (Output, Duration) -> Duration): Schedule<Input, Output>
 
-  public abstract fun modifyNanos(f: suspend (Output, Double) -> Double): Schedule<Input, Output>
+  @ExperimentalTime
+  public fun modifyNanos(f: suspend (Output, Double) -> Double): Schedule<Input, Output> =
+    modify { output, d -> f(output, d.toDouble(NANOSECONDS)).nanoseconds }
 
   /**
    * Runs an effectful handler on every input. Does not alter the decision.
@@ -388,13 +387,13 @@ public sealed class Schedule<Input, Output> {
    * Combines two schedules. Continues only when both continue and chooses the maximum delay.
    */
   public infix fun <A : Input, B> and(other: Schedule<A, B>): Schedule<A, Pair<Output, B>> =
-    combineNanos(other, { a, b -> a && b }, { a, b -> max(a, b) }, ::Pair)
+    combine(other, { a, b -> a && b }, { a, b -> a max b }, ::Pair)
 
   /**
    * Combines two schedules. Continues if one continues and chooses the minimum delay.
    */
   public infix fun <A : Input, B> or(other: Schedule<A, B>): Schedule<A, Pair<Output, B>> =
-    combineNanos(other, { a, b -> a || b }, { a, b -> min(a, b) }, ::Pair)
+    combine(other, { a, b -> a || b }, { a, b -> a min b }, ::Pair)
 
   /**
    * Combines two schedules with [and] but throws away the left schedule's result.
@@ -408,13 +407,14 @@ public sealed class Schedule<Input, Output> {
   public infix fun <A : Input, B> zipLeft(other: Schedule<A, B>): Schedule<A, Output> =
     (this and other).map(Pair<Output, B>::first)
 
-  @ExperimentalTime
   public fun delay(f: suspend (duration: Duration) -> Duration): Schedule<Input, Output> =
     modify { _, duration -> f(duration) }
 
+  @ExperimentalTime
   public fun delayedNanos(f: suspend (duration: Double) -> Double): Schedule<Input, Output> =
     modifyNanos { _, duration -> f(duration) }
 
+  @ExperimentalTime
   public fun jittered(genRand: suspend () -> Double): Schedule<Input, Output> =
     modifyNanos { _, duration ->
       val n = genRand.invoke()
@@ -422,7 +422,6 @@ public sealed class Schedule<Input, Output> {
     }
 
   @JvmName("jitteredDuration")
-  @ExperimentalTime
   public fun jittered(genRand: suspend () -> Duration): Schedule<Input, Output> =
     modify { _, duration ->
       val n = genRand.invoke()
@@ -435,6 +434,7 @@ public sealed class Schedule<Input, Output> {
    * By requiring Kotlin's [Random] as a parameter, this function is deterministic and testable.
    * The result returned by [Random.nextDouble] between 0.0 and 1.0 is multiplied with the current duration.
    */
+  @ExperimentalTime
   public fun jittered(random: Random = Random.Default): Schedule<Input, Output> =
     jittered(suspend { random.nextDouble(0.0, 1.0) })
 
@@ -474,7 +474,7 @@ public sealed class Schedule<Input, Output> {
           val step = update(a, state)
           if (!step.cont) return Either.Right(step.finish.value())
           else {
-            delay((step.delayInNanos / 1_000_000).toLong())
+            delay(step.duration)
 
             // Set state before looping again
             last = { step.finish.value() }
@@ -504,7 +504,7 @@ public sealed class Schedule<Input, Output> {
               emit(Either.Right(step.finish.value()))
               loop = false
             } else {
-              delay((step.delayInNanos / 1_000_000).toLong())
+              delay(step.duration)
               val output = step.finish.value()
               // Set state before looping again and emit Output
               emit(Either.Right(output))
@@ -533,14 +533,14 @@ public sealed class Schedule<Input, Output> {
         }
       }
 
-    override fun <A : Input, B, C> combineNanos(
+    override fun <A : Input, B, C> combine(
       other: Schedule<A, B>,
       zipContinue: (cont: Boolean, otherCont: Boolean) -> Boolean,
-      zipDuration: (duration: Double, otherDuration: Double) -> Double,
+      zipDuration: (duration: Duration, otherDuration: Duration) -> Duration,
       zip: (Output, B) -> C
     ): Schedule<A, C> = (other as ScheduleImpl<Any?, A, B>).let { o ->
       ScheduleImpl(suspend { Pair(initialState.invoke(), o.initialState.invoke()) }) { i, s: Pair<State, Any?> ->
-        update(i, s.first).combineNanos(o.update(i, s.second), zipContinue, zipDuration, zip)
+        update(i, s.first).combine(o.update(i, s.second), zipContinue, zipDuration, zip)
       }
     }
 
@@ -581,12 +581,12 @@ public sealed class Schedule<Input, Output> {
         )
       }
 
-    override fun modifyNanos(f: suspend (output: Output, duration: Double) -> Double): Schedule<Input, Output> =
+    override fun modify(f: suspend (output: Output, duration: Duration) -> Duration): Schedule<Input, Output> =
       updated { update ->
         { a: Input, s: State ->
           val step = update(a, s)
-          val d = f(step.finish.value(), step.delayInNanos)
-          step.copy(delayInNanos = d)
+          val d = f(step.finish.value(), step.duration)
+          step.copy(duration = d)
         }
       }
 
@@ -617,7 +617,7 @@ public sealed class Schedule<Input, Output> {
         ScheduleImpl(suspend { Pair(initialState.invoke(), other.initialState.invoke()) }) { i, s ->
           val dec1 = update(i, s.first)
           val dec2 = other.update(dec1.finish.value(), s.second)
-          dec1.combineNanos(dec2, { a, b -> a && b }, { a, b -> a + b }, { _, b -> b })
+          dec1.combine(dec2, { a, b -> a && b }, { a, b -> a + b }, { _, b -> b })
         }
       }
 
@@ -627,7 +627,7 @@ public sealed class Schedule<Input, Output> {
         ScheduleImpl(suspend { Pair(initialState.invoke(), other.initialState.invoke()) }) { i, s ->
           val dec1 = update(i.first, s.first)
           val dec2 = other.update(i.second, s.second)
-          dec1.combineNanos(dec2, { a, b -> a && b }, { a, b -> max(a, b) }, f)
+          dec1.combine(dec2, { a, b -> a && b }, { a, b -> a max b }, f)
         }
       }
 
@@ -683,20 +683,27 @@ public sealed class Schedule<Input, Output> {
    */
   public data class Decision<out A, out B>(
     val cont: Boolean,
-    val delayInNanos: Double,
+    val duration: Duration,
     val state: A,
     val finish: Eval<B>
   ) {
 
+    public constructor(
+      cont: Boolean,
+      delayInNanos: Double,
+      state: A,
+      finish: Eval<B>
+    ) : this(cont, delayInNanos.nanoseconds, state, finish)
+
     @ExperimentalTime
-    val duration: Duration
-      get() = delayInNanos.nanoseconds
+    val delayInNanos: Double
+      get() = duration.toDouble(NANOSECONDS)
 
     public operator fun not(): Decision<A, B> =
       copy(cont = !cont)
 
     public fun <C, D> bimap(f: (A) -> C, g: (B) -> D): Decision<C, D> =
-      Decision(cont, delayInNanos, f(state), finish.map(g))
+      Decision(cont, duration, f(state), finish.map(g))
 
     public fun <C> mapLeft(f: (A) -> C): Decision<C, B> =
       bimap(f, ::identity)
@@ -704,19 +711,15 @@ public sealed class Schedule<Input, Output> {
     public fun <D> map(g: (B) -> D): Decision<A, D> =
       bimap(::identity, g)
 
+    @ExperimentalTime
     public fun <C, D, E> combineNanos(
       other: Decision<C, D>,
       f: (Boolean, Boolean) -> Boolean,
       g: (Double, Double) -> Double,
       zip: (B, D) -> E
-    ): Decision<Pair<A, C>, E> = Decision(
-      f(cont, other.cont),
-      g(delayInNanos, other.delayInNanos),
-      Pair(state, other.state),
-      finish.flatMap { first -> other.finish.map { second -> zip(first, second) } }
-    )
+    ): Decision<Pair<A, C>, E> =
+      combine(other, f, { x, y -> g(x.toDouble(NANOSECONDS), y.toDouble(NANOSECONDS)).nanoseconds }, zip)
 
-    @ExperimentalTime
     public fun <C, D, E> combine(
       other: Decision<C, D>,
       f: (Boolean, Boolean) -> Boolean,
@@ -724,7 +727,7 @@ public sealed class Schedule<Input, Output> {
       zip: (B, D) -> E
     ): Decision<Pair<A, C>, E> = Decision(
       f(cont, other.cont),
-      g(delayInNanos.nanoseconds, other.delayInNanos.nanoseconds).toDouble(NANOSECONDS),
+      g(duration, other.duration),
       Pair(state, other.state),
       finish.flatMap { first -> other.finish.map { second -> zip(first, second) } }
     )
@@ -733,31 +736,31 @@ public sealed class Schedule<Input, Output> {
       if (other !is Decision<*, *>) false
       else cont == other.cont &&
         state == other.state &&
-        delayInNanos == other.delayInNanos &&
+        duration == other.duration &&
         finish.value() == other.finish.value()
 
     override fun hashCode(): Int {
       var result = cont.hashCode()
-      result = 31 * result + delayInNanos.hashCode()
+      result = 31 * result + duration.hashCode()
       result = 31 * result + (state?.hashCode() ?: 0)
       result = 31 * result + finish.hashCode()
       return result
     }
 
     public companion object {
+      @ExperimentalTime
       public fun <A, B> cont(d: Double, a: A, b: Eval<B>): Decision<A, B> =
+        cont(d.nanoseconds, a, b)
+
+      @ExperimentalTime
+      public fun <A, B> done(d: Double, a: A, b: Eval<B>): Decision<A, B> =
+        done(d.nanoseconds, a, b)
+
+      public fun <A, B> cont(d: Duration, a: A, b: Eval<B>): Decision<A, B> =
         Decision(true, d, a, b)
 
-      public fun <A, B> done(d: Double, a: A, b: Eval<B>): Decision<A, B> =
-        Decision(false, d, a, b)
-
-      @ExperimentalTime
-      public fun <A, B> cont(d: Duration, a: A, b: Eval<B>): Decision<A, B> =
-        cont(d.toDouble(NANOSECONDS), a, b)
-
-      @ExperimentalTime
       public fun <A, B> done(d: Duration, a: A, b: Eval<B>): Decision<A, B> =
-        done(d.toDouble(NANOSECONDS), a, b)
+        Decision(false, d, a, b)
     }
   }
 
@@ -777,7 +780,7 @@ public sealed class Schedule<Input, Output> {
      */
     public fun <A> identity(): Schedule<A, A> =
       Schedule({ }) { a, s ->
-        Decision.cont(0.0, s, Eval.now(a))
+        Decision.cont(ZERO, s, Eval.now(a))
       }
 
     /**
@@ -794,7 +797,7 @@ public sealed class Schedule<Input, Output> {
     public fun <I, A> unfoldLazy(c: suspend () -> A, f: suspend (A) -> A): Schedule<I, A> =
       Schedule(c) { _: I, acc ->
         val a = f(acc)
-        Decision.cont(0.0, a, Eval.now(a))
+        Decision.cont(ZERO, a, Eval.now(a))
       }
 
     /**
@@ -814,8 +817,8 @@ public sealed class Schedule<Input, Output> {
      */
     public fun <A> recurs(n: Int): Schedule<A, Int> =
       Schedule(suspend { 0 }) { _: A, acc ->
-        if (acc < n) Decision.cont(0.0, acc + 1, Eval.now(acc + 1))
-        else Decision.done(0.0, acc, Eval.now(acc))
+        if (acc < n) Decision.cont(ZERO, acc + 1, Eval.now(acc + 1))
+        else Decision.done(ZERO, acc, Eval.now(acc))
       }
 
     /**
@@ -831,7 +834,7 @@ public sealed class Schedule<Input, Output> {
      */
     public fun <A> never(): Schedule<A, Nothing> =
       Schedule<Unit, A, Nothing>(suspend { awaitCancellation() }) { _, _ ->
-        Decision(false, 0.0, Unit, Eval.later { throw IllegalArgumentException("Impossible") })
+        Decision(false, ZERO, Unit, Eval.later { throw IllegalArgumentException("Impossible") })
       }
 
     /**
@@ -846,6 +849,7 @@ public sealed class Schedule<Input, Output> {
      */
     @Suppress("UNCHECKED_CAST")
     @JvmName("delayedNanos")
+    @ExperimentalTime
     public fun <A> delayed(delaySchedule: Schedule<A, Double>): Schedule<A, Double> =
       (delaySchedule.modifyNanos { a, b -> a + b } as ScheduleImpl<Any?, A, Double>)
         .reconsider { _, dec -> dec.copy(finish = Eval.now(dec.delayInNanos)) }
@@ -858,12 +862,11 @@ public sealed class Schedule<Input, Output> {
      * A common use case is to define a unfolding schedule and use the result to change the delay.
      *  For an example see the implementation of [spaced], [linear], [fibonacci] or [exponential]
      */
-    @ExperimentalTime
     @Suppress("UNCHECKED_CAST")
     @JvmName("delayedDuration")
     public fun <A> delayed(delaySchedule: Schedule<A, Duration>): Schedule<A, Duration> =
       (delaySchedule.modify { a, b -> a + b } as ScheduleImpl<Any?, A, Duration>)
-        .reconsider { _, dec -> dec.copy(finish = Eval.now(dec.delayInNanos.nanoseconds)) }
+        .reconsider { _, dec -> dec.copy(finish = Eval.now(dec.duration)) }
 
     /**
      * Creates a Schedule which collects all its inputs in a list.
@@ -896,25 +899,25 @@ public sealed class Schedule<Input, Output> {
       identity<A>().logOutput(f)
 
     @Suppress("UNCHECKED_CAST")
+    @ExperimentalTime
     public fun <A> delayInNanos(): Schedule<A, Double> =
       (forever<A>() as ScheduleImpl<Int, A, Int>).reconsider { _: A, decision ->
         Decision(
           cont = decision.cont,
-          delayInNanos = decision.delayInNanos,
+          duration = decision.duration,
           state = decision.state,
           finish = Eval.now(decision.delayInNanos)
         )
       }
 
-    @ExperimentalTime
     @Suppress("UNCHECKED_CAST")
     public fun <A> duration(): Schedule<A, Duration> =
       (forever<A>() as ScheduleImpl<Int, A, Int>).reconsider { _: A, decision ->
         Decision(
           cont = decision.cont,
-          delayInNanos = decision.delayInNanos,
+          duration = decision.duration,
           state = decision.state,
-          finish = Eval.now(decision.delayInNanos.nanoseconds)
+          finish = Eval.now(decision.duration)
         )
       }
 
@@ -922,11 +925,12 @@ public sealed class Schedule<Input, Output> {
      * Creates a Schedule that returns its decisions.
      */
     @Suppress("UNCHECKED_CAST")
+    @ExperimentalTime
     public fun <A> decision(): Schedule<A, Boolean> =
       (forever<A>() as ScheduleImpl<Int, A, Int>).reconsider { _: A, decision ->
         Decision(
           cont = decision.cont,
-          delayInNanos = decision.delayInNanos,
+          duration = decision.duration,
           state = decision.state,
           finish = Eval.now(decision.cont)
         )
@@ -937,6 +941,7 @@ public sealed class Schedule<Input, Output> {
      *
      * @param interval fixed delay in nanoseconds
      */
+    @ExperimentalTime
     public fun <A> spaced(interval: Double): Schedule<A, Int> =
       forever<A>().delayedNanos { d -> d + interval }
 
@@ -945,15 +950,15 @@ public sealed class Schedule<Input, Output> {
      *
      * @param interval fixed delay in [Duration]
      */
-    @ExperimentalTime
     public fun <A> spaced(interval: Duration): Schedule<A, Int> =
-      forever<A>().delayedNanos { d -> d + interval.toDouble(NANOSECONDS) }
+      forever<A>().delay { d -> d + interval }
 
     /**
      * Creates a Schedule that continues with increasing delay by adding the last two delays.
      *
      * @param one initial delay in nanoseconds
      */
+    @ExperimentalTime
     public fun <A> fibonacci(one: Double): Schedule<A, Double> =
       delayed(
         unfold<A, Pair<Double, Double>>(Pair(0.0, one)) { (del, acc) ->
@@ -964,10 +969,9 @@ public sealed class Schedule<Input, Output> {
     /**
      * Creates a Schedule that continues with increasing delay by adding the last two delays.
      */
-    @ExperimentalTime
     public fun <A> fibonacci(one: Duration): Schedule<A, Duration> =
       delayed(
-        unfold<A, Pair<Duration, Duration>>(Pair(0.nanoseconds, one)) { (del, acc) ->
+        unfold<A, Pair<Duration, Duration>>(Pair(ZERO, one)) { (del, acc) ->
           Pair(acc, del + acc)
         }.map { it.first }
       )
@@ -977,13 +981,13 @@ public sealed class Schedule<Input, Output> {
      *
      * @param base the base delay in nanoseconds
      */
+    @ExperimentalTime
     public fun <A> linear(base: Double): Schedule<A, Double> =
       delayed(forever<A>().map { base * it })
 
     /**
      * Creates a Schedule which increases its delay linearly, by n * base where n is the number of executions.
      */
-    @ExperimentalTime
     public fun <A> linear(base: Duration): Schedule<A, Duration> =
       delayed(forever<A>().map { base * it })
 
@@ -993,6 +997,7 @@ public sealed class Schedule<Input, Output> {
      *
      * @param base the base delay in nanoseconds
      */
+    @ExperimentalTime
     public fun <A> exponential(base: Double, factor: Double = 2.0): Schedule<A, Double> =
       delayed(forever<A>().map { base * factor.pow(it).roundToInt() })
 
@@ -1000,7 +1005,6 @@ public sealed class Schedule<Input, Output> {
      * Creates a Schedule that increases its delay exponentially with a given factor and base.
      * Delays can be calculated as [base] * factor ^ n where n is the number of executions.
      */
-    @ExperimentalTime
     public fun <A> exponential(base: Duration, factor: Double = 2.0): Schedule<A, Duration> =
       delayed(forever<A>().map { base * factor.pow(it).roundToInt() })
   }
@@ -1028,6 +1032,7 @@ public suspend fun <A, B> Schedule<Throwable, B>.retryOrElse(
  * Also offers a function to handle errors if they are encountered during retrial.
  */
 @Suppress("UNCHECKED_CAST")
+
 public suspend fun <A, B, C> Schedule<Throwable, B>.retryOrElseEither(
   fa: suspend () -> A,
   orElse: suspend (Throwable, B) -> C
@@ -1045,8 +1050,14 @@ public suspend fun <A, B, C> Schedule<Throwable, B>.retryOrElseEither(
       dec = update(e, state)
       state = dec.state
 
-      if (dec.cont) delay((dec.delayInNanos / 1_000_000).toLong())
+      if (dec.cont) delay(dec.duration)
       else return Either.Left(orElse(e.nonFatalOrThrow(), dec.finish.value()))
     }
   }
 }
+
+private infix fun Duration.max(other: Duration): Duration =
+  if (this >= other) this else other
+
+private infix fun Duration.min(other: Duration): Duration =
+  if (this <= other) this else other

--- a/arrow-libs/fx/arrow-fx-resilience/src/commonMain/kotlin/arrow/fx/resilience/flow.kt
+++ b/arrow-libs/fx/arrow-fx-resilience/src/commonMain/kotlin/arrow/fx/resilience/flow.kt
@@ -44,7 +44,7 @@ public fun <A, B> Flow<A>.retry(schedule: Schedule<Throwable, B>): Flow<A> = flo
     state = dec.state
 
     if (dec.cont) {
-      delay((dec.delayInNanos / 1_000_000).toLong())
+      delay(dec.duration)
       true
     } else {
       false

--- a/arrow-libs/fx/arrow-fx-resilience/src/commonTest/kotlin/arrow/fx/resilience/ScheduleTest.kt
+++ b/arrow-libs/fx/arrow-fx-resilience/src/commonTest/kotlin/arrow/fx/resilience/ScheduleTest.kt
@@ -151,36 +151,33 @@ class ScheduleTest : StringSpec({
       sec * 1_000_000_000.0
 
     "Schedule.fibonacci()" {
-      val i = secondsToNanos(10)
       val n = 10
-      val res = Schedule.fibonacci<Any?>(i).calculateSchedule(0, n)
+      val res = Schedule.fibonacci<Any?>(10.seconds).calculateSchedule(0, n)
 
       val sum = res.fold(ZERO) { acc, v -> acc + v.duration }
-      val fib = fibs(i).drop(1).take(n)
+      val fib = fibs(secondsToNanos(10)).drop(1).take(n)
 
       res.all { it.cont } shouldBe true
       sum.toDouble(DurationUnit.NANOSECONDS) shouldBe fib.sum()
     }
 
     "Schedule.linear()" {
-      val i = secondsToNanos(10)
       val n = 10
-      val res = Schedule.linear<Any?>(i).calculateSchedule(0, n)
+      val res = Schedule.linear<Any?>(10.seconds).calculateSchedule(0, n)
 
       val sum = res.fold(ZERO) { acc, v -> acc + v.duration }
-      val exp = linear(i).drop(1).take(n)
+      val exp = linear(secondsToNanos(10)).drop(1).take(n)
 
       res.all { it.cont } shouldBe true
       sum.toDouble(DurationUnit.NANOSECONDS) shouldBe exp.sum()
     }
 
     "Schedule.exponential()" {
-      val i = secondsToNanos(10)
       val n = 10
-      val res = Schedule.exponential<Any?>(i).calculateSchedule(0, n)
+      val res = Schedule.exponential<Any?>(10.seconds).calculateSchedule(0, n)
 
       val sum = res.fold(ZERO) { acc, v -> acc + v.duration }
-      val expSum = exp(i).drop(1).take(n).sum()
+      val expSum = exp(secondsToNanos(10)).drop(1).take(n).sum()
 
       res.all { it.cont } shouldBe true
       sum.toDouble(DurationUnit.NANOSECONDS) shouldBe expSum


### PR DESCRIPTION
Fixes #2744 

I've only made the changes in the `arrow-fx-resilience` module, but they could be copied to `arrow-fx-coroutines` if desired.