### PR TITLE
Deprecate Const & Eval towards 2.x.x

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Const.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Const.kt
@@ -2,6 +2,7 @@ package arrow.core
 
 import arrow.typeclasses.Semigroup
 
+@Deprecated("Const is deprecated in Arrow Core and will be removed in 2.x.x. \n If Const is crucial for you, please let us know on the Arrow Github. Thanks!\n" + " https://github.com/arrow-kt/arrow/issues\n")
 public data class Const<A, out T>(private val value: A) {
 
   @Suppress("UNCHECKED_CAST")

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Eval.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Eval.kt
@@ -57,6 +57,7 @@ import kotlin.jvm.JvmStatic
  * <!--- KNIT example-eval-01.kt -->
  *
  */
+@Deprecated("Eval is deprecated in Arrow Core and will be removed in 2.x.x. \n If Eval is crucial for you, please let us know on the Arrow Github. Thanks!\n" + " https://github.com/arrow-kt/arrow/issues\n")
 public sealed class Eval<out A> {
 
   public companion object {


### PR DESCRIPTION
In 2.x.x we want to remove `Const` & `Eval`.
This PR adds the deprecations for those data types into 1.x.x series.