### PR TITLE
Introduce isLeft & isRight predicate API for Either

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -170,8 +170,10 @@ public abstract class arrow/core/Either {
 	public final fun getOrNull ()Ljava/lang/Object;
 	public final fun isEmpty ()Z
 	public final fun isLeft ()Z
+	public final fun isLeft (Lkotlin/jvm/functions/Function1;)Z
 	public final fun isNotEmpty ()Z
 	public final fun isRight ()Z
+	public final fun isRight (Lkotlin/jvm/functions/Function1;)Z
 	public static final fun lift (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public static final fun lift (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -783,7 +783,7 @@ public sealed class Either<out A, out B> {
   )
   @JsName("_isRight")
   internal abstract val isRight: Boolean
-  
+
   /**
    * Returns `true` if this is a [Left], `false` otherwise.
    * Used only for performance instead of fold.
@@ -810,7 +810,65 @@ public sealed class Either<out A, out B> {
     }
     return this@Either is Right<B>
   }
-  
+
+  /**
+   * Returns `false` if [Right]
+   * or returns the result of the given [predicate] to the [Left] value.
+   *
+   * ```kotlin
+   * import arrow.core.Either
+   * import arrow.core.Either.Left
+   * import arrow.core.Either.Right
+   * import io.kotest.matchers.shouldBe
+   *
+   * fun test() {
+   *  Left(12).isLeft { it > 10 } shouldBe true
+   *  Left(7).isLeft { it > 10 } shouldBe false
+   *
+   *  val right: Either<Int, String> = Right("Hello World")
+   *  right.isLeft { it > 10 } shouldBe false
+   * }
+   * ```
+   * <!--- KNIT example-either-34.kt -->
+   * <!--- TEST lines.isEmpty() -->
+   */
+  public inline fun isLeft(predicate: (A) -> Boolean): Boolean {
+    contract {
+      returns(true) implies (this@Either is Left<A>)
+      returns(false) implies (this@Either is Right<B>)
+    }
+    return this@Either is Left<A> && predicate(value)
+  }
+
+  /**
+   * Returns `false` if [Left]
+   * or returns the result of the given [predicate] to the [Right] value.
+   *
+   * ```kotlin
+   * import arrow.core.Either
+   * import arrow.core.Either.Left
+   * import arrow.core.Either.Right
+   * import io.kotest.matchers.shouldBe
+   *
+   * fun test() {
+   *  Right(12).isRight { it > 10 } shouldBe true
+   *  Right(7).isRight { it > 10 } shouldBe false
+   *
+   *  val left: Either<String, Int> = Left("Hello World")
+   *  left.isRight { it > 10 } shouldBe false
+   * }
+   * ```
+   * <!--- KNIT example-either-35.kt -->
+   * <!--- TEST lines.isEmpty() -->
+   */
+  public inline fun isRight(predicate: (B) -> Boolean): Boolean {
+    contract {
+      returns(true) implies (this@Either is Right<B>)
+      returns(false) implies (this@Either is Left<A>)
+    }
+    return this@Either is Right<B> && predicate(value)
+  }
+
   /**
    * Transform an [Either] into a value of [C].
    * Alternative to using `when` to fold an [Either] into a value [C].
@@ -828,7 +886,7 @@ public sealed class Either<out A, out B> {
    *     .fold({ -1 }, { fail("Cannot be right") }) shouldBe -1
    * }
    * ```
-   * <!--- KNIT example-either-34.kt -->
+   * <!--- KNIT example-either-36.kt -->
    * <!--- TEST lines.isEmpty() -->
    *
    * @param ifLeft transform the [Either.Left] type [A] to [C].
@@ -852,28 +910,28 @@ public sealed class Either<out A, out B> {
   )
   public inline fun <C> foldLeft(initial: C, rightOperation: (C, B) -> C): C =
     fold({ initial }) { rightOperation(initial, it) }
-  
+
   @Deprecated(
     NicheAPI + "Prefer when or fold instead",
     ReplaceWith("fold({ MN.empty() }) { b -> MN.run { MN.empty().combine(f(b)) } }")
   )
   public fun <C> foldMap(MN: Monoid<C>, f: (B) -> C): C =
     fold({ MN.empty() }) { b -> MN.run { MN.empty().combine(f(b)) } }
-  
+
   @Deprecated(
     NicheAPI + "Prefer when or fold instead",
     ReplaceWith("fold({ f(c, it) }, { g(c, it) })")
   )
   public inline fun <C> bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fold({ f(c, it) }, { g(c, it) })
-  
+
   @Deprecated(
     NicheAPI + "Prefer when or fold instead",
     ReplaceWith("MN.run { fold({ MN.empty().combine(f(it)) }, { MN.empty().combine(g(it)) }) }")
   )
   public inline fun <C> bifoldMap(MN: Monoid<C>, f: (A) -> C, g: (B) -> C): C =
     MN.run { fold({ MN.empty().combine(f(it)) }, { MN.empty().combine(g(it)) }) }
-  
+
   /**
    * Swap the generic parameters [A] and [B] of this [Either].
    *
@@ -886,12 +944,12 @@ public sealed class Either<out A, out B> {
    *   Either.Right("right").swap() shouldBe Either.Left("right")
    * }
    * ```
-   * <!--- KNIT example-either-35.kt -->
+   * <!--- KNIT example-either-37.kt -->
    * <!-- TEST lines.isEmpty() -->
    */
   public fun swap(): Either<B, A> =
     fold({ Right(it) }, { Left(it) })
-  
+
   /**
    * Map, or transform, the right value [B] of this [Either] to a new value [C].
    *
@@ -904,7 +962,7 @@ public sealed class Either<out A, out B> {
    *   Either.Left(12).map { _: Nothing -> "flower" } shouldBe Either.Left(12)
    * }
    * ```
-   * <!--- KNIT example-either-36.kt -->
+   * <!--- KNIT example-either-38.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public inline fun <C> map(f: (right: B) -> C): Either<A, C> {
@@ -914,7 +972,7 @@ public sealed class Either<out A, out B> {
     return flatMap { Right(f(it)) }
   }
 
-  
+
   /**
    * Map, or transform, the left value [A] of this [Either] to a new value [C].
    *
@@ -927,7 +985,7 @@ public sealed class Either<out A, out B> {
    *  Either.Left(12).mapLeft { _: Int -> "flower" }  shouldBe Either.Left("flower")
    * }
    * ```
-   * <!--- KNIT example-either-37.kt -->
+   * <!--- KNIT example-either-39.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public inline fun <C> mapLeft(f: (A) -> C): Either<C, B> {
@@ -936,21 +994,21 @@ public sealed class Either<out A, out B> {
     }
     return fold({ Left(f(it)) }, { Right(it) })
   }
-  
+
   @Deprecated(
     "tapLeft is being renamed to onLeft to be more consistent with the Kotlin Standard Library naming",
     ReplaceWith("onLeft(f)")
   )
   public inline fun tapLeft(f: (left: A) -> Unit): Either<A, B> =
     onLeft(f)
-  
+
   @Deprecated(
     "tap is being renamed to onRight to be more consistent with the Kotlin Standard Library naming",
     ReplaceWith("onRight(f)")
   )
   public inline fun tap(f: (right: B) -> Unit): Either<A, B> =
     onRight(f)
-  
+
   /**
    * Performs the given [action] on the encapsulated [B] value if this instance represents [Either.Right].
    * Returns the original [Either] unchanged.
@@ -963,7 +1021,7 @@ public sealed class Either<out A, out B> {
    *   Either.Right(1).onRight(::println) shouldBe Either.Right(1)
    * }
    * ```
-   * <!--- KNIT example-either-38.kt -->
+   * <!--- KNIT example-either-40.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public inline fun onRight(action: (right: B) -> Unit): Either<A, B> {
@@ -972,7 +1030,7 @@ public sealed class Either<out A, out B> {
     }
     return also { if (it.isRight()) action(it.value) }
   }
-  
+
   /**
    * Performs the given [action] on the encapsulated [A] if this instance represents [Either.Left].
    * Returns the original [Either] unchanged.
@@ -985,7 +1043,7 @@ public sealed class Either<out A, out B> {
    *   Either.Left(2).onLeft(::println) shouldBe Either.Left(2)
    * }
    * ```
-   * <!--- KNIT example-either-39.kt -->
+   * <!--- KNIT example-either-41.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public inline fun onLeft(action: (left: A) -> Unit): Either<A, B> {
@@ -994,7 +1052,7 @@ public sealed class Either<out A, out B> {
     }
     return also { if (it.isLeft()) action(it.value) }
   }
-  
+
   /**
    * Map over Left and Right of this Either
    */
@@ -1004,33 +1062,14 @@ public sealed class Either<out A, out B> {
   )
   public inline fun <C, D> bimap(leftOperation: (left: A) -> C, rightOperation: (right: B) -> D): Either<C, D> =
     map(rightOperation).mapLeft(leftOperation)
-  
-  /**
-   * Returns `false` if [Left] or returns the result of the application of
-   * the given predicate to the [Right] value.
-   *
-   * Example:
-   * ```kotlin
-   * import arrow.core.Either
-   * import arrow.core.Either.Left
-   *
-   * fun main() {
-   *  Either.Right(12).exists { it > 10 } // Result: true
-   *  Either.Right(7).exists { it > 10 }  // Result: false
-   *
-   *  val left: Either<Int, Int> = Left(12)
-   *  left.exists { it > 10 }      // Result: false
-   * }
-   * ```
-   * <!--- KNIT example-either-40.kt -->
-   */
+
   @Deprecated(
-    NicheAPI + "Prefer when or fold instead",
-    ReplaceWith("fold({ false }, predicate)")
+    NicheAPI + "Prefer isRight",
+    ReplaceWith("isRight(predicate)")
   )
   public inline fun exists(predicate: (B) -> Boolean): Boolean =
     fold({ false }, predicate)
-  
+
   /**
    * Returns `true` if [Left] or returns the result of the application of
    * the given predicate to the [Right] value.
@@ -1050,7 +1089,7 @@ public sealed class Either<out A, out B> {
   )
   public inline fun all(predicate: (B) -> Boolean): Boolean =
     fold({ true }, predicate)
-  
+
   @Deprecated(
     "orNull is being renamed to getOrNull to be more consistent with the Kotlin Standard Library naming",
     ReplaceWith("getOrNull()")
@@ -1062,7 +1101,7 @@ public sealed class Either<out A, out B> {
     }
     return fold({ null }, { it })
   }
-  
+
   /**
    * Returns the encapsulated value [B] if this instance represents [Either.Right] or `null` if it is [Either.Left].
    *
@@ -1075,7 +1114,7 @@ public sealed class Either<out A, out B> {
    *   Either.Left(12).getOrNull() shouldBe null
    * }
    * ```
-   * <!--- KNIT example-either-41.kt -->
+   * <!--- KNIT example-either-42.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public fun getOrNull(): B? {
@@ -1085,9 +1124,9 @@ public sealed class Either<out A, out B> {
     }
     return getOrElse { null }
   }
-  
+
   public fun orNone(): Option<B> = getOrNone()
-  
+
   /**
    * Transforms [Either] into [Option],
    * where the encapsulated value [B] is wrapped in [Some] when this instance represents [Either.Right],
@@ -1104,18 +1143,18 @@ public sealed class Either<out A, out B> {
    *   Either.Left(12).getOrNone() shouldBe None
    * }
    * ```
-   * <!--- KNIT example-either-42.kt -->
+   * <!--- KNIT example-either-43.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public fun getOrNone(): Option<B> = fold({ None }, { Some(it) })
-  
+
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or map",
     ReplaceWith("if (n <= 0) Right(emptyList()) else map { b -> List(n) { b } }")
   )
   public fun replicate(n: Int): Either<A, List<B>> =
     if (n <= 0) Right(emptyList()) else map { b -> List(n) { b } }
-  
+
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
     ReplaceWith("fold({ emptyList() }, { fa(it).map(::Right) })")
@@ -1124,7 +1163,7 @@ public sealed class Either<out A, out B> {
   @OverloadResolutionByLambdaReturnType
   public inline fun <C> traverse(fa: (B) -> Iterable<C>): List<Either<A, C>> =
     fold({ emptyList() }, { fa(it).map(::Right) })
-  
+
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
     ReplaceWith("fold({ None }, { right -> fa(right).map(::Right) })")
@@ -1133,18 +1172,18 @@ public sealed class Either<out A, out B> {
   @OverloadResolutionByLambdaReturnType
   public inline fun <C> traverse(fa: (B) -> Option<C>): Option<Either<A, C>> =
     fold({ None }, { right -> fa(right).map(::Right) })
-  
+
   @Deprecated("traverseOption is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
   public inline fun <C> traverseOption(fa: (B) -> Option<C>): Option<Either<A, C>> =
     traverse(fa)
-  
+
   @Deprecated(
     RedundantAPI + "Use orNull() and Kotlin nullable types",
     ReplaceWith("orNull()?.let(fa)?.right()")
   )
   public inline fun <C> traverseNullable(fa: (B) -> C?): Either<A, C>? =
     orNull()?.let(fa)?.right()
-  
+
   // TODO will be renamed to mapAccumulating in 2.x.x. Backport, and deprecate in 1.x.x
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType
@@ -1153,32 +1192,32 @@ public sealed class Either<out A, out B> {
       is Right -> fa(this.value).map(::Right)
       is Left -> this.valid()
     }
-  
+
   @Deprecated("traverseValidated is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
   public inline fun <AA, C> traverseValidated(fa: (B) -> Validated<AA, C>): Validated<AA, Either<A, C>> =
     traverse(fa)
-  
+
   @Deprecated(
     NicheAPI + "Prefer explicit fold instead",
     ReplaceWith("fold({ fe(it).map { aa -> Left(aa) } }, { fa(it).map { c -> Right(c) } })")
   )
   public inline fun <AA, C> bitraverse(fe: (A) -> Iterable<AA>, fa: (B) -> Iterable<C>): List<Either<AA, C>> =
     fold({ fe(it).map { aa -> Left(aa) } }, { fa(it).map { c -> Right(c) } })
-  
+
   @Deprecated(
     NicheAPI + "Prefer explicit fold instead",
     ReplaceWith("fold({ fl(it).map(::Left) }, { fr(it).map(::Right) })")
   )
   public inline fun <AA, C> bitraverseOption(fl: (A) -> Option<AA>, fr: (B) -> Option<C>): Option<Either<AA, C>> =
     fold({ fl(it).map(::Left) }, { fr(it).map(::Right) })
-  
+
   @Deprecated(
     NicheAPI + "Prefer explicit fold instead",
     ReplaceWith("fold({ fl(it)?.let(::Left) }, { fr(it)?.let(::Right) })")
   )
   public inline fun <AA, C> bitraverseNullable(fl: (A) -> AA?, fr: (B) -> C?): Either<AA, C>? =
     fold({ fl(it)?.let(::Left) }, { fr(it)?.let(::Right) })
-  
+
   @Deprecated(
     NicheAPI + "Prefer explicit fold instead",
     ReplaceWith("fold({ fe(it).map { Left(it) } }, { fa(it).map { Right(it) } })")
@@ -1188,14 +1227,14 @@ public sealed class Either<out A, out B> {
     fa: (B) -> Validated<AA, D>,
   ): Validated<AA, Either<C, D>> =
     fold({ fe(it).map { Left(it) } }, { fa(it).map { Right(it) } })
-  
+
   @Deprecated(
     NicheAPI + "Prefer Kotlin nullable syntax instead",
     ReplaceWith("orNull()?.takeIf(predicate)")
   )
   public inline fun findOrNull(predicate: (B) -> Boolean): B? =
     orNull()?.takeIf(predicate)
-  
+
   /**
    * Returns `true` if [Left]
    *
@@ -1209,14 +1248,14 @@ public sealed class Either<out A, out B> {
    *   Either.Right("foo").isEmpty() // Result: false
    * }
    * ```
-   * <!--- KNIT example-either-43.kt -->
+   * <!--- KNIT example-either-44.kt -->
    */
   @Deprecated(
     RedundantAPI + "Use `is Either.Left<*>`, `when`, or `fold` instead",
     ReplaceWith("(this is Either.Left<*>)")
   )
   public fun isEmpty(): Boolean = isLeft
-  
+
   /**
    * Returns `true` if [Right]
    *
@@ -1231,65 +1270,65 @@ public sealed class Either<out A, out B> {
    *   //sampleEnd
    * }
    * ```
-   * <!--- KNIT example-either-44.kt -->
+   * <!--- KNIT example-either-45.kt -->
    */
   @Deprecated(
     RedundantAPI + "Use `is Either.Right<*>`, `when`, or `fold` instead",
     ReplaceWith("(this is Either.Right<*>)")
   )
   public fun isNotEmpty(): Boolean = isRight
-  
+
   /**
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
   public data class Left<out A> constructor(val value: A) : Either<A, Nothing>() {
     override val isLeft = true
     override val isRight = false
-    
+
     override fun toString(): String = "Either.Left($value)"
-    
+
     public companion object {
       @Deprecated("Unused, will be removed from bytecode in Arrow 2.x.x", ReplaceWith("Left(Unit)"))
       @PublishedApi
       internal val leftUnit: Either<Unit, Nothing> = Left(Unit)
     }
   }
-  
+
   /**
    * The right side of the disjoint union, as opposed to the [Left] side.
    */
   public data class Right<out B> constructor(val value: B) : Either<Nothing, B>() {
     override val isLeft = false
     override val isRight = true
-    
+
     override fun toString(): String = "Either.Right($value)"
-    
+
     public companion object {
       @PublishedApi
       internal val unit: Either<Nothing, Unit> = Right(Unit)
     }
   }
-  
+
   override fun toString(): String = fold(
     { "Either.Left($it)" },
     { "Either.Right($it)" }
   )
-  
+
   public fun toValidatedNel(): ValidatedNel<A, B> =
     fold({ Validated.invalidNel(it) }, ::Valid)
-  
+
   public fun toValidated(): Validated<A, B> =
     fold({ it.invalid() }, { it.valid() })
-  
+
   public companion object {
-    
+
     @Deprecated(
       RedundantAPI + "Prefer Kotlin nullable syntax, or ensureNotNull inside Either DSL",
       ReplaceWith("a?.right() ?: Unit.left()")
     )
     @JvmStatic
     public fun <A> fromNullable(a: A?): Either<Unit, A> = a?.right() ?: Unit.left()
-    
+
     /**
      * Will create an [Either] from the result of evaluating the first parameter using the functions
      * provided on second and third parameters. Second parameter represents function for creating
@@ -1309,7 +1348,7 @@ public sealed class Either<out A, out B> {
     @JvmStatic
     public inline fun <L, R> conditionally(test: Boolean, ifFalse: () -> L, ifTrue: () -> R): Either<L, R> =
       if (test) Right(ifTrue()) else Left(ifFalse())
-    
+
     @JvmStatic
     @JvmName("tryCatch")
     public inline fun <R> catch(f: () -> R): Either<Throwable, R> {
@@ -1331,7 +1370,7 @@ public sealed class Either<out A, out B> {
       contract { callsInPlace(f, InvocationKind.EXACTLY_ONCE) }
       return catch(f).flatten()
     }
-    
+
     @Deprecated(
       RedundantAPI + "Compose catch with mapLeft instead",
       ReplaceWith("catch(f).mapLeft(fe)")
@@ -1345,7 +1384,7 @@ public sealed class Either<out A, out B> {
       }
       return catch(f).mapLeft(fe)
     }
-    
+
     /**
      * The resolve function can resolve any function that yields an Either into one type of value.
      *
@@ -1397,7 +1436,7 @@ public sealed class Either<out A, out B> {
      *   println(result)
      *  }
      *  ```
-     * <!--- KNIT example-either-45.kt -->
+     * <!--- KNIT example-either-46.kt -->
      */
     @JvmStatic
     @Deprecated(
@@ -1406,7 +1445,7 @@ public sealed class Either<out A, out B> {
     )
     public fun <A, B, C> lift(f: (B) -> C): (Either<A, B>) -> Either<A, C> =
       { it.map(f) }
-    
+
     @JvmStatic
     @Deprecated(
       RedundantAPI + "Prefer explicitly creating lambdas",
@@ -1885,7 +1924,7 @@ public sealed class Either<out A, out B> {
       }
     }
   }
-  
+
   @Deprecated(
     RedundantAPI + "Map with Unit",
     ReplaceWith("map { }")
@@ -1931,7 +1970,7 @@ public inline fun <B> Either<*, B>.getOrElse(default: () -> B): B =
  *   Either.Left(12).getOrElse { it + 5 } shouldBe 17
  * }
  * ```
- * <!--- KNIT example-either-46.kt -->
+ * <!--- KNIT example-either-47.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 public inline fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
@@ -1952,7 +1991,7 @@ public inline fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
  *   Left(12).orNull()  // Result: null
  * }
  * ```
- * <!--- KNIT example-either-47.kt -->
+ * <!--- KNIT example-either-48.kt -->
  */
 @Deprecated(
   "Duplicated API. Please use Either's member function orNull. This will be removed towards Arrow 2.0",
@@ -1975,7 +2014,7 @@ public fun <B> Either<*, B>.orNull(): B? =
  *   Left(12).getOrHandle { it + 5 } // Result: 17
  * }
  * ```
- * <!--- KNIT example-either-48.kt -->
+ * <!--- KNIT example-either-49.kt -->
  */
 @Deprecated(
   RedundantAPI + "Use other getOrElse signature",
@@ -2007,7 +2046,7 @@ public inline fun <A, B> Either<A, B>.getOrHandle(default: (A) -> B): B =
  *   left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
  * }
  * ```
- * <!--- KNIT example-either-49.kt -->
+ * <!--- KNIT example-either-50.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer if-else statement inside either DSL, or replace with explicit flatMap",
@@ -2044,7 +2083,7 @@ public inline fun <A, B> Either<A, B>.filterOrElse(predicate: (B) -> Boolean, de
  *   //sampleEnd
  * }
  * ```
- * <!--- KNIT example-either-50.kt -->
+ * <!--- KNIT example-either-51.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer if-else statement inside either DSL, or replace with explicit flatMap",
@@ -2067,7 +2106,7 @@ public inline fun <A, B> Either<A, B>.filterOrOther(predicate: (B) -> Boolean, d
  *   Left(12).merge() // Result: 12
  * }
  * ```
- * <!--- KNIT example-either-51.kt -->
+ * <!--- KNIT example-either-52.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 public inline fun <A> Either<A, A>.merge(): A =
@@ -2093,7 +2132,7 @@ public inline fun <A> Either<A, A>.merge(): A =
  *   Left(12).leftIfNull({ -1 })    // Result: Left(12)
  * }
  * ```
- * <!--- KNIT example-either-52.kt -->
+ * <!--- KNIT example-either-53.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit flatMap",
@@ -2154,7 +2193,7 @@ public fun <A> A.right(): Either<Nothing, A> = Right(this)
  *   null.rightIfNotNull { "left" }    // Left(a="left")
  * }
  * ```
- * <!--- KNIT example-either-53.kt -->
+ * <!--- KNIT example-either-54.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer Kotlin nullable syntax",
@@ -2248,7 +2287,7 @@ public fun <A, B> Iterable<Either<A, B>>.combineAll(MA: Monoid<A>, MB: Monoid<B>
  *   println(chars)
  * }
  * ```
- * <!--- KNIT example-either-54.kt -->
+ * <!--- KNIT example-either-55.kt -->
  */
 public fun <A, C, B : C> Either<A, B>.widen(): Either<A, C> =
   this
@@ -2568,7 +2607,7 @@ public fun <E> E.toEitherNel(): EitherNel<E, Nothing> =
  *   fallback shouldBe Either.Right(5)
  * }
  * ```
- * <!--- KNIT example-either-55.kt -->
+ * <!--- KNIT example-either-56.kt -->
  * <!--- TEST lines.isEmpty() -->
  *
  * When shifting a new error [EE] into the [Either.Left] channel,
@@ -2585,7 +2624,7 @@ public fun <E> E.toEitherNel(): EitherNel<E, Nothing> =
  *   listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
  * }
  * ```
- * <!--- KNIT example-either-56.kt -->
+ * <!--- KNIT example-either-57.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @OptIn(ExperimentalTypeInference::class)
@@ -2626,7 +2665,7 @@ public inline fun <E, EE, A> Either<E, A>.recover(@BuilderInference recover: Rai
  *   failure shouldBe Either.Left("failure")
  * }
  * ```
- * <!--- KNIT example-either-57.kt -->
+ * <!--- KNIT example-either-58.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @OptIn(ExperimentalTypeInference::class)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -778,7 +778,7 @@ public sealed class Either<out A, out B> {
    * Used only for performance instead of fold.
    */
   @Deprecated(
-    RedundantAPI + "isRight()",
+    RedundantAPI + "Use isRight()",
     ReplaceWith("isRight()")
   )
   @JsName("_isRight")
@@ -1063,6 +1063,25 @@ public sealed class Either<out A, out B> {
   public inline fun <C, D> bimap(leftOperation: (left: A) -> C, rightOperation: (right: B) -> D): Either<C, D> =
     map(rightOperation).mapLeft(leftOperation)
 
+  /**
+   * Returns `false` if [Left] or returns the result of the application of
+   * the given predicate to the [Right] value.
+   *
+   * Example:
+   * ```kotlin
+   * import arrow.core.Either
+   * import arrow.core.Either.Left
+   *
+   * fun main() {
+   *  Either.Right(12).exists { it > 10 } // Result: true
+   *  Either.Right(7).exists { it > 10 }  // Result: false
+   *
+   *  val left: Either<Int, Int> = Left(12)
+   *  left.exists { it > 10 }      // Result: false
+   * }
+   * ```
+   * <!--- KNIT example-either-40.kt -->
+   */
   @Deprecated(
     NicheAPI + "Prefer isRight",
     ReplaceWith("isRight(predicate)")
@@ -1251,7 +1270,7 @@ public sealed class Either<out A, out B> {
    * <!--- KNIT example-either-44.kt -->
    */
   @Deprecated(
-    RedundantAPI + "isLeft()",
+    RedundantAPI + "Use isLeft()",
     ReplaceWith("isLeft()")
   )
   public fun isEmpty(): Boolean = isLeft
@@ -1273,7 +1292,7 @@ public sealed class Either<out A, out B> {
    * <!--- KNIT example-either-45.kt -->
    */
   @Deprecated(
-    RedundantAPI + "isRight()",
+    RedundantAPI + "Use isRight()",
     ReplaceWith("isRight()")
   )
   public fun isNotEmpty(): Boolean = isRight

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1080,7 +1080,7 @@ public sealed class Either<out A, out B> {
    *  left.exists { it > 10 }      // Result: false
    * }
    * ```
-   * <!--- KNIT example-either-40.kt -->
+   * <!--- KNIT example-either-42.kt -->
    */
   @Deprecated(
     NicheAPI + "Prefer isRight",
@@ -1133,7 +1133,7 @@ public sealed class Either<out A, out B> {
    *   Either.Left(12).getOrNull() shouldBe null
    * }
    * ```
-   * <!--- KNIT example-either-42.kt -->
+   * <!--- KNIT example-either-43.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public fun getOrNull(): B? {
@@ -1162,7 +1162,7 @@ public sealed class Either<out A, out B> {
    *   Either.Left(12).getOrNone() shouldBe None
    * }
    * ```
-   * <!--- KNIT example-either-43.kt -->
+   * <!--- KNIT example-either-44.kt -->
    * <!--- TEST lines.isEmpty() -->
    */
   public fun getOrNone(): Option<B> = fold({ None }, { Some(it) })
@@ -1267,7 +1267,7 @@ public sealed class Either<out A, out B> {
    *   Either.Right("foo").isEmpty() // Result: false
    * }
    * ```
-   * <!--- KNIT example-either-44.kt -->
+   * <!--- KNIT example-either-45.kt -->
    */
   @Deprecated(
     RedundantAPI + "Use isLeft()",
@@ -1289,7 +1289,7 @@ public sealed class Either<out A, out B> {
    *   //sampleEnd
    * }
    * ```
-   * <!--- KNIT example-either-45.kt -->
+   * <!--- KNIT example-either-46.kt -->
    */
   @Deprecated(
     RedundantAPI + "Use isRight()",
@@ -1455,7 +1455,7 @@ public sealed class Either<out A, out B> {
      *   println(result)
      *  }
      *  ```
-     * <!--- KNIT example-either-46.kt -->
+     * <!--- KNIT example-either-47.kt -->
      */
     @JvmStatic
     @Deprecated(
@@ -1989,7 +1989,7 @@ public inline fun <B> Either<*, B>.getOrElse(default: () -> B): B =
  *   Either.Left(12).getOrElse { it + 5 } shouldBe 17
  * }
  * ```
- * <!--- KNIT example-either-47.kt -->
+ * <!--- KNIT example-either-48.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 public inline fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
@@ -2010,7 +2010,7 @@ public inline fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
  *   Left(12).orNull()  // Result: null
  * }
  * ```
- * <!--- KNIT example-either-48.kt -->
+ * <!--- KNIT example-either-49.kt -->
  */
 @Deprecated(
   "Duplicated API. Please use Either's member function orNull. This will be removed towards Arrow 2.0",
@@ -2033,7 +2033,7 @@ public fun <B> Either<*, B>.orNull(): B? =
  *   Left(12).getOrHandle { it + 5 } // Result: 17
  * }
  * ```
- * <!--- KNIT example-either-49.kt -->
+ * <!--- KNIT example-either-50.kt -->
  */
 @Deprecated(
   RedundantAPI + "Use other getOrElse signature",
@@ -2065,7 +2065,7 @@ public inline fun <A, B> Either<A, B>.getOrHandle(default: (A) -> B): B =
  *   left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
  * }
  * ```
- * <!--- KNIT example-either-50.kt -->
+ * <!--- KNIT example-either-51.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer if-else statement inside either DSL, or replace with explicit flatMap",
@@ -2102,7 +2102,7 @@ public inline fun <A, B> Either<A, B>.filterOrElse(predicate: (B) -> Boolean, de
  *   //sampleEnd
  * }
  * ```
- * <!--- KNIT example-either-51.kt -->
+ * <!--- KNIT example-either-52.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer if-else statement inside either DSL, or replace with explicit flatMap",
@@ -2125,7 +2125,7 @@ public inline fun <A, B> Either<A, B>.filterOrOther(predicate: (B) -> Boolean, d
  *   Left(12).merge() // Result: 12
  * }
  * ```
- * <!--- KNIT example-either-52.kt -->
+ * <!--- KNIT example-either-53.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 public inline fun <A> Either<A, A>.merge(): A =
@@ -2151,7 +2151,7 @@ public inline fun <A> Either<A, A>.merge(): A =
  *   Left(12).leftIfNull({ -1 })    // Result: Left(12)
  * }
  * ```
- * <!--- KNIT example-either-53.kt -->
+ * <!--- KNIT example-either-54.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit flatMap",
@@ -2212,7 +2212,7 @@ public fun <A> A.right(): Either<Nothing, A> = Right(this)
  *   null.rightIfNotNull { "left" }    // Left(a="left")
  * }
  * ```
- * <!--- KNIT example-either-54.kt -->
+ * <!--- KNIT example-either-55.kt -->
  */
 @Deprecated(
   RedundantAPI + "Prefer Kotlin nullable syntax",
@@ -2306,7 +2306,7 @@ public fun <A, B> Iterable<Either<A, B>>.combineAll(MA: Monoid<A>, MB: Monoid<B>
  *   println(chars)
  * }
  * ```
- * <!--- KNIT example-either-55.kt -->
+ * <!--- KNIT example-either-56.kt -->
  */
 public fun <A, C, B : C> Either<A, B>.widen(): Either<A, C> =
   this
@@ -2626,7 +2626,7 @@ public fun <E> E.toEitherNel(): EitherNel<E, Nothing> =
  *   fallback shouldBe Either.Right(5)
  * }
  * ```
- * <!--- KNIT example-either-56.kt -->
+ * <!--- KNIT example-either-57.kt -->
  * <!--- TEST lines.isEmpty() -->
  *
  * When shifting a new error [EE] into the [Either.Left] channel,
@@ -2643,7 +2643,7 @@ public fun <E> E.toEitherNel(): EitherNel<E, Nothing> =
  *   listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
  * }
  * ```
- * <!--- KNIT example-either-57.kt -->
+ * <!--- KNIT example-either-58.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @OptIn(ExperimentalTypeInference::class)
@@ -2684,7 +2684,7 @@ public inline fun <E, EE, A> Either<E, A>.recover(@BuilderInference recover: Rai
  *   failure shouldBe Either.Left("failure")
  * }
  * ```
- * <!--- KNIT example-either-58.kt -->
+ * <!--- KNIT example-either-59.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @OptIn(ExperimentalTypeInference::class)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -778,8 +778,8 @@ public sealed class Either<out A, out B> {
    * Used only for performance instead of fold.
    */
   @Deprecated(
-    RedundantAPI + "Use `is Either.Right<*>`, `when`, or `fold` instead",
-    ReplaceWith("(this is Either.Right<*>)")
+    RedundantAPI + "isRight()",
+    ReplaceWith("isRight()")
   )
   @JsName("_isRight")
   internal abstract val isRight: Boolean
@@ -789,8 +789,8 @@ public sealed class Either<out A, out B> {
    * Used only for performance instead of fold.
    */
   @Deprecated(
-    RedundantAPI + "Use `is Either.Left<*>`, `when`, or `fold` instead",
-    ReplaceWith("(this is Either.Left<*>)")
+    RedundantAPI + "Use isLeft()",
+    ReplaceWith("isLeft()")
   )
   @JsName("_isLeft")
   internal abstract val isLeft: Boolean
@@ -1251,8 +1251,8 @@ public sealed class Either<out A, out B> {
    * <!--- KNIT example-either-44.kt -->
    */
   @Deprecated(
-    RedundantAPI + "Use `is Either.Left<*>`, `when`, or `fold` instead",
-    ReplaceWith("(this is Either.Left<*>)")
+    RedundantAPI + "isLeft()",
+    ReplaceWith("isLeft()")
   )
   public fun isEmpty(): Boolean = isLeft
 
@@ -1273,8 +1273,8 @@ public sealed class Either<out A, out B> {
    * <!--- KNIT example-either-45.kt -->
    */
   @Deprecated(
-    RedundantAPI + "Use `is Either.Right<*>`, `when`, or `fold` instead",
-    ReplaceWith("(this is Either.Right<*>)")
+    RedundantAPI + "isRight()",
+    ReplaceWith("isRight()")
   )
   public fun isNotEmpty(): Boolean = isRight
 

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-34.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-34.kt
@@ -2,13 +2,14 @@
 package arrow.core.examples.exampleEither34
 
 import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.Either.Right
 import io.kotest.matchers.shouldBe
-import io.kotest.assertions.fail
 
 fun test() {
-  Either.Right(1)
-    .fold({ fail("Cannot be left") }, { it + 1 }) shouldBe 2
+ Left(12).isLeft { it > 10 } shouldBe true
+ Left(7).isLeft { it > 10 } shouldBe false
 
-  Either.Left(RuntimeException("Boom!"))
-    .fold({ -1 }, { fail("Cannot be right") }) shouldBe -1
+ val right: Either<Int, String> = Right("Hello World")
+ right.isLeft { it > 10 } shouldBe false
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-35.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-35.kt
@@ -2,9 +2,14 @@
 package arrow.core.examples.exampleEither35
 
 import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.Either.Right
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Left("left").swap() shouldBe Either.Right("left")
-  Either.Right("right").swap() shouldBe Either.Left("right")
+ Right(12).isRight { it > 10 } shouldBe true
+ Right(7).isRight { it > 10 } shouldBe false
+
+ val left: Either<String, Int> = Left("Hello World")
+ left.isRight { it > 10 } shouldBe false
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-36.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-36.kt
@@ -3,8 +3,12 @@ package arrow.core.examples.exampleEither36
 
 import arrow.core.Either
 import io.kotest.matchers.shouldBe
+import io.kotest.assertions.fail
 
 fun test() {
-  Either.Right(12).map { _: Int ->"flower" } shouldBe Either.Right("flower")
-  Either.Left(12).map { _: Nothing -> "flower" } shouldBe Either.Left(12)
+  Either.Right(1)
+    .fold({ fail("Cannot be left") }, { it + 1 }) shouldBe 2
+
+  Either.Left(RuntimeException("Boom!"))
+    .fold({ -1 }, { fail("Cannot be right") }) shouldBe -1
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-37.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-37.kt
@@ -5,6 +5,6 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
- Either.Right(12).mapLeft { _: Nothing -> "flower" } shouldBe Either.Right(12)
- Either.Left(12).mapLeft { _: Int -> "flower" }  shouldBe Either.Left("flower")
+  Either.Left("left").swap() shouldBe Either.Right("left")
+  Either.Right("right").swap() shouldBe Either.Left("right")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-38.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-38.kt
@@ -5,5 +5,6 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(1).onRight(::println) shouldBe Either.Right(1)
+  Either.Right(12).map { _: Int ->"flower" } shouldBe Either.Right("flower")
+  Either.Left(12).map { _: Nothing -> "flower" } shouldBe Either.Left(12)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-39.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-39.kt
@@ -5,5 +5,6 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Left(2).onLeft(::println) shouldBe Either.Left(2)
+ Either.Right(12).mapLeft { _: Nothing -> "flower" } shouldBe Either.Right(12)
+ Either.Left(12).mapLeft { _: Int -> "flower" }  shouldBe Either.Left("flower")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-40.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-40.kt
@@ -2,12 +2,8 @@
 package arrow.core.examples.exampleEither40
 
 import arrow.core.Either
-import arrow.core.Either.Left
+import io.kotest.matchers.shouldBe
 
-fun main() {
- Either.Right(12).exists { it > 10 } // Result: true
- Either.Right(7).exists { it > 10 }  // Result: false
-
- val left: Either<Int, Int> = Left(12)
- left.exists { it > 10 }      // Result: false
+fun test() {
+  Either.Right(1).onRight(::println) shouldBe Either.Right(1)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-41.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-41.kt
@@ -5,6 +5,5 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(12).getOrNull() shouldBe 12
-  Either.Left(12).getOrNull() shouldBe null
+  Either.Left(2).onLeft(::println) shouldBe Either.Left(2)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-42.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-42.kt
@@ -2,9 +2,12 @@
 package arrow.core.examples.exampleEither42
 
 import arrow.core.Either
-import io.kotest.matchers.shouldBe
+import arrow.core.Either.Left
 
-fun test() {
-  Either.Right(12).getOrNull() shouldBe 12
-  Either.Left(12).getOrNull() shouldBe null
+fun main() {
+ Either.Right(12).exists { it > 10 } // Result: true
+ Either.Right(7).exists { it > 10 }  // Result: false
+
+ val left: Either<Int, Int> = Left(12)
+ left.exists { it > 10 }      // Result: false
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-42.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-42.kt
@@ -2,11 +2,9 @@
 package arrow.core.examples.exampleEither42
 
 import arrow.core.Either
-import arrow.core.Some
-import arrow.core.None
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(12).getOrNone() shouldBe Some(12)
-  Either.Left(12).getOrNone() shouldBe None
+  Either.Right(12).getOrNull() shouldBe 12
+  Either.Left(12).getOrNull() shouldBe null
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-43.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-43.kt
@@ -2,11 +2,9 @@
 package arrow.core.examples.exampleEither43
 
 import arrow.core.Either
-import arrow.core.Some
-import arrow.core.None
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(12).getOrNone() shouldBe Some(12)
-  Either.Left(12).getOrNone() shouldBe None
+  Either.Right(12).getOrNull() shouldBe 12
+  Either.Left(12).getOrNull() shouldBe null
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-43.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-43.kt
@@ -1,10 +1,12 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither43
 
-import arrow.core.*
+import arrow.core.Either
+import arrow.core.Some
+import arrow.core.None
+import io.kotest.matchers.shouldBe
 
- fun main(args: Array<String>) {
-  //sampleStart
-  Either.Left("foo").isEmpty()  // Result: true
-  Either.Right("foo").isEmpty() // Result: false
+fun test() {
+  Either.Right(12).getOrNone() shouldBe Some(12)
+  Either.Left(12).getOrNone() shouldBe None
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-44.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-44.kt
@@ -1,10 +1,12 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither44
 
-import arrow.core.*
+import arrow.core.Either
+import arrow.core.Some
+import arrow.core.None
+import io.kotest.matchers.shouldBe
 
- fun main(args: Array<String>) {
-  //sampleStart
-  Either.Left("foo").isEmpty()  // Result: true
-  Either.Right("foo").isEmpty() // Result: false
+fun test() {
+  Either.Right(12).getOrNone() shouldBe Some(12)
+  Either.Left(12).getOrNone() shouldBe None
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-44.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-44.kt
@@ -1,11 +1,10 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither44
 
- import arrow.core.*
+import arrow.core.*
 
  fun main(args: Array<String>) {
   //sampleStart
-  Either.Left("foo").isNotEmpty()  // Result: false
-  Either.Right("foo").isNotEmpty() // Result: true
-  //sampleEnd
+  Either.Left("foo").isEmpty()  // Result: true
+  Either.Right("foo").isEmpty() // Result: false
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-45.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-45.kt
@@ -1,3 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither45
 
+ import arrow.core.*
+
+ fun main(args: Array<String>) {
+  //sampleStart
+  Either.Left("foo").isNotEmpty()  // Result: false
+  Either.Right("foo").isNotEmpty() // Result: true
+  //sampleEnd
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-45.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-45.kt
@@ -1,11 +1,10 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither45
 
- import arrow.core.*
+import arrow.core.*
 
  fun main(args: Array<String>) {
   //sampleStart
-  Either.Left("foo").isNotEmpty()  // Result: false
-  Either.Right("foo").isNotEmpty() // Result: true
-  //sampleEnd
+  Either.Left("foo").isEmpty()  // Result: true
+  Either.Right("foo").isEmpty() // Result: false
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-46.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-46.kt
@@ -1,3 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither46
 
+ import arrow.core.*
+
+ fun main(args: Array<String>) {
+  //sampleStart
+  Either.Left("foo").isNotEmpty()  // Result: false
+  Either.Right("foo").isNotEmpty() // Result: true
+  //sampleEnd
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-46.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-46.kt
@@ -1,10 +1,3 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither46
 
-import arrow.core.Either
-import arrow.core.getOrElse
-import io.kotest.matchers.shouldBe
-
-fun test() {
-  Either.Left(12).getOrElse { it + 5 } shouldBe 17
-}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-47.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-47.kt
@@ -1,10 +1,10 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither47
 
-import arrow.core.Either.Right
-import arrow.core.Either.Left
+import arrow.core.Either
+import arrow.core.getOrElse
+import io.kotest.matchers.shouldBe
 
-fun main() {
-  Right(12).orNull() // Result: 12
-  Left(12).orNull()  // Result: null
+fun test() {
+  Either.Left(12).getOrElse { it + 5 } shouldBe 17
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-47.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-47.kt
@@ -1,10 +1,3 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither47
 
-import arrow.core.Either
-import arrow.core.getOrElse
-import io.kotest.matchers.shouldBe
-
-fun test() {
-  Either.Left(12).getOrElse { it + 5 } shouldBe 17
-}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-48.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-48.kt
@@ -3,9 +3,8 @@ package arrow.core.examples.exampleEither48
 
 import arrow.core.Either.Right
 import arrow.core.Either.Left
-import arrow.core.getOrHandle
 
 fun main() {
-  Right(12).getOrHandle { 17 } // Result: 12
-  Left(12).getOrHandle { it + 5 } // Result: 17
+  Right(12).orNull() // Result: 12
+  Left(12).orNull()  // Result: null
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-48.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-48.kt
@@ -1,10 +1,10 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither48
 
-import arrow.core.Either.Right
-import arrow.core.Either.Left
+import arrow.core.Either
+import arrow.core.getOrElse
+import io.kotest.matchers.shouldBe
 
-fun main() {
-  Right(12).orNull() // Result: 12
-  Left(12).orNull()  // Result: null
+fun test() {
+  Either.Left(12).getOrElse { it + 5 } shouldBe 17
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-49.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-49.kt
@@ -3,9 +3,8 @@ package arrow.core.examples.exampleEither49
 
 import arrow.core.Either.Right
 import arrow.core.Either.Left
-import arrow.core.getOrHandle
 
 fun main() {
-  Right(12).getOrHandle { 17 } // Result: 12
-  Left(12).getOrHandle { it + 5 } // Result: 17
+  Right(12).orNull() // Result: 12
+  Left(12).orNull()  // Result: null
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-49.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-49.kt
@@ -1,14 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither49
 
-import arrow.core.Either.*
-import arrow.core.Either
-import arrow.core.filterOrElse
+import arrow.core.Either.Right
+import arrow.core.Either.Left
+import arrow.core.getOrHandle
 
 fun main() {
-  Right(12).filterOrElse({ it > 10 }, { -1 }) // Result: Right(12)
-  Right(7).filterOrElse({ it > 10 }, { -1 })  // Result: Left(-1)
-
-  val left: Either<Int, Int> = Left(12)
-  left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
+  Right(12).getOrHandle { 17 } // Result: 12
+  Left(12).getOrHandle { it + 5 } // Result: 17
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-50.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-50.kt
@@ -1,17 +1,14 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither50
 
-import arrow.core.*
+import arrow.core.Either.*
+import arrow.core.Either
+import arrow.core.filterOrElse
 
-suspend fun main(): Unit {
-  //sampleStart
-  Either.Right(7).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
-    .let(::println) // Either.Left(Value '7' is not equal to 10")
+fun main() {
+  Right(12).filterOrElse({ it > 10 }, { -1 }) // Result: Right(12)
+  Right(7).filterOrElse({ it > 10 }, { -1 })  // Result: Left(-1)
 
-  Either.Right(10).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
-    .let(::println) // Either.Right(10)
-
-  Either.Left(12).filterOrOther({ str: String -> str.contains("impossible") }, { -1 })
-    .let(::println) // Either.Left(12)
-  //sampleEnd
+  val left: Either<Int, Int> = Left(12)
+  left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-50.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-50.kt
@@ -1,14 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither50
 
-import arrow.core.Either.*
-import arrow.core.Either
-import arrow.core.filterOrElse
+import arrow.core.Either.Right
+import arrow.core.Either.Left
+import arrow.core.getOrHandle
 
 fun main() {
-  Right(12).filterOrElse({ it > 10 }, { -1 }) // Result: Right(12)
-  Right(7).filterOrElse({ it > 10 }, { -1 })  // Result: Left(-1)
-
-  val left: Either<Int, Int> = Left(12)
-  left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
+  Right(12).getOrHandle { 17 } // Result: 12
+  Left(12).getOrHandle { it + 5 } // Result: 17
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-51.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-51.kt
@@ -1,17 +1,14 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither51
 
-import arrow.core.*
+import arrow.core.Either.*
+import arrow.core.Either
+import arrow.core.filterOrElse
 
-suspend fun main(): Unit {
-  //sampleStart
-  Either.Right(7).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
-    .let(::println) // Either.Left(Value '7' is not equal to 10")
+fun main() {
+  Right(12).filterOrElse({ it > 10 }, { -1 }) // Result: Right(12)
+  Right(7).filterOrElse({ it > 10 }, { -1 })  // Result: Left(-1)
 
-  Either.Right(10).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
-    .let(::println) // Either.Right(10)
-
-  Either.Left(12).filterOrOther({ str: String -> str.contains("impossible") }, { -1 })
-    .let(::println) // Either.Left(12)
-  //sampleEnd
+  val left: Either<Int, Int> = Left(12)
+  left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-51.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-51.kt
@@ -1,11 +1,17 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither51
 
-import arrow.core.Either.Left
-import arrow.core.Either.Right
-import arrow.core.merge
+import arrow.core.*
 
-fun test() {
-  Right(12).merge() // Result: 12
-  Left(12).merge() // Result: 12
+suspend fun main(): Unit {
+  //sampleStart
+  Either.Right(7).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
+    .let(::println) // Either.Left(Value '7' is not equal to 10")
+
+  Either.Right(10).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
+    .let(::println) // Either.Right(10)
+
+  Either.Left(12).filterOrOther({ str: String -> str.contains("impossible") }, { -1 })
+    .let(::println) // Either.Left(12)
+  //sampleEnd
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-52.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-52.kt
@@ -1,12 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither52
 
-import arrow.core.Either.*
-import arrow.core.leftIfNull
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.merge
 
-fun main() {
-  Right(12).leftIfNull({ -1 })   // Result: Right(12)
-  Right(null).leftIfNull({ -1 }) // Result: Left(-1)
-
-  Left(12).leftIfNull({ -1 })    // Result: Left(12)
+fun test() {
+  Right(12).merge() // Result: 12
+  Left(12).merge() // Result: 12
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-52.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-52.kt
@@ -1,11 +1,17 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither52
 
-import arrow.core.Either.Left
-import arrow.core.Either.Right
-import arrow.core.merge
+import arrow.core.*
 
-fun test() {
-  Right(12).merge() // Result: 12
-  Left(12).merge() // Result: 12
+suspend fun main(): Unit {
+  //sampleStart
+  Either.Right(7).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
+    .let(::println) // Either.Left(Value '7' is not equal to 10")
+
+  Either.Right(10).filterOrOther({ it == 10 }, { "Value '$it' is not equal to 10" })
+    .let(::println) // Either.Right(10)
+
+  Either.Left(12).filterOrOther({ str: String -> str.contains("impossible") }, { -1 })
+    .let(::println) // Either.Left(12)
+  //sampleEnd
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-53.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-53.kt
@@ -1,9 +1,12 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither53
 
-import arrow.core.rightIfNotNull
+import arrow.core.Either.*
+import arrow.core.leftIfNull
 
 fun main() {
-  "value".rightIfNotNull { "left" } // Right(b="value")
-  null.rightIfNotNull { "left" }    // Left(a="left")
+  Right(12).leftIfNull({ -1 })   // Result: Right(12)
+  Right(null).leftIfNull({ -1 }) // Result: Left(-1)
+
+  Left(12).leftIfNull({ -1 })    // Result: Left(12)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-53.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-53.kt
@@ -1,12 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither53
 
-import arrow.core.Either.*
-import arrow.core.leftIfNull
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.merge
 
-fun main() {
-  Right(12).leftIfNull({ -1 })   // Result: Right(12)
-  Right(null).leftIfNull({ -1 }) // Result: Left(-1)
-
-  Left(12).leftIfNull({ -1 })    // Result: Left(12)
+fun test() {
+  Right(12).merge() // Result: 12
+  Left(12).merge() // Result: 12
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-54.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-54.kt
@@ -1,13 +1,9 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither54
 
-import arrow.core.*
+import arrow.core.rightIfNotNull
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val string: Either<Int, String> = "Hello".right()
-  val chars: Either<Int, CharSequence> =
-    string.widen<Int, CharSequence, String>()
-  //sampleEnd
-  println(chars)
+fun main() {
+  "value".rightIfNotNull { "left" } // Right(b="value")
+  null.rightIfNotNull { "left" }    // Left(a="left")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-54.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-54.kt
@@ -1,9 +1,12 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither54
 
-import arrow.core.rightIfNotNull
+import arrow.core.Either.*
+import arrow.core.leftIfNull
 
 fun main() {
-  "value".rightIfNotNull { "left" } // Right(b="value")
-  null.rightIfNotNull { "left" }    // Left(a="left")
+  Right(12).leftIfNull({ -1 })   // Result: Right(12)
+  Right(null).leftIfNull({ -1 }) // Result: Left(-1)
+
+  Left(12).leftIfNull({ -1 })    // Result: Left(12)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-55.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-55.kt
@@ -1,13 +1,9 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither55
 
-import arrow.core.*
+import arrow.core.rightIfNotNull
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val string: Either<Int, String> = "Hello".right()
-  val chars: Either<Int, CharSequence> =
-    string.widen<Int, CharSequence, String>()
-  //sampleEnd
-  println(chars)
+fun main() {
+  "value".rightIfNotNull { "left" } // Right(b="value")
+  null.rightIfNotNull { "left" }    // Left(a="left")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-55.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-55.kt
@@ -1,12 +1,13 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither55
 
-import arrow.core.Either
-import arrow.core.recover
-import io.kotest.matchers.shouldBe
+import arrow.core.*
 
-fun test() {
-  val error: Either<String, Int> = Either.Left("error")
-  val fallback: Either<Nothing, Int> = error.recover { it.length }
-  fallback shouldBe Either.Right(5)
+fun main(args: Array<String>) {
+  //sampleStart
+  val string: Either<Int, String> = "Hello".right()
+  val chars: Either<Int, CharSequence> =
+    string.widen<Int, CharSequence, String>()
+  //sampleEnd
+  println(chars)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-56.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-56.kt
@@ -7,6 +7,6 @@ import io.kotest.matchers.shouldBe
 
 fun test() {
   val error: Either<String, Int> = Either.Left("error")
-  val listOfErrors: Either<List<Char>, Int> = error.recover { shift(it.toList()) }
-  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
+  val fallback: Either<Nothing, Int> = error.recover { it.length }
+  fallback shouldBe Either.Right(5)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-56.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-56.kt
@@ -1,12 +1,13 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither56
 
-import arrow.core.Either
-import arrow.core.recover
-import io.kotest.matchers.shouldBe
+import arrow.core.*
 
-fun test() {
-  val error: Either<String, Int> = Either.Left("error")
-  val fallback: Either<Nothing, Int> = error.recover { it.length }
-  fallback shouldBe Either.Right(5)
+fun main(args: Array<String>) {
+  //sampleStart
+  val string: Either<Int, String> = "Hello".right()
+  val chars: Either<Int, CharSequence> =
+    string.widen<Int, CharSequence, String>()
+  //sampleEnd
+  println(chars)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-57.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-57.kt
@@ -7,6 +7,6 @@ import io.kotest.matchers.shouldBe
 
 fun test() {
   val error: Either<String, Int> = Either.Left("error")
-  val listOfErrors: Either<List<Char>, Int> = error.recover { shift(it.toList()) }
-  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
+  val fallback: Either<Nothing, Int> = error.recover { it.length }
+  fallback shouldBe Either.Right(5)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-57.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-57.kt
@@ -2,20 +2,11 @@
 package arrow.core.examples.exampleEither57
 
 import arrow.core.Either
-import arrow.core.catch
-import io.kotest.assertions.throwables.shouldThrowUnit
+import arrow.core.recover
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
-
-  val caught: Either<Nothing, Int> = left.catch { _: Throwable -> 1 }
-  val failure: Either<String, Int> = left.catch { _: Throwable -> shift("failure") }
-
-  shouldThrowUnit<RuntimeException> {
-    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
-  }
-
-  caught shouldBe Either.Right(1)
-  failure shouldBe Either.Left("failure")
+  val error: Either<String, Int> = Either.Left("error")
+  val listOfErrors: Either<List<Char>, Int> = error.recover { shift(it.toList()) }
+  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-58.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-58.kt
@@ -2,20 +2,11 @@
 package arrow.core.examples.exampleEither58
 
 import arrow.core.Either
-import arrow.core.catch
-import io.kotest.assertions.throwables.shouldThrowUnit
+import arrow.core.recover
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
-
-  val caught: Either<Nothing, Int> = left.catch { _: Throwable -> 1 }
-  val failure: Either<String, Int> = left.catch { _: Throwable -> shift("failure") }
-
-  shouldThrowUnit<RuntimeException> {
-    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
-  }
-
-  caught shouldBe Either.Right(1)
-  failure shouldBe Either.Left("failure")
+  val error: Either<String, Int> = Either.Left("error")
+  val listOfErrors: Either<List<Char>, Int> = error.recover { shift(it.toList()) }
+  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-58.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-58.kt
@@ -1,0 +1,21 @@
+// This file was automatically generated from Either.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleEither58
+
+import arrow.core.Either
+import arrow.core.catch
+import io.kotest.assertions.throwables.shouldThrowUnit
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
+
+  val caught: Either<Nothing, Int> = left.catch { _: Throwable -> 1 }
+  val failure: Either<String, Int> = left.catch { _: Throwable -> shift("failure") }
+
+  shouldThrowUnit<RuntimeException> {
+    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
+  }
+
+  caught shouldBe Either.Right(1)
+  failure shouldBe Either.Left("failure")
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-59.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-59.kt
@@ -1,0 +1,21 @@
+// This file was automatically generated from Either.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleEither59
+
+import arrow.core.Either
+import arrow.core.catch
+import io.kotest.assertions.throwables.shouldThrowUnit
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
+
+  val caught: Either<Nothing, Int> = left.catch { _: Throwable -> 1 }
+  val failure: Either<String, Int> = left.catch { _: Throwable -> shift("failure") }
+
+  shouldThrowUnit<RuntimeException> {
+    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
+  }
+
+  caught shouldBe Either.Right(1)
+  failure shouldBe Either.Left("failure")
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
@@ -32,24 +32,20 @@ class EitherKnitTest : StringSpec({
     arrow.core.examples.exampleEither41.test()
   }
 
-  "ExampleEither42" {
-    arrow.core.examples.exampleEither42.test()
-  }
-
   "ExampleEither43" {
     arrow.core.examples.exampleEither43.test()
   }
 
-  "ExampleEither47" {
-    arrow.core.examples.exampleEither47.test()
+  "ExampleEither44" {
+    arrow.core.examples.exampleEither44.test()
   }
 
-  "ExampleEither52" {
-    arrow.core.examples.exampleEither52.test()
+  "ExampleEither48" {
+    arrow.core.examples.exampleEither48.test()
   }
 
-  "ExampleEither56" {
-    arrow.core.examples.exampleEither56.test()
+  "ExampleEither53" {
+    arrow.core.examples.exampleEither53.test()
   }
 
   "ExampleEither57" {
@@ -58,6 +54,10 @@ class EitherKnitTest : StringSpec({
 
   "ExampleEither58" {
     arrow.core.examples.exampleEither58.test()
+  }
+
+  "ExampleEither59" {
+    arrow.core.examples.exampleEither59.test()
   }
 
 }) {

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
@@ -8,12 +8,12 @@ class EitherKnitTest : StringSpec({
     arrow.core.examples.exampleEither34.test()
   }
 
-  "ExampleEither36" {
-    arrow.core.examples.exampleEither36.test()
+  "ExampleEither35" {
+    arrow.core.examples.exampleEither35.test()
   }
 
-  "ExampleEither37" {
-    arrow.core.examples.exampleEither37.test()
+  "ExampleEither36" {
+    arrow.core.examples.exampleEither36.test()
   }
 
   "ExampleEither38" {
@@ -24,6 +24,10 @@ class EitherKnitTest : StringSpec({
     arrow.core.examples.exampleEither39.test()
   }
 
+  "ExampleEither40" {
+    arrow.core.examples.exampleEither40.test()
+  }
+
   "ExampleEither41" {
     arrow.core.examples.exampleEither41.test()
   }
@@ -32,16 +36,16 @@ class EitherKnitTest : StringSpec({
     arrow.core.examples.exampleEither42.test()
   }
 
-  "ExampleEither46" {
-    arrow.core.examples.exampleEither46.test()
+  "ExampleEither43" {
+    arrow.core.examples.exampleEither43.test()
   }
 
-  "ExampleEither51" {
-    arrow.core.examples.exampleEither51.test()
+  "ExampleEither47" {
+    arrow.core.examples.exampleEither47.test()
   }
 
-  "ExampleEither55" {
-    arrow.core.examples.exampleEither55.test()
+  "ExampleEither52" {
+    arrow.core.examples.exampleEither52.test()
   }
 
   "ExampleEither56" {
@@ -50,6 +54,10 @@ class EitherKnitTest : StringSpec({
 
   "ExampleEither57" {
     arrow.core.examples.exampleEither57.test()
+  }
+
+  "ExampleEither58" {
+    arrow.core.examples.exampleEither58.test()
   }
 
 }) {


### PR DESCRIPTION
In an interesting https://github.com/arrow-kt/arrow/pull/2913#discussion_r1097879312 between myself, @myuwono and @franciscodr in [Option API deprecation](https://github.com/arrow-kt/arrow/pull/2913) we came up with a set of new operators to replace `exists` in a new meaningful API that we thought was very Kotlin idiomatic.

This PR adds the relevant APIs for `Either`.