### PR TITLE
Fix semantics of `untilOutput` and `untilInput`

### DIFF
--- a/arrow-libs/fx/arrow-fx-resilience/src/commonMain/kotlin/arrow/fx/resilience/Schedule.kt
+++ b/arrow-libs/fx/arrow-fx-resilience/src/commonMain/kotlin/arrow/fx/resilience/Schedule.kt
@@ -370,16 +370,16 @@ public sealed class Schedule<Input, Output> {
     check { input, _ -> f(input) }
 
   /**
-   * `untilOutput(f) = whileOutput(f).not()`
+   * `untilOutput(f) = whileOutput { !f(it) }`
    */
   public fun untilOutput(f: suspend (Output) -> Boolean): Schedule<Input, Output> =
-    !whileOutput(f)
+    whileOutput { !f(it) }
 
   /**
-   * `untilInput(f) = whileInput(f).not()`
+   * `untilInput(f) = whileInput { !f(it) }`
    */
   public fun <A : Input> untilInput(f: suspend (A) -> Boolean): Schedule<A, Output> =
-    !whileInput(f)
+    whileInput { !f(it) }
 
   public fun <B, C> dimap(f: suspend (B) -> Input, g: (Output) -> C): Schedule<B, C> =
     contramap(f).map(g)

--- a/arrow-libs/fx/arrow-fx-resilience/src/commonTest/kotlin/arrow/fx/resilience/ScheduleTest.kt
+++ b/arrow-libs/fx/arrow-fx-resilience/src/commonTest/kotlin/arrow/fx/resilience/ScheduleTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.zip
+import kotlinx.coroutines.withTimeout
 
 internal data class SideEffect(var counter: Int = 0) {
   fun increment() {
@@ -280,6 +281,22 @@ class ScheduleTest : StringSpec({
         .retryOrElseEither({ throw ex }) { e, _ -> e }
 
       res.fold({ it shouldBe ex }, { fail("The impossible happened") })
+    }
+
+    "Schedule stops retrying if first of more predicates is met" {
+      val ex = Throwable("Hello")
+
+      val schedule = Schedule.exponential<Throwable>(1.0.milliseconds)
+        .untilOutput { it > 50.0.milliseconds }
+        .untilInput<Throwable> { it is IllegalStateException }
+
+      val result: Either<Throwable, Unit> = withTimeout(10.seconds) {
+        schedule.retryOrElseEither({
+          throw ex
+        }, { t, _ -> t })
+      }
+
+      result.fold({ it shouldBe ex }, { fail("The impossible happened") })
     }
   }
 )


### PR DESCRIPTION
Fixes #2846

It seems that this was a semantic problem. Here's the diff between the previous and the proposed version:

```diff kotlin
public fun untilOutput(f: suspend (Output) -> Boolean): Schedule<Input, Output> =
-    !whileOutput(f)
+    whileOutput { !f(it) }
```

The former version applies `whileOutput(f)` and then negates, which applies to the *entire* `Schedule`. However, this is not right if you have several conditions, the right thing to do is to negate *only* the given `f`.