### PR TITLE
WIP: Attempt at fixing ior recover issue

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -156,7 +156,7 @@ public class IorRaise<Error> @PublishedApi internal constructor(
     map { it.bind() }
 
   @RaiseDSL
-  public fun <A> Ior<Error, A>.bind(): A =
+  public override fun <A> Ior<Error, A>.bind(): A =
     when (this) {
       is Ior.Left -> raise(value)
       is Ior.Right -> value

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -6,6 +6,7 @@
 package arrow.core.raise
 
 import arrow.core.Either
+import arrow.core.Ior
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptySet
 import arrow.core.Validated
@@ -237,6 +238,14 @@ public interface Raise<in Error> {
     is Either.Left -> raise(value)
     is Either.Right -> value
   }
+
+  @RaiseDSL
+  public fun <A> Ior<Error, A>.bind(): A =
+    when (this) {
+      is Ior.Left -> raise(value)
+      is Ior.Right -> value
+      is Ior.Both -> rightValue
+    }
 
   public fun <K, A> Map<K, Either<Error, A>>.bindAll(): Map<K, A> =
     mapValues { (_, a) -> a.bind() }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
@@ -3,15 +3,11 @@ package arrow.core.raise
 import arrow.core.Either
 import arrow.core.Ior
 import arrow.core.test.nonEmptyList
-import arrow.typeclasses.Semigroup
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.list
-import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -78,5 +74,14 @@ class IorSpec : StringSpec({
        throw boom
       }
     }.message shouldBe "Boom!"
+  }
+
+  "Recover works as expected" {
+    ior(String::plus) {
+      val one = recover({ Ior.Left("Hello").bind() }) { 1 }
+      val two = Ior.Right(2).bind()
+      val three = Ior.Both(", World", 3).bind()
+      one + two + 3
+    } shouldBe Ior.Both(", World", 6)
   }
 })


### PR DESCRIPTION
See Issue: https://github.com/arrow-kt/arrow/issues/3051

This PR is a work in progress naive fix for the issue highlighted above. It works in the sense that tests pass but I am guessing this may have problems I am not fully aware of. The idea here was to prevent `bind()` inside the `recover(...)` block from using the `IorRaise` scope and instead use the `Raise<Error>` scope. `IorRaise` has it's own scope to manage `combine(...)` for dealing with `Ior.Both`

A consequence of this "fix" is that `recover` has no concept of `combine`. Personally, I don't find this to be too odd. You are essentially creating a "sub raise" and recovering from anything that goes wrong. This does mean that the left value on an `Ior.Both` is dropped inside the `recover` block. However, I didn't want to start totally changing the API and figured this PR could at least serve as a discussion point for how this could be resolved. I can see adding special versions of the recover function to allow for handling Both values and combining them but wanted to keep this simple for now. 