### PR TITLE
Optics `copy` with assignment plug-in

### DIFF
--- a/arrow-libs/optics/arrow-optics/api/arrow-optics.api
+++ b/arrow-libs/optics/arrow-optics/api/arrow-optics.api
@@ -1,10 +1,12 @@
 public abstract interface class arrow/optics/Copy {
+	public abstract fun getRef (Larrow/optics/PSetter;)Larrow/optics/Reference;
 	public abstract fun inside (Larrow/optics/PTraversal;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun set (Larrow/optics/PSetter;Ljava/lang/Object;)V
 	public abstract fun transform (Larrow/optics/PTraversal;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class arrow/optics/Copy$DefaultImpls {
+	public static fun getRef (Larrow/optics/Copy;Larrow/optics/PSetter;)Larrow/optics/Reference;
 	public static fun inside (Larrow/optics/Copy;Larrow/optics/PTraversal;Lkotlin/jvm/functions/Function1;)V
 }
 
@@ -155,6 +157,9 @@ public final class arrow/optics/ListKt {
 	public static final fun snoc (Ljava/util/List;Ljava/lang/Object;)Ljava/util/List;
 	public static final fun uncons (Ljava/util/List;)Lkotlin/Pair;
 	public static final fun unsnoc (Ljava/util/List;)Lkotlin/Pair;
+}
+
+public abstract interface annotation class arrow/optics/OpticsCopy : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class arrow/optics/OpticsCopyMarker : java/lang/annotation/Annotation {
@@ -826,6 +831,16 @@ public final class arrow/optics/PTraversal$DefaultImpls {
 
 public final class arrow/optics/PrismKt {
 	public static final fun Prism (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Larrow/optics/PPrism;
+}
+
+public final class arrow/optics/Reference {
+	public fun <init> (Larrow/optics/Copy;Larrow/optics/PSetter;)V
+	public final fun assign (Ljava/lang/Object;)V
+	public final fun copy (Larrow/optics/Copy;Larrow/optics/PSetter;)Larrow/optics/Reference;
+	public static synthetic fun copy$default (Larrow/optics/Reference;Larrow/optics/Copy;Larrow/optics/PSetter;ILjava/lang/Object;)Larrow/optics/Reference;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class arrow/optics/dsl/AtKt {

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.arrowGradleConfig.kotlin)
   alias(libs.plugins.arrowGradleConfig.publish)
   alias(libs.plugins.arrowGradleConfig.versioning)
+  alias(libs.plugins.kotlin.assignment)
   alias(libs.plugins.kotlinx.kover)
   alias(libs.plugins.kotest.multiplatform)
   alias(libs.plugins.spotless)
@@ -65,6 +66,10 @@ kotlin {
       }
     }
   }
+}
+
+assignment {
+  annotation("arrow.optics.OpticsCopy")
 }
 
 //fun DependencyHandlerScope.kspTest(dependencyNotation: Any): Unit {

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Copy.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Copy.kt
@@ -2,6 +2,17 @@ package arrow.optics
 
 import kotlin.experimental.ExperimentalTypeInference
 
+// used by the Kotlin assignment plug-in
+public annotation class OpticsCopy
+
+@OpticsCopy
+public data class Reference<A, B>(
+  private val copy: Copy<A>,
+  private val setter: Setter<A, B>
+) {
+  public fun assign(b: B) { with(copy) { setter.set(b) } }
+}
+
 @DslMarker
 public annotation class OpticsCopyMarker
 
@@ -11,6 +22,9 @@ public interface Copy<A> {
    * Changes the value of the element(s) pointed by the [Setter].
    */
   public infix fun <B> Setter<A, B>.set(b: B)
+
+  public val <B> Setter<A, B>.ref: Reference<A, B> get() =
+    Reference(this@Copy, this)
 
   /**
    * Transforms the value of the element(s) pointed by the [Traversal].

--- a/arrow-libs/optics/arrow-optics/src/commonTest/kotlin/arrow/optics/CopyTest.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonTest/kotlin/arrow/optics/CopyTest.kt
@@ -1,0 +1,17 @@
+package arrow.optics
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.checkAll
+
+class CopyTest : StringSpec({
+  "copy functionality works with assignment" {
+    checkAll(Arb.user()) { u ->
+      val new = u.copy {
+        User.token.ref = "Hello"
+      }
+      new.token.value shouldBe "Hello"
+    }
+  }
+})

--- a/arrow-libs/optics/arrow-optics/src/commonTest/kotlin/arrow/optics/TestDomain.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonTest/kotlin/arrow/optics/TestDomain.kt
@@ -62,7 +62,11 @@ internal data class Token(val value: String) {
 internal fun Arb.Companion.token(): Arb<Token> =
   Arb.string().map { Token(it) }
 
-internal data class User(val token: Token)
+internal data class User(val token: Token) {
+  companion object {
+    val token: Setter<User, String> = PLens.user() + PSetter.token()
+  }
+}
 
 internal fun Arb.Companion.user(): Arb<User> =
   Arb.token().map { User(it) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
   alias(libs.plugins.kotlin.binaryCompatibilityValidator)
   alias(libs.plugins.arrowGradleConfig.nexus)
   alias(libs.plugins.spotless) apply false
+  alias(libs.plugins.kotlin.assignment) apply false
 }
 
 apply(plugin = libs.plugins.kotlinx.knit.get().pluginId)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotestGr
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibilityValidator" }
+kotlin-assignment = { id = "org.jetbrains.kotlin.plugin.assignment", version.ref = "kotlin" }
 kotlinx-knit = { id = "org.jetbrains.kotlinx.knit", version.ref = "knit" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
There's a new [compiler plug-in](https://github.com/JetBrains/kotlin/commit/09d6dfc8bf1a8499f461de4227b1585c6072d0f0) (and its corresponding [Gradle plug-in](https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.assignment)) to overload Kotlin's assignment operator. This is quite nice for the `copy` DSL, since we can use `=` there directly.

Alas, the plug-in is not so powerful (yet), and it gets confused if `assign` is defined as an extension method inside an interface. For that reason, right now you need to use an intermediate call to `ref`,

```kotlin
lens.ref = newValue
```

which returns a `Reference<A, B>` which can later be used by the plug-in.