### PR TITLE
Deprecate Iterable.traverse, and some niche APIs. Hygiene on Iterable documentation

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -651,6 +651,7 @@ public final class arrow/core/IterableKt {
 	public static final fun salign (Ljava/lang/Iterable;Larrow/typeclasses/Semigroup;Ljava/lang/Iterable;)Ljava/lang/Iterable;
 	public static final fun separateEither (Ljava/lang/Iterable;)Lkotlin/Pair;
 	public static final fun separateValidated (Ljava/lang/Iterable;)Lkotlin/Pair;
+	public static final fun seperateIor (Ljava/lang/Iterable;)Lkotlin/Pair;
 	public static final fun sequence (Ljava/lang/Iterable;)Larrow/core/Either;
 	public static final fun sequence (Ljava/lang/Iterable;)Larrow/core/Option;
 	public static final fun sequence (Ljava/lang/Iterable;)Larrow/core/Validated;

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-13.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-13.kt
@@ -2,12 +2,12 @@
 package arrow.core.examples.exampleIterable13
 
 import arrow.core.*
+import io.kotest.matchers.shouldBe
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val result =
-   listOf(("A" to 1).bothIor(), ("B" to 2).bothIor(), "C".leftIor())
-     .unalign()
-  //sampleEnd
-  println(result)
+fun test() {
+   listOf(
+     Pair("A", 1).bothIor(),
+     Pair("B", 2).bothIor(),
+     "C".leftIor()
+   ).seperateIor() shouldBe Pair(listOf("A", "B", "C"), listOf(1, 2))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-14.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-14.kt
@@ -2,13 +2,11 @@
 package arrow.core.examples.exampleIterable14
 
 import arrow.core.*
+import io.kotest.matchers.shouldBe
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val result =
-     listOf(1, 2, 3).unalign {
-       it.leftIor()
-     }
-  //sampleEnd
-  println(result)
+fun test() {
+   listOf(1, 2, 3, 4).unalign {
+     if(it % 2 == 0) it.rightIor()
+     else it.leftIor()
+   } shouldBe Pair(listOf(1, 3), listOf(2, 4))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-15.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-15.kt
@@ -2,11 +2,9 @@
 package arrow.core.examples.exampleIterable15
 
 import arrow.core.*
+import io.kotest.matchers.shouldBe
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val result =
-   listOf("A", "B", "C").split()
-  //sampleEnd
-  println(result)
+fun test() {
+  emptyList<Int>().split() shouldBe null
+  listOf("A", "B", "C").split() shouldBe Pair(listOf("B", "C"), "A")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-16.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-16.kt
@@ -2,12 +2,10 @@
 package arrow.core.examples.exampleIterable16
 
 import arrow.core.*
+import io.kotest.matchers.shouldBe
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val tags = List(10) { "#" }
-  val result =
-   tags.interleave(listOf("A", "B", "C"))
-  //sampleEnd
-  println(result)
+fun test() {
+  val list1 = listOf(1, 2, 3)
+  val list2 = listOf(4, 5, 6, 7, 8)
+  list1.interleave(list2) shouldBe listOf(1, 4, 2, 5, 3, 6, 7, 8)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-17.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-17.kt
@@ -2,11 +2,11 @@
 package arrow.core.examples.exampleIterable17
 
 import arrow.core.*
+import io.kotest.matchers.shouldBe
 
-fun main(args: Array<String>) {
-  //sampleStart
-  val result =
-   listOf(1,2,3).unweave { i -> listOf("$i, ${i + 1}") }
-  //sampleEnd
-  println(result)
+fun test() {
+  val ints = listOf(1, 2)
+  val res = ints.unweave { i -> listOf(i, i + 1, i + 2) }
+  res shouldBe listOf(1, 2, 2, 3, 3, 4)
+  res shouldBe ints.interleave(ints.flatMap { listOf(it + 1, it + 2) })
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-19.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-iterable-19.kt
@@ -1,0 +1,10 @@
+// This file was automatically generated from Iterable.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleIterable19
+
+import arrow.core.*
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  listOf("A".left(), 2.right(), "C".left(), 4.right())
+    .separateEither() shouldBe Pair(listOf("A", "C"), listOf(2, 4))
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/IterableKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/IterableKnitTest.kt
@@ -12,6 +12,26 @@ class IterableKnitTest : StringSpec({
     arrow.core.examples.exampleIterable02.test()
   }
 
+  "ExampleIterable13" {
+    arrow.core.examples.exampleIterable13.test()
+  }
+
+  "ExampleIterable14" {
+    arrow.core.examples.exampleIterable14.test()
+  }
+
+  "ExampleIterable15" {
+    arrow.core.examples.exampleIterable15.test()
+  }
+
+  "ExampleIterable16" {
+    arrow.core.examples.exampleIterable16.test()
+  }
+
+  "ExampleIterable19" {
+    arrow.core.examples.exampleIterable19.test()
+  }
+
 }) {
   override fun timeout(): Long = 1000
 }


### PR DESCRIPTION
Some changes overlap with #2960 from @abendt, namely changes to `seperateIor` and `unalign` so I'm keeping this PR as a DRAFT until that work is finished. Some more deprecations need to happen here, but they're being made in #2935 so this PR will also wait until those changes are merged.

In addition to deprecating `Iterable.traverse` methods in favour of DSL + map I've also deprecated:

 - `replicate`
 - `reduceRightOrNull` in favour of `asReversed().reduceOrNull`
 - `ifThen` in favour Kotlin Std functionality `flatMap(ffa).ifEmpty<List<B>`

I think most methods such as `crossWalk`, `align` and `padXXX` are useful methods to keep for Iterable.kt.