### PR TITLE
Fix `traverse` for `Either` and `Option`

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1201,21 +1201,21 @@ public sealed class Either<out A, out B> {
 
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
-    ReplaceWith("fold({ emptyList() }, { fa(it).map(::Right) })")
+    ReplaceWith("fold({ listOf(it.left()) }, { fa(it).map(::Right) })")
   )
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType
   public inline fun <C> traverse(fa: (B) -> Iterable<C>): List<Either<A, C>> =
-    fold({ emptyList() }, { fa(it).map(::Right) })
+    fold({ listOf(it.left()) }, { fa(it).map(::Right) })
 
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
-    ReplaceWith("fold({ None }, { right -> fa(right).map(::Right) })")
+    ReplaceWith("fold({ Some(it.left()) }, { right -> fa(right).map(::Right) })")
   )
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType
   public inline fun <C> traverse(fa: (B) -> Option<C>): Option<Either<A, C>> =
-    fold({ None }, { right -> fa(right).map(::Right) })
+    fold({ Some(it.left()) }, { right -> fa(right).map(::Right) })
 
   @Deprecated("traverseOption is being renamed to traverse to simplify the Arrow API", ReplaceWith("traverse(fa)"))
   public inline fun <C> traverseOption(fa: (B) -> Option<C>): Option<Either<A, C>> =
@@ -1223,10 +1223,10 @@ public sealed class Either<out A, out B> {
 
   @Deprecated(
     RedundantAPI + "Use orNull() and Kotlin nullable types",
-    ReplaceWith("orNull()?.let(fa)?.right()")
+    ReplaceWith("fold({ it.left() }) { fa(it)?.right() }", "arrow.core.left", "arrow.core.right")
   )
   public inline fun <C> traverseNullable(fa: (B) -> C?): Either<A, C>? =
-    orNull()?.let(fa)?.right()
+    fold({ it.left() }) { fa(it)?.right() }
 
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
@@ -2570,18 +2570,18 @@ public inline fun <A, B, C, D> Either<A, B>.redeemWith(fa: (A) -> Either<C, D>, 
 @Deprecated(
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
-    "fold({ listOf<Either<A, B>>() }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
-    "arrow.core.right",
+    "fold({ listOf<Either<A, B>>(it.left()) }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
+    "arrow.core.right", "arrow.core.left"
   )
 )
 public fun <A, B> Either<A, Iterable<B>>.sequence(): List<Either<A, B>> =
-  fold({ emptyList() }, { iterable -> iterable.map { it.right() } })
+  fold({ listOf(it.left()) }, { iterable -> iterable.map { it.right() } })
 
 @Deprecated(
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
-    "this.fold<Option<Either<A, B>>>({ None }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
-    "arrow.core.right",
+    "this.fold<Option<Either<A, B>>>({ Some(it.left()) }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
+    "arrow.core.right", "arrow.core.left"
   )
 )
 public fun <A, B> Either<A, Option<B>>.sequenceOption(): Option<Either<A, B>> =
@@ -2590,20 +2590,17 @@ public fun <A, B> Either<A, Option<B>>.sequenceOption(): Option<Either<A, B>> =
 @Deprecated(
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
-    "orNull()?.orNull()?.right<B>().toOption<Either<A, B>>()",
-    "arrow.core.toOption",
-    "arrow.core.right",
-    "arrow.core.left"
+    "this.fold<Option<Either<A, B>>>({ Some(it.left()) }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
+    "arrow.core.right", "arrow.core.left"
   )
 )
 public fun <A, B> Either<A, Option<B>>.sequence(): Option<Either<A, B>> =
-  orNull()?.orNull()?.right().toOption()
+  fold({ Some(it.left()) }) { it.map { it.right() } }
 
 @Deprecated(
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
     "this.fold<Either<A, B>?>({ it.left() }, { it?.right() })",
-    "arrow.core.toOption",
     "arrow.core.right",
     "arrow.core.left"
   )
@@ -2613,10 +2610,14 @@ public fun <A, B> Either<A, B?>.sequenceNullable(): Either<A, B>? =
 
 @Deprecated(
   "Prefer Kotlin nullable syntax",
-  ReplaceWith("orNull()?.right()", "arrow.core.right")
+  ReplaceWith(
+    "this.fold<Either<A, B>?>({ it.left() }, { it?.right() })",
+    "arrow.core.right",
+    "arrow.core.left"
+  )
 )
 public fun <A, B> Either<A, B?>.sequence(): Either<A, B>? =
-  orNull()?.right()
+  this.fold<Either<A, B>?>({ it.left() }, { it?.right() })
 
 @Deprecated(
   "sequenceValidated is being renamed to sequence to simplify the Arrow API",

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1201,7 +1201,11 @@ public sealed class Either<out A, out B> {
 
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
-    ReplaceWith("fold({ listOf(it.left()) }, { fa(it).map(::Right) })")
+    ReplaceWith(
+      "fold({ listOf(it.left()) }, { fa(it).map(::Right) })", 
+      "arrow.core.Either.Right",
+      "arrow.core.Either.left"
+    )
   )
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType
@@ -1210,7 +1214,12 @@ public sealed class Either<out A, out B> {
 
   @Deprecated(
     NicheAPI + "Prefer using the Either DSL, or explicit fold or when",
-    ReplaceWith("fold({ Some(it.left()) }, { right -> fa(right).map(::Right) })")
+    ReplaceWith(
+      "fold({ Some(it.left()) }, { right -> fa(right).map(::Right) })",
+      "arrow.core.Either.Right",
+      "arrow.core.Some",
+      "arrow.core.left"
+    )
   )
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType
@@ -2581,7 +2590,11 @@ public fun <A, B> Either<A, Iterable<B>>.sequence(): List<Either<A, B>> =
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
     "this.fold<Option<Either<A, B>>>({ Some(it.left()) }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
-    "arrow.core.right", "arrow.core.left"
+    "arrow.core.Either",
+    "arrow.core.Option",
+    "arrow.core.Some",
+    "arrow.core.left",
+    "arrow.core.right"
   )
 )
 public fun <A, B> Either<A, Option<B>>.sequenceOption(): Option<Either<A, B>> =
@@ -2591,7 +2604,11 @@ public fun <A, B> Either<A, Option<B>>.sequenceOption(): Option<Either<A, B>> =
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
     "this.fold<Option<Either<A, B>>>({ Some(it.left()) }, { iterable -> iterable.map<B, Either<A, B>> { it.right() } })",
-    "arrow.core.right", "arrow.core.left"
+    "arrow.core.Either",
+    "arrow.core.Option",
+    "arrow.core.Some",
+    "arrow.core.left",
+    "arrow.core.right"
   )
 )
 public fun <A, B> Either<A, Option<B>>.sequence(): Option<Either<A, B>> =
@@ -2601,6 +2618,7 @@ public fun <A, B> Either<A, Option<B>>.sequence(): Option<Either<A, B>> =
   "Prefer Kotlin nullable syntax inside either DSL, or replace with explicit fold",
   ReplaceWith(
     "this.fold<Either<A, B>?>({ it.left() }, { it?.right() })",
+    "arrow.core.Either",
     "arrow.core.right",
     "arrow.core.left"
   )
@@ -2612,6 +2630,7 @@ public fun <A, B> Either<A, B?>.sequenceNullable(): Either<A, B>? =
   "Prefer Kotlin nullable syntax",
   ReplaceWith(
     "this.fold<Either<A, B>?>({ it.left() }, { it?.right() })",
+    "arrow.core.Either",
     "arrow.core.right",
     "arrow.core.left"
   )

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -1129,7 +1129,9 @@ public sealed class Option<out A> {
     NicheAPI + "Prefer using the Option DSL, or explicit fold or when",
     ReplaceWith(
       "fold({ listOf(None) }) { a -> fa(a).map(::Some) }",
-      "arrow.core.Some")
+      "arrow.core.None",
+      "arrow.core.Some"
+    )
   )
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -1128,14 +1128,14 @@ public sealed class Option<out A> {
   @Deprecated(
     NicheAPI + "Prefer using the Option DSL, or explicit fold or when",
     ReplaceWith(
-      "fold({ emptyList() }) { a -> fa(a).map(::Some) }",
+      "fold({ listOf(None) }) { a -> fa(a).map(::Some) }",
       "arrow.core.Some")
   )
   @OptIn(ExperimentalTypeInference::class)
   @OverloadResolutionByLambdaReturnType
   public inline fun <B> traverse(fa: (A) -> Iterable<B>): List<Option<B>> {
     contract { callsInPlace(fa, InvocationKind.AT_MOST_ONCE) }
-    return fold({ emptyList() }, { a -> fa(a).map { Some(it) } })
+    return fold({ listOf(None) }, { a -> fa(a).map { Some(it) } })
   }
 
   @Deprecated(

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/OptionTest.kt
@@ -352,7 +352,7 @@ class OptionTest : StringSpec({
       val some: Option<String> = Some("value")
       val none: Option<String> = None
       some.traverse { listOf(it) } shouldBe listOf(Some("value"))
-      none.traverse { listOf(it) } shouldBe emptyList()
+      none.traverse { listOf(it) } shouldBe listOf(None)
     }
 
     "sequence should be consistent with traverse" {


### PR DESCRIPTION
@nomisRev realized that our current implementations of `traverse` do not respect the expected laws. Let's compare with Haskell (where `Just` is the equivalent of `Some`, and `[x]` means `listOf(x)`).

```haskell
> mapM (\x -> Just 3) (Left 2)
Just (Left 2)
> mapM (\x -> [3]) (Left 2)
[Left 2]
```

However, our current implementation would return `None` and an empty list in those cases. This PR implements the law-abiding implementations, which return `Left` wrapped in the corresponding type instead of the "error path" of those.

One important question here is whether we should consider this a bug, and thus just release the modifier implementation as part of 1.2.0, or whether this is a breaking change, and thus we should wait until 2.0 and release this fixed implementation under a different name.

Note: the implementation for `Ior` seems to be lawful.