### PR TITLE
refactor: migrate ResultSpec to kotlin-test

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/ResultSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/ResultSpec.kt
@@ -1,31 +1,31 @@
 package arrow.core.raise
 
-import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
-@Suppress("UNREACHABLE_CODE")
-class ResultSpec : StringSpec({
+class ResultSpec {
   val boom = RuntimeException("Boom!")
 
-  "Result - exception" {
+  @Test fun resultException() = runTest {
     result {
       throw boom
     } shouldBe Result.failure(boom)
   }
 
-  "Result - success" {
+  @Test fun resultSuccess() = runTest {
     result { 1 } shouldBe Result.success(1)
   }
 
-  "Result - raise" {
+  @Test fun resultRaise() = runTest {
     result { raise(boom) } shouldBe Result.failure(boom)
   }
 
-  "Recover works as expected" {
+  @Test fun recoverWorksAsExpected() = runTest {
     result {
       val one: Int = recover({ Result.failure<Int>(boom).bind() }) { 1 }
       val two = Result.success(2).bind()
       one + two
     } shouldBe Result.success(3)
   }
-})
+}


### PR DESCRIPTION
Closes #3156 