### PR TITLE
Use of macos-latest runner for building the landing page

### DIFF
--- a/.github/workflows/publish-landing-page.yaml
+++ b/.github/workflows/publish-landing-page.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow that builds the landing page to use `macos-latest` runner instead of `ubuntu-latest` becuase homebrew has been removed from $PATH on Ubuntu images.