### PR TITLE
Change NonEmptySet type parameter name from T to A

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
@@ -3,19 +3,19 @@ package arrow.core
 import kotlin.jvm.JvmInline
 
 @JvmInline
-public value class NonEmptySet<out T> private constructor(
-  private val elements: Set<T>
-) : Set<T> by elements {
+public value class NonEmptySet<out A> private constructor(
+  private val elements: Set<A>
+) : Set<A> by elements {
 
-  public constructor(first: T, rest: Set<T>) : this(setOf(first) + rest)
+  public constructor(first: A, rest: Set<A>) : this(setOf(first) + rest)
 
-  public operator fun plus(set: Set<@UnsafeVariance T>): NonEmptySet<T> =
+  public operator fun plus(set: Set<@UnsafeVariance A>): NonEmptySet<A> =
     NonEmptySet(elements + set)
 
-  public operator fun plus(element: @UnsafeVariance T): NonEmptySet<T> =
+  public operator fun plus(element: @UnsafeVariance A): NonEmptySet<A> =
     NonEmptySet(elements + element)
 
-  public fun <R> map(transform: (@UnsafeVariance T) -> R): NonEmptySet<R> =
+  public fun <R> map(transform: (@UnsafeVariance A) -> R): NonEmptySet<R> =
     NonEmptySet(elements.mapTo(mutableSetOf(), transform))
 
   override fun isEmpty(): Boolean = false
@@ -33,17 +33,17 @@ public value class NonEmptySet<out T> private constructor(
     elements.hashCode()
 }
 
-public fun <T> nonEmptySetOf(first: T, vararg rest: T): NonEmptySet<T> =
+public fun <A> nonEmptySetOf(first: A, vararg rest: A): NonEmptySet<A> =
   NonEmptySet(first, rest.toSet())
 
-public fun <T> Iterable<T>.toNonEmptySetOrNull(): NonEmptySet<T>? =
+public fun <A> Iterable<A>.toNonEmptySetOrNull(): NonEmptySet<A>? =
   firstOrNull()?.let { NonEmptySet(it, minus(it).toSet()) }
 
-public fun <T> Iterable<T>.toNonEmptySetOrNone(): Option<NonEmptySet<T>> =
+public fun <A> Iterable<A>.toNonEmptySetOrNone(): Option<NonEmptySet<A>> =
   toNonEmptySetOrNull().toOption()
 
-public fun <T> Set<T>.toNonEmptySetOrNull(): NonEmptySet<T>? =
+public fun <A> Set<A>.toNonEmptySetOrNull(): NonEmptySet<A>? =
   firstOrNull()?.let { NonEmptySet(it, minus(it)) }
 
-public fun <T> Set<T>.toNonEmptySetOrNone(): Option<NonEmptySet<T>> =
+public fun <A> Set<A>.toNonEmptySetOrNone(): Option<NonEmptySet<A>> =
   toNonEmptySetOrNull().toOption()


### PR DESCRIPTION
This pull request is related to the issue https://github.com/arrow-kt/arrow/issues/3041 reported by @mikeat in mid-April.

After publishing version `1.1.6-alpha.74`, Arrow started to break any Kapt task when using Raise/Effect with the following error:
```
ExampleImpl.java:12: error: cannot access Raise
    public final kotlin.jvm.functions.Function2<arrow.core.raise.Raise<? super MyError>, kotlin.coroutines.Continuation<? super java.lang.String>, java.lang.Object> example() {
                                                                ^
  bad class file: /Users/kaiser/.gradle/caches/modules-2/files-2.1/io.arrow-kt/arrow-core-jvm/1.2.0-RC/815591a96f11786ae0ff746a4931fee9c0e46ac4/arrow-core-jvm-1.2.0-RC.jar(/arrow/core/raise/Raise.class)
    undeclared type variable: T
    Please remove or make sure it appears in the correct subdirectory of the classpath.
```

Thanks to the valuable help from @serras, we discovered that the compiler was generating the wrong bytecode for the `bindAll` function defined as an extension function for `NonEmptySet`. The generated function was using an undefined type parameter `T`. You can see more details of the compiler bug in [this comment](https://github.com/arrow-kt/arrow/issues/3041#issuecomment-1573373525).

As a workaround for this compiler issue, we propose changing the type parameter used for the elements of the `NonEmptySet` from `T` to `A` to align it with the `bindAll` function.

This screenshot shows that the bytecode uses the type parameter `A` for the `Set` class now instead of `T`

![Screenshot 2023-06-02 at 12 17 41](https://github.com/arrow-kt/arrow/assets/1200151/e41cdbec-d16b-42f7-9db2-d0ca5dcd1562)
