### PR TITLE
Create action to auto update a PR when destination branch is pushed

### DIFF
--- a/.github/workflows/auto-update-pr.yaml
+++ b/.github/workflows/auto-update-pr.yaml
@@ -1,0 +1,14 @@
+name: auto-update-pr
+on:
+  push: {}
+jobs:
+  autoupdate:
+    name: Auto update PR
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.TOKEN_GITHUB_ACTION }}"
+          PR_FILTER: "ready_for_review"
+          EXCLUDED_LABELS: "dependencies,wontfix"
+          MERGE_MSG: "Branch was auto-updated."


### PR DESCRIPTION
This PR creates a Github Action that uses [autoupdate](https://github.com/marketplace/actions/auto-update) to keep all opened PRs up-to-date whenever a push is done to the PR destination branch