### PR TITLE
New idea for `Eval`

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -443,6 +443,23 @@ public final class arrow/core/Eval$Now$Companion {
 	public final fun getUnit ()Larrow/core/Eval;
 }
 
+public final class arrow/core/Eval2Kt {
+	public static final fun flatMap (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function3;
+	public static final fun foldEval2 (Ljava/util/List;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function3;
+	public static final fun foldRightEval2 (Ljava/util/List;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function3;
+	public static final fun map (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function3;
+	public static final fun memoize (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function3;
+	public static final fun value (Lkotlin/jvm/functions/Function3;)Ljava/lang/Object;
+}
+
+public final class arrow/core/Eval2Utils {
+	public static final field INSTANCE Larrow/core/Eval2Utils;
+	public final fun always (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function3;
+	public final fun defer (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function3;
+	public final fun later (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function3;
+	public final fun now (Ljava/lang/Object;)Lkotlin/jvm/functions/Function3;
+}
+
 public final class arrow/core/EvalKt {
 	public static final fun iterateRight (Ljava/util/Iterator;Larrow/core/Eval;Lkotlin/jvm/functions/Function2;)Larrow/core/Eval;
 	public static final fun replicate (Larrow/core/Eval;I)Larrow/core/Eval;
@@ -1656,6 +1673,10 @@ public final class arrow/core/SortedMapKKt {
 
 public final class arrow/core/StringKt {
 	public static final fun escaped (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class arrow/core/Token {
+	public static final field INSTANCE Larrow/core/Token;
 }
 
 public final class arrow/core/Tuple10 {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Eval2.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Eval2.kt
@@ -1,0 +1,56 @@
+package arrow.core
+
+import kotlin.DeepRecursiveFunction
+
+public object Token
+
+public typealias Eval2<A> = suspend DeepRecursiveScope<Token, *>.(Token) -> A
+
+public fun <A> Eval2<A>.value(): A = DeepRecursiveFunction(this).invoke(Token)
+
+public inline fun <A, B> Eval2<A>.map(crossinline f: (A) -> B): Eval2<B> = flatMap { Eval2Utils.now(f(it)) }
+
+public fun <A, B> Eval2<A>.flatMap(f: (A) -> Eval2<B>): Eval2<B> = { token ->
+  val x = this@flatMap(token)
+  callRecursive(token)
+  f(x)(token)
+}
+
+public fun <A> Eval2<A>.memoize(): Eval2<A> = this
+
+public object Eval2Utils {
+  public fun <A> now(a: A): Eval2<A> = { a }
+
+  public fun <A> later(f: () -> A): Eval2<A> {
+    val value by lazy(f)
+    return { value }
+  }
+
+  public fun <A> always(f: () -> A): Eval2<A> = { f() }
+
+  public fun <A> defer(f: () -> Eval2<A>): Eval2<A> = { token ->
+    callRecursive(token)
+    f()(token)
+  }
+}
+
+public fun <E, L, R> foldEval2(
+  elements: List<E>,
+  zero: R,
+  f: (R, E) -> Eval2<Either<L, R>>
+): Eval2<Either<L, R>> =
+  when (val head = elements.firstOrNull()) {
+    null -> Eval2Utils.now(zero.right())
+    else -> f(zero, head).flatMap { result ->
+      when (result) {
+        is Either.Left -> Eval2Utils.now(result)
+        is Either.Right -> foldEval2(elements.drop(1), result.value, f)
+      }
+    }
+  }
+
+public fun <A, B> List<A>.foldRightEval2(b: Eval2<B>, f: (A, Eval2<B>) -> B): Eval2<B> =
+  when (val head = firstOrNull()) {
+    null -> b
+    else -> Eval2Utils.later { f(head, drop(1).foldRightEval2(b, f)) }
+  }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EvalTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EvalTest.kt
@@ -10,15 +10,15 @@ internal data class SideEffect(var counter: Int = 0) {
   }
 }
 
-private fun recur(limit: Int, sideEffect: SideEffect): (Int) -> Eval<Int> {
+private fun recur(limit: Int, sideEffect: SideEffect): (Int) -> Eval2<Int> {
   return { num ->
     if (num <= limit) {
       sideEffect.increment()
-      Eval.defer {
+      Eval2Utils.defer {
         recur(limit, sideEffect).invoke(num + 1)
       }
     } else {
-      Eval.now(-1)
+      Eval2Utils.now(-1)
     }
   }
 }
@@ -27,7 +27,7 @@ class EvalTest : StringSpec({
 
     "should map wrapped value" {
       val sideEffect = SideEffect()
-      val mapped = Eval.now(0)
+      val mapped = Eval2Utils.now(0)
         .map { sideEffect.increment(); it + 1 }
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 1
@@ -40,7 +40,7 @@ class EvalTest : StringSpec({
 
     "later should lazily evaluate values once" {
       val sideEffect = SideEffect()
-      val mapped = Eval.later { sideEffect.increment(); sideEffect.counter }
+      val mapped = Eval2Utils.later { sideEffect.increment(); sideEffect.counter }
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 1
       sideEffect.counter shouldBe 1
@@ -52,7 +52,7 @@ class EvalTest : StringSpec({
 
     "later should memoize values" {
       val sideEffect = SideEffect()
-      val mapped = Eval.later { sideEffect.increment(); sideEffect.counter }.memoize()
+      val mapped = Eval2Utils.later { sideEffect.increment(); sideEffect.counter }.memoize()
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 1
       sideEffect.counter shouldBe 1
@@ -64,7 +64,7 @@ class EvalTest : StringSpec({
 
     "always should lazily evaluate values repeatedly" {
       val sideEffect = SideEffect()
-      val mapped = Eval.always { sideEffect.increment(); sideEffect.counter }
+      val mapped = Eval2Utils.always { sideEffect.increment(); sideEffect.counter }
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 1
       sideEffect.counter shouldBe 1
@@ -76,7 +76,7 @@ class EvalTest : StringSpec({
 
     "always should memoize values" {
       val sideEffect = SideEffect()
-      val mapped = Eval.always { sideEffect.increment(); sideEffect.counter }.memoize()
+      val mapped = Eval2Utils.always { sideEffect.increment(); sideEffect.counter }.memoize()
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 1
       sideEffect.counter shouldBe 1
@@ -88,7 +88,7 @@ class EvalTest : StringSpec({
 
     "defer should lazily evaluate other Evals" {
       val sideEffect = SideEffect()
-      val mapped = Eval.defer { sideEffect.increment(); Eval.later { sideEffect.increment(); sideEffect.counter } }
+      val mapped = Eval2Utils.defer { sideEffect.increment(); Eval2Utils.later { sideEffect.increment(); sideEffect.counter } }
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 2
       sideEffect.counter shouldBe 2
@@ -100,7 +100,7 @@ class EvalTest : StringSpec({
 
     "defer should memoize Eval#later" {
       val sideEffect = SideEffect()
-      val mapped = Eval.defer { sideEffect.increment(); Eval.later { sideEffect.increment(); sideEffect.counter } }.memoize()
+      val mapped = Eval2Utils.defer { sideEffect.increment(); Eval2Utils.later { sideEffect.increment(); sideEffect.counter } }.memoize()
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 2
       sideEffect.counter shouldBe 2
@@ -112,7 +112,7 @@ class EvalTest : StringSpec({
 
     "defer should memoize Eval#now" {
       val sideEffect = SideEffect()
-      val mapped = Eval.defer { sideEffect.increment(); Eval.now(sideEffect.counter) }.memoize()
+      val mapped = Eval2Utils.defer { sideEffect.increment(); Eval2Utils.now(sideEffect.counter) }.memoize()
       sideEffect.counter shouldBe 0
       mapped.value() shouldBe 1
       sideEffect.counter shouldBe 1
@@ -125,7 +125,7 @@ class EvalTest : StringSpec({
     "flatMap should complete without blowing up the stack" {
       val limit = stackSafeIteration()
       val sideEffect = SideEffect()
-      val flatMapped = Eval.now(0).flatMap(recur(limit, sideEffect))
+      val flatMapped = Eval2Utils.now(0).flatMap(recur(limit, sideEffect))
       sideEffect.counter shouldBe 0
       flatMapped.value() shouldBe -1
       sideEffect.counter shouldBe limit + 1


### PR DESCRIPTION
⚠️ _This doesn't work yet!_

Based on the discussion in #3039, I've tried to make a simplified implementation of `Eval` based on `DeepRecursiveFunction`. The idea is to use their `callRecursive` as suspension points to live in the heap.

```kotlin
public typealias Eval2<A> = suspend DeepRecursiveScope<Token, *>.(Token) -> A

public fun <A, B> Eval2<A>.flatMap(f: (A) -> Eval2<B>): Eval2<B> = { token ->
  val x = this@flatMap(token)
  callRecursive(token)
  f(x)(token)
}
```

Alas, the simplest test,

```kotlin
val mapped = Eval2Utils.now(0).map { sideEffect.increment(); it + 1 }
```

leads to a terrible error about exceeding the memory limits,

```
arrow.core.EvalTest[jvm] > should map wrapped value[jvm] FAILED
    java.lang.OutOfMemoryError: GC overhead limit exceeded
        at kotlin.ResultKt.createFailure(Result.kt:122)
        at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:46)
        at kotlinx.coroutines.TimeoutKt.withTimeoutOrNull(Timeout.kt:104)
        at io.kotest.engine.test.interceptors.InvocationTimeoutInterceptor.intercept(InvocationTimeoutInterceptor.kt:42)
        ...
```

I'm just putting it here in case somebody else wants to give it a thought and maybe make it work.

@nomisRev, @404- and @alexandru were involved in the discussion back then.