### PR TITLE
Add CNAME file to Dokka output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ target/
 
 
 _site/
+docs/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata

--- a/arrow-site/docs/CNAME
+++ b/arrow-site/docs/CNAME
@@ -1,1 +1,0 @@
-arrow-kt.io

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,9 +111,18 @@ tasks {
   val undocumentedProjects =
     listOf(project(":arrow-optics-ksp-plugin"))
 
-  dokkaGfmMultiModule { removeChildTasks(undocumentedProjects) }
-  dokkaHtmlMultiModule { removeChildTasks(undocumentedProjects) }
-  dokkaJekyllMultiModule { removeChildTasks(undocumentedProjects) }
+  dokkaGfmMultiModule {
+    dependsOn("copyCNameFile")
+    removeChildTasks(undocumentedProjects)
+  }
+  dokkaHtmlMultiModule {
+    dependsOn("copyCNameFile")
+    removeChildTasks(undocumentedProjects)
+  }
+  dokkaJekyllMultiModule {
+    dependsOn("copyCNameFile")
+    removeChildTasks(undocumentedProjects)
+  }
 
   getByName("knitPrepare").dependsOn(getTasksByName("dokka", true))
 
@@ -126,6 +135,11 @@ tasks {
     val folder = docFolder()
     val content = folder.listFiles()?.filter { it != folder }
     delete(content)
+  }
+
+  register<Copy>("copyCNameFile") {
+    from(layout.projectDirectory.dir("static").file("CNAME"))
+    into(layout.projectDirectory.dir("docs"))
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,15 +111,7 @@ tasks {
   val undocumentedProjects =
     listOf(project(":arrow-optics-ksp-plugin"))
 
-  dokkaGfmMultiModule {
-    dependsOn("copyCNameFile")
-    removeChildTasks(undocumentedProjects)
-  }
   dokkaHtmlMultiModule {
-    dependsOn("copyCNameFile")
-    removeChildTasks(undocumentedProjects)
-  }
-  dokkaJekyllMultiModule {
     dependsOn("copyCNameFile")
     removeChildTasks(undocumentedProjects)
   }

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+apidocs.arrow-kt.io


### PR DESCRIPTION
After deploying the documentation files in the GitHub Pages branch, we are facing the same issue as in the arrow-website repo. The previous documentation is deleted every time a new release is published, so we lose the custom domain configuration (the CNAME file is removed). That means we need to set up the domain again, causing some downtime for the API docs site. 

To avoid that, this pull request copies the CNAME into the Dokka output folder every time we run the Dokka command.