### PR TITLE
Mention ignoreErrors in nullable's documentation

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -42,6 +42,9 @@ public inline fun <Error, A> either(@BuilderInference block: Raise<Error>.() -> 
  *
  * Read more about running a [Raise] computation in the
  * [Arrow docs](https://arrow-kt.io/learn/typed-errors/working-with-typed-errors/#running-and-inspecting-results).
+ *
+ * @see NullableRaise.ignoreErrors By default, `nullable` only allows raising `null`.
+ * Calling [ignoreErrors][NullableRaise.ignoreErrors] inside `nullable` allows to raise any error, which will be returned to the caller as if `null` was raised.
  */
 public inline fun <A> nullable(block: NullableRaise.() -> A): A? =
   merge { block(NullableRaise(this)) }


### PR DESCRIPTION
> Issue: #3138

Intuitively, I always expected `nullable` to accept `raise(Any?)` and swallow the error, simply returning `null`. The discussion in the linked issue brought `ignoreErrors` to my attention, which corresponds to my use-case.

To help future users discover it as well, I added a "See also" section to `nullable`'s API documentation.