### PR TITLE
Add exist fun to Either, for migration from Validated

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -160,6 +160,7 @@ public abstract class arrow/core/Either {
 	public final fun bitraverseOption (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public final fun bitraverseValidated (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
 	public static final fun conditionally (ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Larrow/core/Either;
+	public final fun exist (Lkotlin/jvm/functions/Function1;)Z
 	public final fun exists (Lkotlin/jvm/functions/Function1;)Z
 	public final fun findOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1083,6 +1083,13 @@ public sealed class Either<out A, out B> {
   public inline fun exists(predicate: (B) -> Boolean): Boolean =
     fold({ false }, predicate)
 
+  @Deprecated(
+    "Facilitates the migration from Validated to Either.",
+    ReplaceWith("isRight(predicate)")
+  )
+  public inline fun exist(predicate: (B) -> Boolean): Boolean =
+    exists(predicate)
+
   /**
    * Returns `true` if [Left] or returns the result of the application of
    * the given predicate to the [Right] value.


### PR DESCRIPTION
Fixes #2938 by introducing a deprecated new `exist` fun for `Either`, just to allow migration coming from `Validated` which had this method instead of the `exists` in `Option` and `Either`.