### PR TITLE
Add withError and (Eager)Effect.mapError

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3436,8 +3436,8 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun ior (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
-	public static final fun mapError (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public static final fun mapError (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public static final fun mapError (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static final fun mapError (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Larrow/core/NonEmptyList;Lkotlin/jvm/functions/Function2;)Larrow/core/NonEmptyList;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/util/List;

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3436,6 +3436,8 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun ior (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
+	public static final fun mapError (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public static final fun mapError (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Larrow/core/NonEmptyList;Lkotlin/jvm/functions/Function2;)Larrow/core/NonEmptyList;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun mapOrAccumulate (Larrow/core/raise/Raise;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
@@ -3465,6 +3467,7 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun toValidated (Lkotlin/jvm/functions/Function1;)Larrow/core/Validated;
 	public static final fun toValidated (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun traced (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun withError (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function9;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function8;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function7;)Ljava/lang/Object;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
@@ -116,7 +116,7 @@ public suspend inline infix fun <Error, A> Effect<Error, A>.getOrElse(recover: s
  * ```
  * <!--- KNIT example-effect-error-04.kt -->
  */
-public infix fun <Error, OtherError, A> Effect<Error, A>.mapError(@BuilderInference transform: suspend (error: Error) -> OtherError): Effect<OtherError, A> =
+public infix fun <Error, OtherError, A> Effect<Error, A>.mapError(transform: suspend (error: Error) -> OtherError): Effect<OtherError, A> =
   effect { withError({ transform(it) }) { invoke() } }
 
 public infix fun <Error, OtherError, A> EagerEffect<Error, A>.recover(@BuilderInference recover: Raise<OtherError>.(error: Error) -> A): EagerEffect<OtherError, A> =
@@ -152,5 +152,5 @@ public inline infix fun <Error, A> EagerEffect<Error, A>.getOrElse(recover: (err
  * ```
  * <!--- KNIT example-effect-error-05.kt -->
  */
-public infix fun <Error, OtherError, A> EagerEffect<Error, A>.mapError(@BuilderInference transform: (error: Error) -> OtherError): EagerEffect<OtherError, A> =
+public infix fun <Error, OtherError, A> EagerEffect<Error, A>.mapError(transform: (error: Error) -> OtherError): EagerEffect<OtherError, A> =
   eagerEffect { withError({ transform(it) }) { invoke() } }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
@@ -111,12 +111,12 @@ public suspend inline infix fun <Error, A> Effect<Error, A>.getOrElse(recover: s
  * val error = effect<Error, User> { raise(Error) } // Raise(error)
  *
  * val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
- * val b = error.mapError<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
+ * val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)
  * val c = error.mapError<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)
  * ```
  * <!--- KNIT example-effect-error-04.kt -->
  */
-public infix fun <Error, OtherError, A> Effect<Error, A>.mapError(@BuilderInference transform: suspend Raise<OtherError>.(error: Error) -> OtherError): Effect<OtherError, A> =
+public infix fun <Error, OtherError, A> Effect<Error, A>.mapError(@BuilderInference transform: suspend (error: Error) -> OtherError): Effect<OtherError, A> =
   effect { withError({ transform(it) }) { invoke() } }
 
 public infix fun <Error, OtherError, A> EagerEffect<Error, A>.recover(@BuilderInference recover: Raise<OtherError>.(error: Error) -> A): EagerEffect<OtherError, A> =
@@ -148,9 +148,9 @@ public inline infix fun <Error, A> EagerEffect<Error, A>.getOrElse(recover: (err
  * val error = eagerEffect<Error, User> { raise(Error) } // Raise(error)
  *
  * val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
- * val b = error.mapError<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
+ * val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)
  * ```
  * <!--- KNIT example-effect-error-05.kt -->
  */
-public infix fun <Error, OtherError, A> EagerEffect<Error, A>.mapError(@BuilderInference transform: Raise<OtherError>.(error: Error) -> OtherError): EagerEffect<OtherError, A> =
+public infix fun <Error, OtherError, A> EagerEffect<Error, A>.mapError(@BuilderInference transform: (error: Error) -> OtherError): EagerEffect<OtherError, A> =
   eagerEffect { withError({ transform(it) }) { invoke() } }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -456,7 +456,7 @@ public inline fun <Error, B : Any> Raise<Error>.ensureNotNull(value: B?, raise: 
 
 /**
  * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [OtherError],
- * and recover by providing a transform [OtherError] into [Error], which is raised to the outer [Raise].
+ * and transform any raised [OtherError] into [Error], which is raised to the outer [Raise].
  *
  * <!--- INCLUDE
  * import arrow.core.Either

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -453,3 +453,36 @@ public inline fun <Error, B : Any> Raise<Error>.ensureNotNull(value: B?, raise: 
   }
   return value ?: raise(raise())
 }
+
+/**
+ * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [OtherError],
+ * and recover by providing a transform [OtherError] into [Error], which is raised to the outer [Raise].
+ *
+ * <!--- INCLUDE
+ * import arrow.core.Either
+ * import arrow.core.raise.either
+ * import arrow.core.raise.withError
+ * import io.kotest.matchers.shouldBe
+ * -->
+ * ```kotlin
+ * fun test() {
+ *   either<Int, String> {
+ *     withError(String::length) {
+ *       raise("failed")
+ *     }
+ *   } shouldBe Either.Left(6)
+ * }
+ * ```
+ * <!--- KNIT example-raise-dsl-11.kt -->
+ * <!--- TEST lines.isEmpty() -->
+ */
+@RaiseDSL
+public inline fun <Error, OtherError, A> Raise<Error>.withError(
+  transform: (OtherError) -> Error,
+  @BuilderInference block: Raise<OtherError>.() -> A
+): A {
+  contract {
+    callsInPlace(transform, AT_MOST_ONCE)
+  }
+  return recover(block) { raise(transform(it)) }
+}

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
@@ -252,17 +252,6 @@ class EagerEffectSpec : StringSpec({
     }
   }
 
-  "mapError - raise and raise other error" {
-    checkAll(Arb.long(), Arb.string()) { l, s ->
-      (eagerEffect<Long, Int> {
-        raise(l)
-      } mapError { ll ->
-        ll shouldBe l
-        raise(s)
-      }).fold(::identity) { unreachable() } shouldBe s
-    }
-  }
-
   "mapError - success" {
     checkAll(Arb.int()) { i ->
       (eagerEffect<Long, Int> { i } mapError { unreachable() })

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
@@ -240,4 +240,33 @@ class EagerEffectSpec : StringSpec({
         .fold({ unreachable() }, { unreachable() })
     }.message shouldBe "Boom!"
   }
+
+  "mapError - raise and transform error" {
+    checkAll(Arb.long(), Arb.string()) { l, s ->
+      (eagerEffect<Long, Int> {
+        raise(l)
+      } mapError { ll ->
+        ll shouldBe l
+        s
+      }).fold(::identity) { unreachable() } shouldBe s
+    }
+  }
+
+  "mapError - raise and raise other error" {
+    checkAll(Arb.long(), Arb.string()) { l, s ->
+      (eagerEffect<Long, Int> {
+        raise(l)
+      } mapError { ll ->
+        ll shouldBe l
+        raise(s)
+      }).fold(::identity) { unreachable() } shouldBe s
+    }
+  }
+
+  "mapError - success" {
+    checkAll(Arb.int()) { i ->
+      (eagerEffect<Long, Int> { i } mapError { unreachable() })
+        .get() shouldBe i
+    }
+  }
 })

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
@@ -773,20 +773,6 @@ class EffectSpec : StringSpec({
     }
   }
 
-  "mapError - raise and raise other error" {
-    checkAll(
-      Arb.long().suspend(),
-      Arb.string().suspend()
-    ) { l, s ->
-      (effect<Long, Int> {
-        raise(l())
-      } mapError { ll ->
-        ll shouldBe l()
-        raise(s())
-      }).fold(::identity) { unreachable() } shouldBe s()
-    }
-  }
-
   "mapError - success" {
     checkAll(Arb.int().suspend()) { i ->
       (effect<Long, Int> { i() } mapError { unreachable() })

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-04.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-04.kt
@@ -10,5 +10,5 @@ object Error
 val error = effect<Error, User> { raise(Error) } // Raise(error)
 
 val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
-val b = error.mapError<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
+val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)
 val c = error.mapError<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-04.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-04.kt
@@ -1,0 +1,14 @@
+// This file was automatically generated from ErrorHandlers.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleEffectError04
+
+import arrow.core.raise.effect
+import arrow.core.raise.mapError
+
+object User
+object Error
+
+val error = effect<Error, User> { raise(Error) } // Raise(error)
+
+val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
+val b = error.mapError<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
+val c = error.mapError<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-05.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-05.kt
@@ -10,4 +10,4 @@ object Error
 val error = eagerEffect<Error, User> { raise(Error) } // Raise(error)
 
 val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
-val b = error.mapError<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
+val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-05.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-05.kt
@@ -1,0 +1,13 @@
+// This file was automatically generated from ErrorHandlers.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleEffectError05
+
+import arrow.core.raise.eagerEffect
+import arrow.core.raise.mapError
+
+object User
+object Error
+
+val error = eagerEffect<Error, User> { raise(Error) } // Raise(error)
+
+val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
+val b = error.mapError<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-11.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-11.kt
@@ -1,0 +1,15 @@
+// This file was automatically generated from Raise.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleRaiseDsl11
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.withError
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  either<Int, String> {
+    withError(String::length) {
+      raise("failed")
+    }
+  } shouldBe Either.Left(6)
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/RaiseKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/RaiseKnitTest.kt
@@ -40,6 +40,10 @@ class RaiseKnitTest : StringSpec({
     arrow.core.examples.exampleRaiseDsl10.test()
   }
 
+  "ExampleRaiseDsl11" {
+    arrow.core.examples.exampleRaiseDsl11.test()
+  }
+
 }) {
   override fun timeout(): Long = 1000
 }


### PR DESCRIPTION
Fixes #3053 
I'm not sure if `mapError` is the best name for it, but `withError` felt weird as an extension on `Effect`. Also, mapError's transform parameter seems too "busy" with `suspend` and `Raise`. At least the `Raise<OtherError>` could be removed, but then someone wanted to call a function inside that raises `OtherError`, they'd need to wrap in `either{ ... }.merge()` or something along those lines, and so I figured exposing the `Raise<OtherError>` might help in that case. Maybe there should be a `Raise` builder that merges the error and result automatically? This could be helpful especially if they're subclasses of each other.

@CLOVIS-AI 