### PR TITLE
Speed up retrofit related long running tests (arrow-kt#2908)

### DIFF
--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt
@@ -10,9 +10,13 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.spec.style.stringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -20,8 +24,6 @@ import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
-import java.net.SocketException
-import java.net.SocketTimeoutException
 
 @ExperimentalSerializationApi
 class NetworkEitherCallAdapterTestSuite : StringSpec({
@@ -39,8 +41,12 @@ private fun networkEitherCallAdapterTests(
   beforeAny {
     server = MockWebServer()
     server!!.start()
+    val client = OkHttpClient.Builder()
+      .readTimeout(200, TimeUnit.MILLISECONDS)
+      .build()
     service = Retrofit.Builder()
       .baseUrl(server!!.url("/"))
+      .client(client)
       .addConverterFactory(jsonConverterFactory)
       .addCallAdapterFactory(EitherCallAdapterFactory.create())
       .build()


### PR DESCRIPTION
### Issue
This is a part of changes related to https://github.com/arrow-kt/arrow/issues/2908 issue.

### Description
Current PR raised to fix next long running tests connected with [retrofit](https://github.com/square/retrofit) http client:
```
     should return IOError when no responsearrow.retrofit.adapter.either.networkhandling.NetworkEitherCallAdapterTestSuite:arrow-core-retrofit:test | PASSED | 10.889s
 (2) should return IOError when no responsearrow.retrofit.adapter.either.networkhandling.NetworkEitherCallAdapterTestSuite:arrow-core-retrofit:test | PASSED | 10.041s
 (1) should return IOError when no responsearrow.retrofit.adapter.either.networkhandling.NetworkEitherCallAdapterTestSuite:arrow-core-retrofit:test | PASSED | 9.448s
```
After changes I see next timings on my local machine:
```
    should return IOError when no response	0.237s	passed
(1) should return IOError when no response	0.204s	passed
(2) should return IOError when no response	0.203s	passed
```

### Root cause
Out of the box retrofit is using default `OkHttpClient` if no other client passed during creation. Meanwhile `OkHttpClient` has default value of read timeout that is equal to 10 seconds.
As a fix - decreased read timeout to 0.2 seconds
