### PR TITLE
Set up Spotless

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -240,3 +240,30 @@ jobs:
         with:
           commit_message: Update API files
           file_pattern: arrow-libs/**/api/*.api
+
+  spotless:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: apiDump
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: spotlessApply
+
+      - name: "Apply formatting"
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply
+          file_pattern: arrow-libs/**/*.kt
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -256,12 +256,12 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
-      - name: apiDump
+      - name: spotlessApply
         uses: gradle/gradle-build-action@v2
         with:
           arguments: spotlessApply
 
-      - name: "Apply formatting"
+      - name: "Commit newly formatted files"
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Apply

--- a/arrow-libs/core/arrow-annotations/build.gradle.kts
+++ b/arrow-libs/core/arrow-annotations/build.gradle.kts
@@ -5,6 +5,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.kotlin)
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.arrowGradleConfig.versioning)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 kotlin {

--- a/arrow-libs/core/arrow-atomic/build.gradle.kts
+++ b/arrow-libs/core/arrow-atomic/build.gradle.kts
@@ -7,6 +7,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotest.multiplatform)
   alias(libs.plugins.kotlinx.kover)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/core/arrow-continuations/build.gradle.kts
+++ b/arrow-libs/core/arrow-continuations/build.gradle.kts
@@ -7,6 +7,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
   alias(libs.plugins.kotest.multiplatform)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/core/arrow-core-retrofit/build.gradle.kts
+++ b/arrow-libs/core/arrow-core-retrofit/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.kotlinx.serialization) // Needed for testing only
   alias(libs.plugins.kotlinx.kover)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER"))

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapter.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapter.kt
@@ -17,7 +17,7 @@ import java.lang.reflect.Type
 internal class ArrowEitherCallAdapter<E, R>(
   retrofit: Retrofit,
   errorType: Type,
-  private val bodyType: Type
+  private val bodyType: Type,
 ) : CallAdapter<R, Call<Either<E, R>>> {
 
   private val errorConverter: Converter<ResponseBody, E> =
@@ -30,7 +30,7 @@ internal class ArrowEitherCallAdapter<E, R>(
   class EitherCall<E, R>(
     private val original: Call<R>,
     private val errorConverter: Converter<ResponseBody, E>,
-    private val bodyType: Type
+    private val bodyType: Type,
   ) : Call<Either<E, R>> {
 
     override fun enqueue(callback: Callback<Either<E, R>>) {
@@ -52,7 +52,7 @@ internal class ArrowEitherCallAdapter<E, R>(
             },
             { errorBody, _ ->
               Response.success(errorBody.left())
-            }
+            },
           )
         }
       })

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ArrowResponseECallAdapter.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ArrowResponseECallAdapter.kt
@@ -16,7 +16,7 @@ import java.lang.reflect.Type
 internal class ArrowResponseECallAdapter<E, R>(
   retrofit: Retrofit,
   errorType: Type,
-  private val bodyType: Type
+  private val bodyType: Type,
 ) : CallAdapter<R, Call<ResponseE<E, R>>> {
 
   private val errorConverter: Converter<ResponseBody, E> =
@@ -29,7 +29,7 @@ internal class ArrowResponseECallAdapter<E, R>(
   class ResponseECall<E, R>(
     private val original: Call<R>,
     private val errorConverter: Converter<ResponseBody, E>,
-    private val bodyType: Type
+    private val bodyType: Type,
   ) : Call<ResponseE<E, R>> {
 
     override fun enqueue(callback: Callback<ResponseE<E, R>>) {
@@ -51,7 +51,7 @@ internal class ArrowResponseECallAdapter<E, R>(
             },
             { errorBody, responseV ->
               Response.success(ResponseE(responseV.raw(), errorBody.left()))
-            }
+            },
           )
         }
       })

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/EitherCallAdapterFactory.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/EitherCallAdapterFactory.kt
@@ -78,7 +78,7 @@ public class EitherCallAdapterFactory : CallAdapter.Factory() {
       val name = parseTypeName(returnType)
       throw IllegalArgumentException(
         "Return type must be parameterized as " +
-          "$name<Foo> or $name<out Foo>"
+          "$name<Foo> or $name<out Foo>",
       )
     }
 
@@ -90,16 +90,17 @@ public class EitherCallAdapterFactory : CallAdapter.Factory() {
 
   private fun eitherAdapter(
     returnType: ParameterizedType,
-    retrofit: Retrofit
+    retrofit: Retrofit,
   ): CallAdapter<Type, out Call<out Any>>? {
     val wrapperType = getParameterUpperBound(0, returnType)
     return when (getRawType(wrapperType)) {
       Either::class.java -> {
         val (errorType, bodyType) = extractErrorAndReturnType(wrapperType, returnType)
-        if (errorType == CallError::class.java)
+        if (errorType == CallError::class.java) {
           NetworkEitherCallAdapter(bodyType)
-        else
+        } else {
           ArrowEitherCallAdapter<Any, Type>(retrofit, errorType, bodyType)
+        }
       }
       ResponseE::class.java -> {
         val (errorType, bodyType) = extractErrorAndReturnType(wrapperType, returnType)
@@ -114,7 +115,7 @@ public class EitherCallAdapterFactory : CallAdapter.Factory() {
       val name = parseTypeName(returnType)
       throw IllegalArgumentException(
         "Return type must be parameterized as " +
-          "$name<ErrorBody, ResponseBody> or $name<out ErrorBody, out ResponseBody>"
+          "$name<ErrorBody, ResponseBody> or $name<out ErrorBody, out ResponseBody>",
       )
     }
     val errorType = getParameterUpperBound(0, wrapperType)

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ResponseE.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/ResponseE.kt
@@ -6,7 +6,7 @@ import okhttp3.Response
 
 public data class ResponseE<E, A>(
   val raw: Response,
-  val body: Either<E, A>
+  val body: Either<E, A>,
 ) {
 
   val code: Int = raw.code()

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/eitherAdapter.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/eitherAdapter.kt
@@ -14,7 +14,7 @@ internal inline fun <E, R, T> onResponseFn(
   bodyType: Type,
   response: Response<R>,
   newResponseFn: (R, Response<R>) -> Response<T>,
-  errorResponseFn: (E, Response<R>) -> Response<T>
+  errorResponseFn: (E, Response<R>) -> Response<T>,
 ) {
   if (response.isSuccessful) {
     val body = response.body()

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/networkhandling/CallError.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/networkhandling/CallError.kt
@@ -13,7 +13,7 @@ public sealed class CallError
 public data class HttpError(
   val code: Int,
   val message: String,
-  val body: String
+  val body: String,
 ) : CallError()
 
 /**

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapter.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapter.kt
@@ -13,7 +13,7 @@ import java.io.IOException
 import java.lang.reflect.Type
 
 internal class NetworkEitherCallAdapter<R>(
-  private val successType: Type
+  private val successType: Type,
 ) : CallAdapter<R, Call<Either<CallError, R?>>> {
 
   override fun adapt(call: Call<R?>): Call<Either<CallError, R?>> = EitherCall(call, successType)
@@ -23,7 +23,7 @@ internal class NetworkEitherCallAdapter<R>(
 
 private class EitherCall<R>(
   private val delegate: Call<R>,
-  private val successType: Type
+  private val successType: Type,
 ) : Call<Either<CallError, R>> {
 
   override fun enqueue(callback: Callback<Either<CallError, R>>) = delegate.enqueue(
@@ -40,7 +40,7 @@ private class EitherCall<R>(
           return HttpError(
             code = code(),
             message = message(),
-            body = errorBody
+            body = errorBody,
           ).left()
         }
 
@@ -57,8 +57,8 @@ private class EitherCall<R>(
             IllegalStateException(
               "Response code is ${code()} but body is null.\n" +
                 "If you expect response body to be null then define your API method as returning Unit:\n" +
-                "@POST fun postSomething(): Either<CallError, Unit>"
-            )
+                "@POST fun postSomething(): Either<CallError, Unit>",
+            ),
           ).left()
         }
       }
@@ -71,7 +71,7 @@ private class EitherCall<R>(
         }
         callback.onResponse(this@EitherCall, Response.success(error.left()))
       }
-    }
+    },
   )
 
   override fun timeout(): Timeout = delegate.timeout()

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/ArrowEitherCallAdapterTest.kt
@@ -18,73 +18,72 @@ class ArrowEitherCallAdapterTest : StringSpec({
   lateinit var server: MockWebServer
   lateinit var service: SuspendApiTestClient
 
-    beforeAny {
-      server = MockWebServer()
-      server.start()
-      service = Retrofit.Builder()
-        .baseUrl(server.url("/"))
-        .addConverterFactory(GsonConverterFactory.create())
-        .addCallAdapterFactory(EitherCallAdapterFactory.create())
-        .build()
-        .create(SuspendApiTestClient::class.java)
-    }
+  beforeAny {
+    server = MockWebServer()
+    server.start()
+    service = Retrofit.Builder()
+      .baseUrl(server.url("/"))
+      .addConverterFactory(GsonConverterFactory.create())
+      .addCallAdapterFactory(EitherCallAdapterFactory.create())
+      .build()
+      .create(SuspendApiTestClient::class.java)
+  }
 
-    afterAny { server.shutdown() }
+  afterAny { server.shutdown() }
 
-    "should return ResponseMock for 200 with valid JSON" {
-      server.enqueue(MockResponse().setBody("""{"response":"Arrow rocks"}"""))
+  "should return ResponseMock for 200 with valid JSON" {
+    server.enqueue(MockResponse().setBody("""{"response":"Arrow rocks"}"""))
 
-      val body = service.getEither()
+    val body = service.getEither()
 
-      body shouldBe ResponseMock("Arrow rocks").right()
-    }
+    body shouldBe ResponseMock("Arrow rocks").right()
+  }
 
-    "should return Unit when service method returns Unit and null body received" {
-      server.enqueue(MockResponse().setResponseCode(204))
+  "should return Unit when service method returns Unit and null body received" {
+    server.enqueue(MockResponse().setResponseCode(204))
 
-      val body = service.postSomething("Sample string")
+    val body = service.postSomething("Sample string")
 
-      body shouldBe Unit.right()
-    }
+    body shouldBe Unit.right()
+  }
 
-    "should return Unit when service method returns Unit and JSON body received" {
-      server.enqueue(MockResponse().setBody("""{"response":"Arrow rocks"}"""))
+  "should return Unit when service method returns Unit and JSON body received" {
+    server.enqueue(MockResponse().setBody("""{"response":"Arrow rocks"}"""))
 
-      val body = service.postSomething("Sample string")
+    val body = service.postSomething("Sample string")
 
-      body shouldBe Unit.right()
-    }
+    body shouldBe Unit.right()
+  }
 
-    "should return ErrorMock for 400 with valid JSON" {
-      server.enqueue(MockResponse().setBody("""{"errorCode":666}""").setResponseCode(400))
+  "should return ErrorMock for 400 with valid JSON" {
+    server.enqueue(MockResponse().setBody("""{"errorCode":666}""").setResponseCode(400))
 
-      val body = service.getEither()
+    val body = service.getEither()
 
-      body shouldBe ErrorMock(666).left()
-    }
+    body shouldBe ErrorMock(666).left()
+  }
 
-    "should throw for 200 with invalid JSON" {
-      server.enqueue(MockResponse().setBody("""not a valid JSON"""))
+  "should throw for 200 with invalid JSON" {
+    server.enqueue(MockResponse().setBody("""not a valid JSON"""))
 
-      val body = runCatching { service.getEither() }
+    val body = runCatching { service.getEither() }
 
-      body.isFailure shouldBe true
-    }
+    body.isFailure shouldBe true
+  }
 
-    "should throw for 400 and invalid JSON" {
-      server.enqueue(MockResponse().setBody("""not a valid JSON""").setResponseCode(400))
+  "should throw for 400 and invalid JSON" {
+    server.enqueue(MockResponse().setBody("""not a valid JSON""").setResponseCode(400))
 
-      val body = runCatching { service.getEither() }
+    val body = runCatching { service.getEither() }
 
-      body.isFailure shouldBe true
-    }
+    body.isFailure shouldBe true
+  }
 
-    "should throw when server disconnects" {
-      server.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
+  "should throw when server disconnects" {
+    server.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
 
-      val body = runCatching { service.getEither() }
+    val body = runCatching { service.getEither() }
 
-      body.isFailure shouldBe true
-    }
-
+    body.isFailure shouldBe true
+  }
 })

--- a/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/test/kotlin/arrow/retrofit/adapter/either/networkhandling/NetworkEitherCallAdapterTest.kt
@@ -10,9 +10,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.spec.style.stringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.net.SocketException
-import java.net.SocketTimeoutException
-import java.util.concurrent.TimeUnit
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -24,6 +21,9 @@ import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeUnit
 
 @ExperimentalSerializationApi
 class NetworkEitherCallAdapterTestSuite : StringSpec({
@@ -33,7 +33,7 @@ class NetworkEitherCallAdapterTestSuite : StringSpec({
 })
 
 private fun networkEitherCallAdapterTests(
-  jsonConverterFactory: Converter.Factory
+  jsonConverterFactory: Converter.Factory,
 ) = stringSpec {
   var server: MockWebServer? = null
   var service: CallErrorTestClient? = null
@@ -70,7 +70,7 @@ private fun networkEitherCallAdapterTests(
     body shouldBe HttpError(
       code = 400,
       message = "Client Error",
-      body = """{"errorCode":666}"""
+      body = """{"errorCode":666}""",
     ).left()
   }
 
@@ -91,7 +91,7 @@ private fun networkEitherCallAdapterTests(
     body shouldBe HttpError(
       code = 400,
       message = "Client Error",
-      body = """not a valid JSON"""
+      body = """not a valid JSON""",
     ).left()
   }
 

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -9,6 +9,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
   alias(libs.plugins.kotest.multiplatform)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/DeadlockTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/DeadlockTest.kt
@@ -8,74 +8,73 @@ import kotlinx.coroutines.runBlocking
 
 class DeadlockTest : StringSpec({
 
-    "classloader should not deadlock Validated initialization" {
-      runBlocking {
-        (0..10).map { i ->
-          GlobalScope.launch {
-            if (i % 2 == 0) {
-              Validated.Invalid(Unit)
-            } else {
-              Validated.Valid(null)
-            }
+  "classloader should not deadlock Validated initialization" {
+    runBlocking {
+      (0..10).map { i ->
+        GlobalScope.launch {
+          if (i % 2 == 0) {
+            Validated.Invalid(Unit)
+          } else {
+            Validated.Valid(null)
           }
-        }.joinAll()
-      }
+        }
+      }.joinAll()
     }
+  }
 
-    "classloader should not deadlock Either initialization" {
-      runBlocking {
-        (0..10).map { i ->
-          GlobalScope.launch {
-            if (i % 2 == 0) {
-              Either.Left(Unit)
-            } else {
-              Either.Right(null)
-            }
+  "classloader should not deadlock Either initialization" {
+    runBlocking {
+      (0..10).map { i ->
+        GlobalScope.launch {
+          if (i % 2 == 0) {
+            Either.Left(Unit)
+          } else {
+            Either.Right(null)
           }
-        }.joinAll()
-      }
+        }
+      }.joinAll()
     }
+  }
 
-    "classloader should not deadlock Option initialization" {
-      runBlocking {
-        (0..10).map { i ->
-          GlobalScope.launch {
-            if (i % 2 == 0) {
-              None
-            } else {
-              Some(null)
-            }
+  "classloader should not deadlock Option initialization" {
+    runBlocking {
+      (0..10).map { i ->
+        GlobalScope.launch {
+          if (i % 2 == 0) {
+            None
+          } else {
+            Some(null)
           }
-        }.joinAll()
-      }
+        }
+      }.joinAll()
     }
+  }
 
-    "classloader should not deadlock Ior initialization" {
-      runBlocking {
-        (0..10).map { i ->
-          GlobalScope.launch {
-            if (i % 2 == 0) {
-              Ior.Left(Unit)
-            } else {
-              Ior.Right(null)
-            }
+  "classloader should not deadlock Ior initialization" {
+    runBlocking {
+      (0..10).map { i ->
+        GlobalScope.launch {
+          if (i % 2 == 0) {
+            Ior.Left(Unit)
+          } else {
+            Ior.Right(null)
           }
-        }.joinAll()
-      }
+        }
+      }.joinAll()
     }
+  }
 
-    "classloader should not deadlock Eval initialization" {
-      runBlocking {
-        (0..10).map { i ->
-          GlobalScope.launch {
-            if (i % 2 == 0) {
-              Eval.Now(Unit)
-            } else {
-              Eval.Later { null }
-            }
+  "classloader should not deadlock Eval initialization" {
+    runBlocking {
+      (0..10).map { i ->
+        GlobalScope.launch {
+          if (i % 2 == 0) {
+            Eval.Now(Unit)
+          } else {
+            Eval.Later { null }
           }
-        }.joinAll()
-      }
+        }
+      }.joinAll()
     }
-
+  }
 })

--- a/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/EitherJvmTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/EitherJvmTest.kt
@@ -11,7 +11,7 @@ class EitherJvmTest : StringSpec({
   "resolve should throw a Throwable when a fatal Throwable is thrown" {
     checkAll(
       Arb.suspendFunThatThrowsFatalThrowable(),
-      Arb.any()
+      Arb.any(),
     ) { f: suspend () -> Either<Any, Any>, returnObject: Any ->
 
       val comparator: Comparator<Person> =
@@ -24,7 +24,7 @@ class EitherJvmTest : StringSpec({
           success = { a -> handleWithPureFunction(a, returnObject) },
           error = { e -> handleWithPureFunction(e, returnObject) },
           throwable = { t -> handleWithPureFunction(t, returnObject) },
-          unrecoverableState = { handleWithPureFunction(it) }
+          unrecoverableState = { handleWithPureFunction(it) },
         )
       }
     }

--- a/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/EvalJvmTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/EvalJvmTest.kt
@@ -32,7 +32,7 @@ private data class DeepEval(val eval: Eval<Int>) {
         arbitrary { O.Map { it + 1 } },
         arbitrary { O.FlatMap { Eval.Now(it) } },
         arbitrary { O.Memoize() },
-        arbitrary { O.Defer() }
+        arbitrary { O.Defer() },
       )
     }
   }

--- a/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/NonFatalJvmTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/java/arrow/core/NonFatalJvmTest.kt
@@ -12,7 +12,7 @@ class NonFatalJvmTest : StringSpec({
       OutOfMemoryError(),
       LinkageError(),
       object : VirtualMachineError() {
-      }
+      },
     )
 
   "Test fatals using #invoke()" {

--- a/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(plugin = "io.kotest.multiplatform")

--- a/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
@@ -7,6 +7,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
   alias(libs.plugins.kotest.multiplatform)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 kotlin {

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
@@ -51,7 +51,7 @@ class OpticsProcessor(private val codegen: CodeGenerator, private val logger: KS
           .createNewFile(
             Dependencies(aggregating = true, *listOfNotNull(klass.containingFile).toTypedArray()),
             it.`package`,
-            it.name + "__Optics"
+            it.name + "__Optics",
           )
           .writer()
       writer.write(it.asFileText())

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/domain.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/domain.kt
@@ -2,7 +2,11 @@ package arrow.optics.plugin.internals
 
 import arrow.optics.plugin.companionObject
 import com.google.devtools.ksp.getVisibility
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.Visibility
 import java.util.Locale
 
 data class ADT(val pckg: KSName, val declaration: KSClassDeclaration, val targets: List<Target>) {
@@ -35,7 +39,7 @@ enum class OpticsTarget {
   LENS,
   PRISM,
   OPTIONAL,
-  DSL
+  DSL,
 }
 
 typealias IsoTarget = Target.Iso
@@ -105,6 +109,7 @@ sealed class Focus {
 
   abstract val className: String
   abstract val paramName: String
+
   // only used for type-refining prisms
   abstract val refinedType: KSType?
   abstract val onlyOneSealedSubclass: Boolean
@@ -158,7 +163,7 @@ data class Snippet(
   val `package`: String,
   val name: String,
   val imports: Set<String> = emptySet(),
-  val content: String
+  val content: String,
 ) {
   val fqName = "$`package`.$name"
 }
@@ -168,4 +173,4 @@ fun Snippet.asFileText(): String =
             |${if (`package`.isNotBlank() && `package` != "`unnamed package`") "package $`package`" else ""}
             |${imports.joinToString(prefix = "\n", separator = "\n", postfix = "\n")}
             |$content
-            """.trimMargin()
+  """.trimMargin()

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
@@ -8,7 +8,7 @@ fun generateLensDsl(ele: ADT, optic: DataClassDsl): Snippet {
     `package` = ele.packageName,
     name = ele.simpleName,
     content = processLensSyntax(ele, optic.foci, className),
-    imports = setOf(import)
+    imports = setOf(import),
   )
 }
 
@@ -18,7 +18,7 @@ fun generateOptionalDsl(ele: ADT, optic: DataClassDsl): Snippet {
     `package` = ele.packageName,
     name = ele.simpleName,
     content = processOptionalSyntax(ele, optic, className),
-    imports = setOf(import)
+    imports = setOf(import),
   )
 }
 
@@ -28,7 +28,7 @@ fun generatePrismDsl(ele: ADT, isoOptic: SealedClassDsl): Snippet {
     `package` = ele.packageName,
     name = ele.simpleName,
     content = processPrismSyntax(ele, isoOptic, className),
-    imports = setOf(import)
+    imports = setOf(import),
   )
 }
 
@@ -38,7 +38,7 @@ fun generateIsoDsl(ele: ADT, isoOptic: ValueClassDsl): Snippet {
     `package` = ele.packageName,
     name = ele.simpleName,
     content = processIsoSyntax(ele, isoOptic, className),
-    imports = setOf(import)
+    imports = setOf(import),
   )
 }
 
@@ -46,39 +46,41 @@ private fun processLensSyntax(ele: ADT, foci: List<Focus>, className: String): S
   return if (ele.typeParameters.isEmpty()) {
     foci.joinToString(separator = "\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Lens<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Lens<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Optional<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Optional<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Getter<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Getter<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Setter<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Traversal<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Fold<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Every<S, ${focus.className}> inline get() = this + ${className}.${focus.lensParamName()}
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Lens<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Lens<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Optional<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Optional<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Getter<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Getter<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Setter<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Traversal<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Fold<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Every<S, ${focus.className}> inline get() = this + $className.${focus.lensParamName()}
+    |
+      """.trimMargin()
     }
   } else {
     val sourceClassNameWithParams = "${ele.sourceClassName}${ele.angledTypeParameters}"
-    val joinedTypeParams = ele.typeParameters.joinToString(separator=",")
+    val joinedTypeParams = ele.typeParameters.joinToString(separator = ",")
     foci.joinToString(separator = "\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Lens<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Lens<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Optional<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Optional<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Getter<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Getter<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Setter<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Traversal<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Fold<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Every<S, ${focus.className}> = this + ${className}.${focus.lensParamName()}()
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Lens<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Lens<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Optional<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Optional<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Getter<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Getter<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Setter<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Traversal<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Fold<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Every<S, ${focus.className}> = this + $className.${focus.lensParamName()}()
+    |
+      """.trimMargin()
     }
   }
 }
 
 private fun processOptionalSyntax(ele: ADT, optic: DataClassDsl, className: String): String {
   val sourceClassNameWithParams = "${ele.sourceClassName}${ele.angledTypeParameters}"
-  val joinedTypeParams = ele.typeParameters.joinToString(separator=",")
+  val joinedTypeParams = ele.typeParameters.joinToString(separator = ",")
   return optic.foci.filterNot { it is NonNullFocus }.joinToString(separator = "\n") { focus ->
     val targetClassName =
       when (focus) {
@@ -87,27 +89,29 @@ private fun processOptionalSyntax(ele: ADT, optic: DataClassDsl, className: Stri
         is Focus.NonNull -> ""
       }
     if (ele.typeParameters.isEmpty()) {
-    """
-    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.paramName}: $Setter<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.paramName}: $Fold<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.paramName}: $Every<S, $targetClassName> inline get() = this + ${className}.${focus.paramName}
-    |""".trimMargin()
+      """
+    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.paramName}: $Setter<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.paramName}: $Fold<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.paramName}: $Every<S, $targetClassName> inline get() = this + $className.${focus.paramName}
+    |
+      """.trimMargin()
     } else {
       """
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.paramName}(): $Setter<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.paramName}(): $Fold<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.paramName}(): $Every<S, $targetClassName> = this + ${className}.${focus.paramName}()
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.paramName}(): $Setter<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.paramName}(): $Fold<S, $targetClassName> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.paramName}(): $Every<S, $targetClassName> = this + $className.${focus.paramName}()
+    |
+      """.trimMargin()
     }
   }
 }
@@ -116,33 +120,35 @@ private fun processPrismSyntax(ele: ADT, dsl: SealedClassDsl, className: String)
   return if (ele.typeParameters.isEmpty()) {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.paramName}: $Setter<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.paramName}: $Fold<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.paramName}: $Every<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.paramName}: $Setter<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.paramName}: $Fold<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.paramName}: $Every<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |
+      """.trimMargin()
     }
   } else {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       val sourceClassNameWithParams = focus.refinedType?.qualifiedString() ?: "${ele.sourceClassName}${ele.angledTypeParameters}"
       val joinedTypeParams = when {
         focus.refinedArguments.isEmpty() -> ""
-        else -> focus.refinedArguments.joinToString(separator=",")
+        else -> focus.refinedArguments.joinToString(separator = ",")
       }
       """
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<S, ${focus.className}> = this + ${className}.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<S, ${focus.className}> = this + $className.${focus.paramName}()
     |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, ${focus.className}> = this + ${ele.sourceClassName}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.paramName}(): $Setter<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.paramName}(): $Fold<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.paramName}(): $Every<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.paramName}(): $Setter<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.paramName}(): $Fold<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.paramName}(): $Every<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |
+      """.trimMargin()
     }
   }
 }
@@ -151,33 +157,35 @@ private fun processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): S
   if (ele.typeParameters.isEmpty()) {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.paramName}: $Iso<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.paramName}: $Lens<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.paramName}: $Setter<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.paramName}: $Fold<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.paramName}: $Every<S, ${focus.className}> inline get() = this + ${className}.${focus.paramName}
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline val <S> $Iso<S, ${ele.sourceClassName}>.${focus.paramName}: $Iso<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Lens<S, ${ele.sourceClassName}>.${focus.paramName}: $Lens<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Optional<S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Prism<S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Setter<S, ${ele.sourceClassName}>.${focus.paramName}: $Setter<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Traversal<S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Fold<S, ${ele.sourceClassName}>.${focus.paramName}: $Fold<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <S> $Every<S, ${ele.sourceClassName}>.${focus.paramName}: $Every<S, ${focus.className}> inline get() = this + $className.${focus.paramName}
+    |
+      """.trimMargin()
     }
   } else {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       val sourceClassNameWithParams = focus.refinedType?.qualifiedString() ?: "${ele.sourceClassName}${ele.angledTypeParameters}"
       val joinedTypeParams = when {
         focus.refinedArguments.isEmpty() -> ""
-        else -> focus.refinedArguments.joinToString(separator=",")
+        else -> focus.refinedArguments.joinToString(separator = ",")
       }
       """
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.paramName}(): $Iso<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.paramName}(): $Lens<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.paramName}(): $Setter<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.paramName}(): $Fold<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.paramName}(): $Every<S, ${focus.className}> = this + ${className}.${focus.paramName}()
-    |""".trimMargin()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Iso<S, $sourceClassNameWithParams>.${focus.paramName}(): $Iso<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Lens<S, $sourceClassNameWithParams>.${focus.paramName}(): $Lens<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Optional<S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Prism<S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Setter<S, $sourceClassNameWithParams>.${focus.paramName}(): $Setter<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Traversal<S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Fold<S, $sourceClassNameWithParams>.${focus.paramName}(): $Fold<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <S,$joinedTypeParams> $Every<S, $sourceClassNameWithParams>.${focus.paramName}(): $Every<S, ${focus.className}> = this + $className.${focus.paramName}()
+    |
+      """.trimMargin()
     }
   }
 

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/errors.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/errors.kt
@@ -5,14 +5,16 @@ val String.otherClassTypeErrorMessage
     """
       |$this cannot be annotated with @optics
       | ^
-      |Only data, sealed, and value classes can be annotated with @optics""".trimMargin()
+      |Only data, sealed, and value classes can be annotated with @optics
+    """.trimMargin()
 
 val String.typeParametersErrorMessage
   get() =
     """
       |$this cannot be annotated with @optics
       | ^
-      |Only classes with no type parameters can be annotated with @optics""".trimMargin()
+      |Only classes with no type parameters can be annotated with @optics
+    """.trimMargin()
 
 val String.lensErrorMessage
   get() =
@@ -21,7 +23,7 @@ val String.lensErrorMessage
       |                                       ^
       |arrow.optics.OpticsTarget.LENS is an invalid @optics argument for $this.
       |It is only valid for data classes.
-      """.trimMargin()
+    """.trimMargin()
 
 val String.optionalErrorMessage
   get() =
@@ -30,7 +32,7 @@ val String.optionalErrorMessage
       |                                           ^
       |arrow.optics.OpticsTarget.OPTIONAL is an invalid @optics argument for $this.
       |It is only valid for data classes.
-      """.trimMargin()
+    """.trimMargin()
 
 val String.prismErrorMessage
   get() =
@@ -39,7 +41,7 @@ val String.prismErrorMessage
       |                                        ^
       |arrow.optics.OpticsTarget.PRISM is an invalid @optics argument for $this.
       |It is only valid for sealed classes.
-      """.trimMargin()
+    """.trimMargin()
 
 val String.isoErrorMessage
   get() =
@@ -48,7 +50,7 @@ val String.isoErrorMessage
       |                                      ^
       |arrow.optics.OpticsTarget.ISO is an invalid @optics argument for $this.
       |It is only valid for data and value classes.
-      """.trimMargin()
+    """.trimMargin()
 
 val String.isoTooBigErrorMessage
   get() =
@@ -56,7 +58,7 @@ val String.isoTooBigErrorMessage
       |Cannot generate arrow.optics.Iso for $this
       |                                      ^
       |Iso generation is supported for data classes with up to 22 constructor parameters.
-      """.trimMargin()
+    """.trimMargin()
 
 val String.dslErrorMessage
   get() =
@@ -65,11 +67,12 @@ val String.dslErrorMessage
       |                                                    ^
       |arrow.optics.OpticsTarget.DSL is an invalid @optics argument for $this.
       |It is only valid for data classes and sealed classes.
-      """.trimMargin()
+    """.trimMargin()
 
 val String.noCompanion
   get() =
     """
       |$this must declare a companion object
       | ^
-      |A companion object is required for the generated optics""".trimMargin()
+      |A companion object is required for the generated optics
+    """.trimMargin()

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/isos.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/isos.kt
@@ -32,7 +32,7 @@ private fun processElement(iso: ADT, target: Target): String {
     "nineteenth",
     "twentieth",
     "twentyFirst",
-    "twentySecond"
+    "twentySecond",
   )
 
   fun Focus.format(): String =
@@ -79,5 +79,6 @@ private fun processElement(iso: ADT, target: Target): String {
         |  get = { ${iso.sourceName}: $sourceClassNameWithParams -> ${tupleConstructor()} },
         |  reverseGet = { ${classConstructorFromTuple()} }
         |)
-        |""".trimMargin()
+        |
+  """.trimMargin()
 }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
@@ -6,7 +6,7 @@ internal fun generateLenses(ele: ADT, target: LensTarget) =
   Snippet(
     `package` = ele.packageName,
     name = ele.simpleName,
-    content = processElement(ele, target.foci)
+    content = processElement(ele, target.foci),
   )
 
 private fun String.toUpperCamelCase(): String =
@@ -17,7 +17,7 @@ private fun String.toUpperCamelCase(): String =
         it.replaceFirstChar {
           if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
         }
-      }
+      },
     )
 
 private fun processElement(adt: ADT, foci: List<Focus>): String {
@@ -34,17 +34,18 @@ private fun processElement(adt: ADT, foci: List<Focus>): String {
   |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.${
       focus.paramName.plusIfNotBlank(
         prefix = "`",
-        postfix = "`"
+        postfix = "`",
       )
     } },
   |  set = { ${adt.sourceName}: $sourceClassNameWithParams, value: ${focus.className} -> ${adt.sourceName}.copy(${
       focus.paramName.plusIfNotBlank(
         prefix = "`",
-        postfix = "`"
+        postfix = "`",
       )
     } = value) }
   |)
-  |""".trimMargin()
+  |
+    """.trimMargin()
   }
 }
 

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/optional.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/optional.kt
@@ -5,8 +5,8 @@ internal fun generateOptionals(ele: ADT, target: OptionalTarget) =
     `package` = ele.packageName,
     name = ele.simpleName,
     imports =
-      setOf("import arrow.core.left", "import arrow.core.right", "import arrow.core.toOption"),
-    content = processElement(ele, target.foci)
+    setOf("import arrow.core.left", "import arrow.core.right", "import arrow.core.toOption"),
+    content = processElement(ele, target.foci),
   )
 
 private fun processElement(ele: ADT, foci: List<Focus>): String =
@@ -30,7 +30,7 @@ private fun processElement(ele: ADT, foci: List<Focus>): String =
       "{ ${ele.sourceName}: $sourceClassNameWithParams -> ${ele.sourceName}.${
         focus.paramName.plusIfNotBlank(
           prefix = "`",
-          postfix = "`"
+          postfix = "`",
         )
       }$toNullable?.right() ?: ${ele.sourceName}.left() }"
     fun setF(fromNullable: String = "") =
@@ -48,5 +48,6 @@ private fun processElement(ele: ADT, foci: List<Focus>): String =
       |  getOrModify = $getOrModify,
       |  set = { ${ele.sourceName}: $sourceClassNameWithParams, value: $targetClassName -> $set }
       |)
-      |""".trimMargin()
+      |
+    """.trimMargin()
   }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/prism.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/prism.kt
@@ -5,8 +5,8 @@ internal fun generatePrisms(ele: ADT, target: PrismTarget) =
     `package` = ele.packageName,
     name = ele.simpleName,
     imports =
-      setOf("import arrow.core.left", "import arrow.core.right", "import arrow.core.identity"),
-    content = processElement(ele, target.foci)
+    setOf("import arrow.core.left", "import arrow.core.right", "import arrow.core.identity"),
+    content = processElement(ele, target.foci),
   )
 
 private fun processElement(ele: ADT, foci: List<Focus>): String {
@@ -24,7 +24,9 @@ private fun processElement(ele: ADT, foci: List<Focus>): String {
         "${ele.visibilityModifierName} inline fun $angledTypeParameters ${ele.sourceClassName}.Companion.${focus.paramName}(): $Prism<$sourceClassNameWithParams, ${focus.className}>"
     }
 
-    val elseBranch = if (focus.onlyOneSealedSubclass) "" else """
+    val elseBranch = if (focus.onlyOneSealedSubclass) {
+      ""
+    } else """
   |      else -> ${ele.sourceName}.left()
     """.trimMargin()
 
@@ -38,6 +40,7 @@ private fun processElement(ele: ADT, foci: List<Focus>): String {
   |  },
   |  reverseGet = ::identity
   |)
-  |""".trimMargin()
+  |
+    """.trimMargin()
   }
 }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/processor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/processor.kt
@@ -4,7 +4,11 @@ import arrow.optics.plugin.isDataClass
 import arrow.optics.plugin.isSealed
 import arrow.optics.plugin.isValue
 import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.Variance.INVARIANT
 import java.util.Locale
 
@@ -28,23 +32,23 @@ internal fun adt(c: KSClassDeclaration, logger: KSPLogger): ADT =
             .let(::PrismTarget)
         OpticsTarget.DSL -> evalAnnotatedDslElement(c, logger)
       }
-    }
+    },
   )
 
 internal fun KSClassDeclaration.targets(): List<OpticsTarget> =
   targetsFromOpticsAnnotation().let { targets ->
     when {
       isSealed ->
-        if (targets.isEmpty())
+        if (targets.isEmpty()) {
           listOf(OpticsTarget.PRISM, OpticsTarget.DSL)
-        else targets.filter { it == OpticsTarget.PRISM || it == OpticsTarget.DSL }
+        } else targets.filter { it == OpticsTarget.PRISM || it == OpticsTarget.DSL }
       isValue ->
         listOf(OpticsTarget.ISO, OpticsTarget.DSL)
           .filter { targets.isEmpty() || it in targets }
       else ->
-        if (targets.isEmpty())
+        if (targets.isEmpty()) {
           listOf(OpticsTarget.ISO, OpticsTarget.LENS, OpticsTarget.OPTIONAL, OpticsTarget.DSL)
-        else targets.filter {
+        } else targets.filter {
           when (it) {
             OpticsTarget.ISO, OpticsTarget.LENS, OpticsTarget.OPTIONAL, OpticsTarget.DSL -> true
             else -> false
@@ -59,7 +63,7 @@ internal fun KSClassDeclaration.targetsFromOpticsAnnotation(): List<OpticsTarget
     ?.arguments
     ?.flatMap { (it.value as? ArrayList<*>).orEmpty().mapNotNull { it as? KSType } }
     ?.mapNotNull {
-      when (it.qualifiedString() ) {
+      when (it.qualifiedString()) {
         "arrow.optics.OpticsTarget.ISO" -> OpticsTarget.ISO
         "arrow.optics.OpticsTarget.LENS" -> OpticsTarget.LENS
         "arrow.optics.OpticsTarget.PRISM" -> OpticsTarget.PRISM
@@ -72,7 +76,7 @@ internal fun KSClassDeclaration.targetsFromOpticsAnnotation(): List<OpticsTarget
 internal fun evalAnnotatedPrismElement(
   element: KSClassDeclaration,
   errorMessage: String,
-  logger: KSPLogger
+  logger: KSPLogger,
 ): List<Focus> =
   when {
     element.isSealed -> {
@@ -82,7 +86,7 @@ internal fun evalAnnotatedPrismElement(
           it.primaryConstructor?.returnType?.resolve()?.qualifiedString() ?: it.qualifiedNameOrSimpleName,
           it.simpleName.asString().replaceFirstChar { c -> c.lowercase(Locale.getDefault()) },
           it.superTypes.first().resolve(),
-          onlyOneSealedSubclass = sealedSubclasses.size == 1
+          onlyOneSealedSubclass = sealedSubclasses.size == 1,
         )
       }
     }
@@ -101,7 +105,7 @@ internal fun KSClassDeclaration.sealedSubclassFqNameList(): List<String> =
 internal fun evalAnnotatedDataClass(
   element: KSClassDeclaration,
   errorMessage: String,
-  logger: KSPLogger
+  logger: KSPLogger,
 ): List<Focus> =
   when {
     element.isDataClass ->
@@ -120,11 +124,11 @@ internal fun evalAnnotatedDslElement(element: KSClassDeclaration, logger: KSPLog
       DataClassDsl(
         element
           .getConstructorTypesNames()
-          .zip(element.getConstructorParamNames(), Focus.Companion::invoke)
+          .zip(element.getConstructorParamNames(), Focus.Companion::invoke),
       )
     element.isValue ->
       ValueClassDsl(
-        Focus(element.getConstructorTypesNames().first(), element.getConstructorParamNames().first())
+        Focus(element.getConstructorTypesNames().first(), element.getConstructorParamNames().first()),
       )
     element.isSealed ->
       SealedClassDsl(evalAnnotatedPrismElement(element, element.qualifiedNameOrSimpleName.prismErrorMessage, logger))
@@ -134,7 +138,7 @@ internal fun evalAnnotatedDslElement(element: KSClassDeclaration, logger: KSPLog
 internal fun evalAnnotatedIsoElement(
   element: KSClassDeclaration,
   errorMessage: String,
-  logger: KSPLogger
+  logger: KSPLogger,
 ): List<Focus> =
   when {
     element.isDataClass ->

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/utils.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/utils.kt
@@ -15,7 +15,6 @@ fun String.plusIfNotBlank(prefix: String = "", postfix: String = "") =
 fun KSName.asSanitizedString(delimiter: String = ".", prefix: String = "") =
   asString().splitToSequence(delimiter).joinToString(delimiter, prefix) { if (it in kotlinKeywords) "`$it`" else it }
 
-
 private val kotlinKeywords = setOf(
   // Hard keywords
   "as",

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/Compilation.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/Compilation.kt
@@ -62,7 +62,7 @@ fun buildCompilation(text: String, allWarningsAsErrors: Boolean = false) = Kotli
   classpaths = listOf(
     "arrow-annotations:$arrowVersion",
     "arrow-core:$arrowVersion",
-    "arrow-optics:$arrowVersion"
+    "arrow-optics:$arrowVersion",
   ).map { classpathOf(it) }
   symbolProcessorProviders = listOf(OpticsProcessorProvider())
   sources = listOf(SourceFile.kotlin(SOURCE_FILENAME, text.trimMargin()))

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/Utils.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/Utils.kt
@@ -65,4 +65,3 @@ const val dslValues =
       |    Four to "four"
       |  )
       |)"""
-

--- a/arrow-libs/optics/arrow-optics-reflect/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-reflect/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/optics/arrow-optics-reflect/src/main/kotlin/arrow/optics/Reflection.kt
+++ b/arrow-libs/optics/arrow-optics-reflect/src/main/kotlin/arrow/optics/Reflection.kt
@@ -3,21 +3,23 @@ package arrow.optics
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import kotlin.reflect.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
 import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.safeCast
 
 /** Focuses on those elements of the specified [klass] */
-public fun <S: Any, A: S> instance(klass: KClass<A>): Prism<S, A> =
-  object: Prism<S, A> {
+public fun <S : Any, A : S> instance(klass: KClass<A>): Prism<S, A> =
+  object : Prism<S, A> {
     override fun getOrModify(source: S): Either<S, A> =
       klass.safeCast(source)?.right() ?: source.left()
     override fun reverseGet(focus: A): S = focus
   }
 
 /** Focuses on those elements of the specified class */
-public inline fun <S: Any, reified A: S> instance(): Prism<S, A> =
-  object: Prism<S, A> {
+public inline fun <S : Any, reified A : S> instance(): Prism<S, A> =
+  object : Prism<S, A> {
     override fun getOrModify(source: S): Either<S, A> =
       (source as? A)?.right() ?: source.left()
     override fun reverseGet(focus: A): S = focus
@@ -36,7 +38,7 @@ public val <S, A> ((S) -> A).ogetter: Getter<S, A>
 public val <S, A> KProperty1<S, A>.lens: Lens<S, A>
   get() = PLens(
     get = this,
-    set = { s, a -> clone(this, s, a) }
+    set = { s, a -> clone(this, s, a) },
   )
 
 /** [Optional] that focuses on a nullable field */

--- a/arrow-libs/optics/arrow-optics-reflect/src/test/kotlin/arrow/optics/ReflectionTest.kt
+++ b/arrow-libs/optics/arrow-optics-reflect/src/test/kotlin/arrow/optics/ReflectionTest.kt
@@ -11,47 +11,46 @@ import io.kotest.property.checkAll
 data class Person(val name: String, val friends: List<String>)
 
 sealed interface Cutlery
-object Fork: Cutlery
-object Spoon: Cutlery
+object Fork : Cutlery
+object Spoon : Cutlery
 
-object ReflectionTest: StringSpec({
+object ReflectionTest : StringSpec({
 
-    "optional for function" {
-      checkAll(Arb.list(Arb.int())) { ints ->
-        val firsty = { it: List<Int> -> it.firstOrNull() }
-        firsty.ogetter.get(ints) shouldBe ints.firstOrNull()
-      }
+  "optional for function" {
+    checkAll(Arb.list(Arb.int())) { ints ->
+      val firsty = { it: List<Int> -> it.firstOrNull() }
+      firsty.ogetter.get(ints) shouldBe ints.firstOrNull()
     }
+  }
 
-    "lenses for field, get" {
-      checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
-        val p = Person(nm, fs.toMutableList())
-        Person::name.lens.get(p) shouldBe nm
-      }
+  "lenses for field, get" {
+    checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
+      val p = Person(nm, fs.toMutableList())
+      Person::name.lens.get(p) shouldBe nm
     }
+  }
 
-    "lenses for field, set" {
-      checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
-        val p = Person(nm, fs.toMutableList())
-        val m = Person::name.lens.modify(p) { it.capitalize() }
-        m shouldBe Person(nm.capitalize(), fs)
-      }
+  "lenses for field, set" {
+    checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
+      val p = Person(nm, fs.toMutableList())
+      val m = Person::name.lens.modify(p) { it.capitalize() }
+      m shouldBe Person(nm.capitalize(), fs)
     }
+  }
 
-    "traversal for list, set" {
-      checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
-        val p = Person(nm, fs)
-        val m = Person::friends.every.modify(p) { it.capitalize() }
-        m shouldBe Person(nm, fs.map { it.capitalize() })
-      }
+  "traversal for list, set" {
+    checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
+      val p = Person(nm, fs)
+      val m = Person::friends.every.modify(p) { it.capitalize() }
+      m shouldBe Person(nm, fs.map { it.capitalize() })
     }
+  }
 
-    "instances" {
-      val things = listOf(Fork, Spoon, Fork)
-      val forks = Every.list<Cutlery>() compose instance<Cutlery, Fork>()
-      val spoons = Every.list<Cutlery>() compose instance<Cutlery, Spoon>()
-      forks.size(things) shouldBe 2
-      spoons.size(things) shouldBe 1
-    }
-
+  "instances" {
+    val things = listOf(Fork, Spoon, Fork)
+    val forks = Every.list<Cutlery>() compose instance<Cutlery, Fork>()
+    val spoons = Every.list<Cutlery>() compose instance<Cutlery, Spoon>()
+    forks.size(things) shouldBe 2
+    spoons.size(things) shouldBe 1
+  }
 })

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -7,6 +7,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
   alias(libs.plugins.kotest.multiplatform)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/resilience/arrow-resilience/build.gradle.kts
+++ b/arrow-libs/resilience/arrow-resilience/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.arrowGradleConfig.versioning)
   alias(libs.plugins.kotlinx.kover)
+  alias(libs.plugins.spotless)
+}
+
+spotless {
+  kotlin {
+    ktlint().editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+  }
 }
 
 val enableCompatibilityMetadataVariant =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform) apply false
   alias(libs.plugins.kotlin.binaryCompatibilityValidator)
   alias(libs.plugins.arrowGradleConfig.nexus)
+  alias(libs.plugins.spotless) apply false
 }
 
 apply(plugin = libs.plugins.kotlinx.knit.get().pluginId)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlinxSerialization = "1.5.1"
 mockWebServer = "4.11.0"
 retrofit = "2.9.0"
 retrofitKotlinxSerialization = "1.0.0"
+spotlessVersion = "6.19.0"
 
 [libraries]
 arrow-kotlinMetadata = { module = "io.arrow-kt:kotlin-metadata", version.ref = "kotlin" }
@@ -67,3 +68,4 @@ kotlinx-knit = { id = "org.jetbrains.kotlinx.knit", version.ref = "knit" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotlessVersion" }


### PR DESCRIPTION
Fixes #2522

- Adds Spotless to every project
- Automatic commit of formatted files using GitHub Actions
- First pass of `spotlessApply`

Some considerations:
- Spotless is set up to use ktlint as formatter; this matches better the style we've been using, and is the only formatter (AFAIK) that supports modern Kotlin features such as context receivers
- The `standard:filename` rule has been disabled because Knit generates files starting with a lowercase letter