### PR TITLE
Link KotlinX Coroutines to Arrow Fx Coroutines docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,7 @@ subprojects {
           matchingRegex.set(".*\\.internal.*")
           suppress.set(true)
         }
+        if (project.name == "arrow-fx-coroutines") externalDocumentationLink("https://kotlinlang.org/api/kotlinx.coroutines/")
         skipDeprecated.set(true)
         reportUndocumented.set(false)
         val baseUrl: String = checkNotNull(properties["pom.smc.url"]?.toString())


### PR DESCRIPTION
Tried to set it up `arrow-fx-coroutines/build.gradle.kts` but couldn't get that to work.
Tested locally, and now types like `CoroutineScope` automatically get linked to the official API docs of KotlinX Coroutines.