### PR TITLE
Recommend Either.getOrElse for handleError instead of recover

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -2275,14 +2275,11 @@ public inline fun <A, B, C> Either<A, B>.handleErrorWith(f: (A) -> Either<C, B>)
 
 @Deprecated(
   RedundantAPI + "Prefer the new recover API",
-  ReplaceWith(
-    "this.recover<A, Nothing, B> { f(it) }",
-    "arrow.core.recover"
-  )
+  ReplaceWith("getOrElse(f).right()", "arrow.core.right", "arrow.core.getOrElse")
 )
 public inline fun <A, B> Either<A, B>.handleError(f: (A) -> B): Either<A, B> {
   contract { callsInPlace(f, InvocationKind.AT_MOST_ONCE) }
-  return recover { a -> f(a) }
+  return getOrElse(f).right()
 }
 
 @Deprecated(


### PR DESCRIPTION
Recommending `getOrElse` for `handleError` gives a better flowing of types than using `Either<Nothing, A>`,
and is more in line with the changes made in [Removes autobind DSL in favor of getOrElse](https://github.com/arrow-kt/arrow/pull/2968).

`recover` is a replacement for `handleErrorWith` and using it for `handleError` (sadly) results in poor inference, because `@BuilderInference` doesn't infer `Nothing` when `EE` is not used.