### PR TITLE
Deprecate Validated

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1144,6 +1144,10 @@ public sealed class Either<out A, out B> {
     return getOrElse { null }
   }
 
+  @Deprecated(
+    "orNone is being renamed to getOrNone to be more consistent with the Kotlin Standard Library naming",
+    ReplaceWith("getOrNone()")
+  )
   public fun orNone(): Option<B> = getOrNone()
 
   /**
@@ -1338,6 +1342,9 @@ public sealed class Either<out A, out B> {
 
   public fun toValidated(): Validated<A, B> =
     fold({ it.invalid() }, { it.valid() })
+
+  public fun toIor(): Ior<A, B> =
+    fold({ Ior.Left(it) }, { Ior.Right(it) })
 
   public companion object {
 
@@ -1950,6 +1957,13 @@ public sealed class Either<out A, out B> {
   )
   public fun void(): Either<A, Unit> =
     map { }
+
+  @Deprecated(
+    "Facilitates the migration from Validated to Either, you can simply remove this method call.",
+    ReplaceWith("this")
+  )
+  public fun toEither(): Either<A, B> =
+    this
 }
 
 /**
@@ -2602,7 +2616,7 @@ public const val RedundantAPI: String =
 public fun <E, A> Either<E, A>.toEitherNel(): EitherNel<E, A> =
   mapLeft { nonEmptyListOf(it) }
 
-public fun <E> E.toEitherNel(): EitherNel<E, Nothing> =
+public fun <E> E.leftNel(): EitherNel<E, Nothing> =
   nonEmptyListOf(this).left()
 
 /**

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Validated.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Validated.kt
@@ -8,23 +8,36 @@ import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 
+@Deprecated(DeprMsg + "ValidatedNel is being replaced by EitherNel")
 public typealias ValidatedNel<E, A> = Validated<Nel<E>, A>
+
 public typealias Valid<A> = Validated.Valid<A>
+
 public typealias Invalid<E> = Validated.Invalid<E>
 
+@Deprecated(DeprMsg + "You can find more details about how to migrate on the Github release page, or the 1.2.0 release post.")
 public sealed class Validated<out E, out A> {
 
   public companion object {
 
+    @Deprecated(
+      DeprMsg + "Use leftNel instead to construct the equivalent Either value",
+      ReplaceWith("e.leftNel()", "arrow.core.leftNel")
+    )
     @JvmStatic
     public fun <E, A> invalidNel(e: E): ValidatedNel<E, A> = Invalid(nonEmptyListOf(e))
 
+    @Deprecated(
+      DeprMsg + "Use right instead to construct the equivalent Either value",
+      ReplaceWith("a.right()", "arrow.core.right")
+    )
     @JvmStatic
     public fun <E, A> validNel(a: A): ValidatedNel<E, A> = Valid(a)
 
     /**
      * Converts an `Either<E, A>` to a `Validated<E, A>`.
      */
+    @Deprecated(DeprMsg)
     @JvmStatic
     public fun <E, A> fromEither(e: Either<E, A>): Validated<E, A> = e.fold({ Invalid(it) }, { Valid(it) })
 
@@ -32,21 +45,30 @@ public sealed class Validated<out E, out A> {
      * Converts an `Option<A>` to a `Validated<E, A>`, where the provided `ifNone` output value is returned as [Invalid]
      * when the specified `Option` is `None`.
      */
+    @Deprecated(
+      DeprAndNicheMsg + "Prefer using toEither on Option instead",
+      ReplaceWith("o.toEither(ifNone).toValidated()")
+    )
     @JvmStatic
     public inline fun <E, A> fromOption(o: Option<A>, ifNone: () -> E): Validated<E, A> =
-      o.fold(
-        { Invalid(ifNone()) },
-        { Valid(it) }
-      )
+      o.toEither(ifNone).toValidated()
 
     /**
      * Converts a nullable `A?` to a `Validated<E, A>`, where the provided `ifNull` output value is returned as [Invalid]
      * when the specified value is null.
      */
+    @Deprecated(
+      DeprAndNicheMsg + "Prefer Kotlin nullable syntax, or ensureNotNull inside Either DSL",
+      ReplaceWith("value?.valid() ?: ifNull().invalid()")
+    )
     @JvmStatic
     public inline fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
-      value?.let(::Valid) ?: Invalid(ifNull())
+      value?.valid() ?: ifNull().invalid()
 
+    @Deprecated(
+      DeprMsg + "Use Either.catch instead",
+      ReplaceWith("Either.catch(f).toValidated()")
+    )
     @JvmStatic
     @JvmName("tryCatch")
     public inline fun <A> catch(f: () -> A): Validated<Throwable, A> =
@@ -56,11 +78,19 @@ public sealed class Validated<out E, out A> {
         e.nonFatalOrThrow().invalid()
       }
 
+    @Deprecated(
+      DeprAndNicheMsg + "Use Either.catch and mapLeft instead",
+      ReplaceWith("Either.catch(f).mapLeft(recover).toValidated()")
+    )
     @JvmStatic
     @JvmName("tryCatch")
     public inline fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
       catch(f).mapLeft(recover)
 
+    @Deprecated(
+      DeprAndNicheMsg + "Use Either.catch and toEitherNel instead",
+      ReplaceWith("Either.catch(f).toEitherNel().toValidated()")
+    )
     @JvmStatic
     public inline fun <A> catchNel(f: () -> A): ValidatedNel<Throwable, A> =
       try {
@@ -69,6 +99,10 @@ public sealed class Validated<out E, out A> {
         e.nonFatalOrThrow().invalidNel()
       }
 
+    @Deprecated(
+      DeprAndNicheMsg + "Prefer creating explicit lambdas instead",
+      ReplaceWith("{ it.map(f) }")
+    )
     @JvmStatic
     public inline fun <E, A, B> lift(crossinline f: (A) -> B): (Validated<E, A>) -> Validated<E, B> =
       { fa -> fa.map(f) }
@@ -91,6 +125,10 @@ public sealed class Validated<out E, out A> {
      * ```
      * <!--- KNIT example-validated-01.kt -->
      */
+    @Deprecated(
+      DeprAndNicheMsg + "Prefer creating explicit lambdas instead",
+      ReplaceWith("{ it.bimap(fl, fr) }")
+    )
     @JvmStatic
     public inline fun <A, B, C, D> lift(
       crossinline fl: (A) -> C,
@@ -116,6 +154,10 @@ public sealed class Validated<out E, out A> {
    * ```
    * <!--- KNIT example-validated-02.kt -->
    */
+  @Deprecated(
+    DeprAndNicheMsg + "Use map on Either after refactoring instead",
+    ReplaceWith("toEither().map { }.toValidated()")
+  )
   public fun void(): Validated<E, Unit> =
     map { Unit }
 
@@ -186,6 +228,10 @@ public sealed class Validated<out E, out A> {
   ): Validated<B, C>? =
     fold({ fe(it)?.let(::Invalid) }, { fa(it)?.let(::Valid) })
 
+  @Deprecated(
+    DeprMsg + "Use fold on Either after refactoring instead",
+    ReplaceWith("toEither().fold({ MB.empty() }, f)")
+  )
   public inline fun <B> foldMap(MB: Monoid<B>, f: (A) -> B): B =
     fold({ MB.empty() }, f)
 
@@ -194,6 +240,10 @@ public sealed class Validated<out E, out A> {
     { "Validated.Valid($it)" }
   )
 
+  @Deprecated(
+    DeprMsg + "Use Right to construct Either values instead",
+    ReplaceWith("Either.Right(value)", "arrow.core.Either")
+  )
   public data class Valid<out A>(val value: A) : Validated<Nothing, A>() {
     override fun toString(): String = "Validated.Valid($value)"
 
@@ -204,38 +254,75 @@ public sealed class Validated<out E, out A> {
     }
   }
 
+  @Deprecated(
+    DeprMsg + "Use Left to construct Either values instead",
+    ReplaceWith("Either.Left(value)", "arrow.core.Either")
+  )
   public data class Invalid<out E>(val value: E) : Validated<E, Nothing>() {
     override fun toString(): String = "Validated.Invalid($value)"
   }
 
+  @Deprecated(
+    DeprMsg + "Use fold on Either after refactoring",
+    ReplaceWith("fold(fe, fa)")
+  )
   public inline fun <B> fold(fe: (E) -> B, fa: (A) -> B): B =
     when (this) {
       is Valid -> fa(value)
       is Invalid -> (fe(value))
     }
 
+  @Deprecated(
+    DeprMsg + "Use isRight on Either after refactoring",
+    ReplaceWith("toEither().isRight()")
+  )
   public val isValid: Boolean =
     fold({ false }, { true })
+
+  @Deprecated(
+    DeprMsg + "Use isLeft on Either after refactoring",
+    ReplaceWith("toEither().isLeft()")
+  )
   public val isInvalid: Boolean =
     fold({ true }, { false })
 
   /**
    * Is this Valid and matching the given predicate
    */
+  @Deprecated(
+    DeprMsg + "Use isRight on Either after refactoring",
+    ReplaceWith("toEither().isRight(predicate)")
+  )
   public inline fun exist(predicate: (A) -> Boolean): Boolean =
     fold({ false }, predicate)
 
+  @Deprecated(
+    DeprAndNicheMsg + "Use getOrNull and takeIf on Either after refactoring",
+    ReplaceWith("toEither().getOrNull()?.takeIf(predicate)")
+  )
   public inline fun findOrNull(predicate: (A) -> Boolean): A? =
     when (this) {
       is Valid -> if (predicate(this.value)) this.value else null
       is Invalid -> null
     }
 
+  @Deprecated(
+    DeprAndNicheMsg + "Use fold on Either after refactoring",
+    ReplaceWith("toEither().fold({ true }, predicate)")
+  )
   public inline fun all(predicate: (A) -> Boolean): Boolean =
     fold({ true }, predicate)
 
+  @Deprecated(
+    DeprMsg + "Use isRight on Either after refactoring",
+    ReplaceWith("toEither().isLeft()")
+  )
   public fun isEmpty(): Boolean = isInvalid
 
+  @Deprecated(
+    DeprMsg + "Use isRight on Either after refactoring",
+    ReplaceWith("toEither().isRight()")
+  )
   public fun isNotEmpty(): Boolean = isValid
 
   /**
@@ -247,6 +334,10 @@ public sealed class Validated<out E, out A> {
   /**
    * Returns Valid values wrapped in Some, and None for Invalid values
    */
+  @Deprecated(
+    DeprMsg + "Use getOrNone on Either after refactoring",
+    ReplaceWith("toEither().getOrNone()")
+  )
   public fun toOption(): Option<A> =
     fold({ None }, ::Some)
 
@@ -254,10 +345,18 @@ public sealed class Validated<out E, out A> {
    * Convert this value to a single element List if it is Valid,
    * otherwise return an empty List
    */
+  @Deprecated(
+    DeprAndNicheMsg + "Use fold instead",
+    ReplaceWith("fold({ emptyList() }, ::listOf)")
+  )
   public fun toList(): List<A> =
-    fold({ listOf() }, ::listOf)
+    fold({ emptyList() }, ::listOf)
 
   /** Lift the Invalid value into a NonEmptyList. */
+  @Deprecated(
+    DeprMsg + "Use toEitherNel directly instead",
+    ReplaceWith("toEither().toEitherNel().toValidated()")
+  )
   public fun toValidatedNel(): ValidatedNel<E, A> =
     fold({ invalidNel(it) }, ::Valid)
 
@@ -265,8 +364,12 @@ public sealed class Validated<out E, out A> {
    * Convert to an Either, apply a function, convert back. This is handy
    * when you want to use the Monadic properties of the Either type.
    */
+  @Deprecated(
+    DeprMsg + "Use Either directly instead",
+    ReplaceWith("toEither().let(f).toValidated()")
+  )
   public inline fun <EE, B> withEither(f: (Either<E, A>) -> Either<EE, B>): Validated<EE, B> =
-    fromEither(f(toEither()))
+    toEither().let(f).toValidated()
 
   /**
    * From [arrow.typeclasses.Bifunctor], maps both types of this Validated.
@@ -279,6 +382,10 @@ public sealed class Validated<out E, out A> {
   /**
    * Apply a function to a Valid value, returning a new Valid value
    */
+  @Deprecated(
+    DeprMsg + "Use map on Either after refactoring",
+    ReplaceWith("toEither().mapLeft(f).toValidated()")
+  )
   public inline fun <B> map(f: (A) -> B): Validated<E, B> =
     bimap(::identity, f)
 
@@ -286,6 +393,10 @@ public sealed class Validated<out E, out A> {
    * Apply a function to an Invalid value, returning a new Invalid value.
    * Or, if the original valid was Valid, return it.
    */
+  @Deprecated(
+    DeprMsg + "Use mapLeft on Either after refactoring",
+    ReplaceWith("toEither().mapLeft(f).toValidated()")
+  )
   public inline fun <EE> mapLeft(f: (E) -> EE): Validated<EE, A> =
     bimap(f, ::identity)
 
@@ -306,12 +417,17 @@ public sealed class Validated<out E, out A> {
    * ```
    * <!--- KNIT example-validated-03.kt -->
    */
+  @Deprecated(
+    DeprMsg + "Use onLeft on Either after refactoring",
+    ReplaceWith("toEither().onRight(f).toValidated()")
+  )
   public inline fun tapInvalid(f: (E) -> Unit): Validated<E, A> =
     when (this) {
       is Invalid -> {
         f(this.value)
         this
       }
+
       is Valid -> this
     }
 
@@ -332,6 +448,10 @@ public sealed class Validated<out E, out A> {
    * ```
    * <!--- KNIT example-validated-04.kt -->
    */
+  @Deprecated(
+    DeprMsg + "Use onRight on Either after refactoring",
+    ReplaceWith("toEither().onRight(f).toValidated()")
+  )
   public inline fun tap(f: (A) -> Unit): Validated<E, A> =
     when (this) {
       is Invalid -> this
@@ -345,16 +465,38 @@ public sealed class Validated<out E, out A> {
    * apply the given function to the value with the given B when
    * valid, otherwise return the given B
    */
+  @Deprecated(
+    DeprMsg + "Use fold on Either after refactoring",
+    ReplaceWith("toEither().fold({ b }) { f(b, it) }")
+  )
   public inline fun <B> foldLeft(b: B, f: (B, A) -> B): B =
-    fold({ b }, { f(b, it) })
+    toEither().fold({ b }) { f(b, it) }
 
+  @Deprecated(
+    DeprMsg + "Use widen on Either after refactoring",
+    ReplaceWith("toEither().swap()")
+  )
   public fun swap(): Validated<A, E> =
     fold(::Valid, ::Invalid)
 }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), fb.toEither(), ::Pair).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public fun <E, A, B> Validated<E, A>.zip(SE: Semigroup<E>, fb: Validated<E, B>): Validated<E, Pair<A, B>> =
-  zip(SE, fb, ::Pair)
+  Either.zipOrAccumulate({ a, b -> SE.run { a.combine(b) } }, toEither(), fb.toEither(), ::Pair).toValidated()
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -375,6 +517,13 @@ public inline fun <E, A, B, Z> Validated<E, A>.zip(
     f(a, b)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -396,6 +545,13 @@ public inline fun <E, A, B, C, Z> Validated<E, A>.zip(
     f(a, b, c)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -418,6 +574,13 @@ public inline fun <E, A, B, C, D, Z> Validated<E, A>.zip(
     f(a, b, c, d)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -441,6 +604,13 @@ public inline fun <E, A, B, C, D, EE, Z> Validated<E, A>.zip(
     f(a, b, c, d, e)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, FF, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -465,6 +635,13 @@ public inline fun <E, A, B, C, D, EE, FF, Z> Validated<E, A>.zip(
     f(a, b, c, d, e, ff)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -479,6 +656,13 @@ public inline fun <E, A, B, C, D, EE, F, G, Z> Validated<E, A>.zip(
     f(a, b, c, d, e, ff, g)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), h.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, H, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -494,6 +678,13 @@ public inline fun <E, A, B, C, D, EE, F, G, H, Z> Validated<E, A>.zip(
     f(a, b, c, d, e, ff, g, h)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), h.toEither(), i.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, H, I, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -510,6 +701,13 @@ public inline fun <E, A, B, C, D, EE, F, G, H, I, Z> Validated<E, A>.zip(
     f(a, b, c, d, e, ff, g, h, i)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate({ a, b -> SE.run<Semigroup<E>, E> { a.combine(b) } }, toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), h.toEither(), i.toEither(), j.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, H, I, J, Z> Validated<E, A>.zip(
   SE: Semigroup<E>,
   b: Validated<E, B>,
@@ -551,12 +749,26 @@ public inline fun <E, A, B, C, D, EE, F, G, H, I, J, Z> Validated<E, A>.zip(
     Validated.Invalid(accumulatedError as E)
   }
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   f: (A, B) -> Z
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -564,6 +776,13 @@ public inline fun <E, A, B, C, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -572,6 +791,13 @@ public inline fun <E, A, B, C, D, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, d, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -581,6 +807,13 @@ public inline fun <E, A, B, C, D, EE, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, d, e, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, FF, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -591,6 +824,13 @@ public inline fun <E, A, B, C, D, EE, FF, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, d, e, ff, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -602,6 +842,13 @@ public inline fun <E, A, B, C, D, EE, F, G, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, d, e, ff, g, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), h.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, H, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -614,6 +861,13 @@ public inline fun <E, A, B, C, D, EE, F, G, H, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, d, e, ff, g, h, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), h.toEither(), i.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, H, I, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -627,6 +881,13 @@ public inline fun <E, A, B, C, D, EE, F, G, H, I, Z> ValidatedNel<E, A>.zip(
 ): ValidatedNel<E, Z> =
   zip(Semigroup.nonEmptyList(), b, c, d, e, ff, g, h, i, f)
 
+@Deprecated(
+  DeprMsg + "zipOrAccumulate for Either now exposes this same functionality",
+  ReplaceWith(
+    "Either.zipOrAccumulate(toEither(), b.toEither(), c.toEither(), d.toEither(), e.toEither(), ff.toEither(), g.toEither(), h.toEither(), i.toEither(), j.toEither(), f).toValidated()",
+    "arrow.core.Either"
+  )
+)
 public inline fun <E, A, B, C, D, EE, F, G, H, I, J, Z> ValidatedNel<E, A>.zip(
   b: ValidatedNel<E, B>,
   c: ValidatedNel<E, C>,
@@ -642,7 +903,7 @@ public inline fun <E, A, B, C, D, EE, F, G, H, I, J, Z> ValidatedNel<E, A>.zip(
   zip(Semigroup.nonEmptyList(), b, c, d, e, ff, g, h, i, j, f)
 
 /**
- * Given [A] is a sub type of [B], re-type this value from Validated<E, A> to Validated<E, B>
+ * Given [A] is a subtype of [B], re-type this value from Validated<E, A> to Validated<E, B>
  *
  * ```kotlin
  * import arrow.core.*
@@ -658,9 +919,17 @@ public inline fun <E, A, B, C, D, EE, F, G, H, I, J, Z> ValidatedNel<E, A>.zip(
  * ```
  * <!--- KNIT example-validated-05.kt -->
  */
+@Deprecated(
+  DeprMsg + "Use widen on Either after refactoring",
+  ReplaceWith("toEither().widen()")
+)
 public fun <E, B, A : B> Validated<E, A>.widen(): Validated<E, B> =
   this
 
+@Deprecated(
+  DeprMsg + "Use leftWiden on Either after refactoring",
+  ReplaceWith("toEither().leftWiden()")
+)
 public fun <EE, E : EE, A> Validated<E, A>.leftWiden(): Validated<EE, A> =
   this
 
@@ -695,27 +964,40 @@ public fun <E, A> Validated<E, A>.combineAll(MA: Monoid<A>): A =
 public fun <E, A> Validated<E, Iterable<A>>.sequence(): List<Validated<E, A>> =
   traverse(::identity)
 
-@Deprecated("sequenceEither is being renamed to sequence to simplify the Arrow API", ReplaceWith("sequence()", "arrow.core.sequence"))
+@Deprecated(
+  "sequenceEither is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence()", "arrow.core.sequence")
+)
 public fun <E, A, B> Validated<A, Either<E, B>>.sequenceEither(): Either<E, Validated<A, B>> =
   sequence()
 
 public fun <E, A, B> Validated<A, Either<E, B>>.sequence(): Either<E, Validated<A, B>> =
   traverse(::identity)
 
-@Deprecated("sequenceOption is being renamed to sequence to simplify the Arrow API", ReplaceWith("sequence()", "arrow.core.sequence"))
+@Deprecated(
+  "sequenceOption is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence()", "arrow.core.sequence")
+)
 public fun <A, B> Validated<A, Option<B>>.sequenceOption(): Option<Validated<A, B>> =
   sequence()
 
 public fun <A, B> Validated<A, Option<B>>.sequence(): Option<Validated<A, B>> =
   traverse(::identity)
 
-@Deprecated("sequenceNullable is being renamed to sequence to simplify the Arrow API", ReplaceWith("sequence()", "arrow.core.sequence"))
+@Deprecated(
+  "sequenceNullable is being renamed to sequence to simplify the Arrow API",
+  ReplaceWith("sequence()", "arrow.core.sequence")
+)
 public fun <A, B> Validated<A, B?>.sequenceNullable(): Validated<A, B>? =
   sequence()
 
 public fun <A, B> Validated<A, B?>.sequence(): Validated<A, B>? =
   traverseNullable(::identity)
 
+@Deprecated(
+  DeprMsg + "Use compareTo on Either after refactoring",
+  ReplaceWith("toEither().getOrElse { default() }")
+)
 public operator fun <E : Comparable<E>, A : Comparable<A>> Validated<E, A>.compareTo(other: Validated<E, A>): Int =
   fold(
     { l1 -> other.fold({ l2 -> l1.compareTo(l2) }, { -1 }) },
@@ -725,38 +1007,62 @@ public operator fun <E : Comparable<E>, A : Comparable<A>> Validated<E, A>.compa
 /**
  * Return the Valid value, or the default if Invalid
  */
+@Deprecated(
+  DeprMsg + "Use getOrElse on Either after refactoring",
+  ReplaceWith("toEither().getOrElse { default() }")
+)
 public inline fun <E, A> Validated<E, A>.getOrElse(default: () -> A): A =
-  fold({ default() }, ::identity)
+  toEither().getOrElse { default() }
 
 /**
  * Return the Valid value, or null if Invalid
  */
+@Deprecated(
+  DeprMsg + "Use getOrNull on Either after refactoring",
+  ReplaceWith("toEither().getOrNull()")
+)
 public fun <E, A> Validated<E, A>.orNull(): A? =
-  getOrElse { null }
+  toEither().getOrNull()
 
+@Deprecated(
+  DeprMsg + "Use getOrNone on Either after refactoring",
+  ReplaceWith("toEither().getOrNone()")
+)
 public fun <E, A> Validated<E, A>.orNone(): Option<A> =
-  fold({ None }, { Some(it) })
+  toEither().getOrNone()
 
 /**
  * Return the Valid value, or the result of f if Invalid
  */
+@Deprecated(
+  DeprMsg + "Use getOrElse on Either after refactoring",
+  ReplaceWith("toEither().getOrElse(f)")
+)
 public inline fun <E, A> Validated<E, A>.valueOr(f: (E) -> A): A =
-  fold({ f(it) }, ::identity)
+  toEither().getOrElse(f)
 
 /**
  * If `this` is valid return `this`, otherwise if `that` is valid return `that`, otherwise combine the failures.
  * This is similar to [orElse] except that here failures are accumulated.
  */
-public inline fun <E, A> Validated<E, A>.findValid(SE: Semigroup<E>, that: () -> Validated<E, A>): Validated<E, A> =
-  fold(
-    { e ->
-      that().fold(
-        { ee -> Invalid(SE.run { e.combine(ee) }) },
-        { Valid(it) }
-      )
-    },
-    { Valid(it) }
+@Deprecated(
+  DeprAndNicheMsg + "Use recover on Either after refactoring",
+  ReplaceWith(
+    "toEither().recover { e -> that().mapLeft { ee -> SE.run { e.combine(ee) } }.bind() }.toValidated()",
+    "arrow.core.recover"
   )
+)
+public inline fun <E, A> Validated<E, A>.findValid(SE: Semigroup<E>, that: () -> Validated<E, A>): Validated<E, A> =
+  toEither().recover { e -> that().mapLeft { ee -> SE.run { e.combine(ee) } }.bind() }.toValidated()
+//  fold(
+//    { e ->
+//      that().fold(
+//        { ee -> Invalid(SE.run { e.combine(ee) }) },
+//        { Valid(it) }
+//      )
+//    },
+//    { Valid(it) }
+//  )
 
 /**
  * Apply a function to a Valid value, returning a new Validation that may be valid or invalid
@@ -774,83 +1080,126 @@ public inline fun <E, A> Validated<E, A>.findValid(SE: Semigroup<E>, that: () ->
  * ```
  * <!--- KNIT example-validated-06.kt -->
  */
+@Deprecated(
+  DeprMsg + "Use Either DSL or flatMap instead after refactoring.",
+  ReplaceWith("toEither().flatMap { f(it).toEither() }.toValidated()")
+)
 public inline fun <E, A, B> Validated<E, A>.andThen(f: (A) -> Validated<E, B>): Validated<E, B> =
-  when (this) {
-    is Validated.Valid -> f(value)
-    is Validated.Invalid -> this
-  }
+  toEither().flatMap { f(it).toEither() }.toValidated()
 
 /**
  * Return this if it is Valid, or else fall back to the given default.
  * The functionality is similar to that of [findValid] except for failure accumulation,
  * where here only the error on the right is preserved and the error on the left is ignored.
  */
+@Deprecated(
+  DeprMsg + "Use recover on Either instead after refactoring.",
+  ReplaceWith("toEither().recover { default().bind() }.toValidated()")
+)
 public inline fun <E, A> Validated<E, A>.orElse(default: () -> Validated<E, A>): Validated<E, A> =
-  fold(
-    { default() },
-    { Valid(it) }
-  )
+  toEither().recover { default().bind() }.toValidated()
 
+@Deprecated(
+  DeprMsg + "Use recover on Either instead after refactoring.",
+  ReplaceWith("toEither().recover { e -> f(e).bind() }.toValidated()")
+)
 public inline fun <E, A> Validated<E, A>.handleErrorWith(f: (E) -> Validated<E, A>): Validated<E, A> =
-  when (this) {
-    is Validated.Valid -> this
-    is Validated.Invalid -> f(this.value)
-  }
+  toEither().recover { e -> f(e).bind() }.toValidated()
 
+@Deprecated(
+  DeprMsg + "Use recover on Either instead after refactoring.",
+  ReplaceWith("toEither().recover<E, Nothing, A> { e -> f(e) }.toValidated()")
+)
 public inline fun <E, A> Validated<E, A>.handleError(f: (E) -> A): Validated<Nothing, A> =
-  when (this) {
-    is Validated.Valid -> this
-    is Validated.Invalid -> Valid(f(this.value))
-  }
+  toEither().recover<E, Nothing, A> { e -> f(e) }.toValidated()
 
+@Deprecated(
+  DeprMsg + "Use fold on Either instead after refactoring.",
+  ReplaceWith("fold(fe, fa).valid()")
+)
 public inline fun <E, A, B> Validated<E, A>.redeem(fe: (E) -> B, fa: (A) -> B): Validated<E, B> =
-  when (this) {
-    is Validated.Valid -> map(fa)
-    is Validated.Invalid -> Valid(fe(this.value))
-  }
+  fold(fe, fa).valid()
 
+@Deprecated(
+  DeprMsg + "Validated is deprecated in favor of Either",
+  ReplaceWith("toEither().valid()")
+)
 public fun <E, A> Validated<E, A>.attempt(): Validated<Nothing, Either<E, A>> =
-  map { Right(it) }.handleError { Left(it) }
+  toEither().valid()
 
+@Deprecated(
+  DeprMsg + "Use merge() on Either instead after refactoring.",
+  ReplaceWith("toEither().merge()")
+)
 public inline fun <A> Validated<A, A>.merge(): A =
-  fold(::identity, ::identity)
+  toEither().merge()
 
+@Deprecated(
+  DeprMsg + "Use Either.zipOrAccumulate instead",
+  ReplaceWith("Either.zipOrAccumulate({ a, b -> SE.run { a.combine(b) } }, toEither(), y.toEither(), { a, b -> SA.run { a.combine(b) } }).toValidated()")
+)
 public fun <E, A> Validated<E, A>.combine(
   SE: Semigroup<E>,
   SA: Semigroup<A>,
   y: Validated<E, A>
 ): Validated<E, A> =
-  when {
-    this is Valid && y is Valid -> Valid(SA.run { value.combine(y.value) })
-    this is Invalid && y is Invalid -> Invalid(SE.run { value.combine(y.value) })
-    this is Invalid -> this
-    else -> y
-  }
+  Either.zipOrAccumulate(
+    { a, b -> SE.run { a.combine(b) } },
+    toEither(),
+    y.toEither(),
+    { a, b -> SA.run { a.combine(b) } }).toValidated()
 
+@Deprecated(
+  DeprAndNicheMsg,
+  ReplaceWith(
+    "toEither().recover { e -> y.toEither().recover { ee -> raise(SE.run { e.combine(ee) })) }.bind() }.toValidated()",
+    "arrow.core.recover"
+  )
+)
 public fun <E, A> Validated<E, A>.combineK(SE: Semigroup<E>, y: Validated<E, A>): Validated<E, A> {
-  return when (this) {
-    is Valid -> this
-    is Invalid -> when (y) {
-      is Invalid -> Invalid(SE.run { this@combineK.value.combine(y.value) })
-      is Valid -> y
-    }
-  }
+  return toEither().recover { e -> y.toEither().recover { ee -> raise(SE.run { e.combine(ee) }) }.bind() }
+    .toValidated()
 }
 
 /**
  * Converts the value to an Ior<E, A>
  */
+@Deprecated(
+  DeprMsg + "Use toIor on Either after refactoring Validated to Either",
+  ReplaceWith("toEither().toIor()")
+)
 public fun <E, A> Validated<E, A>.toIor(): Ior<E, A> =
-  fold({ Ior.Left(it) }, { Ior.Right(it) })
+  toEither().toIor()
 
+@Deprecated(
+  DeprMsg + "Use right instead to construct the equivalent Either value",
+  ReplaceWith("this.right()", "arrow.core.right")
+)
 public inline fun <A> A.valid(): Validated<Nothing, A> =
   Valid(this)
 
+@Deprecated(
+  DeprMsg + "Use left instead to construct the equivalent Either value",
+  ReplaceWith("this.left()", "arrow.core.left")
+)
 public inline fun <E> E.invalid(): Validated<E, Nothing> =
   Invalid(this)
 
+@Deprecated(
+  DeprMsg + "Use right instead to construct the equivalent Either value",
+  ReplaceWith("this.right()", "arrow.core.right")
+)
 public inline fun <A> A.validNel(): ValidatedNel<Nothing, A> =
   Validated.validNel(this)
 
+@Deprecated(
+  DeprMsg + "Use leftNel instead to construct the equivalent Either value",
+  ReplaceWith("this.leftNel()", "arrow.core.leftNel")
+)
 public inline fun <E> E.invalidNel(): ValidatedNel<E, Nothing> =
   Validated.invalidNel(this)
+
+private const val DeprMsg = "Validated functionally is being merged into Either.\n"
+
+private const val DeprAndNicheMsg =
+  "Validated functionaliy is being merged into Either, but this API is niche and will be removed in the future. If this method is crucial for you, please let us know on the Arrow Github. Thanks!\n https://github.com/arrow-kt/arrow/issues\n"

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -194,7 +194,10 @@ public interface Raise<in R> {
     is Either.Right -> value
   }
 
-  /* Will be removed in subsequent PRs for Arrow 2.x.x */
+  @Deprecated(
+    "Validated is deprecated in favor of Either.",
+    ReplaceWith("toEither().bind()")
+  )
   public fun <A> Validated<R, A>.bind(): A = when (this) {
     is Validated.Invalid -> raise(value)
     is Validated.Valid -> value


### PR DESCRIPTION
Suggested migration process using `ReplaceWith`:
 - Migrate all methods, `zip` -> `zipOrAccumulate`, `getOrElse`, etc to their `toEither()` equivalents using `Replace in entire project` action from IntelliJ
 - Migrate all functions returning `Validated` or `ValidatedNel`, and their `invalid`, `invalidNel()`, etc constructors. (This piece can potentially be scripted like https://gist.github.com/nomisRev/e01ddc354c84b8b626c23d024706b916)
 - `Replace in entire project` `Either.toEither()` intermediate method

=> Now all `Validated` usage should be somewhat automatically be replaced in the project in 3~4 steps.
