### PR TITLE
Serialization module

### DIFF
--- a/arrow-libs/core/arrow-core-serialization/api/arrow-core-serialization.api
+++ b/arrow-libs/core/arrow-core-serialization/api/arrow-core-serialization.api
@@ -1,0 +1,54 @@
+public final class arrow/core/serialization/EitherSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Larrow/core/Either;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Larrow/core/Either;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class arrow/core/serialization/IorSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Larrow/core/Ior;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Larrow/core/Ior;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class arrow/core/serialization/NonEmptyListSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Larrow/core/NonEmptyList;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Larrow/core/NonEmptyList;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class arrow/core/serialization/NonEmptySetSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-J9TPrxk (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/Set;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-EvCv4gE (Lkotlinx/serialization/encoding/Encoder;Ljava/util/Set;)V
+}
+
+public final class arrow/core/serialization/OptionSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Larrow/core/Option;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Larrow/core/Option;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class arrow/core/serialization/ValidatedSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Larrow/core/Validated;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Larrow/core/Validated;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+

--- a/arrow-libs/core/arrow-core-serialization/build.gradle.kts
+++ b/arrow-libs/core/arrow-core-serialization/build.gradle.kts
@@ -1,0 +1,50 @@
+@file:Suppress("DSL_SCOPE_VIOLATION")
+
+plugins {
+  id(libs.plugins.kotlin.multiplatform.get().pluginId)
+  alias(libs.plugins.arrowGradleConfig.kotlin)
+  alias(libs.plugins.arrowGradleConfig.publish)
+  alias(libs.plugins.arrowGradleConfig.versioning)
+  alias(libs.plugins.kotest.multiplatform)
+  id(libs.plugins.kotlinx.serialization.get().pluginId)
+}
+
+apply(from = property("ANIMALSNIFFER_MPP"))
+
+val enableCompatibilityMetadataVariant =
+  providers.gradleProperty("kotlin.mpp.enableCompatibilityMetadataVariant")
+    .orNull?.toBoolean() == true
+
+if (enableCompatibilityMetadataVariant) {
+  tasks.withType<Test>().configureEach {
+    exclude("**/*")
+  }
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.arrowCore)
+        api(libs.kotlin.stdlibCommon)
+        api(libs.kotlinx.serializationCore)
+      }
+    }
+    if (!enableCompatibilityMetadataVariant) {
+      commonTest {
+        dependencies {
+          implementation(libs.kotlinx.serializationJson)
+          implementation(libs.kotest.frameworkEngine)
+          implementation(libs.kotest.assertionsCore)
+          implementation(libs.kotest.property)
+        }
+      }
+
+      jvmTest {
+        dependencies {
+          runtimeOnly(libs.kotest.runnerJUnit5)
+        }
+      }
+    }
+  }
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/EitherSerializer.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/EitherSerializer.kt
@@ -1,0 +1,62 @@
+package arrow.core.serialization
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.left
+import arrow.core.none
+import arrow.core.right
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+
+public class EitherSerializer<A, B>(
+  private val errorSerializer: KSerializer<A>,
+  private val elementSerializer: KSerializer<B>,
+) : KSerializer<Either<A, B>> {
+
+  override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Either") {
+    element("left", errorSerializer.descriptor, isOptional = true)
+    element("right", elementSerializer.descriptor, isOptional = true)
+  }
+  override fun serialize(encoder: Encoder, value: Either<A, B>) {
+    encoder.encodeStructure(descriptor) {
+      when (value) {
+        is Either.Left -> encodeSerializableElement(descriptor, 0, errorSerializer, value.value)
+        is Either.Right -> encodeSerializableElement(descriptor, 1, elementSerializer, value.value)
+      }
+    }
+  }
+  override fun deserialize(decoder: Decoder): Either<A, B> {
+    var leftValue: Option<A> = none()
+    var rightValue: Option<B> = none()
+    decoder.decodeStructure(descriptor) {
+      while (true) {
+        when (val index = decodeElementIndex(descriptor)) {
+          0 -> {
+            leftValue = Some(decodeSerializableElement(descriptor, 0, errorSerializer))
+          }
+          1 -> {
+            rightValue = Some(decodeSerializableElement(descriptor, 1, elementSerializer))
+          }
+          CompositeDecoder.DECODE_DONE -> break
+          else -> error("unexpected index: $index")
+        }
+      }
+    }
+    return when {
+      leftValue is None && rightValue is None -> throw SerializationException("No information found for this Either")
+      leftValue is Some && rightValue is Some -> throw SerializationException("Both Left and Right specified for Either")
+      leftValue is Some -> (leftValue as Some<A>).value.left()
+      rightValue is Some -> (rightValue as Some<B>).value.right()
+      else -> error("this should never happen")
+    }
+  }
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/IorSerializer.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/IorSerializer.kt
@@ -1,0 +1,64 @@
+package arrow.core.serialization
+
+import arrow.core.Ior
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.none
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+
+public class IorSerializer<A, B>(
+  private val errorSerializer: KSerializer<A>,
+  private val elementSerializer: KSerializer<B>,
+) : KSerializer<Ior<A, B>> {
+
+  override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Ior") {
+    element("left", errorSerializer.descriptor, isOptional = true)
+    element("right", elementSerializer.descriptor, isOptional = true)
+  }
+  override fun serialize(encoder: Encoder, value: Ior<A, B>) {
+    encoder.encodeStructure(descriptor) {
+      when (value) {
+        is Ior.Left -> encodeSerializableElement(descriptor, 0, errorSerializer, value.value)
+        is Ior.Right -> encodeSerializableElement(descriptor, 1, elementSerializer, value.value)
+        is Ior.Both -> {
+          encodeSerializableElement(descriptor, 0, errorSerializer, value.leftValue)
+          encodeSerializableElement(descriptor, 1, elementSerializer, value.rightValue)
+        }
+      }
+    }
+  }
+  override fun deserialize(decoder: Decoder): Ior<A, B> {
+    var leftValue: Option<A> = none()
+    var rightValue: Option<B> = none()
+    decoder.decodeStructure(descriptor) {
+      while (true) {
+        when (val index = decodeElementIndex(descriptor)) {
+          0 -> {
+            leftValue = Some(decodeSerializableElement(descriptor, 0, errorSerializer))
+          }
+          1 -> {
+            rightValue = Some(decodeSerializableElement(descriptor, 1, elementSerializer))
+          }
+          CompositeDecoder.DECODE_DONE -> break
+          else -> error("unexpected index: $index")
+        }
+      }
+    }
+    return when {
+      leftValue is None && rightValue is None -> throw SerializationException("No information found for this Ior")
+      leftValue is Some && rightValue is Some -> Ior.Both((leftValue as Some<A>).value, (rightValue as Some<B>).value)
+      leftValue is Some -> Ior.Left((leftValue as Some<A>).value)
+      rightValue is Some -> Ior.Right((rightValue as Some<B>).value)
+      else -> error("this should never happen")
+    }
+  }
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/NonEmptyCollectionSerializers.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/NonEmptyCollectionSerializers.kt
@@ -1,0 +1,46 @@
+package arrow.core.serialization
+
+import arrow.core.NonEmptyList
+import arrow.core.NonEmptySet
+import arrow.core.toNonEmptyListOrNull
+import arrow.core.toNonEmptySetOrNull
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.SetSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+public class NonEmptyListSerializer<T>(
+  elementSerializer: KSerializer<T>
+) : KSerializer<NonEmptyList<T>> {
+  private val listSerializer: KSerializer<List<T>> = ListSerializer(elementSerializer)
+
+  @OptIn(ExperimentalSerializationApi::class)
+  override val descriptor: SerialDescriptor =
+    SerialDescriptor("NonEmptyList", listSerializer.descriptor)
+  override fun serialize(encoder: Encoder, value: NonEmptyList<T>) {
+    listSerializer.serialize(encoder, value.toList())
+  }
+  override fun deserialize(decoder: Decoder): NonEmptyList<T> =
+    listSerializer.deserialize(decoder).toNonEmptyListOrNull()
+      ?: throw SerializationException("expected non-empty list")
+}
+
+public class NonEmptySetSerializer<T>(
+  elementSerializer: KSerializer<T>
+) : KSerializer<NonEmptySet<T>> {
+  private val setSerializer: KSerializer<Set<T>> = SetSerializer(elementSerializer)
+
+  @OptIn(ExperimentalSerializationApi::class)
+  override val descriptor: SerialDescriptor =
+    SerialDescriptor("NonEmptySet", setSerializer.descriptor)
+  override fun serialize(encoder: Encoder, value: NonEmptySet<T>) {
+    setSerializer.serialize(encoder, value.toSet())
+  }
+  override fun deserialize(decoder: Decoder): NonEmptySet<T> =
+    setSerializer.deserialize(decoder).toNonEmptySetOrNull()
+      ?: throw SerializationException("expected non-empty set")
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/OptionSerializer.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/OptionSerializer.kt
@@ -1,0 +1,22 @@
+package arrow.core.serialization
+
+import arrow.core.Option
+import arrow.core.toOption
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+public class OptionSerializer<T : Any>(
+  elementSerializer: KSerializer<T>
+) : KSerializer<Option<T>> {
+  private val nullableSerializer: KSerializer<T?> = elementSerializer.nullable
+
+  override val descriptor: SerialDescriptor = nullableSerializer.descriptor
+  override fun serialize(encoder: Encoder, value: Option<T>) {
+    nullableSerializer.serialize(encoder, value.getOrNull())
+  }
+  override fun deserialize(decoder: Decoder): Option<T> =
+    nullableSerializer.deserialize(decoder).toOption()
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/ValidatedSerializer.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/ValidatedSerializer.kt
@@ -1,0 +1,63 @@
+package arrow.core.serialization
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.Validated
+import arrow.core.invalid
+import arrow.core.none
+import arrow.core.some
+import arrow.core.valid
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+
+public class ValidatedSerializer<A, B>(
+  private val errorSerializer: KSerializer<A>,
+  private val elementSerializer: KSerializer<B>,
+) : KSerializer<Validated<A, B>> {
+
+  override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Validated") {
+    element("invalid", errorSerializer.descriptor, isOptional = true)
+    element("valid", elementSerializer.descriptor, isOptional = true)
+  }
+  override fun serialize(encoder: Encoder, value: Validated<A, B>) {
+    encoder.encodeStructure(descriptor) {
+      when (value) {
+        is Validated.Invalid -> encodeSerializableElement(descriptor, 0, errorSerializer, value.value)
+        is Validated.Valid -> encodeSerializableElement(descriptor, 1, elementSerializer, value.value)
+      }
+    }
+  }
+  override fun deserialize(decoder: Decoder): Validated<A, B> {
+    var invalidValue: Option<A> = none()
+    var validValue: Option<B> = none()
+    decoder.decodeStructure(descriptor) {
+      while (true) {
+        when (val index = decodeElementIndex(descriptor)) {
+          0 -> {
+            invalidValue = decodeSerializableElement(descriptor, 0, errorSerializer).some()
+          }
+          1 -> {
+            validValue = decodeSerializableElement(descriptor, 1, elementSerializer).some()
+          }
+          CompositeDecoder.DECODE_DONE -> break
+          else -> error("unexpected index: $index")
+        }
+      }
+    }
+    return when {
+      invalidValue is None && validValue is None -> throw SerializationException("No information found for this Either")
+      invalidValue is Some && validValue is Some -> throw SerializationException("Both Left and Right specified for Either")
+      invalidValue is Some -> (invalidValue as Some<A>).value.invalid()
+      validValue is Some -> (validValue as Some<B>).value.valid()
+      else -> error("this should never happen")
+    }
+  }
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/BackAgainTest.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/BackAgainTest.kt
@@ -1,0 +1,75 @@
+@file:UseSerializers(
+  EitherSerializer::class,
+  IorSerializer::class,
+  ValidatedSerializer::class,
+  OptionSerializer::class,
+  NonEmptyListSerializer::class,
+  NonEmptySetSerializer::class
+)
+
+package arrow.core.serialization
+
+import arrow.core.Either
+import arrow.core.Ior
+import arrow.core.NonEmptyList
+import arrow.core.NonEmptySet
+import arrow.core.Option
+import arrow.core.Validated
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.Arb
+import io.kotest.property.checkAll
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import kotlinx.serialization.Serializable
+
+/*
+ These types are needed to "trick" the kotlinx.serialization plug-in
+ to use the corresponding (de)serializers for those types.
+ */
+
+@Serializable
+data class EitherInside<A, B>(val thing: Either<A, B>)
+
+@Serializable
+data class IorInside<A, B>(val thing: Ior<A, B>)
+
+@Serializable
+data class ValidatedInside<A, B>(val thing: Validated<A, B>)
+
+@Serializable
+data class OptionInside<A>(val thing: Option<A>)
+
+@Serializable
+data class NonEmptyListInside<A>(val thing: NonEmptyList<A>)
+
+@Serializable
+data class NonEmptySetInside<A>(val thing: NonEmptySet<A>)
+
+inline fun <reified T> StringSpec.backAgain(generator: Arb<T>) {
+  "there and back again, ${T::class.simpleName}" {
+    checkAll(generator) { e ->
+      val result = Json.encodeToJsonElement<T>(e)
+      val back = Json.decodeFromJsonElement<T>(result)
+      back shouldBe e
+    }
+  }
+}
+
+/**
+ * Checks that the result of serializing a value into JSON,
+ * and then deserializing it, gives back the original.
+ */
+class BackAgainTest : StringSpec({
+  backAgain(Arb.either(Arb.string(), Arb.int()).map(::EitherInside))
+  backAgain(Arb.ior(Arb.string(), Arb.int()).map(::IorInside))
+  backAgain(Arb.validated(Arb.string(), Arb.int()).map(::ValidatedInside))
+  backAgain(Arb.option(Arb.string()).map(::OptionInside))
+  backAgain(Arb.nonEmptyList(Arb.int()).map(::NonEmptyListInside))
+  backAgain(Arb.nonEmptySet(Arb.int()).map(::NonEmptySetInside))
+})

--- a/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/Generators.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/Generators.kt
@@ -1,0 +1,42 @@
+package arrow.core.serialization
+
+import arrow.core.Either
+import arrow.core.Ior
+import arrow.core.NonEmptyList
+import arrow.core.NonEmptySet
+import arrow.core.Option
+import arrow.core.Validated
+import arrow.core.toNonEmptySetOrNull
+import arrow.core.toOption
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.choice
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.arbitrary.set
+import kotlin.math.max
+
+fun <A> Arb.Companion.nonEmptyList(arb: Arb<A>, range: IntRange = 0 .. 100): Arb<NonEmptyList<A>> =
+  Arb.bind(arb, Arb.list(arb, range), ::NonEmptyList)
+
+fun <A> Arb.Companion.nonEmptySet(arb: Arb<A>, range: IntRange = 0 .. 100): Arb<NonEmptySet<A>> =
+  Arb.set(arb, max(range.first, 1) .. range.last).map { it.toNonEmptySetOrNull()!! }
+
+fun <B> Arb.Companion.option(arb: Arb<B>): Arb<Option<B>> =
+  arb.orNull().map { it.toOption() }
+
+fun <E, A> Arb.Companion.either(arbE: Arb<E>, arbA: Arb<A>): Arb<Either<E, A>> {
+  val arbLeft = arbE.map { Either.Left(it) }
+  val arbRight = arbA.map { Either.Right(it) }
+  return Arb.choice(arbLeft, arbRight)
+}
+
+fun <E, A> Arb.Companion.validated(arbE: Arb<E>, arbA: Arb<A>): Arb<Validated<E, A>> =
+  Arb.either(arbE, arbA).map { Validated.fromEither(it) }
+
+fun <A, B> Arb.Companion.ior(arbA: Arb<A>, arbB: Arb<B>): Arb<Ior<A, B>> =
+  arbA.alignWith(arbB) { it }
+
+private fun <A, B, R> Arb<A>.alignWith(arbB: Arb<B>, transform: (Ior<A, B>) -> R): Arb<R> =
+  Arb.bind(this, arbB) { a, b -> transform(Ior.Both(a, b)) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
   alias(libs.plugins.kotest.multiplatform) apply false
   alias(libs.plugins.kotlinx.kover)
   alias(libs.plugins.kotlin.multiplatform) apply false
+  alias(libs.plugins.kotlinx.serialization) apply false
   alias(libs.plugins.kotlin.binaryCompatibilityValidator)
   alias(libs.plugins.arrowGradleConfig.nexus)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ kotlin.mpp.stability.nowarn=true
 # https://youtrack.jetbrains.com/issue/KT-32476
 kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.ignoreDisabledTargets=true
+kotlin.native.cacheKind.linuxX64=none
 # https://youtrack.jetbrains.com/issue/KT-45545#focus=Comments-27-4773544.0-0
 kapt.use.worker.api=false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ kotlin-stdlibCommon = { module = "org.jetbrains.kotlin:kotlin-stdlib-common" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 kotlin-stdlibJS = { module = "org.jetbrains.kotlin:kotlin-stdlib-js" }
 kotlinx-knit = { module = "org.jetbrains.kotlinx:kotlinx-knit", version.ref = "knit" }
+kotlinx-serializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinx-serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 squareup-okhttpMockWebServer = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockWebServer" }
 squareup-retrofitConverterGson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,9 @@ project(":arrow-continuations").projectDir = file("arrow-libs/core/arrow-continu
 include("arrow-core-retrofit")
 project(":arrow-core-retrofit").projectDir = file("arrow-libs/core/arrow-core-retrofit")
 
+include("arrow-core-serialization")
+project(":arrow-core-serialization").projectDir = file("arrow-libs/core/arrow-core-serialization")
+
 // FX
 include("arrow-fx-coroutines")
 project(":arrow-fx-coroutines").projectDir = file("arrow-libs/fx/arrow-fx-coroutines")


### PR DESCRIPTION
Fixes #1829 

This defines the serializers to be used in the simplest way possible, which is "bringing them in" for `@Serializable` annotations by writing this at the top of the file (it can get smaller if fewer types are used).

```kotlin
@file:UseSerializers(
  EitherSerializer::class,
  IorSerializer::class,
  ValidatedSerializer::class,
  OptionSerializer::class,
  NonEmptyListSerializer::class,
  NonEmptySetSerializer::class
)
```