### PR TITLE
Enable Automatic Modules for JVM

### DIFF
--- a/arrow-libs/core/arrow-annotations/build.gradle.kts
+++ b/arrow-libs/core/arrow-annotations/build.gradle.kts
@@ -33,3 +33,9 @@ kotlin {
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.annotations"
+  }
+}

--- a/arrow-libs/core/arrow-atomic/build.gradle.kts
+++ b/arrow-libs/core/arrow-atomic/build.gradle.kts
@@ -75,3 +75,9 @@ kotlin {
     }
   }
 }
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.atomic"
+  }
+}

--- a/arrow-libs/core/arrow-continuations/build.gradle.kts
+++ b/arrow-libs/core/arrow-continuations/build.gradle.kts
@@ -56,3 +56,9 @@ kotlin {
     }
   }
 }
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.continuations"
+  }
+}

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -68,3 +68,9 @@ kotlin {
 tasks.named<KotlinCompile>("compileTestKotlinJvm") {
   kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.core"
+  }
+}

--- a/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
@@ -57,3 +57,9 @@ kotlin {
     }
   }
 }
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.fx.coroutines"
+  }
+}

--- a/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
@@ -57,3 +57,9 @@ kotlin {
     }
   }
 }
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.fx.stm"
+  }
+}

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -76,3 +76,9 @@ kotlin {
 //dependencies {
 //  kspTest(projects.arrowOpticsKspPlugin)
 //}
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.optics"
+  }
+}

--- a/arrow-libs/resilience/arrow-resilience/build.gradle.kts
+++ b/arrow-libs/resilience/arrow-resilience/build.gradle.kts
@@ -39,3 +39,9 @@ kotlin {
     }
   }
 }
+
+tasks.jar {
+  manifest {
+    attributes["Automatic-Module-Name"] = "arrow.resilience"
+  }
+}


### PR DESCRIPTION
According to [this blog post](https://michaelbfullan.com/the-state-of-the-jpms-in-2022/), by adding `Automatic-Module-Name` to the JAR we're one step forward in supporting Java Modules, as requested in #2800.

@durganmcbroom could you help us figuring out whether this is a step in the right direction? Does including this remove the need to "monkey-patching" the module system in Java 9+?