### PR TITLE
ignoreErrors for Raise

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3333,6 +3333,30 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi : java/lang/annotation/Annotation {
 }
 
+public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/Raise {
+	public fun <init> (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function0;)V
+	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
+	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bindAll (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
+	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
+	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
+	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
+	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun ensure (Z)V
+	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
+	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public fun <init> (Lkotlin/jvm/functions/Function2;Ljava/util/concurrent/atomic/AtomicReference;Larrow/core/raise/Raise;)V
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3381,6 +3405,7 @@ public final class arrow/core/raise/NullableRaise : arrow/core/raise/Raise {
 	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ensure (Z)V
 	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
@@ -3411,6 +3436,7 @@ public final class arrow/core/raise/OptionRaise : arrow/core/raise/Raise {
 	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ensure (Z)V
 	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun raise (Larrow/core/None;)Ljava/lang/Void;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -95,7 +95,8 @@ public inline fun <Error, A> ior(noinline combineError: (Error, Error) -> Error,
 }
 
 /**
- * Implementation of [Raise] that ignores errors.
+ * Implementation of [Raise] used by `ignoreErrors`.
+ * You should never use this directly.
  */
 public class IgnoreErrorsRaise<N>(
   private val raise: Raise<N>,
@@ -167,6 +168,10 @@ public class NullableRaise(private val raise: Raise<Null>) : Raise<Null> by rais
     else -> nullable
   }
 
+  /**
+   * Introduces a scope where you can [bind] errors of any type,
+   * but no information is saved in the [raise] case.
+   */
   @RaiseDSL
   public inline fun <A> ignoreErrors(
     @BuilderInference block: IgnoreErrorsRaise<Null>.() -> A,
@@ -255,6 +260,10 @@ public class OptionRaise(private val raise: Raise<None>) : Raise<None> by raise 
     is Some<A> -> option.value
   }
 
+  /**
+   * Introduces a scope where you can [bind] errors of any type,
+   * but no information is saved in the [raise] case.
+   */
   @RaiseDSL
   public inline fun <A> ignoreErrors(
     @BuilderInference block: IgnoreErrorsRaise<None>.() -> A,

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -69,6 +69,22 @@ class NullableSpec : StringSpec({
     } shouldBe "1"
   }
 
+  "binding either in nullable" {
+    nullable {
+      val number = Either.Right("s".length)
+      val string = number.map(Int::toString).bind()
+      string
+    } shouldBe "1"
+  }
+
+  "binding either in nullable, ignore errors" {
+    nullable {
+      val number = Either.Right("s".length) as Either<Boolean, Int>
+      val string = ignoreErrors { number.map(Int::toString).bind() }
+      string
+    } shouldBe "1"
+  }
+
   "short circuit option" {
     nullable<Int> {
       val number = Some("s".length)

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -79,7 +79,7 @@ class NullableSpec : StringSpec({
 
   "binding either in nullable, ignore errors" {
     nullable {
-      val number: Either<Boolean Int> = Either.Right("s".length)
+      val number = Either.Right("s".length) as Either<Boolean, Int>
       val string = ignoreErrors { number.map(Int::toString).bind() }
       string
     } shouldBe "1"

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -79,7 +79,7 @@ class NullableSpec : StringSpec({
 
   "binding either in nullable, ignore errors" {
     nullable {
-      val number = Either.Right("s".length) as Either<Boolean, Int>
+      val number: Either<Boolean Int> = Either.Right("s".length)
       val string = ignoreErrors { number.map(Int::toString).bind() }
       string
     } shouldBe "1"


### PR DESCRIPTION
Alternative to #3099, from [this Slack thread](https://kotlinlang.slack.com/archives/C5UPMM0A0/p1689601177846049)

This adds a new `ignoreErrors` function in `nullable` and `option` which "swallows" every error. This is needed because `withError` is a bit cumbersome, and it doesn't always type as nicely.