### PR TITLE
Simplify recover, and catch APIs. Add getOrElse

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -990,6 +990,8 @@ public final class arrow/core/OptionKt {
 	public static final fun some (Ljava/lang/Object;)Larrow/core/Option;
 	public static final fun toMap (Larrow/core/Option;)Ljava/util/Map;
 	public static final fun toOption (Ljava/lang/Object;)Larrow/core/Option;
+	public static final fun toOption (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun unalign (Larrow/core/Option;)Lkotlin/Pair;
 	public static final fun unalign (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Lkotlin/Pair;
 	public static final fun unite (Larrow/core/Option;Larrow/typeclasses/Monoid;)Larrow/core/Option;
@@ -3414,6 +3416,8 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun get (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrElse (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun getOrElse (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun getOrNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun ior (Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun mapErrorNel (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Larrow/typeclasses/Semigroup;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
@@ -3434,9 +3438,7 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun toEither (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toIor (Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun toIor (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun toOption (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun toOption (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
-	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toOption (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toResult (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun toResult (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3204,11 +3204,9 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public fun <init> ()V
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3229,11 +3227,9 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise, arrow/typ
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
 	public final fun bind (Larrow/core/Ior;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3255,21 +3251,17 @@ public final class arrow/core/raise/NullableRaise : arrow/core/raise/Raise {
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun attempt-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Either;)Ljava/lang/Object;
 	public static final fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Option;)Ljava/lang/Object;
-	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Validated;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun bind-impl (Larrow/core/raise/Raise;Ljava/lang/Object;)Ljava/lang/Object;
-	public static fun bind-impl (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun box-impl (Larrow/core/raise/Raise;)Larrow/core/raise/NullableRaise;
@@ -3312,20 +3304,16 @@ public final class arrow/core/raise/OptionRaise : arrow/core/raise/Raise {
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun attempt-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Either;)Ljava/lang/Object;
 	public static final fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Option;)Ljava/lang/Object;
-	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Validated;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun bind-impl (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun box-impl (Larrow/core/raise/Raise;)Larrow/core/raise/OptionRaise;
@@ -3367,11 +3355,9 @@ public final class arrow/core/raise/OptionRaise : arrow/core/raise/Raise {
 public abstract interface class arrow/core/raise/Raise {
 	public abstract fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public abstract fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/Validated;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3389,11 +3375,9 @@ public abstract interface class arrow/core/raise/Raise {
 public final class arrow/core/raise/Raise$DefaultImpls {
 	public static fun attempt (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/raise/Raise;Larrow/core/Either;)Ljava/lang/Object;
-	public static fun bind (Larrow/core/raise/Raise;Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/raise/Raise;Larrow/core/Validated;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/raise/Raise;Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/raise/Raise;Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun bind (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun catch (Larrow/core/raise/Raise;Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3413,7 +3397,7 @@ public abstract interface annotation class arrow/core/raise/RaiseDSL : java/lang
 public final class arrow/core/raise/RaiseKt {
 	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun catch (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun catch (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
 	public static final fun catch (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
 	public static final fun catch (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
@@ -3426,6 +3410,10 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun fold (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun get (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun get (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getOrElse (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun getOrElse (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun ior (Larrow/typeclasses/Semigroup;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun mapErrorNel (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Larrow/typeclasses/Semigroup;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
@@ -3437,8 +3425,8 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun orNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun orNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun raisedOrRethrow (Ljava/util/concurrent/CancellationException;Larrow/core/raise/DefaultRaise;)Ljava/lang/Object;
-	public static final fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static final fun recover (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
 	public static final fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
 	public static final fun result (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -3478,20 +3466,16 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun attempt-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Either;)Ljava/lang/Object;
-	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/Validated;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun bind-impl (Larrow/core/raise/Raise;Ljava/lang/Object;)Ljava/lang/Object;
-	public static fun bind-impl (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun bind-impl (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun box-impl (Larrow/core/raise/Raise;)Larrow/core/raise/ResultRaise;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -2,6 +2,8 @@
 package arrow.core
 
 import arrow.core.Either.Right
+import arrow.core.raise.EagerEffect
+import arrow.core.raise.Effect
 import arrow.core.raise.OptionRaise
 import arrow.core.raise.option
 import arrow.typeclasses.Monoid
@@ -1270,6 +1272,12 @@ public infix fun <T> Option<T>.or(value: Option<T>): Option<T> = if (isEmpty()) 
 }
 
 public fun <T> T?.toOption(): Option<T> = this?.let { Some(it) } ?: None
+
+/** Run the [Effect] by returning [Option] of [A], or [None] if raised with [None]. */
+public suspend fun <A> Effect<None, A>.toOption(): Option<A> = option { invoke() }
+
+/** Run the [EagerEffect] by returning [Option] of [A], or [None] if raised with [None]. */
+public fun <A> EagerEffect<None, A>.toOption(): Option<A> = option { invoke() }
 
 @Deprecated(
   NicheAPI + "Prefer using if-else statement",

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -61,7 +61,7 @@ public value class NullableRaise(private val cont: Raise<Null>) : Raise<Null> {
   @RaiseDSL
   public fun ensure(value: Boolean): Unit = ensure(value) { null }
   override fun raise(r: Nothing?): Nothing = cont.raise(r)
-  public fun <B> Option<B>.bind(): B = bind { raise(null) }
+  public fun <B> Option<B>.bind(): B = getOrElse { raise(null) }
 
   public fun <B> B?.bind(): B {
     contract { returns() implies (this@bind != null) }
@@ -83,7 +83,7 @@ public value class ResultRaise(private val cont: Raise<Throwable>) : Raise<Throw
 @JvmInline
 public value class OptionRaise(private val cont: Raise<None>) : Raise<None> {
   override fun raise(r: None): Nothing = cont.raise(r)
-  public fun <B> Option<B>.bind(): B = bind { raise(None) }
+  public fun <B> Option<B>.bind(): B = getOrElse { raise(None) }
   public fun ensure(value: Boolean): Unit = ensure(value) { None }
 
   public fun <B> ensureNotNull(value: B?): B {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -67,7 +67,7 @@ public value class NullableRaise(private val cont: Raise<Null>) : Raise<Null> {
   }
 
   public fun <B> ensureNotNull(value: B?): B {
-    contract { returnsNotNull() }
+    contract { returns() implies (value != null) }
     return ensureNotNull(value) { null }
   }
 }
@@ -85,7 +85,7 @@ public value class OptionRaise(private val cont: Raise<None>) : Raise<None> {
   public fun ensure(value: Boolean): Unit = ensure(value) { None }
 
   public fun <B> ensureNotNull(value: B?): B {
-    contract { returnsNotNull() }
+    contract { returns() implies (value != null) }
     return ensureNotNull(value) { None }
   }
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -23,10 +23,8 @@ import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
-public inline fun <E, A> either(@BuilderInference block: Raise<E>.() -> A): Either<E, A> {
-  contract { callsInPlace(block, EXACTLY_ONCE) }
-  return fold({ block.invoke(this) }, { Either.Left(it) }, { Either.Right(it) })
-}
+public inline fun <E, A> either(@BuilderInference block: Raise<E>.() -> A): Either<E, A> =
+  fold({ block.invoke(this) }, { Either.Left(it) }, { Either.Right(it) })
 
 public inline fun <A> nullable(block: NullableRaise.() -> A): A? {
   contract { callsInPlace(block, EXACTLY_ONCE) }
@@ -69,7 +67,7 @@ public value class NullableRaise(private val cont: Raise<Null>) : Raise<Null> {
   }
 
   public fun <B> ensureNotNull(value: B?): B {
-    contract { returns() implies (value != null) }
+    contract { returnsNotNull() }
     return ensureNotNull(value) { null }
   }
 }
@@ -87,7 +85,7 @@ public value class OptionRaise(private val cont: Raise<None>) : Raise<None> {
   public fun ensure(value: Boolean): Unit = ensure(value) { None }
 
   public fun <B> ensureNotNull(value: B?): B {
-    contract { returns() implies (value != null) }
+    contract { returnsNotNull() }
     return ensureNotNull(value) { None }
   }
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Effect.kt
@@ -3,6 +3,7 @@
 @file:OptIn(ExperimentalTypeInference::class)
 package arrow.core.raise
 
+import arrow.core.identity
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
@@ -673,3 +674,12 @@ public inline fun <R, A> effect(@BuilderInference noinline block: suspend Raise<
 public typealias EagerEffect<R, A> = Raise<R>.() -> A
 
 public inline fun <R, A> eagerEffect(@BuilderInference noinline block: Raise<R>.() -> A): EagerEffect<R, A> = block
+
+public suspend fun <A> Effect<A, A>.merge(): A = getOrElse(::identity)
+public fun <A> EagerEffect<A, A>.merge(): A = getOrElse(::identity)
+
+@Suppress("IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")
+public suspend fun <A> Effect<Nothing, A>.get(): A = getOrElse(::identity)
+
+@Suppress("IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")
+public fun <A> EagerEffect<Nothing, A>.get(): A = getOrElse(::identity)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
@@ -108,3 +108,9 @@ public inline infix fun <reified T : Throwable, E, A> EagerEffect<E, A>.catch(
   @BuilderInference crossinline recover: Raise<E>.(T) -> A,
 ): EagerEffect<E, A> =
   eagerEffect { catch { t: Throwable -> if (t is T) recover(t) else throw t } }
+
+public suspend inline infix fun <E, A> Effect<E, A>.getOrElse(onRaise: (E) -> A): A =
+  recover({ invoke() }, onRaise)
+
+public inline infix fun <E, A> EagerEffect<E, A>.getOrElse(onRaise: (E) -> A): A =
+  recover({ invoke() }, onRaise)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Fold.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Fold.kt
@@ -90,7 +90,6 @@ public inline fun <R, A, B> fold(
   transform: (value: A) -> B,
 ): B {
   contract {
-    callsInPlace(program, EXACTLY_ONCE)
     callsInPlace(error, AT_MOST_ONCE)
     callsInPlace(recover, AT_MOST_ONCE)
     callsInPlace(transform, AT_MOST_ONCE)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
@@ -4,7 +4,6 @@ package arrow.core.raise
 
 import arrow.core.Either
 import arrow.core.Ior
-import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
 import arrow.core.Validated
@@ -23,17 +22,27 @@ public fun <E, A> EagerEffect<E, A>.toValidated(): Validated<E, A> = fold({ Vali
 public suspend fun <E, A> Effect<E, A>.toIor(): Ior<E, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
 public fun <E, A> EagerEffect<E, A>.toIor(): Ior<E, A> = fold({ Ior.Left(it) }) { Ior.Right(it) }
 
+@Deprecated(
+  "orNull is being renamed to getOrNull to be more consistent with the Kotlin Standard Library naming",
+  ReplaceWith("getOrNull()", "arrow.core.raise.getOrNull")
+)
+public suspend fun <E, A> Effect<E, A>.orNull(): A? = getOrElse { null }
+
+@Deprecated(
+  "orNull is being renamed to getOrNull to be more consistent with the Kotlin Standard Library naming",
+  ReplaceWith("getOrNull()", "arrow.core.raise.getOrNull")
+)
+public fun <E, A> EagerEffect<E, A>.orNull(): A? = getOrElse { null }
+
 /** Run the [Effect] by returning [A], or `null` if raised with [E]. */
-public suspend fun <E, A> Effect<E, A>.orNull(): A? = fold({ _: E -> null }) { it }
-public fun <E, A> EagerEffect<E, A>.orNull(): A? = fold({ _: E -> null }) { it }
+public suspend fun <E, A> Effect<E, A>.getOrNull(): A? = getOrElse { null }
+
+/** Run the [EagerEffect] by returning [A], or `null` if raised with [E]. */
+public fun <E, A> EagerEffect<E, A>.getOrNull(): A? = getOrElse { null }
 
 /** Run the [Effect] by returning [Option] of [A], [orElse] run the fallback lambda and returning its result of [Option] of [A]. */
 public suspend fun <E, A> Effect<E, A>.toOption(orElse: suspend (E) -> Option<A>): Option<A> = fold(orElse) { Some(it) }
 public inline fun <E, A> EagerEffect<E, A>.toOption(orElse: (E) -> Option<A>): Option<A> = fold(orElse) { Some(it) }
-
-/** Run the [Effect] by returning [Option] of [A], or [None] if raised with [None]. */
-public suspend fun <A> Effect<None, A>.toOption(): Option<A> = option { invoke() }
-public fun <A> EagerEffect<None, A>.toOption(): Option<A> = option { invoke() }
 
 /** Run the [Effect] by returning [Result] of [A], [orElse] run the fallback lambda and returning its result of [Result] of [A]. */
 public suspend fun <E, A> Effect<E, A>.toResult(orElse: suspend (E) -> Result<A>): Result<A> =

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Mappers.kt
@@ -8,7 +8,6 @@ import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
 import arrow.core.Validated
-import arrow.core.identity
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
@@ -45,6 +44,3 @@ public inline fun <E, A> EagerEffect<E, A>.toResult(orElse:  (E) -> Result<A>): 
 /** Run the [Effect] by returning [Result] of [A], or [Result.Failure] if raised with [Throwable]. */
 public suspend fun <A> Effect<Throwable, A>.toResult(): Result<A> = result { invoke() }
 public fun <A> EagerEffect<Throwable, A>.toResult(): Result<A> = result { invoke() }
-
-public suspend fun <A> Effect<A, A>.merge(): A = fold(::identity, ::identity)
-public fun <A> EagerEffect<A, A>.merge(): A = fold(::identity, ::identity)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -2,16 +2,16 @@
 @file:Suppress("DEPRECATION")
 @file:JvmMultifileClass
 @file:JvmName("RaiseKt")
+
 package arrow.core.raise
 
 import arrow.core.Either
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.Some
 import arrow.core.Validated
 import arrow.core.continuations.EffectScope
 import arrow.core.identity
+import arrow.core.nonFatalOrThrow
 import arrow.core.recover
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind.AT_MOST_ONCE
 import kotlin.contracts.InvocationKind.EXACTLY_ONCE
@@ -39,7 +39,7 @@ public annotation class RaiseDSL
  * ```kotlin
  * fun Raise<String>.failure(): Int = raise("failed")
  *
- * fun Raise<Nothing>.recovered(): Int =
+ * fun recovered(): Int =
  *   recover({ failure() }) { _: String -> 1 }
  * ```
  * <!--- KNIT example-raise-dsl-01.kt -->
@@ -96,11 +96,11 @@ public annotation class RaiseDSL
  *
  * fun Raise<String>.failure(): Int = raise("failed")
  *
- * fun Raise<Nothing>.recovered(): Int = recover({ failure() }) { _: String -> 1 }
+ * fun recovered(): Int = recover({ failure() }) { _: String -> 1 }
  * -->
  * ```kotlin
  * fun test() {
- *   val either = either { failure() }
+ *   val either: Either<Nothing, Int> = either { failure() }
  *     .recover { _: String -> recovered() }
  *
  *   either shouldBe Either.Right(1)
@@ -152,6 +152,7 @@ public interface Raise<in R> {
    * @see [recover] if you want to attempt to recover from any _logical failure_.
    */
   public operator fun <A> EagerEffect<R, A>.invoke(): A = invoke(this@Raise)
+
   @RaiseDSL
   public fun <A> EagerEffect<R, A>.bind(): A = invoke(this@Raise)
 
@@ -163,6 +164,7 @@ public interface Raise<in R> {
    * @see [recover] if you want to attempt to recover from any _logical failure_.
    */
   public suspend operator fun <A> Effect<R, A>.invoke(): A = invoke(this@Raise)
+
   @RaiseDSL
   public suspend fun <A> Effect<R, A>.bind(): A = invoke(this@Raise)
 
@@ -206,87 +208,6 @@ public interface Raise<in R> {
     is Validated.Valid -> value
   }
 
-  /**
-   * Extract the [Result.success] value out of [Result],
-   * because [Result] works with [Throwable] as its error type you need to [transform] [Throwable] to [R].
-   *
-   * Note that this functions can currently not be _inline_ without Context Receivers,
-   * and thus doesn't allow suspension in its error handler.
-   * To do so, use [Result.recover] and [bind].
-   *
-   * <!--- INCLUDE
-   * import arrow.core.Either
-   * import arrow.core.raise.either
-   * import arrow.core.raise.recover
-   * import kotlinx.coroutines.delay
-   * import io.kotest.matchers.shouldBe
-   * -->
-   * ```kotlin
-   * suspend fun test() {
-   *   val one: Result<Int> = Result.success(1)
-   *   val failure: Result<Int> = Result.failure(RuntimeException("Boom!"))
-   *
-   *   either {
-   *     val x = one.bind { -1 }
-   *     val y = failure.bind { failure: Throwable ->
-   *       raise("Something bad happened: ${failure.message}")
-   *     }
-   *     val z = failure.recover { failure: Throwable ->
-   *       delay(10)
-   *       1
-   *     }.bind { raise("Something bad happened: ${it.message}") }
-   *     x + y + z
-   *   } shouldBe Either.Left("Something bad happened: Boom!")
-   * }
-   * ```
-   * <!--- KNIT example-raise-dsl-05.kt -->
-   * <!--- TEST lines.isEmpty() -->
-   */
-  @RaiseDSL
-  public fun <A> Result<A>.bind(transform: (Throwable) -> R): A =
-    fold(::identity) { throwable -> raise(transform(throwable)) }
-
-  /**
-   * Extract the [Some] value out of [Option],
-   * because [Option] works with [None] as its error type you need to [transform] [None] to [R].
-   *
-   * Note that this functions can currently not be _inline_ without Context Receivers,
-   * and thus doesn't allow suspension in its error handler.
-   * To do so, use [Option.recover] and [bind].
-   *
-   * <!--- INCLUDE
-   * import arrow.core.Either
-   * import arrow.core.None
-   * import arrow.core.Option
-   * import arrow.core.recover
-   * import arrow.core.raise.either
-   * import kotlinx.coroutines.delay
-   * import io.kotest.matchers.shouldBe
-   * -->
-   * ```kotlin
-   * suspend fun test() {
-   *   val empty: Option<Int> = None
-   *   either {
-   *     val x: Int = empty.bind { _: None -> 1 }
-   *     val y: Int = empty.bind { _: None -> raise("Something bad happened: Boom!") }
-   *     val z: Int = empty.recover { _: None ->
-   *       delay(10)
-   *       1
-   *     }.bind { raise("Something bad happened: Boom!") }
-   *     x + y + z
-   *   } shouldBe Either.Left("Something bad happened: Boom!")
-   * }
-   * ```
-   * <!--- KNIT example-raise-dsl-06.kt -->
-   * <!--- TEST lines.isEmpty() -->
-   */
-  @RaiseDSL
-  public fun <A> Option<A>.bind(transform: Raise<R>.(None) -> A): A =
-    when (this) {
-      None -> transform(None)
-      is Some -> value
-    }
-
   @RaiseDSL
   public suspend infix fun <E, A> Effect<E, A>.recover(@BuilderInference resolve: suspend Raise<R>.(E) -> A): A =
     fold<E, A, A>({ this@recover.invoke(this) }, { throw it }, { resolve(it) }) { it }
@@ -294,7 +215,7 @@ public interface Raise<in R> {
   /** @see [recover] */
   @RaiseDSL
   public infix fun <E, A> EagerEffect<E, A>.recover(@BuilderInference resolve: Raise<R>.(E) -> A): A =
-    recover({ invoke() }, resolve)
+    recover({ invoke() }) { resolve(it) }
 
   /**
    * Execute the [Effect] resulting in [A],
@@ -322,7 +243,8 @@ public interface Raise<in R> {
 
 /**
  * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [E],
- * and recover by providing a fallback value of type [A] or raising a new error of type [R].
+ * and recover by providing a transform [E] into a fallback value of type [A].
+ * Base implementation of `effect { f() } getOrElse { fallback() }`.
  *
  * <!--- INCLUDE
  * import arrow.core.Either
@@ -331,23 +253,21 @@ public interface Raise<in R> {
  * import io.kotest.matchers.shouldBe
  * -->
  * ```kotlin
- * suspend fun test() {
- *   either<Nothing, Int> {
- *     recover({ raise("failed") }) { str -> str.length }
- *   } shouldBe Either.Right(6)
+ * fun test() {
+ *   recover({ raise("failed") }) { str -> str.length } shouldBe 6
  *
- *   either {
+ *   either<Int, String> {
  *     recover({ raise("failed") }) { str -> raise(-1) }
  *   } shouldBe Either.Left(-1)
  * }
  * ```
- * <!--- KNIT example-raise-dsl-07.kt -->
+ * <!--- KNIT example-raise-dsl-05.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @RaiseDSL
-public inline fun <R, E, A> Raise<R>.recover(
+public inline fun <E, A> recover(
   @BuilderInference action: Raise<E>.() -> A,
-  @BuilderInference recover: Raise<R>.(E) -> A,
+  @BuilderInference recover: (E) -> A,
 ): A {
   contract {
     callsInPlace(action, EXACTLY_ONCE)
@@ -356,38 +276,123 @@ public inline fun <R, E, A> Raise<R>.recover(
   return fold<E, A, A>({ action(this) }, { throw it }, { recover(it) }, { it })
 }
 
+/**
+ * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [E],
+ * and [recover] by providing a transform [E] into a fallback value of type [A],
+ * or [catch] any unexpected exceptions by providing a transform [Throwable] into a fallback value of type [A],
+ *
+ * <!--- INCLUDE
+ * import arrow.core.raise.recover
+ * import arrow.core.raise.Raise
+ * import io.kotest.matchers.shouldBe
+ * -->
+ * ```kotlin
+ * fun test() {
+ *   recover(
+ *     { raise("failed") },
+ *     { str -> str.length }
+ *   ) { t -> t.message ?: -1 } shouldBe 6
+ *
+ *   fun Raise<String>.boom(): Int = throw RuntimeException("BOOM")
+ *
+ *   recover(
+ *     { boom() },
+ *     { str -> str.length }
+ *   ) { t -> t.message ?: -1 } shouldBe 4
+ * }
+ * ```
+ * <!--- KNIT example-raise-dsl-06.kt -->
+ * <!--- TEST lines.isEmpty() -->
+ */
 @RaiseDSL
-public inline fun <R, E, A> Raise<R>.recover(
+public inline fun <E, A> recover(
   @BuilderInference action: Raise<E>.() -> A,
-  @BuilderInference recover: Raise<R>.(E) -> A,
-  @BuilderInference catch: Raise<R>.(Throwable) -> A,
+  @BuilderInference recover: (E) -> A,
+  @BuilderInference catch: (Throwable) -> A,
 ): A {
   contract {
     callsInPlace(action, EXACTLY_ONCE)
     callsInPlace(recover, AT_MOST_ONCE)
     callsInPlace(catch, AT_MOST_ONCE)
   }
-  return fold({ action(this) }, { catch(it) }, { recover(it) }, { it })
+  return fold({ action(this) }, { catch(it) }, { recover(it) }, ::identity)
 }
 
+/**
+ * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [E],
+ * and [recover] by providing a transform [E] into a fallback value of type [A],
+ * or [catch] any unexpected exceptions by providing a transform [Throwable] into a fallback value of type [A],
+ *
+ * <!--- INCLUDE
+ * import arrow.core.raise.recover
+ * import arrow.core.raise.Raise
+ * import io.kotest.matchers.shouldBe
+ * -->
+ * ```kotlin
+ * fun test() {
+ *   recover(
+ *     { raise("failed") },
+ *     { str -> str.length }
+ *   ) { t -> t.message ?: -1 } shouldBe 6
+ *
+ *   fun Raise<String>.boom(): Int = throw RuntimeException("BOOM")
+ *
+ *   recover(
+ *     { boom() },
+ *     { str -> str.length }
+ *   ) { t: RuntimeException -> t.message ?: -1 } shouldBe 4
+ * }
+ * ```
+ * <!--- KNIT example-raise-dsl-07.kt -->
+ * <!--- TEST lines.isEmpty() -->
+ */
 @RaiseDSL
-public inline fun <R, A> Raise<R>.catch(
-  @BuilderInference action: Raise<R>.() -> A,
-  @BuilderInference catch: Raise<R>.(Throwable) -> A,
+@JvmName("recoverReified")
+public inline fun <reified T : Throwable, E, A> recover(
+  @BuilderInference action: Raise<E>.() -> A,
+  @BuilderInference recover: (E) -> A,
+  @BuilderInference catch: (T) -> A,
 ): A {
+  contract {
+    callsInPlace(action, EXACTLY_ONCE)
+    callsInPlace(recover, AT_MOST_ONCE)
+    callsInPlace(catch, AT_MOST_ONCE)
+  }
+  return fold({ action(this) }, { t ->
+    if (t is T) catch(t) else throw t
+  }, { recover(it) }, { it })
+}
+
+/**
+ * Allows safely catching exceptions without capturing [CancellationException],
+ * or fatal exceptions like `OutOfMemoryError` or `VirtualMachineError` on the JVM.
+ *
+ * Alternatively, you can use `try { } catch { }` blocks with [nonFatalOrThrow].
+ * This API offers a similar syntax as the top-level [catch] functions like [Either.catch].
+ */
+@RaiseDSL
+public inline fun <A> catch(action: () -> A, catch: (Throwable) -> A): A {
   contract {
     callsInPlace(action, EXACTLY_ONCE)
     callsInPlace(catch, AT_MOST_ONCE)
   }
-  return fold({ action(this) }, { catch(it) }, { raise(it) }, { it })
+  return try {
+    action()
+  } catch (t: Throwable) {
+    catch(t.nonFatalOrThrow())
+  }
 }
 
+/**
+ * Allows safely catching exceptions of type `T` without capturing [CancellationException],
+ * or fatal exceptions like `OutOfMemoryError` or `VirtualMachineError` on the JVM.
+ *
+ * Alternatively, you can use `try { } catch(e: T) { }` blocks.
+ * This API offers a similar syntax as the top-level [catch] functions like [Either.catch].
+ */
 @RaiseDSL
 @JvmName("catchReified")
-public inline fun <reified T : Throwable, R, A> Raise<R>.catch(
-  @BuilderInference action: Raise<R>.() -> A,
-  @BuilderInference catch: Raise<R>.(T) -> A,
-): A {
+public inline fun <reified T : Throwable, A> catch(action: () -> A, catch: (T) -> A): A {
   contract {
     callsInPlace(action, EXACTLY_ONCE)
     callsInPlace(catch, AT_MOST_ONCE)

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -429,7 +429,7 @@ public inline fun <R> Raise<R>.ensure(condition: Boolean, raise: () -> R) {
 public inline fun <R, B : Any> Raise<R>.ensureNotNull(value: B?, raise: () -> R): B {
   contract {
     callsInPlace(raise, AT_MOST_ONCE)
-    returnsNotNull()
+    returns() implies (value != null)
   }
   return value ?: raise(raise())
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -361,7 +361,7 @@ public inline fun <reified T : Throwable, E, A> recover(
  *
  *   either {
  *     catch({ fetchId() }) { t ->
- *       raise("something went wrong: $t.message")
+ *       raise("something went wrong: ${t.message}")
  *     }
  *   } shouldBe Either.Left("something went wrong: BOOM")
  * }
@@ -400,7 +400,7 @@ public inline fun <A> catch(action: () -> A, catch: (Throwable) -> A): A =
  *
  *   either {
  *     catch({ fetchId() }) { t: RuntimeException ->
- *       raise("something went wrong: $t.message")
+ *       raise("something went wrong: ${t.message}")
  *     }
  *   } shouldBe Either.Left("something went wrong: BOOM")
  * }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/MappersSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/MappersSpec.kt
@@ -55,15 +55,17 @@ class MappersSpec : StringSpec({
     }
   }
 
-  "effect - orNull" {
+  "effect - getOrNull" {
     checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
       effect { a.bind() }.orNull() shouldBe a.getOrNull()
+      effect { a.bind() }.getOrNull() shouldBe a.getOrNull()
     }
   }
 
-  "eagerEffect - orNull" {
+  "eagerEffect - getOrNull" {
     checkAll(Arb.either(Arb.int(), Arb.string())) { a ->
       eagerEffect { a.bind() }.orNull() shouldBe a.getOrNull()
+      eagerEffect { a.bind() }.getOrNull() shouldBe a.getOrNull()
     }
   }
 

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-01.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-01.kt
@@ -6,5 +6,5 @@ import arrow.core.raise.recover
 
 fun Raise<String>.failure(): Int = raise("failed")
 
-fun Raise<Nothing>.recovered(): Int =
+fun recovered(): Int =
   recover({ failure() }) { _: String -> 1 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-03.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-03.kt
@@ -10,10 +10,10 @@ import io.kotest.matchers.shouldBe
 
 fun Raise<String>.failure(): Int = raise("failed")
 
-fun Raise<Nothing>.recovered(): Int = recover({ failure() }) { _: String -> 1 }
+fun recovered(): Int = recover({ failure() }) { _: String -> 1 }
 
 fun test() {
-  val either = either { failure() }
+  val either: Either<Nothing, Int> = either { failure() }
     .recover { _: String -> recovered() }
 
   either shouldBe Either.Right(1)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-05.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-05.kt
@@ -4,22 +4,12 @@ package arrow.core.examples.exampleRaiseDsl05
 import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.recover
-import kotlinx.coroutines.delay
 import io.kotest.matchers.shouldBe
 
-suspend fun test() {
-  val one: Result<Int> = Result.success(1)
-  val failure: Result<Int> = Result.failure(RuntimeException("Boom!"))
+fun test() {
+  recover({ raise("failed") }) { str -> str.length } shouldBe 6
 
-  either {
-    val x = one.bind { -1 }
-    val y = failure.bind { failure: Throwable ->
-      raise("Something bad happened: ${failure.message}")
-    }
-    val z = failure.recover { failure: Throwable ->
-      delay(10)
-      1
-    }.bind { raise("Something bad happened: ${it.message}") }
-    x + y + z
-  } shouldBe Either.Left("Something bad happened: Boom!")
+  either<Int, String> {
+    recover({ raise("failed") }) { str -> raise(-1) }
+  } shouldBe Either.Left(-1)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-06.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-06.kt
@@ -16,5 +16,5 @@ fun test() {
   recover(
     { boom() },
     { str -> str.length }
-  ) { t -> t.message ?: -1 } shouldBe 4
+  ) { t -> t.message?.length ?: -1 } shouldBe 4
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-06.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-06.kt
@@ -1,23 +1,20 @@
 // This file was automatically generated from Raise.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleRaiseDsl06
 
-import arrow.core.Either
-import arrow.core.None
-import arrow.core.Option
-import arrow.core.recover
-import arrow.core.raise.either
-import kotlinx.coroutines.delay
+import arrow.core.raise.recover
+import arrow.core.raise.Raise
 import io.kotest.matchers.shouldBe
 
-suspend fun test() {
-  val empty: Option<Int> = None
-  either {
-    val x: Int = empty.bind { _: None -> 1 }
-    val y: Int = empty.bind { _: None -> raise("Something bad happened: Boom!") }
-    val z: Int = empty.recover { _: None ->
-      delay(10)
-      1
-    }.bind { raise("Something bad happened: Boom!") }
-    x + y + z
-  } shouldBe Either.Left("Something bad happened: Boom!")
+fun test() {
+  recover(
+    { raise("failed") },
+    { str -> str.length }
+  ) { t -> t.message ?: -1 } shouldBe 6
+
+  fun Raise<String>.boom(): Int = throw RuntimeException("BOOM")
+
+  recover(
+    { boom() },
+    { str -> str.length }
+  ) { t -> t.message ?: -1 } shouldBe 4
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-07.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-07.kt
@@ -16,5 +16,5 @@ fun test() {
   recover(
     { boom() },
     { str -> str.length }
-  ) { t: RuntimeException -> t.message ?: -1 } shouldBe 4
+  ) { t: RuntimeException -> t.message?.length ?: -1 } shouldBe 4
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-07.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-07.kt
@@ -1,17 +1,20 @@
 // This file was automatically generated from Raise.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleRaiseDsl07
 
-import arrow.core.Either
-import arrow.core.raise.either
 import arrow.core.raise.recover
+import arrow.core.raise.Raise
 import io.kotest.matchers.shouldBe
 
-suspend fun test() {
-  either<Nothing, Int> {
-    recover({ raise("failed") }) { str -> str.length }
-  } shouldBe Either.Right(6)
+fun test() {
+  recover(
+    { raise("failed") },
+    { str -> str.length }
+  ) { t -> t.message ?: -1 } shouldBe 6
 
-  either {
-    recover({ raise("failed") }) { str -> raise(-1) }
-  } shouldBe Either.Left(-1)
+  fun Raise<String>.boom(): Int = throw RuntimeException("BOOM")
+
+  recover(
+    { boom() },
+    { str -> str.length }
+  ) { t: RuntimeException -> t.message ?: -1 } shouldBe 4
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-08.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-08.kt
@@ -15,7 +15,7 @@ fun test() {
 
   either {
     catch({ fetchId() }) { t ->
-      raise("something went wrong: $t.message")
+      raise("something went wrong: ${t.message}")
     }
   } shouldBe Either.Left("something went wrong: BOOM")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-08.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-08.kt
@@ -1,0 +1,21 @@
+// This file was automatically generated from Raise.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleRaiseDsl08
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.catch
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  catch({ throw RuntimeException("BOOM") }) { t ->
+    "fallback"
+  } shouldBe "fallback"
+
+  fun fetchId(): Int = throw RuntimeException("BOOM")
+
+  either {
+    catch({ fetchId() }) { t ->
+      raise("something went wrong: $t.message")
+    }
+  } shouldBe Either.Left("something went wrong: BOOM")
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-09.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-09.kt
@@ -1,0 +1,21 @@
+// This file was automatically generated from Raise.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleRaiseDsl09
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.catch
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  catch({ throw RuntimeException("BOOM") }) { t ->
+    "fallback"
+  } shouldBe "fallback"
+
+  fun fetchId(): Int = throw RuntimeException("BOOM")
+
+  either {
+    catch({ fetchId() }) { t: RuntimeException ->
+      raise("something went wrong: $t.message")
+    }
+  } shouldBe Either.Left("something went wrong: BOOM")
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-09.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-09.kt
@@ -15,7 +15,7 @@ fun test() {
 
   either {
     catch({ fetchId() }) { t: RuntimeException ->
-      raise("something went wrong: $t.message")
+      raise("something went wrong: ${t.message}")
     }
   } shouldBe Either.Left("something went wrong: BOOM")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/RaiseKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/RaiseKnitTest.kt
@@ -28,6 +28,14 @@ class RaiseKnitTest : StringSpec({
     arrow.core.examples.exampleRaiseDsl07.test()
   }
 
+  "ExampleRaiseDsl08" {
+    arrow.core.examples.exampleRaiseDsl08.test()
+  }
+
+  "ExampleRaiseDsl09" {
+    arrow.core.examples.exampleRaiseDsl09.test()
+  }
+
 }) {
   override fun timeout(): Long = 1000
 }


### PR DESCRIPTION
Draft changes related to #2948 to facilitate the discussion. Also closes #2953 

cc\\ @freynder

## Description about changes (copied from comments in #2948)

The lambda `Raise<R>.() -> A` allows to _bind_, or _unwrap_, `Option` and in the case `None` is encountered it will invoke the lambda. The lambda allows to _raise_ a value of `R` into the outer `interface Raise<R>`, or _fallback_ to a value of _A_.

1. The `Raise<R>` lambda receiver is redundant because we're already inside the context of `interface Raise<R>`, so even without the lambda receiver we can call `raise(r)`.
2. Without `Raise<R>`, we have `() -> A` which matches the already existing `Option` API of `getOrElse`.
3. Since this function is defined inside of an `interface`, it cannot be `inline` so it's inferior to the already existing `getOrElse` which is _inline_ and thus allows for `suspend` to pass through.

So this API can be completely replaced by `getOrElse` and simplifies the examples of the KDoc above.

```diff
suspend fun test() {
  val empty: Option<Int> = None
  either {
-    val x: Int = empty.bind { _: None -> 1 }
+    val x: Int = empty.getOrElse { 1 }
-    val y: Int = empty.bind { _: None -> raise("Something bad happened: Boom!") }
+    val y: Int = empty.getOrElse { raise("Something bad happened: Boom!") }
-    val z: Int = empty.recover { _: None ->
+    val z: Int = empty.getOrElse {
      delay(10)
      1
-    }.bind { raise("Something bad happened: Boom!") }
+   }
    x + y + z
  } shouldBe Either.Left("Something bad happened: Boom!")
}
```

As the example shows we can now call `suspend fun delay` directly into the `getOrElse` lambda, and we can also still call `raise` & co from inside the `getOrElse` lambda.

The same applies for `Result#bind`. Since none of this code has yet been released, we can still remove these APIs in favour of the simpler `inline` methods on the original APIs. Fixing this issue also requires some other small changes in [Builders.kt](https://github.com/arrow-kt/arrow/blob/main/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt).

---

There is multiple benefits to this actually, and we should review the current signatures in `arrow.core.raise.*` to see how we can simplify them.

Looking for example at `recover`:

```diff
@RaiseDSL
- public inline fun <R, E, A> Raise<R>.recover(
+ public inline fun <E, A> recover(
  @BuilderInference action: Raise<E>.() -> A,
-  @BuilderInference recover: Raise<R>.(E) -> A,
+  recover: (E) -> A,
): A {
  contract {
    callsInPlace(action, EXACTLY_ONCE)
    callsInPlace(recover, AT_MOST_ONCE)
  }
  return fold<E, A, A>({ action(this) }, { throw it }, { recover(it) }, { it })
}
```

Besides still supporting the current use-cases it also makes this function more general purpose, because you can now use it to execute `Raise<E>` based programs and _resolve_ the error completely without **having to** stick to `Raise<E>`.

---