### PR TITLE
Revert "Inline `AtomicBoolean`"

### DIFF
--- a/arrow-libs/core/arrow-atomic/api/arrow-atomic.api
+++ b/arrow-libs/core/arrow-atomic/api/arrow-atomic.api
@@ -1,28 +1,19 @@
 public final class arrow/atomic/AtomicBoolean {
-	public static final synthetic fun box-impl (Ljava/util/concurrent/atomic/AtomicInteger;)Larrow/atomic/AtomicBoolean;
-	public static final fun compareAndSet-impl (Ljava/util/concurrent/atomic/AtomicInteger;ZZ)Z
-	public static fun constructor-impl (Z)Ljava/util/concurrent/atomic/AtomicInteger;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/util/concurrent/atomic/AtomicInteger;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/concurrent/atomic/AtomicInteger;)Z
-	public static final fun get-impl (Ljava/util/concurrent/atomic/AtomicInteger;)Z
-	public static final fun getAndSet-impl (Ljava/util/concurrent/atomic/AtomicInteger;Z)Z
-	public static final fun getValue-impl (Ljava/util/concurrent/atomic/AtomicInteger;)Z
-	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/util/concurrent/atomic/AtomicInteger;)I
-	public static final fun set-impl (Ljava/util/concurrent/atomic/AtomicInteger;Z)V
-	public static final fun setValue-impl (Ljava/util/concurrent/atomic/AtomicInteger;Z)V
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/util/concurrent/atomic/AtomicInteger;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/util/concurrent/atomic/AtomicInteger;
+	public fun <init> (Z)V
+	public final fun compareAndSet (ZZ)Z
+	public final fun get ()Z
+	public final fun getAndSet (Z)Z
+	public final fun getValue ()Z
+	public final fun set (Z)V
+	public final fun setValue (Z)V
 }
 
 public final class arrow/atomic/AtomicBooleanKt {
-	public static final fun getAndUpdate-NCWaHEY (Ljava/util/concurrent/atomic/AtomicInteger;Lkotlin/jvm/functions/Function1;)Z
-	public static final fun loop-NCWaHEY (Ljava/util/concurrent/atomic/AtomicInteger;Lkotlin/jvm/functions/Function1;)Ljava/lang/Void;
-	public static final fun tryUpdate-NCWaHEY (Ljava/util/concurrent/atomic/AtomicInteger;Lkotlin/jvm/functions/Function1;)Z
-	public static final fun update-NCWaHEY (Ljava/util/concurrent/atomic/AtomicInteger;Lkotlin/jvm/functions/Function1;)V
-	public static final fun updateAndGet-NCWaHEY (Ljava/util/concurrent/atomic/AtomicInteger;Lkotlin/jvm/functions/Function1;)Z
+	public static final fun getAndUpdate (Larrow/atomic/AtomicBoolean;Lkotlin/jvm/functions/Function1;)Z
+	public static final fun loop (Larrow/atomic/AtomicBoolean;Lkotlin/jvm/functions/Function1;)Ljava/lang/Void;
+	public static final fun tryUpdate (Larrow/atomic/AtomicBoolean;Lkotlin/jvm/functions/Function1;)Z
+	public static final fun update (Larrow/atomic/AtomicBoolean;Lkotlin/jvm/functions/Function1;)V
+	public static final fun updateAndGet (Larrow/atomic/AtomicBoolean;Lkotlin/jvm/functions/Function1;)Z
 }
 
 public final class arrow/atomic/AtomicIntKt {

--- a/arrow-libs/core/arrow-atomic/src/commonMain/kotlin/arrow/atomic/AtomicBoolean.kt
+++ b/arrow-libs/core/arrow-atomic/src/commonMain/kotlin/arrow/atomic/AtomicBoolean.kt
@@ -1,13 +1,10 @@
 package arrow.atomic
 
-import kotlin.jvm.JvmInline
-
-@JvmInline
-public value class AtomicBoolean private constructor(private val inner: AtomicInt) {
-  public constructor(value: Boolean): this(AtomicInt(value.toInt()))
+public class AtomicBoolean(value: Boolean) {
+  private val inner = AtomicInt(value.toInt())
 
   public var value: Boolean
-    get() = inner.value.toBoolean()
+    get() = inner.value != 0
     set(value) {
       inner.value = value.toInt()
     }
@@ -21,14 +18,11 @@ public value class AtomicBoolean private constructor(private val inner: AtomicIn
   }
 
   public fun getAndSet(value: Boolean): Boolean =
-    inner.getAndSet(value.toInt()).toBoolean()
+    inner.getAndSet(value.toInt()) == 1
+
+  private fun Boolean.toInt(): Int =
+    if (this) 1 else 0
 }
-
-private inline fun Boolean.toInt(): Int =
-  if (this) 1 else 0
-
-private inline fun Int.toBoolean(): Boolean =
-  this != 0
 
 
 /**


### PR DESCRIPTION
Reverts arrow-kt/arrow#3240

Since this is failing in K2, let's maybe revert this one