### PR TITLE
Result & Sequence missing deprecation and revert post-fixed names

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Result.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Result.kt
@@ -29,13 +29,12 @@ public inline fun <A, B> Result<A>.flatMap(transform: (value: A) -> Result<B>): 
  * Compose a recovering [transform] operation on the failure value [Throwable] whilst flattening [Result].
  * @see recoverCatching if you want run a function that catches and maps recovers with `(Throwable) -> A`.
  */
-public inline fun <A> Result<A>.handleErrorWith(transform: (throwable: Throwable) -> Result<A>): Result<A> {
-  contract { callsInPlace(transform, InvocationKind.AT_MOST_ONCE) }
-  return when (val exception = exceptionOrNull()) {
-    null -> this
-    else -> transform(exception)
-  }
-}
+@Deprecated(
+  "Prefer Kotlin Std Result.recoverCatching instead of handleErrorWith",
+  ReplaceWith("recoverCatching { transform(it).getOrThrow() }")
+)
+public inline fun <A> Result<A>.handleErrorWith(transform: (throwable: Throwable) -> Result<A>): Result<A> =
+  recoverCatching { transform(it).getOrThrow() }
 
 /**
  * Compose both:
@@ -44,6 +43,10 @@ public inline fun <A> Result<A>.handleErrorWith(transform: (throwable: Throwable
  *
  * Combining the powers of [flatMap] and [handleErrorWith].
  */
+@Deprecated(
+  "Prefer Kotlin Std Result.fold instead of redeemWith",
+  ReplaceWith("fold(transform, handleErrorWith)")
+)
 public inline fun <A, B> Result<A>.redeemWith(
   handleErrorWith: (throwable: Throwable) -> Result<B>,
   transform: (value: A) -> Result<B>


### PR DESCRIPTION
This PR adds missing deprecations for `Result`, and `Sequence`.

As discussed on Slack it also reverts the `Sequence` methods that were duplicated with post fixes, in favour of breaking the API in 2.0 from `Sequence` to `List` since those are mostly source-compatible for most intents and purposes. This allows us to keep the original names, instead of names with postfixes after 2.0