### PR TITLE
Use `GITHUB_TOKEN` in auto-update-pr action

### DIFF
--- a/.github/workflows/auto-update-pr.yaml
+++ b/.github/workflows/auto-update-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: "${{ secrets.TOKEN_GITHUB_ACTION }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           PR_FILTER: "ready_for_review"
           EXCLUDED_LABELS: "Skip Auto Update PRs"
           MERGE_MSG: "Branch was auto-updated."


### PR DESCRIPTION
The current `TOKEN_GITHUB_ACTION` signs the update commits using @nomisRev account 😅. We better sign them on behalf of GH Actions. 