### PR TITLE
Fix nested nullable problem for map zip and flatMap implementations

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
@@ -48,27 +48,33 @@ public fun <K, A, B> Map<K, A>.zip(other: Map<K, B>): Map<K, Pair<A, B>> =
  * <!--- KNIT example-map-02.kt -->
  * <!--- lines.isEmpty() -->
  */
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, A, B, C> Map<Key, A>.zip(other: Map<Key, B>, map: (Key, A, B) -> C): Map<Key, C> =
   buildMap(size) {
     this@zip.forEach { (key, bb) ->
-      nullable {
-        put(key, map(key, bb, other[key].bind()))
+      if (other.containsKey(key)) {
+        put(key, map(key, bb, other[key] as B))
       }
     }
   }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
   map: (Key, B, C, D) -> E
 ): Map<Key, E> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(key, map(key, bb, c[key].bind(), d[key].bind()))
+    if (c.containsKey(key) && d.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+
+      put(key, map(key, bb, cc, dd))
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -76,12 +82,17 @@ public inline fun <Key, B, C, D, E, F> Map<Key, B>.zip(
   map: (Key, B, C, D, E) -> F
 ): Map<Key, F> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(key, map(key, bb, c[key].bind(), d[key].bind(), e[key].bind()))
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+
+      put(key, map(key, bb, cc, dd, ee))
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F, G> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -90,12 +101,18 @@ public inline fun <Key, B, C, D, E, F, G> Map<Key, B>.zip(
   map: (Key, B, C, D, E, F) -> G
 ): Map<Key, G> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(key, map(key, bb, c[key].bind(), d[key].bind(), e[key].bind(), f[key].bind()))
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key) && f.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+      val ff = f[key] as F
+
+      put(key, map(key, bb, cc, dd, ee, ff))
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F, G, H> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -105,12 +122,19 @@ public inline fun <Key, B, C, D, E, F, G, H> Map<Key, B>.zip(
   map: (Key, B, C, D, E, F, G) -> H
 ): Map<Key, H> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(key, map(key, bb, c[key].bind(), d[key].bind(), e[key].bind(), f[key].bind(), g[key].bind()))
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key) && f.containsKey(key) && g.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+      val ff = f[key] as F
+      val gg = g[key] as G
+
+      put(key, map(key, bb, cc, dd, ee, ff, gg))
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F, G, H, I> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -121,12 +145,20 @@ public inline fun <Key, B, C, D, E, F, G, H, I> Map<Key, B>.zip(
   map: (Key, B, C, D, E, F, G, H) -> I
 ): Map<Key, I> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(key, map(key, bb, c[key].bind(), d[key].bind(), e[key].bind(), f[key].bind(), g[key].bind(), h[key].bind()))
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key) && f.containsKey(key) && g.containsKey(key) && h.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+      val ff = f[key] as F
+      val gg = g[key] as G
+      val hh = h[key] as H
+
+      put(key, map(key, bb, cc, dd, ee, ff, gg, hh))
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F, G, H, I, J> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -138,25 +170,23 @@ public inline fun <Key, B, C, D, E, F, G, H, I, J> Map<Key, B>.zip(
   map: (Key, B, C, D, E, F, G, H, I) -> J
 ): Map<Key, J> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key) && f.containsKey(key) && g.containsKey(key) && h.containsKey(key) && i.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+      val ff = f[key] as F
+      val gg = g[key] as G
+      val hh = h[key] as H
+      val ii = i[key] as I
+
       put(
-        key,
-        map(
-          key,
-          bb,
-          c[key].bind(),
-          d[key].bind(),
-          e[key].bind(),
-          f[key].bind(),
-          g[key].bind(),
-          h[key].bind(),
-          i[key].bind()
-        )
+        key, map(key, bb, cc, dd, ee, ff, gg, hh, ii)
       )
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F, G, H, I, J, K> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -169,26 +199,22 @@ public inline fun <Key, B, C, D, E, F, G, H, I, J, K> Map<Key, B>.zip(
   map: (Key, B, C, D, E, F, G, H, I, J) -> K
 ): Map<Key, K> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(
-        key,
-        map(
-          key,
-          bb,
-          c[key].bind(),
-          d[key].bind(),
-          e[key].bind(),
-          f[key].bind(),
-          g[key].bind(),
-          h[key].bind(),
-          i[key].bind(),
-          j[key].bind()
-        )
-      )
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key) && f.containsKey(key) && g.containsKey(key) && h.containsKey(key) && i.containsKey(key) && j.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+      val ff = f[key] as F
+      val gg = g[key] as G
+      val hh = h[key] as H
+      val ii = i[key] as I
+      val jj = j[key] as J
+
+      put(key, map(key, bb, cc, dd, ee, ff, gg, hh, ii, jj))
     }
   }
 }
 
+@Suppress("UNCHECKED_CAST")
 public inline fun <Key, B, C, D, E, F, G, H, I, J, K, L> Map<Key, B>.zip(
   c: Map<Key, C>,
   d: Map<Key, D>,
@@ -202,23 +228,18 @@ public inline fun <Key, B, C, D, E, F, G, H, I, J, K, L> Map<Key, B>.zip(
   map: (Key, B, C, D, E, F, G, H, I, J, K) -> L
 ): Map<Key, L> = buildMap(size) {
   this@zip.forEach { (key, bb) ->
-    nullable {
-      put(
-        key,
-        map(
-          key,
-          bb,
-          c[key].bind(),
-          d[key].bind(),
-          e[key].bind(),
-          f[key].bind(),
-          g[key].bind(),
-          h[key].bind(),
-          i[key].bind(),
-          j[key].bind(),
-          k[key].bind()
-        )
-      )
+    if (c.containsKey(key) && d.containsKey(key) && e.containsKey(key) && f.containsKey(key) && g.containsKey(key) && h.containsKey(key) && i.containsKey(key) && j.containsKey(key) && k.containsKey(key)) {
+      val cc = c[key] as C
+      val dd = d[key] as D
+      val ee = e[key] as E
+      val ff = f[key] as F
+      val gg = g[key] as G
+      val hh = h[key] as H
+      val ii = i[key] as I
+      val jj = j[key] as J
+      val kk = k[key] as K
+
+      put(key, map(key, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk))
     }
   }
 }
@@ -227,10 +248,14 @@ public inline fun <Key, B, C, D, E, F, G, H, I, J, K, L> Map<Key, B>.zip(
  * Transform every [Map.Entry] of the original [Map] using [f],
  * only keeping the [Map.Entry] of the transformed map that match the input [Map.Entry].
  */
+@Suppress("UNCHECKED_CAST")
 public fun <K, A, B> Map<K, A>.flatMap(f: (Map.Entry<K, A>) -> Map<K, B>): Map<K, B> =
   buildMap {
     this@flatMap.forEach { entry ->
-      f(entry)[entry.key]?.let { put(entry.key, it) }
+      val nestedMap = f(entry)
+      if (nestedMap.containsKey(entry.key)) {
+        put(entry.key, nestedMap[entry.key] as B)
+      }
     }
   }
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
@@ -14,6 +14,7 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 
@@ -121,7 +122,7 @@ class MapKTest : StringSpec({
       checkAll(Arb.map(Arb.long(), Arb.boolean()), Arb.map(Arb.long(), Arb.boolean())) { a, b ->
         val aligned = a.align(b)
         a.keys.intersect(b.keys).forEach {
-          aligned[it]?.isBoth shouldBe true
+          aligned[it]?.isBoth() shouldBe true
         }
       }
     }
@@ -139,7 +140,7 @@ class MapKTest : StringSpec({
       checkAll(Arb.map(Arb.long(), Arb.boolean()), Arb.map(Arb.long(), Arb.boolean())) { a, b ->
         val aligned = a.align(b)
         (b.keys - a.keys).forEach { key ->
-          aligned[key]?.isRight shouldBe true
+          aligned[key]?.isRight() shouldBe true
         }
       }
     }
@@ -152,6 +153,23 @@ class MapKTest : StringSpec({
         val result = a.zip(b) { _, aa, bb -> Pair(aa, bb) }
         val expected = a.filter { (k, _) -> b.containsKey(k) }
           .map { (k, v) -> Pair(k, Pair(v, b[k]!!)) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
+    "zip2 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB) { _, aa, bb -> Pair(aa, bb) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Pair(v, mapB[k])) }
           .toMap()
 
         result shouldBe expected
@@ -173,6 +191,23 @@ class MapKTest : StringSpec({
       }
     }
 
+    "zip3 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB) { _, aa, bb, cc -> Triple(aa, bb, cc) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Triple(v, mapB[k], mapB[k])) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
     "zip4" {
       checkAll(
         Arb.map(Arb.intSmall(), Arb.intSmall()),
@@ -182,6 +217,23 @@ class MapKTest : StringSpec({
 
         val expected = a.filter { (k, _) -> b.containsKey(k) }
           .map { (k, v) -> Pair(k, Tuple4(v, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
+    "zip4 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB) { _, aa, bb, cc, dd -> Tuple4(aa, bb, cc, dd) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple4(v, mapB[k], mapB[k], mapB[k])) }
           .toMap()
 
         result shouldBe expected
@@ -203,6 +255,23 @@ class MapKTest : StringSpec({
       }
     }
 
+    "zip5 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB, mapB) { _, aa, bb, cc, dd, ee -> Tuple5(aa, bb, cc, dd, ee) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple5(v, mapB[k], mapB[k], mapB[k], mapB[k])) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
     "zip6" {
       checkAll(
         Arb.map(Arb.intSmall(), Arb.intSmall()),
@@ -212,6 +281,23 @@ class MapKTest : StringSpec({
 
         val expected = a.filter { (k, _) -> b.containsKey(k) }
           .map { (k, v) -> Pair(k, Tuple6(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
+    "zip6 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB, mapB, mapB) { _, aa, bb, cc, dd, ee, ff -> Tuple6(aa, bb, cc, dd, ee, ff) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple6(v, mapB[k], mapB[k], mapB[k], mapB[k], mapB[k])) }
           .toMap()
 
         result shouldBe expected
@@ -233,6 +319,23 @@ class MapKTest : StringSpec({
       }
     }
 
+    "zip7 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB, mapB, mapB, mapB) { _, aa, bb, cc, dd, ee, ff, gg -> Tuple7(aa, bb, cc, dd, ee, ff, gg) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple7(v, mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k])) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
     "zip8" {
       checkAll(
         Arb.map(Arb.intSmall(), Arb.intSmall()),
@@ -243,6 +346,23 @@ class MapKTest : StringSpec({
 
         val expected = a.filter { (k, _) -> b.containsKey(k) }
           .map { (k, v) -> Pair(k, Tuple8(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
+    "zip8 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB, mapB, mapB, mapB, mapB) { _, aa, bb, cc, dd, ee, ff, gg, hh -> Tuple8(aa, bb, cc, dd, ee, ff, gg, hh) }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple8(v, mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k])) }
           .toMap()
 
         result shouldBe expected
@@ -270,6 +390,35 @@ class MapKTest : StringSpec({
 
         val expected = a.filter { (k, _) -> b.containsKey(k) }
           .map { (k, v) -> Pair(k, Tuple9(v, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!, b[k]!!)) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
+    "zip9 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB, mapB, mapB, mapB, mapB, mapB) { _, aa, bb, cc, dd, ee, ff, gg, hh, ii ->
+          Tuple9(
+            aa,
+            bb,
+            cc,
+            dd,
+            ee,
+            ff,
+            gg,
+            hh,
+            ii
+          )
+        }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple9(v, mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k])) }
           .toMap()
 
         result shouldBe expected
@@ -304,6 +453,36 @@ class MapKTest : StringSpec({
       }
     }
 
+    "zip10 with nullables" {
+      checkAll(
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall(), 10..10),
+        Arb.list(Arb.intSmall().orNull(), 10..10)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result = mapA.zip(mapB, mapB, mapB, mapB, mapB, mapB, mapB, mapB, mapB) { _, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj ->
+          Tuple10(
+            aa,
+            bb,
+            cc,
+            dd,
+            ee,
+            ff,
+            gg,
+            hh,
+            ii,
+            jj
+          )
+        }
+        val expected = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, v) -> Pair(k, Tuple10(v, mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k], mapB[k])) }
+          .toMap()
+
+        result shouldBe expected
+      }
+    }
+
     "flatMap" {
       checkAll(
         Arb.map(Arb.string(), Arb.intSmall()),
@@ -312,6 +491,22 @@ class MapKTest : StringSpec({
         val result: Map<String, String> = a.flatMap { b }
         val expected: Map<String, String> = a.filter { (k, _) -> b.containsKey(k) }
           .map { (k, _) -> Pair(k, b[k]!!) }
+          .toMap()
+        result shouldBe expected
+      }
+    }
+
+    "flatMap with nullables" {
+      checkAll(
+        Arb.list(Arb.string(), 5..5),
+        Arb.list(Arb.intSmall(), 5..5),
+        Arb.list(Arb.string().orNull(), 5..5)
+      ) { keys, a, b ->
+        val mapA = keys.zip(a).toMap()
+        val mapB = keys.zip(b).toMap()
+        val result: Map<String, String?> = mapA.flatMap { mapB }
+        val expected: Map<String, String?> = mapA.filter { (k, _) -> mapB.containsKey(k) }
+          .map { (k, _) -> Pair(k, mapB[k]) }
           .toMap()
         result shouldBe expected
       }


### PR DESCRIPTION
This pull request fixes a bug in the `zip` and `flatMap` implementation for `Map` caused by the nested nullable problem. For example, given the following code:
```
val mapA: Map<Int, String> = mapOf(1 to "a", 2 to "b", 3 to "c")
val mapB: Map<Int, String?> = mapOf(1 to "d", 2 to null, 3 to "f")

mapA.zip(mapB) { _, a, b -> Pair(a, b) }
```
It should return:
```
{1=(a, d), 2=(b, null), 3=(c, f)}
```
However, the current `zip` implementation was filtering out the key with a `null` value:
```
{1=(a, d), 3=(c, f)}
```
