### PR TITLE
Inline `NonEmpty` maps

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -183,6 +183,10 @@ public class NonEmptyList<out A>(
   public override inline fun <B> map(transform: (A) -> B): NonEmptyList<B> =
     NonEmptyList(transform(head), tail.map(transform))
 
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <B> mapIndexed(transform: (index: Int, A) -> B): NonEmptyList<B> =
+    NonEmptyList(transform(0, head), tail.mapIndexed { ix, e -> transform(ix + 1, e) })
+
   override fun <B> flatMap(transform: (A) -> NonEmptyCollection<B>): NonEmptyList<B> =
     transform(head).toNonEmptyList() + tail.flatMap(transform)
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -187,8 +187,13 @@ public class NonEmptyList<out A>(
   public override inline fun <B> mapIndexed(transform: (index: Int, A) -> B): NonEmptyList<B> =
     NonEmptyList(transform(0, head), tail.mapIndexed { ix, e -> transform(ix + 1, e) })
 
-  override fun <B> flatMap(transform: (A) -> NonEmptyCollection<B>): NonEmptyList<B> =
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <B> flatMap(transform: (A) -> NonEmptyCollection<B>): NonEmptyList<B> =
     transform(head).toNonEmptyList() + tail.flatMap(transform)
+
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <K> distinctBy(selector: (A) -> K): NonEmptyList<A> =
+    all.distinctBy(selector).toNonEmptyListOrNull()!!
 
   public operator fun plus(l: NonEmptyList<@UnsafeVariance A>): NonEmptyList<A> =
     this + l.all

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
@@ -21,9 +21,6 @@ public value class NonEmptySet<out A> private constructor(
 
   override fun lastOrNull(): A = elements.last()
 
-  override fun distinct(): NonEmptyList<A> =
-    toNonEmptyList()
-
   @Suppress("OVERRIDE_BY_INLINE")
   public override inline fun <B> map(transform: (A) -> B): NonEmptyList<B> =
     elements.map(transform).toNonEmptyListOrNull()!!
@@ -31,6 +28,17 @@ public value class NonEmptySet<out A> private constructor(
   @Suppress("OVERRIDE_BY_INLINE")
   public override inline fun <B> mapIndexed(transform: (index: Int, A) -> B): NonEmptyList<B> =
     elements.mapIndexed(transform).toNonEmptyListOrNull()!!
+
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <B> flatMap(transform: (A) -> NonEmptyCollection<B>): NonEmptyList<B> =
+    elements.flatMap(transform).toNonEmptyListOrNull()!!
+
+  override fun distinct(): NonEmptyList<A> =
+    toNonEmptyList()
+
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <K> distinctBy(selector: (A) -> K): NonEmptyList<A> =
+    elements.distinctBy(selector).toNonEmptyListOrNull()!!
 
   override fun toString(): String = "NonEmptySet(${this.joinToString()})"
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
@@ -4,7 +4,7 @@ import kotlin.jvm.JvmInline
 
 @JvmInline
 public value class NonEmptySet<out A> private constructor(
-  private val elements: Set<A>
+  @PublishedApi internal val elements: Set<A>
 ) : Set<A> by elements, NonEmptyCollection<A> {
 
   public constructor(first: A, rest: Set<A>) : this(setOf(first) + rest)
@@ -20,6 +20,17 @@ public value class NonEmptySet<out A> private constructor(
   override val head: A get() = elements.first()
 
   override fun lastOrNull(): A = elements.last()
+
+  override fun distinct(): NonEmptyList<A> =
+    toNonEmptyList()
+
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <B> map(transform: (A) -> B): NonEmptyList<B> =
+    elements.map(transform).toNonEmptyListOrNull()!!
+
+  @Suppress("OVERRIDE_BY_INLINE")
+  public override inline fun <B> mapIndexed(transform: (index: Int, A) -> B): NonEmptyList<B> =
+    elements.mapIndexed(transform).toNonEmptyListOrNull()!!
 
   override fun toString(): String = "NonEmptySet(${this.joinToString()})"
 


### PR DESCRIPTION
Fixes #3116 

This overrides `map` and `mapIndexed` with `inline` definitions, so they can be used in combination with `suspend` computations. Unfortunately this cannot be provided in general within `NonEmptyCollection`, because `inline` members are not allowed in interfaces.