### PR TITLE
Remove references to shift in Either.kt

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -2428,7 +2428,7 @@ public fun <E> E.leftNel(): EitherNel<E, Nothing> =
  *
  * fun test() {
  *   val error: Either<String, Int> = Either.Left("error")
- *   val listOfErrors: Either<List<Char>, Int> = error.recover { shift(it.toList()) }
+ *   val listOfErrors: Either<List<Char>, Int> = error.recover { raise(it.toList()) }
  *   listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
  * }
  * ```
@@ -2459,7 +2459,7 @@ public inline fun <E, EE, A> Either<E, A>.recover(@BuilderInference recover: Rai
  *   val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
  *
  *   val caught: Either<Nothing, Int> = left.catch { _: RuntimeException -> 1 }
- *   val failure: Either<String, Int> = left.catch { _: RuntimeException -> shift("failure") }
+ *   val failure: Either<String, Int> = left.catch { _: RuntimeException -> raise("failure") }
  *
  *   shouldThrowUnit<RuntimeException> {
  *     val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-46.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-46.kt
@@ -7,6 +7,6 @@ import io.kotest.matchers.shouldBe
 
 fun test() {
   val error: Either<String, Int> = Either.Left("error")
-  val listOfErrors: Either<List<Char>, Int> = error.recover { shift(it.toList()) }
+  val listOfErrors: Either<List<Char>, Int> = error.recover { raise(it.toList()) }
   listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-47.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-47.kt
@@ -10,7 +10,7 @@ fun test() {
   val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
 
   val caught: Either<Nothing, Int> = left.catch { _: RuntimeException -> 1 }
-  val failure: Either<String, Int> = left.catch { _: RuntimeException -> shift("failure") }
+  val failure: Either<String, Int> = left.catch { _: RuntimeException -> raise("failure") }
 
   shouldThrowUnit<RuntimeException> {
     val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }


### PR DESCRIPTION
Reported by @Zordid this PR removes the outdated references to `shift` in `Either.kt`. I checked all other references to shift, and could only find any in deprecated packages so this PR should remove all old references to `shift` in new packages.