### PR TITLE
Remove enableCompatibilityMetadataVariant

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemble -Pversion=${{ inputs.version }} -Pkotlin.mpp.enableCompatibilityMetadataVariant=true
+          arguments: assemble -Pversion=${{ inputs.version }}
 
       - name: Upload reports
         if: failure()
@@ -50,4 +50,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pkotlin.mpp.enableCompatibilityMetadataVariant=true -Pversion=${{ inputs.version }}  publishToSonatype closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }}  publishToSonatype closeSonatypeStagingRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,6 @@ allprojects {
   group = property("projects.group").toString()
 }
 
-val enableCompatibilityMetadataVariant =
-  providers.gradleProperty("kotlin.mpp.enableCompatibilityMetadataVariant")
-    .orNull?.toBoolean() == true
-
 subprojects {
   this@subprojects.tasks.withType<DokkaTaskPartial>().configureEach {
     this@subprojects.extensions.findByType<KotlinProjectExtension>()?.sourceSets?.forEach { kotlinSourceSet ->


### PR DESCRIPTION
enableCompatibilityMetadataVariant  is going to be removed in Kotlin 1.9.20. https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#deprecated-gradle-properties-for-hierarchical-structure-support

Blocking Arrow 1.2.1 release