### PR TITLE
Fix Option.tap deprecation message.

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -540,7 +540,7 @@ public sealed class Option<out A> {
    * <!--- KNIT example-option-22.kt -->
    */
   @Deprecated(
-    "tap is being renamed to onNone to be more consistent with the Kotlin Standard Library naming",
+    "tap is being renamed to onSome to be more consistent with the Kotlin Standard Library naming",
     ReplaceWith("onSome(f)")
   )
   public inline fun tap(f: (A) -> Unit): Option<A> {


### PR DESCRIPTION
I assume, the deprecation message for `Option.tap` should be `tap is being renamed to onSome` instead of `tap is being renamed to onNone`.