### PR TITLE
[Backport] MPP No Trace & Improve debugging experience of leaked raise calls

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3185,6 +3185,11 @@ public final class arrow/core/continuations/result {
 	public final fun invoke-gIAlu-s (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public class arrow/core/raise/CancellationExceptionNoTrace : java/util/concurrent/CancellationException {
+	public fun <init> ()V
+	public fun fillInStackTrace ()Ljava/lang/Throwable;
+}
+
 public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public fun <init> ()V
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3199,6 +3204,7 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun complete ()Z
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
@@ -3206,49 +3212,6 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/Effect {
-	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public static final fun catch (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
-	public static final fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public static final fun either (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public static final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun ior (Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
-	public static final fun merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun merge (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun nullable (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun option (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
-	public static final fun orNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun orNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun raisedOrRethrow (Ljava/util/concurrent/CancellationException;Larrow/core/raise/DefaultRaise;)Ljava/lang/Object;
-	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public static final fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public static final fun result (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun toEither (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public static final fun toEither (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toIor (Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
-	public static final fun toIor (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toOption (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
-	public static final fun toOption (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
-	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toResult (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun toResult (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toValidated (Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
-	public static final fun toValidated (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/EffectKt {
-	public static final fun eagerEffect (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
-	public static final fun effect (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
 }
 
 public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise, arrow/typeclasses/Semigroup {
@@ -3438,14 +3401,51 @@ public abstract interface annotation class arrow/core/raise/RaiseDSL : java/lang
 }
 
 public final class arrow/core/raise/RaiseKt {
+	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public static final fun catch (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
+	public static final fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public static final fun eagerEffect (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static final fun effect (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
+	public static final fun either (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun ensure (Larrow/core/raise/Raise;ZLkotlin/jvm/functions/Function0;)V
 	public static final fun ensureNotNull (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun ior (Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun mapErrorNel (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Larrow/typeclasses/Semigroup;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun merge (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun nullable (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun option (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun orNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun orNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun raisedOrRethrow (Ljava/util/concurrent/CancellationException;Larrow/core/raise/DefaultRaise;)Ljava/lang/Object;
 	public static final fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static final fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public static final fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public static final fun result (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun toEither (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public static final fun toEither (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toIor (Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
+	public static final fun toIor (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toOption (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun toOption (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toResult (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun toResult (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toValidated (Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
+	public static final fun toValidated (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function10;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function9;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function8;)Ljava/lang/Object;

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3211,8 +3211,8 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -3238,8 +3238,8 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise, arrow/typ
 	public fun plus (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -3287,11 +3287,11 @@ public final class arrow/core/raise/NullableRaise : arrow/core/raise/Raise {
 	public fun raise (Ljava/lang/Void;)Ljava/lang/Void;
 	public static fun raise-impl (Larrow/core/raise/Raise;Ljava/lang/Void;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Void;)Ljava/lang/Object;
 	public static fun shift-impl (Larrow/core/raise/Raise;Ljava/lang/Void;)Ljava/lang/Object;
@@ -3343,11 +3343,11 @@ public final class arrow/core/raise/OptionRaise : arrow/core/raise/Raise {
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public static fun raise-impl (Larrow/core/raise/Raise;Larrow/core/None;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shift (Larrow/core/None;)Ljava/lang/Object;
 	public synthetic fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun shift-impl (Larrow/core/raise/Raise;Larrow/core/None;)Ljava/lang/Object;
@@ -3373,8 +3373,8 @@ public abstract interface class arrow/core/raise/Raise {
 	public abstract fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public abstract fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public abstract fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -3394,8 +3394,8 @@ public final class arrow/core/raise/Raise$DefaultImpls {
 	public static fun invoke (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun shift (Larrow/core/raise/Raise;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -3507,11 +3507,11 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public fun raise (Ljava/lang/Throwable;)Ljava/lang/Void;
 	public static fun raise-impl (Larrow/core/raise/Raise;Ljava/lang/Throwable;)Ljava/lang/Void;
 	public fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun recover-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Throwable;)Ljava/lang/Object;
 	public static fun shift-impl (Larrow/core/raise/Raise;Ljava/lang/Throwable;)Ljava/lang/Object;

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        api(projects.arrowAtomic)
         api(projects.arrowContinuations)
         api(projects.arrowAnnotations)
         api(libs.kotlin.stdlibCommon)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -35,7 +35,7 @@ public inline fun <A> nullable(block: NullableRaise.() -> A): A? {
 
 public inline fun <A> result(block: ResultRaise.() -> A): Result<A> {
   contract { callsInPlace(block, EXACTLY_ONCE) }
-  return fold({ block(ResultRaise(this)) }, Result.Companion::failure, Result.Companion::success)
+  return fold({ block(ResultRaise(this)) }, Result.Companion::failure, Result.Companion::failure, Result.Companion::success)
 }
 
 public inline fun <A> option(block: OptionRaise.() -> A): Option<A> {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -1,15 +1,16 @@
 @file:JvmMultifileClass
-@file:JvmName("Effect")
+@file:JvmName("RaiseKt")
 @file:OptIn(ExperimentalTypeInference::class, ExperimentalContracts::class)
+
 package arrow.core.raise
 
+import arrow.atomic.Atomic
+import arrow.atomic.updateAndGet
 import arrow.core.Either
 import arrow.core.Ior
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
-import arrow.core.continuations.AtomicRef
-import arrow.core.continuations.updateAndGet
 import arrow.core.getOrElse
 import arrow.core.identity
 import arrow.core.orElse
@@ -44,7 +45,7 @@ public inline fun <A> option(block: OptionRaise.() -> A): Option<A> {
 
 public inline fun <E, A> ior(semigroup: Semigroup<E>, @BuilderInference block: IorRaise<E>.() -> A): Ior<E, A> {
   contract { callsInPlace(block, EXACTLY_ONCE) }
-  val state: AtomicRef<Option<E>> = AtomicRef(None)
+  val state: Atomic<Option<E>> = Atomic(None)
   return fold<E, A, Ior<E, A>>(
     { block(IorRaise(semigroup, state, this)) },
     { e -> throw e },
@@ -61,12 +62,12 @@ public value class NullableRaise(private val cont: Raise<Null>) : Raise<Null> {
   public fun ensure(value: Boolean): Unit = ensure(value) { null }
   override fun raise(r: Nothing?): Nothing = cont.raise(r)
   public fun <B> Option<B>.bind(): B = bind { raise(null) }
-  
+
   public fun <B> B?.bind(): B {
     contract { returns() implies (this@bind != null) }
     return this ?: raise(null)
   }
-  
+
   public fun <B> ensureNotNull(value: B?): B {
     contract { returns() implies (value != null) }
     return ensureNotNull(value) { null }
@@ -84,7 +85,7 @@ public value class OptionRaise(private val cont: Raise<None>) : Raise<None> {
   override fun raise(r: None): Nothing = cont.raise(r)
   public fun <B> Option<B>.bind(): B = bind { raise(None) }
   public fun ensure(value: Boolean): Unit = ensure(value) { None }
-  
+
   public fun <B> ensureNotNull(value: B?): B {
     contract { returns() implies (value != null) }
     return ensureNotNull(value) { None }
@@ -93,12 +94,12 @@ public value class OptionRaise(private val cont: Raise<None>) : Raise<None> {
 
 public class IorRaise<E> @PublishedApi internal constructor(
   semigroup: Semigroup<E>,
-  private val state: AtomicRef<Option<E>>,
+  private val state: Atomic<Option<E>>,
   private val raise: Raise<E>,
 ) : Raise<E>, Semigroup<E> by semigroup {
-  
+
   override fun raise(r: E): Nothing = raise.raise(combine(r))
-  
+
   public fun <B> Ior<E, B>.bind(): B =
     when (this) {
       is Ior.Left -> raise(value)
@@ -108,7 +109,7 @@ public class IorRaise<E> @PublishedApi internal constructor(
         rightValue
       }
     }
-  
+
   private fun combine(other: E): E =
     state.updateAndGet { prev ->
       prev.map { e -> e.combine(other) }.orElse { Some(other) }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Effect.kt
@@ -1,9 +1,11 @@
 @file:JvmMultifileClass
+@file:JvmName("RaiseKt")
 @file:OptIn(ExperimentalTypeInference::class)
 package arrow.core.raise
 
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
 
 /**
  * [Effect] represents a function of `suspend Raise<R>.() -> A`, that short-circuit with a value of `R` or `Throwable`, or completes with a value of `A`.

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
@@ -1,5 +1,5 @@
 @file:JvmMultifileClass
-@file:JvmName("Effect")
+@file:JvmName("RaiseKt")
 @file:OptIn(ExperimentalTypeInference::class)
 package arrow.core.raise
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
@@ -1,5 +1,5 @@
 @file:JvmMultifileClass
-@file:JvmName("Effect")
+@file:JvmName("RaiseKt")
 package arrow.core.raise
 
 import arrow.core.Either

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
@@ -30,7 +30,7 @@ public fun <E, A> EagerEffect<E, A>.orNull(): A? = fold({ _: E -> null }) { it }
 
 /** Run the [Effect] by returning [Option] of [A], [orElse] run the fallback lambda and returning its result of [Option] of [A]. */
 public suspend fun <E, A> Effect<E, A>.toOption(orElse: suspend (E) -> Option<A>): Option<A> = fold(orElse) { Some(it) }
-public fun <E, A> EagerEffect<E, A>.toOption(orElse: (E) -> Option<A>): Option<A> = fold(orElse) { Some(it) }
+public inline fun <E, A> EagerEffect<E, A>.toOption(orElse: (E) -> Option<A>): Option<A> = fold(orElse) { Some(it) }
 
 /** Run the [Effect] by returning [Option] of [A], or [None] if raised with [None]. */
 public suspend fun <A> Effect<None, A>.toOption(): Option<A> = option { invoke() }
@@ -38,9 +38,9 @@ public fun <A> EagerEffect<None, A>.toOption(): Option<A> = option { invoke() }
 
 /** Run the [Effect] by returning [Result] of [A], [orElse] run the fallback lambda and returning its result of [Result] of [A]. */
 public suspend fun <E, A> Effect<E, A>.toResult(orElse: suspend (E) -> Result<A>): Result<A> =
-  fold({ orElse(it) }, { Result.success(it) })
-public fun <E, A> EagerEffect<E, A>.toResult(orElse:  (E) -> Result<A>): Result<A> =
-  fold({ orElse(it) }, { Result.success(it) })
+  fold({ Result.failure(it)  }, { orElse(it) }, { Result.success(it) })
+public inline fun <E, A> EagerEffect<E, A>.toResult(orElse:  (E) -> Result<A>): Result<A> =
+  fold({ Result.failure(it)  }, { orElse(it) }, { Result.success(it) })
 
 /** Run the [Effect] by returning [Result] of [A], or [Result.Failure] if raised with [Throwable]. */
 public suspend fun <A> Effect<Throwable, A>.toResult(): Result<A> = result { invoke() }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -281,7 +281,7 @@ public interface Raise<in R> {
 
   @RaiseDSL
   public suspend infix fun <E, A> Effect<E, A>.recover(@BuilderInference resolve: suspend Raise<R>.(E) -> A): A =
-    recover({ invoke() }) { resolve(it) }
+    fold<E, A, A>({ this@recover.invoke(this) }, { throw it }, { resolve(it) }) { it }
 
   /** @see [recover] */
   @RaiseDSL
@@ -297,18 +297,17 @@ public interface Raise<in R> {
    */
   @RaiseDSL
   public suspend fun <E, A> Effect<E, A>.recover(
-    @BuilderInference action: suspend Raise<E>.() -> A,
     @BuilderInference recover: suspend Raise<R>.(E) -> A,
     @BuilderInference catch: suspend Raise<R>.(Throwable) -> A,
-  ): A = fold({ action(this) }, { catch(it) }, { recover(it) }, { it })
+  ): A = fold({ invoke() }, { catch(it) }, { recover(it) }, { it })
 
   @RaiseDSL
-  public suspend fun <A> Effect<R, A>.catch(
+  public suspend infix fun <A> Effect<R, A>.catch(
     @BuilderInference catch: suspend Raise<R>.(Throwable) -> A,
   ): A = fold({ catch(it) }, { raise(it) }, { it })
 
   @RaiseDSL
-  public fun <A> EagerEffect<R, A>.catch(
+  public infix fun <A> EagerEffect<R, A>.catch(
     @BuilderInference catch: Raise<R>.(Throwable) -> A,
   ): A = fold({ catch(it) }, { raise(it) }, { it })
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -1,4 +1,5 @@
 @file:OptIn(ExperimentalTypeInference::class, ExperimentalContracts::class)
+@file:Suppress("DEPRECATION")
 @file:JvmMultifileClass
 @file:JvmName("RaiseKt")
 package arrow.core.raise
@@ -10,6 +11,7 @@ import arrow.core.Some
 import arrow.core.Validated
 import arrow.core.continuations.EffectScope
 import arrow.core.identity
+import arrow.core.recover
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind.AT_MOST_ONCE
 import kotlin.contracts.InvocationKind.EXACTLY_ONCE
@@ -387,7 +389,7 @@ public inline fun <reified T : Throwable, R, A> Raise<R>.catch(
 }
 
 @RaiseDSL
-public inline fun <R> Raise<R>.ensure(condition: Boolean, raise: () -> R): Unit {
+public inline fun <R> Raise<R>.ensure(condition: Boolean, raise: () -> R) {
   contract {
     callsInPlace(raise, AT_MOST_ONCE)
     returns() implies condition

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
@@ -1,0 +1,221 @@
+package arrow.core.raise
+
+import arrow.core.Either
+import arrow.core.identity
+import arrow.core.left
+import arrow.core.right
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlinx.coroutines.CompletableDeferred
+
+@Suppress("UNREACHABLE_CODE", "UNUSED_EXPRESSION")
+class EagerEffectSpec : StringSpec({
+  "try/catch - can recover from raise" {
+    checkAll(Arb.int(), Arb.string()) { i, s ->
+      eagerEffect {
+        try {
+          raise(s)
+        } catch (e: Throwable) {
+          i
+        }
+      }.fold({ unreachable() }, ::identity) shouldBe i
+    }
+  }
+
+  "try/catch - finally works" {
+    checkAll(Arb.string(), Arb.int()) { s, i ->
+      val promise = CompletableDeferred<Int>()
+      eagerEffect {
+        try {
+          raise(s)
+        } finally {
+          require(promise.complete(i))
+        }
+      }
+        .fold(::identity) { unreachable() } shouldBe s
+      promise.await() shouldBe i
+    }
+  }
+
+  "try/catch - First raise is ignored and second is returned" {
+    checkAll(Arb.int(), Arb.string(), Arb.string()) { i, s, s2 ->
+      eagerEffect<String, Int> {
+        try {
+          raise(s)
+        } catch (e: Throwable) {
+          i
+        }
+        raise(s2)
+      }.fold(::identity) { unreachable() } shouldBe s2
+    }
+  }
+
+  "attempt - catch" {
+    checkAll(Arb.int(), Arb.long()) { i, l ->
+      eagerEffect<String, Int> {
+        eagerEffect<Long, Int> {
+          raise(l)
+        } recover { ll ->
+          ll shouldBe l
+          i
+        }
+      }.fold({ unreachable() }, { it }) shouldBe i
+    }
+  }
+
+  "attempt - no catch" {
+    checkAll(Arb.int(), Arb.long()) { i, l ->
+      eagerEffect<String, Int> {
+        eagerEffect<Long, Int> {
+          i
+        } recover { ll ->
+          ll shouldBe l
+          i + 1
+        }
+      }.fold({ unreachable() }, ::identity) shouldBe i
+    }
+  }
+
+  "attempt - raise from catch" {
+    checkAll(Arb.long(), Arb.string()) { l, error ->
+      eagerEffect {
+        eagerEffect<Long, Int> {
+          raise(l)
+        } recover { ll ->
+          ll shouldBe l
+          raise(error)
+        }
+      }.fold(::identity) { unreachable() } shouldBe error
+    }
+  }
+
+  "success" {
+    eagerEffect<Nothing, Int> { 1 }
+      .fold({ unreachable() }, ::identity) shouldBe 1
+  }
+
+  "short-circuit" {
+    eagerEffect {
+      raise("hello")
+    }.fold(::identity) { unreachable() } shouldBe "hello"
+  }
+
+  "Rethrows exceptions" {
+    val e = RuntimeException("test")
+    Either.catch {
+      eagerEffect<Nothing, Nothing> { throw e }
+        .fold({ unreachable() }, { unreachable() })
+    } shouldBe Either.Left(e)
+  }
+
+  "ensure null in eager either computation" {
+    checkAll(Arb.boolean(), Arb.int(), Arb.string()) { predicate, success, raise ->
+      either {
+        ensure(predicate) { raise }
+        success
+      } shouldBe if (predicate) success.right() else raise.left()
+    }
+  }
+
+  "ensureNotNull in eager either computation" {
+    fun square(i: Int): Int = i * i
+
+    checkAll(Arb.int().orNull(), Arb.string()) { i: Int?, raise: String ->
+      val res = either {
+        ensureNotNull(i) { raise }
+        square(i) // Smart-cast by contract
+      }
+      val expected = i?.let(::square)?.right() ?: raise.left()
+      res shouldBe expected
+    }
+  }
+
+  "catch - happy path" {
+    checkAll(Arb.string()) { str ->
+      eagerEffect<Int, String> {
+        str
+      }.recover<Int, Nothing, String> { unreachable() }
+        .fold({ unreachable() }, ::identity) shouldBe str
+    }
+  }
+
+  "catch - error path and recover" {
+    checkAll(Arb.int(), Arb.string()) { int, fallback ->
+      eagerEffect<Int, String> {
+        raise(int)
+        unreachable()
+      }.recover<Int, Nothing, String> { fallback }
+        .fold({ unreachable() }, ::identity) shouldBe fallback
+    }
+  }
+
+  "catch - error path and re-raise" {
+    checkAll(Arb.int(), Arb.string()) { int, fallback ->
+      eagerEffect<Int, Unit> {
+        raise(int)
+        unreachable()
+      }.recover { raise(fallback) }
+        .fold(::identity) { unreachable() } shouldBe fallback
+    }
+  }
+
+  @Suppress("UNREACHABLE_CODE")
+  "catch - error path and throw" {
+    checkAll(Arb.int(), Arb.string()) { int, msg ->
+      shouldThrow<RuntimeException> {
+        eagerEffect<Int, String> {
+          raise(int)
+          unreachable()
+        }.recover<Int, Nothing, String> { throw RuntimeException(msg) }
+          .fold({ unreachable() }, { unreachable() })
+      }.message.shouldNotBeNull() shouldBe msg
+    }
+  }
+
+  "attempt - happy path" {
+    checkAll(Arb.string()) { str ->
+      eagerEffect<Int, String> {
+        str
+      }.catch { unreachable() }
+        .fold({ unreachable() }, ::identity) shouldBe str
+    }
+  }
+
+  "attempt - error path and recover" {
+    checkAll(Arb.string(), Arb.string()) { msg, fallback ->
+      eagerEffect<Int, String> {
+        throw RuntimeException(msg)
+      }.catch { fallback }
+        .fold({ unreachable() }, ::identity) shouldBe fallback
+    }
+  }
+
+  "attempt - error path and re-raise" {
+    checkAll(Arb.string(), Arb.int()) { msg, fallback ->
+      eagerEffect<Int, Unit> {
+        throw RuntimeException(msg)
+      }.catch { raise(fallback) }
+        .fold(::identity) { unreachable() } shouldBe fallback
+    }
+  }
+
+  "attempt - error path and throw" {
+    checkAll(Arb.string(), Arb.string()) { msg, msg2 ->
+      shouldThrow<RuntimeException> {
+        eagerEffect<Int, String> {
+          throw RuntimeException(msg)
+        }.catch { throw RuntimeException(msg2) }
+          .fold({ unreachable() }, { unreachable() })
+      }.message.shouldNotBeNull() shouldBe msg2
+    }
+  }
+})

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
@@ -1,0 +1,457 @@
+package arrow.core.raise
+
+import arrow.core.Either
+import arrow.core.NonEmptyList
+import arrow.core.identity
+import arrow.core.left
+import arrow.core.right
+import arrow.core.toNonEmptyListOrNull
+import io.kotest.assertions.fail
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.startCoroutine
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Suppress("UNREACHABLE_CODE")
+class EffectSpec : StringSpec({
+  "try/catch - can recover from raise" {
+    checkAll(Arb.int().suspend(), Arb.string().suspend()) { i, s ->
+      effect {
+        try {
+          raise(s())
+        } catch (e: Throwable) {
+          i()
+        }
+      }.fold({ unreachable() }, ::identity) shouldBe i()
+    }
+  }
+
+  "try/catch - finally works" {
+    checkAll(Arb.string().suspend(), Arb.int().suspend()) { s, i ->
+      val promise = CompletableDeferred<Int>()
+      effect {
+        try {
+          raise(s().suspend())
+        } finally {
+          require(promise.complete(i()))
+        }
+      }
+        .fold(::identity) { unreachable() } shouldBe s()
+      promise.await() shouldBe i()
+    }
+  }
+
+  "try/catch - First raise is ignored and second is returned" {
+    checkAll(Arb.int().suspend(), Arb.string().suspend(), Arb.string().suspend()) { i, s, s2 ->
+      effect<String, Int> {
+        try {
+          raise(s())
+        } catch (e: Throwable) {
+          i()
+        }
+        raise(s2())
+      }
+        .fold(::identity) { unreachable() } shouldBe s2()
+    }
+  }
+
+  "attempt - catch" {
+    checkAll(Arb.int().suspend(), Arb.long().suspend()) { i, l ->
+      effect<String, Int> {
+        effect<Long, Int> {
+          raise(l())
+        } recover { ll ->
+          ll shouldBe l()
+          i()
+        }
+      }.fold(::identity, ::identity) shouldBe i()
+    }
+  }
+
+  "attempt - no catch" {
+    checkAll(Arb.int().suspend(), Arb.long().suspend()) { i, l ->
+      effect<String, Int> {
+        effect<Long, Int> {
+          i()
+        } recover { ll ->
+          ll shouldBe l()
+          i() + 1
+        }
+      }.fold(::identity, ::identity) shouldBe i()
+    }
+  }
+
+  "eagerEffect can be consumed within an Effect computation" {
+    checkAll(Arb.int(), Arb.int().suspend()) { a, b ->
+      val eager: EagerEffect<String, Int> =
+        eagerEffect { a }
+
+      effect {
+        val bb = b()
+        val aa = eager()
+        aa + bb
+      }.fold(::identity, ::identity) shouldBe (a + b())
+    }
+  }
+
+  "eagerEffect raise short-circuits effect computation" {
+    checkAll(Arb.string(), Arb.int().suspend()) { a, b ->
+      val eager: EagerEffect<String, Int> =
+        eagerEffect { raise(a) }
+
+      effect {
+        val bb = b()
+        val aa = eager()
+        aa + bb
+      }.fold(::identity, ::identity) shouldBe a
+    }
+  }
+
+  "success" {
+    checkAll(Arb.int().suspend()) { i ->
+      effect<Nothing, Int> { i() }
+        .fold({ unreachable() }, ::identity) shouldBe i()
+    }
+  }
+
+  "short-circuit" {
+    checkAll(Arb.string().suspend()) { msg ->
+      effect {
+        raise(msg())
+      }.fold(::identity) { unreachable() } shouldBe msg()
+    }
+  }
+
+  "Rethrows exceptions" {
+    checkAll(Arb.string().suspend()) { msg ->
+      shouldThrow<RuntimeException> {
+        effect<String, Int> {
+          throw RuntimeException(msg())
+        }.toEither()
+      }.message shouldBe msg()
+    }
+  }
+
+  "Can short-circuit from nested blocks" {
+    checkAll(Arb.string().suspend()) { msg ->
+      effect<String, Int> {
+        effect<Nothing, Long> { raise(msg()) }.fold({ unreachable() }, ::identity)
+        fail("Should never reach this point")
+      }
+        .fold(::identity, ::identity) shouldBe msg()
+    }
+  }
+
+  "Can short-circuit immediately after suspending from nested blocks" {
+    checkAll(Arb.string().suspend()) { msg ->
+      effect<String, Int> {
+        effect<Nothing, Long> {
+          1L.suspend()
+          raise(msg())
+        }.fold({ unreachable() }, ::identity)
+        fail("Should never reach this point")
+      }.fold(::identity, ::identity) shouldBe msg()
+    }
+  }
+
+  "ensure null in either computation" {
+    checkAll(
+      Arb.boolean().suspend(),
+      Arb.int().suspend(),
+      Arb.string().suspend()
+    ) { predicate, success, raise ->
+      either {
+        ensure(predicate()) { raise() }
+        success()
+      } shouldBe if (predicate()) success().right() else raise().left()
+    }
+  }
+
+  "ensureNotNull in either computation" {
+    fun square(i: Int): Int = i * i
+
+    checkAll(Arb.int().orNull().suspend(), Arb.string().suspend()) { i, raise ->
+      val res =
+        either {
+          val ii = i()
+          ensureNotNull(ii) { raise() }
+          square(ii) // Smart-cast by contract
+        }
+      val expected = i()?.let(::square)?.right() ?: raise().left()
+      res shouldBe expected
+    }
+  }
+
+  "#2760 - dispatching in nested Effect blocks does not make the nested Continuation to hang" {
+    checkAll(Arb.string()) { msg ->
+      fun failure(): Effect<Failure, String> = effect {
+        withContext(Dispatchers.Default) {}
+        raise(Failure(msg))
+      }
+
+      effect {
+        failure().bind()
+        1
+      }.fold(
+        recover = { it },
+        transform = { fail("Should never come here") },
+      ) shouldBe Failure(msg)
+    }
+  }
+
+  "#2779 - handleErrorWith does not make nested Continuations hang" {
+    checkAll(Arb.string()) { error ->
+      val failed: Effect<String, Int> = effect {
+        withContext(Dispatchers.Default) {}
+        raise(error)
+      }
+
+      val newError: Effect<List<Char>, Int> =
+        failed.recover { str ->
+          raise(str.reversed().toList())
+        }
+
+      newError.toEither() shouldBe Either.Left(error.reversed().toList())
+    }
+  }
+
+  "#2779 - bind nested in fold does not make nested Continuations hang" {
+    checkAll(Arb.string()) { error ->
+      val failed: Effect<String, Int> = effect {
+        withContext(Dispatchers.Default) {}
+        raise(error)
+      }
+
+      val newError: Effect<List<Char>, Int> =
+        effect {
+          failed.fold({ r ->
+            effect<List<Char>, Int> {
+              raise(r.reversed().toList())
+            }.bind()
+          }, ::identity)
+        }
+
+      newError.toEither() shouldBe Either.Left(error.reversed().toList())
+    }
+  }
+
+  "Can handle thrown exceptions" {
+    checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+      effect<Int, String> {
+        throw RuntimeException(msg())
+      }.fold(
+        { fallback() },
+        ::identity,
+        ::identity
+      ) shouldBe fallback()
+    }
+  }
+
+  "Can raise from thrown exceptions" {
+    checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+      effect {
+        effect<Int, String> {
+          throw RuntimeException(msg())
+        }.fold(
+          { raise(fallback()) },
+          ::identity,
+          { it.length }
+        )
+      }.fold(::identity, ::identity) shouldBe fallback()
+    }
+  }
+
+  "Can throw from thrown exceptions" {
+    checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+      shouldThrow<IllegalStateException> {
+        effect<Int, String> {
+          throw RuntimeException(msg())
+        }.fold(
+          { throw IllegalStateException(fallback()) },
+          ::identity,
+          { it.length }
+        )
+      }.message shouldBe fallback()
+    }
+  }
+
+  "catch - happy path" {
+    checkAll(Arb.string().suspend()) { str ->
+      effect<Int, String> {
+        str()
+      }.recover<Int, Nothing, String> { fail("It should never catch a success value") }
+        .fold({ unreachable() }, ::identity) shouldBe str()
+    }
+  }
+
+  "catch - error path and recover" {
+    checkAll(Arb.int().suspend(), Arb.string().suspend()) { int, fallback ->
+      effect<Int, String> {
+        raise(int())
+        unreachable()
+      }.recover<Int, Nothing, String> { fallback() }
+        .fold({ unreachable() }, ::identity) shouldBe fallback()
+    }
+  }
+
+  "catch - error path and re-raise" {
+    checkAll(Arb.int().suspend(), Arb.string().suspend()) { int, fallback ->
+      effect<Int, Unit> {
+        raise(int())
+        unreachable()
+      }.recover { raise(fallback()) }
+        .fold(::identity, ::identity) shouldBe fallback()
+    }
+  }
+
+  "catch - error path and throw" {
+    checkAll(Arb.int().suspend(), Arb.string().suspend()) { int, msg ->
+      shouldThrow<RuntimeException> {
+        effect<Int, String> {
+          raise(int())
+          unreachable()
+        }.recover<Int, Nothing, String> { throw RuntimeException(msg()) }
+          .fold({ unreachable() }, ::identity)
+      }.message.shouldNotBeNull() shouldBe msg()
+    }
+  }
+
+  "attempt - happy path" {
+    checkAll(Arb.string().suspend()) { str ->
+      effect<Int, String> {
+        str()
+      }.catch { fail("It should never catch a success value") }
+        .fold(::identity, ::identity) shouldBe str()
+    }
+  }
+
+  "attempt - error path and recover" {
+    checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, fallback ->
+      effect<Int, String> {
+        throw RuntimeException(msg())
+      }.catch { fallback() }
+        .fold(::identity, ::identity) shouldBe fallback()
+    }
+  }
+
+  "attempt - error path and re-raise" {
+    checkAll(Arb.string().suspend(), Arb.int().suspend()) { msg, fallback ->
+      effect<Int, Unit> {
+        throw RuntimeException(msg())
+      }.catch { raise(fallback()) }
+        .fold(::identity, ::identity) shouldBe fallback()
+    }
+  }
+
+  "attempt - error path and throw" {
+    checkAll(Arb.string().suspend(), Arb.string().suspend()) { msg, msg2 ->
+      shouldThrow<RuntimeException> {
+        effect<Int, String> {
+          throw RuntimeException(msg())
+        }.catch { throw RuntimeException(msg2()) }
+          .fold(::identity, ::identity)
+      }.message.shouldNotBeNull() shouldBe msg2()
+    }
+  }
+
+  "accumulate, returns every error" {
+    checkAll(Arb.list(Arb.int(), range = 2..100)) { errors ->
+      either<NonEmptyList<Int>, List<String>> {
+        mapOrAccumulate(errors) { raise(it) }
+      } shouldBe errors.toNonEmptyListOrNull()!!.left()
+    }
+  }
+
+  "accumulate, returns no error" {
+    checkAll(Arb.list(Arb.string())) { elements ->
+      either<NonEmptyList<Int>, List<String>> {
+        mapOrAccumulate(elements) { it }
+      } shouldBe elements.right()
+    }
+  }
+
+  "shift leaked results in RaiseLeakException" {
+    shouldThrow<IllegalStateException> {
+      effect {
+        suspend { raise("failure") }
+      }.fold({ fail("Cannot be here") }) { f -> f() }
+    }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+  }
+
+  "shift leaked results in RaiseLeakException with exception" {
+    shouldThrow<IllegalStateException> {
+      val leak = CompletableDeferred<suspend () -> Unit>()
+      effect {
+        leak.complete { raise("failure") }
+        throw RuntimeException("Boom")
+      }.fold(
+        {
+          it.shouldBeTypeOf<RuntimeException>().message shouldBe "Boom"
+          leak.await().invoke()
+        },
+        { fail("Cannot be here") }
+      ) { fail("Cannot be here") }
+    }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+  }
+
+  "shift leaked results in RaiseLeakException after raise" {
+    shouldThrow<IllegalStateException> {
+      val leak = CompletableDeferred<suspend () -> Unit>()
+      effect {
+        leak.complete { raise("failure") }
+        raise("Boom!")
+      }.fold({
+        it shouldBe "Boom!"
+        leak.await().invoke()
+      }) { fail("Cannot be here") }
+    }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+  }
+})
+
+private data class Failure(val msg: String)
+
+// Turn `A` into `suspend () -> A` which tests both the `immediate` and `COROUTINE_SUSPENDED` path.
+private fun <A> Arb<A>.suspend(): Arb<suspend () -> A> =
+  flatMap { a ->
+    arbitrary(listOf(
+      { a },
+      suspend { a.suspend() }
+    )) { suspend { a.suspend() } }
+  }
+
+internal suspend fun Throwable.suspend(): Nothing = suspendCoroutineUninterceptedOrReturn { cont ->
+  suspend { throw this }
+    .startCoroutine(Continuation(Dispatchers.Default) { cont.intercepted().resumeWith(it) })
+
+  COROUTINE_SUSPENDED
+}
+
+internal suspend fun <A> A.suspend(): A = suspendCoroutineUninterceptedOrReturn { cont ->
+  suspend { this }
+    .startCoroutine(Continuation(Dispatchers.Default) { cont.intercepted().resumeWith(it) })
+
+  COROUTINE_SUSPENDED
+}
+
+internal fun unreachable(): Nothing =
+  fail("It should never rexach this point")

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
@@ -3,6 +3,7 @@ package arrow.core.raise
 import arrow.core.Either
 import arrow.core.Ior
 import arrow.typeclasses.Semigroup
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -25,6 +26,14 @@ class IorSpec : StringSpec({
       val two = Ior.Both(", World!", 2).bind()
       one + two
     } shouldBe Ior.Both("Hello, World!", 3)
+  }
+
+  "Accumulates and short-circuits with Left" {
+    ior(Semigroup.string()) {
+      val one = Ior.Both("Hello", 1).bind()
+      val two: Int = Ior.Left(", World!").bind()
+      one + two
+    } shouldBe Ior.Left("Hello, World!")
   }
 
   "Accumulates with Either" {
@@ -58,5 +67,14 @@ class IorSpec : StringSpec({
       val two: Int = Either.Left(", World!").bind()
       one + two
     } shouldBe Ior.Left("Hello, World!")
+  }
+
+  "Ior rethrows exception" {
+    val boom = RuntimeException("Boom!")
+    shouldThrow<RuntimeException> {
+      ior(Semigroup.string()) {
+       throw boom
+      }
+    }.message shouldBe "Boom!"
   }
 })

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
@@ -1,0 +1,62 @@
+package arrow.core.raise
+
+import arrow.core.Either
+import arrow.core.Ior
+import arrow.typeclasses.Semigroup
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+
+@Suppress(
+  "UNREACHABLE_CODE",
+  "IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION",
+  "UNUSED_VARIABLE"
+)
+class IorSpec : StringSpec({
+  "Accumulates" {
+    ior(Semigroup.string()) {
+      val one = Ior.Both("Hello", 1).bind()
+      val two = Ior.Both(", World!", 2).bind()
+      one + two
+    } shouldBe Ior.Both("Hello, World!", 3)
+  }
+
+  "Accumulates with Either" {
+    ior(Semigroup.string()) {
+      val one = Ior.Both("Hello", 1).bind()
+      val two: Int = Either.Left(", World!").bind()
+      one + two
+    } shouldBe Ior.Left("Hello, World!")
+  }
+
+  "Concurrent - arrow.ior bind" {
+    checkAll(Arb.list(Arb.string()).filter(List<String>::isNotEmpty)) { strs ->
+      ior(Semigroup.list()) {
+        strs.mapIndexed { index, s -> async { Ior.Both(listOf(s), index).bind() } }.awaitAll()
+      }
+        .mapLeft { it.toSet() } shouldBe Ior.Both(strs.toSet(), strs.indices.toList())
+    }
+  }
+
+  "Accumulates eagerly" {
+    ior(Semigroup.string()) {
+      val one = Ior.Both("Hello", 1).bind()
+      val two = Ior.Both(", World!", 2).bind()
+      one + two
+    } shouldBe Ior.Both("Hello, World!", 3)
+  }
+
+  "Accumulates with Either eagerly" {
+    ior(Semigroup.string()) {
+      val one = Ior.Both("Hello", 1).bind()
+      val two: Int = Either.Left(", World!").bind()
+      one + two
+    } shouldBe Ior.Left("Hello, World!")
+  }
+})

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/MappersSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/MappersSpec.kt
@@ -1,0 +1,138 @@
+package arrow.core.raise
+
+import arrow.core.Ior
+import arrow.core.None
+import arrow.core.none
+import arrow.core.test.either
+import arrow.core.toOption
+import arrow.core.raise.toOption
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.constant
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
+
+class MappersSpec : StringSpec({
+  "effect - toEither" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      effect { a.bind() }.toEither() shouldBe a
+    }
+  }
+
+  "eagerEffect - toEither" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.toEither() shouldBe a
+    }
+  }
+
+  "effect - toValidated" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      effect { a.bind() }.toValidated() shouldBe a.toValidated()
+    }
+  }
+
+  "eagerEffect - toValidated" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.toValidated() shouldBe a.toValidated()
+    }
+  }
+
+  "effect - toIor" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      effect { a.bind() }.toIor() shouldBe a.fold({ Ior.Left(it) }, { Ior.Right(it) })
+    }
+  }
+
+  "eagerEffect - toIor" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.toIor() shouldBe a.fold({ Ior.Left(it) }, { Ior.Right(it) })
+    }
+  }
+
+  "effect - orNull" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      effect { a.bind() }.orNull() shouldBe a.getOrNull()
+    }
+  }
+
+  "eagerEffect - orNull" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.orNull() shouldBe a.getOrNull()
+    }
+  }
+
+  "effect - toOption { none() }" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      effect { a.bind() }.toOption { none() } shouldBe a.getOrNull().toOption()
+    }
+  }
+
+  "eagerEffect - toOption { none() }" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.toOption { none() } shouldBe a.getOrNull().toOption()
+    }
+  }
+
+  "effect - toOption" {
+    checkAll(Arb.either(Arb.constant(None), Arb.string())) { a ->
+      effect { a.bind() }.toOption() shouldBe a.getOrNull().toOption()
+    }
+  }
+
+  "eagerEffect - toOption" {
+    checkAll(Arb.either(Arb.constant(None), Arb.string())) { a ->
+      eagerEffect { a.bind() }.toOption() shouldBe a.getOrNull().toOption()
+    }
+  }
+
+  "effect - toResult { }" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      effect { a.bind() }.toResult { success(it) } shouldBe a.fold({ success(it) }, { success(it) })
+    }
+  }
+
+  "eagerEffect - toResult { }" {
+    checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.toResult { success(it) } shouldBe a.fold({ success(it) }, { success(it) })
+    }
+  }
+
+  val boom = RuntimeException("Boom!")
+
+  "effect - toResult { } - exception" {
+    effect<Int, String> { throw boom }.toResult { success(it) } shouldBe failure(boom)
+  }
+
+  "eagerEffect - toResult { } - exception" {
+    checkAll(Arb.string()) { a ->
+      eagerEffect<Int, String> { throw boom }.toResult { success(it) } shouldBe failure(boom)
+    }
+  }
+
+  "effect - toResult()" {
+    checkAll(Arb.either(Arb.string().map { RuntimeException(it) }, Arb.string())) { a ->
+      effect { a.bind() }.toResult() shouldBe a.fold({ failure(it) }, { success(it) })
+    }
+  }
+
+  "eagerEffect - toResult()" {
+    checkAll(Arb.either(Arb.string().map { RuntimeException(it) }, Arb.string())) { a ->
+      eagerEffect { a.bind() }.toResult() shouldBe a.fold({ failure(it) }, { success(it) })
+    }
+  }
+
+  "effect - toResult() - exception" {
+    effect<Throwable, String> { throw boom }.toResult() shouldBe failure(boom)
+  }
+
+  "eagerEffect - toResult() - exception" {
+    checkAll(Arb.string()) { a ->
+      eagerEffect<Throwable, String> { throw boom }.toResult() shouldBe failure(boom)
+    }
+  }
+})

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/MappersSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/MappersSpec.kt
@@ -2,6 +2,7 @@ package arrow.core.raise
 
 import arrow.core.Ior
 import arrow.core.None
+import arrow.core.merge
 import arrow.core.none
 import arrow.core.test.either
 import arrow.core.toOption
@@ -133,6 +134,18 @@ class MappersSpec : StringSpec({
   "eagerEffect - toResult() - exception" {
     checkAll(Arb.string()) { a ->
       eagerEffect<Throwable, String> { throw boom }.toResult() shouldBe failure(boom)
+    }
+  }
+
+  "effect - merge" {
+    checkAll(Arb.either(Arb.string(), Arb.string())) { a ->
+      effect { a.bind() }.merge() shouldBe a.merge()
+    }
+  }
+
+  "eagerEffect - merge" {
+    checkAll(Arb.either(Arb.string(), Arb.string())) { a ->
+      eagerEffect { a.bind() }.merge() shouldBe a.merge()
     }
   }
 })

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -1,0 +1,121 @@
+package arrow.core.raise
+
+import arrow.core.Either
+import arrow.core.Some
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.checkAll
+
+@Suppress("UNREACHABLE_CODE")
+class NullableSpec : StringSpec({
+  "ensure null in nullable computation" {
+    checkAll(Arb.boolean(), Arb.int()) { predicate, i ->
+      nullable {
+        ensure(predicate)
+        i
+      } shouldBe if (predicate) i else null
+    }
+  }
+
+  "ensureNotNull in nullable computation" {
+    fun square(i: Int): Int = i * i
+    checkAll(Arb.int().orNull()) { i: Int? ->
+      nullable {
+        ensureNotNull(i)
+        square(i) // Smart-cast by contract
+      } shouldBe i?.let(::square)
+    }
+  }
+
+  "short circuit null" {
+    nullable<Int> {
+      val number: Int = "s".length
+      (number.takeIf { it > 1 }?.toString()).bind()
+      throw IllegalStateException("This should not be executed")
+    } shouldBe null
+  }
+
+  "ensureNotNull short circuit" {
+    nullable<Int> {
+      val number: Int = "s".length
+      ensureNotNull(number.takeIf { it > 1 })
+      throw IllegalStateException("This should not be executed")
+    } shouldBe null
+  }
+
+  "simple case" {
+    nullable {
+      "s".length.bind()
+    } shouldBe 1
+  }
+
+  "multiple types" {
+    nullable {
+      val number = "s".length
+      val string = number.toString().bind()
+      string
+    } shouldBe "1"
+  }
+
+  "binding option in nullable" {
+    nullable {
+      val number = Some("s".length)
+      val string = number.map(Int::toString).bind()
+      string
+    } shouldBe "1"
+  }
+
+  "short circuit option" {
+    nullable<Int> {
+      val number = Some("s".length)
+      number.filter { it > 1 }.map(Int::toString).bind()
+      throw IllegalStateException("This should not be executed")
+    } shouldBe null
+  }
+
+  "when expression" {
+    nullable {
+      val number = "s".length.bind()
+      val string = when (number) {
+        1 -> number.toString()
+        else -> null
+      }.bind()
+      string
+    } shouldBe "1"
+  }
+
+  "if expression" {
+    nullable {
+      val number = "s".length.bind()
+      val string = if (number == 1) {
+        number.toString()
+      } else {
+        null
+      }.bind()
+      string
+    } shouldBe "1"
+  }
+
+  "if expression short circuit" {
+    nullable {
+      val number = "s".length.bind()
+      val string = if (number != 1) {
+        number.toString()
+      } else {
+        null
+      }.bind()
+      string
+    } shouldBe null
+  }
+
+  "Either<Nothing, A> can be bind" {
+    nullable {
+      val either: Either<Nothing, Int> = Either.Right(4)
+      either.bind() + 3
+    } shouldBe 7
+  }
+})

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/OptionSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/OptionSpec.kt
@@ -1,0 +1,30 @@
+package arrow.core.raise
+
+import arrow.core.None
+import arrow.core.toOption
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.checkAll
+
+class OptionSpec : StringSpec({
+  "ensureNotNull in option computation" {
+    fun square(i: Int): Int = i * i
+    checkAll(Arb.int().orNull()) { i: Int? ->
+      option {
+        ensureNotNull(i)
+        square(i) // Smart-cast by contract
+      } shouldBe i.toOption().map(::square)
+    }
+  }
+
+  "short circuit option" {
+    @Suppress("UNREACHABLE_CODE")
+    option {
+      ensureNotNull<Int>(null)
+      throw IllegalStateException("This should not be executed")
+    } shouldBe None
+  }
+})

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/OptionSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/OptionSpec.kt
@@ -1,15 +1,27 @@
 package arrow.core.raise
 
 import arrow.core.None
+import arrow.core.some
 import arrow.core.toOption
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.checkAll
 
 class OptionSpec : StringSpec({
+
+  "ensure" {
+    checkAll(Arb.boolean(), Arb.int()) { b, i ->
+      option {
+        ensure(b)
+        i
+      } shouldBe if (b) i.some() else None
+    }
+  }
+
   "ensureNotNull in option computation" {
     fun square(i: Int): Int = i * i
     checkAll(Arb.int().orNull()) { i: Int? ->

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/ResultSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/ResultSpec.kt
@@ -1,0 +1,23 @@
+package arrow.core.raise
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+@Suppress("UNREACHABLE_CODE")
+class ResultSpec : StringSpec({
+  val boom = RuntimeException("Boom!")
+
+  "Result - exception" {
+    result {
+      throw boom
+    } shouldBe Result.failure(boom)
+  }
+
+  "Result - success" {
+    result { 1 } shouldBe Result.success(1)
+  }
+
+  "Result - raise" {
+    result { raise(boom) } shouldBe Result.failure(boom)
+  }
+})

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/StructuredConcurrencySpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/StructuredConcurrencySpec.kt
@@ -1,0 +1,240 @@
+package arrow.core.raise
+
+import arrow.core.identity
+import arrow.fx.coroutines.ExitCase
+import arrow.fx.coroutines.guaranteeCase
+import io.kotest.assertions.fail
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+
+@Suppress("DeferredResultUnused")
+class StructuredConcurrencySpec : StringSpec({
+  "async - suspendCancellableCoroutine.invokeOnCancellation is called with Raised Continuation" {
+    val started = CompletableDeferred<Unit>()
+    val cancelled = CompletableDeferred<Throwable?>()
+
+    effect {
+      coroutineScope {
+        val never = async {
+          suspendCancellableCoroutine<Nothing> { cont ->
+            cont.invokeOnCancellation { cause ->
+              require(cancelled.complete(cause)) { "cancelled latch was completed twice" }
+            }
+            require(started.complete(Unit))
+          }
+        }
+        async<Int> {
+          started.await()
+          raise("hello")
+        }.await()
+        never.await()
+      }
+    }.fold(::identity) { fail("Should never be here") } shouldBe "hello"
+
+    withTimeout(2.seconds) {
+      cancelled.await().shouldNotBeNull().message shouldBe "Raised Continuation"
+    }
+  }
+
+  "Computation blocks run on parent context" {
+    val parentCtx = currentCoroutineContext()
+    effect<Nothing, Unit> { currentCoroutineContext() shouldBe parentCtx }
+      .fold({ fail("Should never be here") }, ::identity)
+  }
+
+  "Concurrent raise - async await" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      effect {
+        coroutineScope {
+          val fa = async<String> { raise(a) }
+          val fb = async<String> { raise(b) }
+          fa.await() + fb.await()
+        }
+      }
+        .fold(::identity, ::identity) shouldBeIn listOf(a, b)
+    }
+  }
+
+  "Concurrent raise - async await exit results" {
+    checkAll(Arb.int()) { a ->
+      val scopeExit = CompletableDeferred<ExitCase>()
+      val fbExit = CompletableDeferred<ExitCase>()
+      val startLatches = (0..11).map { CompletableDeferred<Unit>() }
+      val nestedExits = (0..10).map { CompletableDeferred<ExitCase>() }
+
+      fun CoroutineScope.asyncTask(
+        start: CompletableDeferred<Unit>,
+        exit: CompletableDeferred<ExitCase>
+      ): Deferred<Unit> = async {
+        guaranteeCase({
+          start.complete(Unit)
+          awaitCancellation()
+        }) { case -> require(exit.complete(case)) }
+      }
+
+      effect<Int, String> {
+        guaranteeCase({
+          coroutineScope {
+            val fa =
+              async<Unit> {
+                startLatches.drop(1).zip(nestedExits) { start, promise ->
+                  asyncTask(start, promise)
+                }
+                startLatches.awaitAll()
+                raise(a)
+              }
+            val fb = asyncTask(startLatches.first(), fbExit)
+            fa.await()
+            fb.await()
+          }
+        }) { case -> require(scopeExit.complete(case)) }
+        fail("Should never come here")
+      }
+        .fold(::identity, ::identity) shouldBe a
+      withTimeout(2.seconds) {
+        scopeExit.await().shouldBeTypeOf<ExitCase.Cancelled>()
+        fbExit.await().shouldBeTypeOf<ExitCase.Cancelled>()
+        nestedExits.awaitAll().forEach { it.shouldBeTypeOf<ExitCase.Cancelled>() }
+      }
+    }
+  }
+
+  "Concurrent raise - async" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      effect {
+        coroutineScope {
+          async { raise(a) }
+          async { raise(b) }
+          "I will be overwritten by raise - coroutineScope waits until all async are finished"
+        }
+      }
+        .fold({ fail("Async is never awaited, and thus ignored.") }, ::identity) shouldBe
+        "I will be overwritten by raise - coroutineScope waits until all async are finished"
+    }
+  }
+
+  "Concurrent raise - async exit results" {
+    checkAll(Arb.int(), Arb.string()) { a, str ->
+      val exitScope = CompletableDeferred<ExitCase>()
+      val startLatches = (0..10).map { CompletableDeferred<Unit>() }
+      val nestedExits = (0..10).map { CompletableDeferred<ExitCase>() }
+
+      fun CoroutineScope.asyncTask(
+        start: CompletableDeferred<Unit>,
+        exit: CompletableDeferred<ExitCase>
+      ): Deferred<Unit> = async {
+        guaranteeCase({
+          start.complete(Unit)
+          awaitCancellation()
+        }) { case -> require(exit.complete(case)) }
+      }
+
+      effect {
+        guaranteeCase({
+          coroutineScope {
+            async<Unit> {
+              startLatches.zip(nestedExits) { start, promise -> asyncTask(start, promise) }
+              startLatches.awaitAll()
+              raise(a)
+            }
+            str
+          }
+        }) { case -> require(exitScope.complete(case)) }
+      }
+        .fold(::identity, ::identity) shouldBe str
+
+      withTimeout(2.seconds) {
+        nestedExits.awaitAll().forEach { it.shouldBeTypeOf<ExitCase.Cancelled>() }
+      }
+    }
+  }
+
+  "Concurrent raise - launch" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      effect {
+        coroutineScope {
+          launch { raise(a) }
+          launch { raise(b) }
+          "raise does not escape `launch`"
+        }
+      }
+        .fold(::identity, ::identity) shouldBe "raise does not escape `launch`"
+    }
+  }
+
+  "Concurrent raise - launch exit results" {
+    checkAll(Arb.int(), Arb.string()) { a, str ->
+      val scopeExit = CompletableDeferred<ExitCase>()
+      val startLatches = (0..10).map { CompletableDeferred<Unit>() }
+      val nestedExits = (0..10).map { CompletableDeferred<ExitCase>() }
+
+      fun CoroutineScope.launchTask(
+        start: CompletableDeferred<Unit>,
+        exit: CompletableDeferred<ExitCase>
+      ): Job = launch {
+        guaranteeCase({
+          start.complete(Unit)
+          awaitCancellation()
+        }) { case -> require(exit.complete(case)) }
+      }
+
+      effect {
+        guaranteeCase({
+          coroutineScope {
+            launch {
+              startLatches.zip(nestedExits) { start, promise -> launchTask(start, promise) }
+              startLatches.awaitAll()
+              raise(a)
+            }
+            str
+          }
+        }) { case -> require(scopeExit.complete(case)) }
+      }
+        .fold(::identity, ::identity) shouldBe str
+      withTimeout(2.seconds) {
+        scopeExit.await().shouldBeTypeOf<ExitCase.Completed>()
+        nestedExits.awaitAll().forEach { it.shouldBeTypeOf<ExitCase.Cancelled>() }
+      }
+    }
+  }
+
+  // `raise` escapes `cont` block, and gets rethrown inside `coroutineScope`.
+  // Effectively awaiting/executing DSL code, outside of the DSL...
+  "async funky scenario #1 - Extract `raise` from `effect` through `async`" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      shouldThrow<IllegalStateException> {
+        coroutineScope {
+          val shiftedAsync =
+            effect<Int, Deferred<String>> {
+              async<Int> { raise(a) }
+              async { raise(b) }
+            }
+              .fold({ fail("shift was never awaited, so it never took effect") }, ::identity)
+          shiftedAsync.await()
+        }
+      }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+    }
+  }
+})

--- a/arrow-libs/core/arrow-core/src/jsMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
+++ b/arrow-libs/core/arrow-core/src/jsMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
@@ -1,0 +1,5 @@
+package arrow.core.raise
+
+import kotlin.coroutines.cancellation.CancellationException
+
+public actual open class CancellationExceptionNoTrace : CancellationException("Raised Continuation")

--- a/arrow-libs/core/arrow-core/src/jvmMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
+++ b/arrow-libs/core/arrow-core/src/jvmMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
@@ -1,0 +1,16 @@
+package arrow.core.raise
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/*
+ * Inspired by KotlinX Coroutines:
+ * https://github.com/Kotlin/kotlinx.coroutines/blob/3788889ddfd2bcfedbff1bbca10ee56039e024a2/kotlinx-coroutines-core/jvm/src/Exceptions.kt#L29
+ */
+public actual open class CancellationExceptionNoTrace : CancellationException("Raised Continuation") {
+  override fun fillInStackTrace(): Throwable {
+    // Prevent Android <= 6.0 bug.
+    stackTrace = emptyArray()
+    // We don't need stacktrace on shift, it hurts performance.
+    return this
+  }
+}

--- a/arrow-libs/core/arrow-core/src/nativeMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
+++ b/arrow-libs/core/arrow-core/src/nativeMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
@@ -1,0 +1,5 @@
+package arrow.core.raise
+
+import kotlin.coroutines.cancellation.CancellationException
+
+public actual open class CancellationExceptionNoTrace : CancellationException("Raised Continuation")


### PR DESCRIPTION
- In #2884 we added `ShiftLeakedException` to improve the debug experience, this PR applies it to https://github.com/arrow-kt/arrow/pull/2912.
- In #2869 we removed stack traces to improve performance of `shift`, this PR applies it to https://github.com/arrow-kt/arrow/pull/2912.
- Aligns `result` behavior from `arrow.core.continuations` where unexpected `Throwable` is also mapped to `Result.failure`.