### PR TITLE
Remove ignored path option in the publish landing page workflow

### DIFF
--- a/.github/workflows/publish-landing-page.yaml
+++ b/.github/workflows/publish-landing-page.yaml
@@ -2,8 +2,6 @@ name: Publish landing page
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
     branches:
       - main
     paths:


### PR DESCRIPTION
GitHub Actions doesn't allow to have both `paths` and `paths-ignore` for a single event.

The `ignore-path` property is not required as this workflow is only triggered when changes happen in the `arrow-site/` folder