### PR TITLE
Remove a bunch of warnings

### DIFF
--- a/arrow-libs/core/arrow-atomic/build.gradle.kts
+++ b/arrow-libs/core/arrow-atomic/build.gradle.kts
@@ -46,10 +46,8 @@ kotlin {
   }
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    freeCompilerArgs = freeCompilerArgs + "-Xexpect-actual-classes"
-  }
+tasks.withType<KotlinCompile> {
+  kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
 }
 
 tasks.withType<Test> {

--- a/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/EitherCallAdapterFactory.kt
+++ b/arrow-libs/core/arrow-core-retrofit/src/main/kotlin/arrow/retrofit/adapter/either/EitherCallAdapterFactory.kt
@@ -110,7 +110,7 @@ public class EitherCallAdapterFactory : CallAdapter.Factory() {
     }
   }
 
-  private inline fun extractErrorAndReturnType(wrapperType: Type, returnType: ParameterizedType): Pair<Type, Type> {
+  private fun extractErrorAndReturnType(wrapperType: Type, returnType: ParameterizedType): Pair<Type, Type> {
     if (wrapperType !is ParameterizedType) {
       val name = parseTypeName(returnType)
       throw IllegalArgumentException(

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -58,6 +58,10 @@ kotlin {
 }
 
 // enables context receivers for Jvm Tests
+tasks.withType<KotlinCompile> {
+  kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
+}
+
 tasks.named<KotlinCompile>("compileTestKotlinJvm") {
   kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1330,6 +1330,7 @@ public inline infix fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
  * <!--- KNIT example-either-33.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <A> Either<A, A>.merge(): A =
   fold(::identity, ::identity)
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -179,7 +179,7 @@ public value class NonEmptyList<out A> @PublishedApi internal constructor(
     else -> head
   }
 
-  @Suppress("OVERRIDE_BY_INLINE")
+  @Suppress("OVERRIDE_BY_INLINE", "NOTHING_TO_INLINE")
   public override inline fun distinct(): NonEmptyList<A> =
     NonEmptyList(all.distinct())
 
@@ -340,6 +340,7 @@ public fun <A> nonEmptyListOf(head: A, vararg t: A): NonEmptyList<A> =
   NonEmptyList(listOf(head) + t)
 
 @JvmName("nel")
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <A> A.nel(): NonEmptyList<A> =
   NonEmptyList(listOf(this))
 
@@ -355,9 +356,11 @@ public inline fun <A, B : Comparable<B>> NonEmptyList<A>.minBy(selector: (A) -> 
 public inline fun <A, B : Comparable<B>> NonEmptyList<A>.maxBy(selector: (A) -> B): A =
   maxByOrNull(selector)!!
 
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <T : Comparable<T>> NonEmptyList<T>.min(): T =
   minOrNull()!!
 
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <T : Comparable<T>> NonEmptyList<T>.max(): T =
   maxOrNull()!!
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonFatal.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonFatal.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.cancellation.CancellationException
  *         else -> "Hello"
  *    }
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   val nonFatal: Either<Throwable, String> =
  *   //sampleStart
  *   try {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -8,7 +8,6 @@ package arrow.core
 import arrow.core.Either.Left
 import arrow.core.Either.Right
 import arrow.core.raise.RaiseAccumulate
-import arrow.core.raise.either
 import arrow.core.raise.fold
 import kotlin.experimental.ExperimentalTypeInference
 
@@ -574,7 +573,7 @@ public fun <A> Sequence<A>.salign(
  * @return a tuple containing Sequence with [Either.Left] and another Sequence with its [Either.Right] values.
  */
 public fun <A, B> Sequence<Either<A, B>>.separateEither(): Pair<List<A>, List<B>> =
-  fold(listOf<A>() to listOf<B>()) { (lefts, rights), either ->
+  fold(listOf<A>() to listOf()) { (lefts, rights), either ->
     when (either) {
       is Left -> lefts + either.value to rights
       is Right -> lefts to rights + either.value
@@ -637,7 +636,7 @@ public fun <Error, A, B> Sequence<A>.mapOrAccumulate(
  * import arrow.core.leftIor
  * import arrow.core.unalign
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   //sampleStart
  *   val result = sequenceOf(("A" to 1).bothIor(), ("B" to 2).bothIor(), "C".leftIor()).unalign()
  *   //sampleEnd
@@ -662,7 +661,7 @@ public fun <A, B> Sequence<Ior<A, B>>.unalign(): Pair<Sequence<A>, Sequence<B>> 
  * import arrow.core.leftIor
  * import arrow.core.unalign
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   //sampleStart
  *   val result = sequenceOf(1, 2, 3).unalign { it.leftIor() }
  *   //sampleEnd
@@ -680,7 +679,7 @@ public fun <A, B, C> Sequence<C>.unalign(fa: (C) -> Ior<A, B>): Pair<Sequence<A>
  * ```kotlin
  * import arrow.core.unweave
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   //sampleStart
  *   val result = sequenceOf(1,2,3).unweave { i -> sequenceOf("$i, ${i + 1}") }
  *   //sampleEnd
@@ -700,7 +699,7 @@ public fun <A, B> Sequence<A>.unweave(ffa: (A) -> Sequence<B>): Sequence<B> =
  * ```kotlin
  * import arrow.core.unzip
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   //sampleStart
  *   val result = sequenceOf("A" to 1, "B" to 2).unzip()
  *   //sampleEnd
@@ -720,7 +719,7 @@ public fun <A, B> Sequence<Pair<A, B>>.unzip(): Pair<Sequence<A>, Sequence<B>> =
  * ```kotlin
  * import arrow.core.unzip
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   //sampleStart
  *   val result =
  *    sequenceOf("A:1", "B:2", "C:3").unzip { e ->
@@ -743,7 +742,7 @@ public fun <A, B, C> Sequence<C>.unzip(fc: (C) -> Pair<A, B>): Pair<Sequence<A>,
  * ```kotlin
  * import arrow.core.widen
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   val original: Sequence<String> = sequenceOf("Hello World")
  *   val result: Sequence<CharSequence> = original.widen()
  * }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
@@ -35,7 +35,7 @@ public fun <K, A, B> Map<K, A>.zip(other: Map<K, B>): Map<K, Pair<A, B>> =
  *
  * fun test() {
  *   mapOf(1 to "A", 2 to "B").zip(mapOf(1 to "1", 2 to "2", 3 to "3")) {
- *     key, a, b -> "$a ~ $b"
+ *     _, a, b -> "$a ~ $b"
  *   } shouldBe mapOf(1 to "A ~ 1", 2 to "B ~ 2")
  * }
  * ```

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/nonFatalOrThrow.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/nonFatalOrThrow.kt
@@ -17,7 +17,7 @@ package arrow.core
  *         else -> "Hello"
  *    }
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   val nonFatal: Either<Throwable, String> =
  *   //sampleStart
  *   try {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/predef.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/predef.kt
@@ -1,5 +1,6 @@
 package arrow.core
 
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <A> identity(a: A): A = a
 
 /**
@@ -14,6 +15,7 @@ internal object EmptyValue {
   inline fun <A> unbox(value: Any?): A =
     if (value === this) null as A else value as A
 
+  @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
   public inline fun <T> combine(first: Any?, second: T, combine: (T, T) -> T): T =
     if (first === EmptyValue) second else combine(first as T, second)
 }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Effect.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Effect.kt
@@ -289,8 +289,8 @@ import kotlin.jvm.JvmName
  * ```kotlin
  * val default5: Effect<String, Int> =
  *   foreign
- *     .catch { ex: RuntimeException -> -1 }
- *     .catch { ex: java.sql.SQLException -> -2 }
+ *     .catch { _: RuntimeException -> -1 }
+ *     .catch { _: java.sql.SQLException -> -2 }
  * ```
  *
  * Finally, since `catch` also supports `suspend` we can safely call other `suspend` code and throw `Throwable` into the `suspend` system.
@@ -338,7 +338,7 @@ import kotlin.jvm.JvmName
  * -->
  * ```kotlin
  * suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
- *   guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+ *   guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
  *
  * ```
  *
@@ -374,7 +374,7 @@ import kotlin.jvm.JvmName
  * import kotlinx.coroutines.awaitCancellation
  *
  * suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
- *  guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+ *  guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
  *
  * suspend fun <A> CompletableDeferred<A>.getOrNull(): A? =
  *  if (isCompleted) await() else null
@@ -413,7 +413,7 @@ import kotlin.jvm.JvmName
  * import kotlinx.coroutines.awaitCancellation
  *
  * suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
- *   guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+ *   guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
  *
  * suspend fun <A> CompletableDeferred<A>.getOrNull(): A? =
  *   if (isCompleted) await() else null
@@ -456,7 +456,7 @@ import kotlin.jvm.JvmName
  *   effect<String, Int> {
  *     bracketCase(
  *       acquire = { File("build.gradle.kts").bufferedReader() },
- *       use = { reader: BufferedReader -> raise(error) },
+ *       use = { _: BufferedReader -> raise(error) },
  *       release = { reader, exitCase ->
  *         reader.close()
  *         exit.complete(exitCase)
@@ -552,7 +552,7 @@ import kotlin.jvm.JvmName
  * }
  *
  * suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
- *   guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+ *   guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
  * -->
  * ```kotlin
  * suspend fun main() {
@@ -664,11 +664,13 @@ import kotlin.jvm.JvmName
  */
 public typealias Effect<Error, A> = suspend Raise<Error>.() -> A
 
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <Error, A> effect(@BuilderInference noinline block: suspend Raise<Error>.() -> A): Effect<Error, A> = block
 
 /** The same behavior and API as [Effect] except without requiring _suspend_. */
 public typealias EagerEffect<Error, A> = Raise<Error>.() -> A
 
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <Error, A> eagerEffect(@BuilderInference noinline block: Raise<Error>.() -> A): EagerEffect<Error, A> = block
 
 public suspend fun <A> Effect<A, A>.merge(): A = merge { invoke() }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/ErrorHandlers.kt
@@ -23,9 +23,9 @@ import kotlin.jvm.JvmName
  *
  * val error = effect<Error, User> { raise(Error) } // Raise(error)
  *
- * val a = error.recover<Error, Error, User> { error -> User } // Success(User)
- * val b = error.recover<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
- * val c = error.recover<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)
+ * val a = error.recover<Error, Error, User> { _ -> User } // Success(User)
+ * val b = error.recover<Error, String, User> { _ -> raise("other-failure") } // Raise(other-failure)
+ * val c = error.recover<Error, Nothing, User> { _ -> throw RuntimeException("BOOM") } // Exception(BOOM)
  * ```
  * <!--- KNIT example-effect-error-01.kt -->
  */
@@ -93,7 +93,7 @@ public fun <Error, A> Effect<Error, A>.catch(): Effect<Error, Result<A>> =
     catch({ Result.success(invoke()) }, Result.Companion::failure)
   }
 
-public suspend inline infix fun <Error, A> Effect<Error, A>.getOrElse(recover: suspend (error: Error) -> A): A =
+public suspend inline infix fun <Error, A> Effect<Error, A>.getOrElse(recover: (error: Error) -> A): A =
   recover({ invoke() }) { recover(it) }
 
 /**
@@ -110,9 +110,9 @@ public suspend inline infix fun <Error, A> Effect<Error, A>.getOrElse(recover: s
  *
  * val error = effect<Error, User> { raise(Error) } // Raise(error)
  *
- * val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
+ * val a = error.mapError<Error, String, User> { _ -> "some-failure" } // Raise(some-failure)
  * val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)
- * val c = error.mapError<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)
+ * val c = error.mapError<Error, Nothing, User> { _ -> throw RuntimeException("BOOM") } // Exception(BOOM)
  * ```
  * <!--- KNIT example-effect-error-04.kt -->
  */
@@ -147,7 +147,7 @@ public inline infix fun <Error, A> EagerEffect<Error, A>.getOrElse(recover: (err
  *
  * val error = eagerEffect<Error, User> { raise(Error) } // Raise(error)
  *
- * val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
+ * val a = error.mapError<Error, String, User> { _ -> "some-failure" } // Raise(some-failure)
  * val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)
  * ```
  * <!--- KNIT example-effect-error-05.kt -->

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -264,7 +264,7 @@ public interface Raise<in Error> {
    *
    *   either {
    *     val x = one.bind()
-   *     val y = recover({ left.bind() }) { failure : String -> 1 }
+   *     val y = recover({ left.bind() }) { _ : String -> 1 }
    *     x + y
    *   } shouldBe Either.Right(2)
    * }
@@ -325,7 +325,7 @@ public interface Raise<in Error> {
  *   recover({ raise("failed") }) { str -> str.length } shouldBe 6
  *
  *   either<Int, String> {
- *     recover({ raise("failed") }) { str -> raise(-1) }
+ *     recover({ raise("failed") }) { _ -> raise(-1) }
  *   } shouldBe Either.Left(-1)
  * }
  * ```
@@ -421,7 +421,7 @@ public inline fun <reified T : Throwable, Error, A> recover(
  * -->
  * ```kotlin
  * fun test() {
- *   catch({ throw RuntimeException("BOOM") }) { t ->
+ *   catch({ throw RuntimeException("BOOM") }) { _ ->
  *     "fallback"
  *   } shouldBe "fallback"
  *
@@ -460,7 +460,7 @@ public inline fun <A> catch(block: () -> A, catch: (throwable: Throwable) -> A):
  * -->
  * ```kotlin
  * fun test() {
- *   catch({ throw RuntimeException("BOOM") }) { t ->
+ *   catch({ throw RuntimeException("BOOM") }) { _ ->
  *     "fallback"
  *   } shouldBe "fallback"
  *

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-01.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-01.kt
@@ -9,6 +9,6 @@ object Error
 
 val error = effect<Error, User> { raise(Error) } // Raise(error)
 
-val a = error.recover<Error, Error, User> { error -> User } // Success(User)
-val b = error.recover<Error, String, User> { error -> raise("other-failure") } // Raise(other-failure)
-val c = error.recover<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)
+val a = error.recover<Error, Error, User> { _ -> User } // Success(User)
+val b = error.recover<Error, String, User> { _ -> raise("other-failure") } // Raise(other-failure)
+val c = error.recover<Error, Nothing, User> { _ -> throw RuntimeException("BOOM") } // Exception(BOOM)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-04.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-04.kt
@@ -9,6 +9,6 @@ object Error
 
 val error = effect<Error, User> { raise(Error) } // Raise(error)
 
-val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
+val a = error.mapError<Error, String, User> { _ -> "some-failure" } // Raise(some-failure)
 val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)
-val c = error.mapError<Error, Nothing, User> { error -> throw RuntimeException("BOOM") } // Exception(BOOM)
+val c = error.mapError<Error, Nothing, User> { _ -> throw RuntimeException("BOOM") } // Exception(BOOM)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-05.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-effect-error-05.kt
@@ -9,5 +9,5 @@ object Error
 
 val error = eagerEffect<Error, User> { raise(Error) } // Raise(error)
 
-val a = error.mapError<Error, String, User> { error -> "some-failure" } // Raise(some-failure)
+val a = error.mapError<Error, String, User> { _ -> "some-failure" } // Raise(some-failure)
 val b = error.mapError<Error, String, User>(Any::toString) // Raise(Error)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-map-02.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-map-02.kt
@@ -6,6 +6,6 @@ import io.kotest.matchers.shouldBe
 
 fun test() {
   mapOf(1 to "A", 2 to "B").zip(mapOf(1 to "1", 2 to "2", 3 to "3")) {
-    key, a, b -> "$a ~ $b"
+    _, a, b -> "$a ~ $b"
   } shouldBe mapOf(1 to "A ~ 1", 2 to "B ~ 2")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-nonfatal-01.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-nonfatal-01.kt
@@ -11,7 +11,7 @@ fun unsafeFunction(i: Int): String =
         else -> "Hello"
    }
 
-fun main(args: Array<String>) {
+fun main() {
   val nonFatal: Either<Throwable, String> =
   //sampleStart
   try {

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-nonfatalorthrow-01.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-nonfatalorthrow-01.kt
@@ -11,7 +11,7 @@ fun unsafeFunction(i: Int): String =
         else -> "Hello"
    }
 
-fun main(args: Array<String>) {
+fun main() {
   val nonFatal: Either<Throwable, String> =
   //sampleStart
   try {

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-04.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-04.kt
@@ -43,8 +43,8 @@ val default4: Effect<Nothing, Int> =
 
 val default5: Effect<String, Int> =
   foreign
-    .catch { ex: RuntimeException -> -1 }
-    .catch { ex: java.sql.SQLException -> -2 }
+    .catch { _: RuntimeException -> -1 }
+    .catch { _: java.sql.SQLException -> -2 }
 
 suspend fun java.sql.SQLException.isForeignKeyViolation(): Boolean = true
 

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-05.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-05.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 
 suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
-  guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+  guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
 
  suspend fun main() {
    val error = "Error"

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-06.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-06.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 
 suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
- guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+ guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
 
 suspend fun <A> CompletableDeferred<A>.getOrNull(): A? =
  if (isCompleted) await() else null

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-07.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-07.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 
 suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
-  guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+  guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
 
 suspend fun <A> CompletableDeferred<A>.getOrNull(): A? =
   if (isCompleted) await() else null

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-08.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-08.kt
@@ -18,7 +18,7 @@ suspend fun main() {
   effect<String, Int> {
     bracketCase(
       acquire = { File("build.gradle.kts").bufferedReader() },
-      use = { reader: BufferedReader -> raise(error) },
+      use = { _: BufferedReader -> raise(error) },
       release = { reader, exitCase ->
         reader.close()
         exit.complete(exitCase)

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-10.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-10.kt
@@ -43,7 +43,7 @@ fun readFile(path: String?): Effect<FileError, Content> = effect {
 }
 
 suspend fun <A> awaitExitCase(exit: CompletableDeferred<ExitCase>): A =
-  guaranteeCase(::awaitCancellation) { exitCase -> exit.complete(exitCase) }
+  guaranteeCase({ awaitCancellation() }) { exitCase -> exit.complete(exitCase) }
 
 suspend fun main() {
   val exit = CompletableDeferred<ExitCase>()

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-05.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-05.kt
@@ -13,7 +13,7 @@ fun test() {
 
   either {
     val x = one.bind()
-    val y = recover({ left.bind() }) { failure : String -> 1 }
+    val y = recover({ left.bind() }) { _ : String -> 1 }
     x + y
   } shouldBe Either.Right(2)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-06.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-06.kt
@@ -10,6 +10,6 @@ fun test() {
   recover({ raise("failed") }) { str -> str.length } shouldBe 6
 
   either<Int, String> {
-    recover({ raise("failed") }) { str -> raise(-1) }
+    recover({ raise("failed") }) { _ -> raise(-1) }
   } shouldBe Either.Left(-1)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-09.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-09.kt
@@ -7,7 +7,7 @@ import arrow.core.raise.catch
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  catch({ throw RuntimeException("BOOM") }) { t ->
+  catch({ throw RuntimeException("BOOM") }) { _ ->
     "fallback"
   } shouldBe "fallback"
 

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-10.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-10.kt
@@ -7,7 +7,7 @@ import arrow.core.raise.catch
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  catch({ throw RuntimeException("BOOM") }) { t ->
+  catch({ throw RuntimeException("BOOM") }) { _ ->
     "fallback"
   } shouldBe "fallback"
 

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-11.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-11.kt
@@ -5,7 +5,7 @@ import arrow.core.bothIor
 import arrow.core.leftIor
 import arrow.core.unalign
 
-fun main(args: Array<String>) {
+fun main() {
   //sampleStart
   val result = sequenceOf(("A" to 1).bothIor(), ("B" to 2).bothIor(), "C".leftIor()).unalign()
   //sampleEnd

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-12.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-12.kt
@@ -4,7 +4,7 @@ package arrow.core.examples.exampleSequence12
 import arrow.core.leftIor
 import arrow.core.unalign
 
-fun main(args: Array<String>) {
+fun main() {
   //sampleStart
   val result = sequenceOf(1, 2, 3).unalign { it.leftIor() }
   //sampleEnd

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-13.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-13.kt
@@ -3,7 +3,7 @@ package arrow.core.examples.exampleSequence13
 
 import arrow.core.unweave
 
-fun main(args: Array<String>) {
+fun main() {
   //sampleStart
   val result = sequenceOf(1,2,3).unweave { i -> sequenceOf("$i, ${i + 1}") }
   //sampleEnd

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-14.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-14.kt
@@ -3,7 +3,7 @@ package arrow.core.examples.exampleSequence14
 
 import arrow.core.unzip
 
-fun main(args: Array<String>) {
+fun main() {
   //sampleStart
   val result = sequenceOf("A" to 1, "B" to 2).unzip()
   //sampleEnd

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-15.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-15.kt
@@ -3,7 +3,7 @@ package arrow.core.examples.exampleSequence15
 
 import arrow.core.unzip
 
-fun main(args: Array<String>) {
+fun main() {
   //sampleStart
   val result =
    sequenceOf("A:1", "B:2", "C:3").unzip { e ->

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-16.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-sequence-16.kt
@@ -3,7 +3,7 @@ package arrow.core.examples.exampleSequence16
 
 import arrow.core.widen
 
-fun main(args: Array<String>) {
+fun main() {
   val original: Sequence<String> = sequenceOf("Hello World")
   val result: Sequence<CharSequence> = original.widen()
 }

--- a/arrow-libs/core/arrow-functions/src/commonTest/kotlin/arrow/core/MemoizationTest.kt
+++ b/arrow-libs/core/arrow-functions/src/commonTest/kotlin/arrow/core/MemoizationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNUSED_PARAMETER")
+
 package arrow.core
 
 import io.kotest.property.checkAll

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Bracket.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Bracket.kt
@@ -32,7 +32,7 @@ public sealed class ExitCase {
  * @see guaranteeCase for registering a handler that executes for any [ExitCase].
  */
 public suspend inline fun <A> onCancel(
-  fa: suspend () -> A,
+  fa: () -> A,
   crossinline onCancel: suspend () -> Unit
 ): A = guaranteeCase(fa) { case ->
   when (case) {
@@ -55,7 +55,7 @@ public suspend inline fun <A> onCancel(
  * @see guaranteeCase for registering a handler that tracks the [ExitCase] of [fa].
  */
 public suspend inline fun <A> guarantee(
-  fa: suspend () -> A,
+  fa: () -> A,
   crossinline finalizer: suspend () -> Unit
 ): A {
   val res = try {
@@ -84,7 +84,7 @@ public suspend inline fun <A> guarantee(
  * @see guarantee for registering a handler that ignores the [ExitCase] of [fa].
  */
 public suspend inline fun <A> guaranteeCase(
-  fa: suspend () -> A,
+  fa: () -> A,
   crossinline finalizer: suspend (ExitCase) -> Unit
 ): A {
   val res = try {
@@ -115,10 +115,10 @@ public suspend inline fun <A> guaranteeCase(
  * ```kotlin
  * import arrow.fx.coroutines.*
  *
- * class File(url: String) {
+ * class File(val url: String) {
  *   fun open(): File = this
  *   fun close(): Unit {}
- *   override fun toString(): String = "This file contains some interesting content!"
+ *   override fun toString(): String = "This file contains some interesting content from $url!"
  * }
  *
  * suspend fun openFile(uri: String): File = File(uri).open()
@@ -140,7 +140,7 @@ public suspend inline fun <A> guaranteeCase(
  */
 public suspend inline fun <A, B> bracket(
   crossinline acquire: suspend () -> A,
-  use: suspend (A) -> B,
+  use: (A) -> B,
   crossinline release: suspend (A) -> Unit
 ): B {
   val acquired = withContext(NonCancellable) {
@@ -191,13 +191,13 @@ public suspend inline fun <A, B> bracket(
  * ```kotlin
  * import arrow.fx.coroutines.*
  *
- * class File(url: String) {
+ * class File(val url: String) {
  *   fun open(): File = this
  *   fun close(): Unit {}
  * }
  *
  * suspend fun File.content(): String =
- *     "This file contains some interesting content!"
+ *     "This file contains some interesting content from $url!"
  * suspend fun openFile(uri: String): File = File(uri).open()
  * suspend fun closeFile(file: File): Unit = file.close()
  *
@@ -223,7 +223,7 @@ public suspend inline fun <A, B> bracket(
  */
 public suspend inline fun <A, B> bracketCase(
   crossinline acquire: suspend () -> A,
-  use: suspend (A) -> B,
+  use: (A) -> B,
   crossinline release: suspend (A, ExitCase) -> Unit
 ): B {
   val acquired = withContext(NonCancellable) {

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParZip.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParZip.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package arrow.fx.coroutines
 
 import kotlinx.coroutines.CoroutineScope

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParZipOrAccumulate.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParZipOrAccumulate.kt
@@ -14,44 +14,44 @@ public suspend inline fun <E, A, B, C> Raise<E>.parZipOrAccumulate(
   crossinline combine: (E, E) -> E,
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
-  crossinline f: suspend CoroutineScope.(A, B) -> C
+  crossinline transform: suspend CoroutineScope.(A, B) -> C
 ): C =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, transform)
 
 public suspend inline fun <E, A, B, C> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
   crossinline combine: (E, E) -> E,
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
-  crossinline f: suspend CoroutineScope.(A, B) -> C
+  crossinline transform: suspend CoroutineScope.(A, B) -> C
 ): C =
   parZip(
     context,
     { either { fa(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fb(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b ->
-    Either.zipOrAccumulate(a, b) { aa, bb -> f(aa, bb) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b) { aa, bb -> transform(aa, bb) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
-  crossinline f: suspend CoroutineScope.(A, B) -> C
+  crossinline transform: suspend CoroutineScope.(A, B) -> C
 ): C =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, transform)
 
 public suspend inline fun <E, A, B, C> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
-  crossinline f: suspend CoroutineScope.(A, B) -> C
+  crossinline transform: suspend CoroutineScope.(A, B) -> C
 ): C =
   parZip(
     context,
     { either { fa(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fb(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b ->
-    Either.zipOrAccumulate(a, b) { aa, bb -> f(aa, bb) }.bind()
+    Either.zipOrAccumulate(a, b) { aa, bb -> transform(aa, bb) }.bind()
   }
 //endregion
 
@@ -61,9 +61,9 @@ public suspend inline fun <E, A, B, C, D> Raise<E>.parZipOrAccumulate(
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
-  crossinline f: suspend CoroutineScope.(A, B, C) -> D
+  crossinline transform: suspend CoroutineScope.(A, B, C) -> D
 ): D =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, transform)
 
 public suspend inline fun <E, A, B, C, D> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -71,7 +71,7 @@ public suspend inline fun <E, A, B, C, D> Raise<E>.parZipOrAccumulate(
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
-  crossinline f: suspend CoroutineScope.(A, B, C) -> D
+  crossinline transform: suspend CoroutineScope.(A, B, C) -> D
 ): D =
   parZip(
     context,
@@ -79,23 +79,23 @@ public suspend inline fun <E, A, B, C, D> Raise<E>.parZipOrAccumulate(
     { either { fb(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fc(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c ->
-    Either.zipOrAccumulate(a, b, c) { aa, bb, cc -> f(aa, bb, cc) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c) { aa, bb, cc -> transform(aa, bb, cc) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
-  crossinline f: suspend CoroutineScope.(A, B, C) -> D
+  crossinline transform: suspend CoroutineScope.(A, B, C) -> D
 ): D =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, transform)
 
 public suspend inline fun <E, A, B, C, D> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
   crossinline fa: suspend ScopedRaiseAccumulate<E>.() -> A,
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
-  crossinline f: suspend CoroutineScope.(A, B, C) -> D
+  crossinline transform: suspend CoroutineScope.(A, B, C) -> D
 ): D =
   parZip(
     context,
@@ -103,7 +103,7 @@ public suspend inline fun <E, A, B, C, D> Raise<NonEmptyList<E>>.parZipOrAccumul
     { either { fb(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fc(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c ->
-    Either.zipOrAccumulate(a, b, c) { aa, bb, cc -> f(aa, bb, cc) }.bind()
+    Either.zipOrAccumulate(a, b, c) { aa, bb, cc -> transform(aa, bb, cc) }.bind()
   }
 //endregion
 
@@ -114,9 +114,9 @@ public suspend inline fun <E, A, B, C, D, F> Raise<E>.parZipOrAccumulate(
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
-  crossinline f: suspend CoroutineScope.(A, B, C, D) -> F
+  crossinline transform: suspend CoroutineScope.(A, B, C, D) -> F
 ): F =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, transform)
 
 public suspend inline fun <E, A, B, C, D, F> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -125,7 +125,7 @@ public suspend inline fun <E, A, B, C, D, F> Raise<E>.parZipOrAccumulate(
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
-  crossinline f: suspend CoroutineScope.(A, B, C, D) -> F
+  crossinline transform: suspend CoroutineScope.(A, B, C, D) -> F
 ): F =
   parZip(
     context,
@@ -134,7 +134,7 @@ public suspend inline fun <E, A, B, C, D, F> Raise<E>.parZipOrAccumulate(
     { either { fc(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fd(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d ->
-    Either.zipOrAccumulate(a, b, c, d) { aa, bb, cc, dd -> f(aa, bb, cc, dd) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c, d) { aa, bb, cc, dd -> transform(aa, bb, cc, dd) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D, F> Raise<NonEmptyList<E>>.parZipOrAccumulate(
@@ -142,9 +142,9 @@ public suspend inline fun <E, A, B, C, D, F> Raise<NonEmptyList<E>>.parZipOrAccu
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
-  crossinline f: suspend CoroutineScope.(A, B, C, D) -> F
+  crossinline transform: suspend CoroutineScope.(A, B, C, D) -> F
 ): F =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, transform)
 
 public suspend inline fun <E, A, B, C, D, F> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -152,7 +152,7 @@ public suspend inline fun <E, A, B, C, D, F> Raise<NonEmptyList<E>>.parZipOrAccu
   crossinline fb: suspend ScopedRaiseAccumulate<E>.() -> B,
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
-  crossinline f: suspend CoroutineScope.(A, B, C, D) -> F
+  crossinline transform: suspend CoroutineScope.(A, B, C, D) -> F
 ): F =
   parZip(
     context,
@@ -161,7 +161,7 @@ public suspend inline fun <E, A, B, C, D, F> Raise<NonEmptyList<E>>.parZipOrAccu
     { either { fc(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fd(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d ->
-    Either.zipOrAccumulate(a, b, c, d) { aa, bb, cc, dd -> f(aa, bb, cc, dd) }.bind()
+    Either.zipOrAccumulate(a, b, c, d) { aa, bb, cc, dd -> transform(aa, bb, cc, dd) }.bind()
   }
 //endregion
 
@@ -173,9 +173,9 @@ public suspend inline fun <E, A, B, C, D, F, G> Raise<E>.parZipOrAccumulate(
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F) -> G
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F) -> G
 ): G =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -185,7 +185,7 @@ public suspend inline fun <E, A, B, C, D, F, G> Raise<E>.parZipOrAccumulate(
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F) -> G
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F) -> G
 ): G =
   parZip(
     context,
@@ -195,7 +195,7 @@ public suspend inline fun <E, A, B, C, D, F, G> Raise<E>.parZipOrAccumulate(
     { either { fd(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { ff(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f ->
-    Either.zipOrAccumulate(a, b, c, d, f) { aa, bb, cc, dd, ff -> f(aa, bb, cc, dd, ff) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c, d, f) { aa, bb, cc, dd, ff -> transform(aa, bb, cc, dd, ff) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D, F, G> Raise<NonEmptyList<E>>.parZipOrAccumulate(
@@ -204,9 +204,9 @@ public suspend inline fun <E, A, B, C, D, F, G> Raise<NonEmptyList<E>>.parZipOrA
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F) -> G
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F) -> G
 ): G =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -215,7 +215,7 @@ public suspend inline fun <E, A, B, C, D, F, G> Raise<NonEmptyList<E>>.parZipOrA
   crossinline fc: suspend ScopedRaiseAccumulate<E>.() -> C,
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F) -> G
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F) -> G
 ): G =
   parZip(
     context,
@@ -225,7 +225,7 @@ public suspend inline fun <E, A, B, C, D, F, G> Raise<NonEmptyList<E>>.parZipOrA
     { either { fd(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { ff(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f ->
-    Either.zipOrAccumulate(a, b, c, d, f) { aa, bb, cc, dd, ff -> f(aa, bb, cc, dd, ff) }.bind()
+    Either.zipOrAccumulate(a, b, c, d, f) { aa, bb, cc, dd, ff -> transform(aa, bb, cc, dd, ff) }.bind()
   }
 //endregion
 
@@ -238,9 +238,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H> Raise<E>.parZipOrAccumulate(
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G) -> H
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G) -> H
 ): H =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -251,7 +251,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H> Raise<E>.parZipOrAccumulate(
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G) -> H
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G) -> H
 ): H =
   parZip(
     context,
@@ -262,7 +262,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H> Raise<E>.parZipOrAccumulate(
     { either { ff(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fg(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f, g ->
-    Either.zipOrAccumulate(a, b, c, d, f, g) { aa, bb, cc, dd, ff, gg -> f(aa, bb, cc, dd, ff, gg) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c, d, f, g) { aa, bb, cc, dd, ff, gg -> transform(aa, bb, cc, dd, ff, gg) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D, F, G, H> Raise<NonEmptyList<E>>.parZipOrAccumulate(
@@ -272,9 +272,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H> Raise<NonEmptyList<E>>.parZip
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G) -> H
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G) -> H
 ): H =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -284,7 +284,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H> Raise<NonEmptyList<E>>.parZip
   crossinline fd: suspend ScopedRaiseAccumulate<E>.() -> D,
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G) -> H
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G) -> H
 ): H =
   parZip(
     context,
@@ -295,7 +295,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H> Raise<NonEmptyList<E>>.parZip
     { either { ff(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fg(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f, g ->
-    Either.zipOrAccumulate(a, b, c, d, f, g) { aa, bb, cc, dd, ff, gg -> f(aa, bb, cc, dd, ff, gg) }.bind()
+    Either.zipOrAccumulate(a, b, c, d, f, g) { aa, bb, cc, dd, ff, gg -> transform(aa, bb, cc, dd, ff, gg) }.bind()
   }
 //endregion
 
@@ -309,9 +309,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<E>.parZipOrAccumulat
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
 ): I =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, fh, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, fh, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -323,7 +323,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<E>.parZipOrAccumulat
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
 ): I =
   parZip(
     context,
@@ -335,7 +335,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<E>.parZipOrAccumulat
     { either { fg(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fh(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f, g, h ->
-    Either.zipOrAccumulate(a, b, c, d, f, g, h) { aa, bb, cc, dd, ff, gg, hh -> f(aa, bb, cc, dd, ff, gg, hh) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c, d, f, g, h) { aa, bb, cc, dd, ff, gg, hh -> transform(aa, bb, cc, dd, ff, gg, hh) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<NonEmptyList<E>>.parZipOrAccumulate(
@@ -346,9 +346,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<NonEmptyList<E>>.par
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
 ): I =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, fh, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, fh, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -359,7 +359,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<NonEmptyList<E>>.par
   crossinline ff: suspend ScopedRaiseAccumulate<E>.() -> F,
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H) -> I
 ): I =
   parZip(
     context,
@@ -371,7 +371,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I> Raise<NonEmptyList<E>>.par
     { either { fg(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fh(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f, g, h ->
-    Either.zipOrAccumulate(a, b, c, d, f, g, h) { aa, bb, cc, dd, ff, gg, hh -> f(aa, bb, cc, dd, ff, gg, hh) }.bind()
+    Either.zipOrAccumulate(a, b, c, d, f, g, h) { aa, bb, cc, dd, ff, gg, hh -> transform(aa, bb, cc, dd, ff, gg, hh) }.bind()
   }
 //endregion
 
@@ -386,9 +386,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<E>.parZipOrAccumu
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
 ): J =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, fh, fi, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, fh, fi, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -401,7 +401,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<E>.parZipOrAccumu
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
 ): J =
   parZip(
     context,
@@ -414,7 +414,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<E>.parZipOrAccumu
     { either { fh(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fi(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f, g, h, i ->
-    Either.zipOrAccumulate(a, b, c, d, f, g, h, i) { aa, bb, cc, dd, ff, gg, hh, ii -> f(aa, bb, cc, dd, ff, gg, hh, ii) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c, d, f, g, h, i) { aa, bb, cc, dd, ff, gg, hh, ii -> transform(aa, bb, cc, dd, ff, gg, hh, ii) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<NonEmptyList<E>>.parZipOrAccumulate(
@@ -426,9 +426,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<NonEmptyList<E>>.
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
 ): J =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, fh, fi, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, fh, fi, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -440,7 +440,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<NonEmptyList<E>>.
   crossinline fg: suspend ScopedRaiseAccumulate<E>.() -> G,
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I) -> J
 ): J =
   parZip(
     context,
@@ -453,7 +453,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J> Raise<NonEmptyList<E>>.
     { either { fh(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fi(ScopedRaiseAccumulate(this, this@parZip)) } },
   ) { a, b, c, d, f, g, h, i ->
-    Either.zipOrAccumulate(a, b, c, d, f, g, h, i) { aa, bb, cc, dd, ff, gg, hh, ii -> f(aa, bb, cc, dd, ff, gg, hh, ii) }.bind()
+    Either.zipOrAccumulate(a, b, c, d, f, g, h, i) { aa, bb, cc, dd, ff, gg, hh, ii -> transform(aa, bb, cc, dd, ff, gg, hh, ii) }.bind()
   }
 //endregion
 
@@ -469,9 +469,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<E>.parZipOrAcc
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
   crossinline fj: suspend ScopedRaiseAccumulate<E>.() -> J,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
 ): K =
-  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, fh, fi, fj, f)
+  parZipOrAccumulate(EmptyCoroutineContext, combine, fa, fb, fc, fd, ff, fg, fh, fi, fj, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<E>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -485,7 +485,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<E>.parZipOrAcc
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
   crossinline fj: suspend ScopedRaiseAccumulate<E>.() -> J,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
 ): K =
   parZip(
     context,
@@ -499,7 +499,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<E>.parZipOrAcc
     { either { fi(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fj(ScopedRaiseAccumulate(this, this@parZip)) } }
   ) { a, b, c, d, f, g, h, i, j ->
-    Either.zipOrAccumulate(a, b, c, d, f, g, h, i, j) { aa, bb, cc, dd, ff, gg, hh, ii, jj -> f(aa, bb, cc, dd, ff, gg, hh, ii, jj) }.getOrElse { raise(it.reduce(combine)) }
+    Either.zipOrAccumulate(a, b, c, d, f, g, h, i, j) { aa, bb, cc, dd, ff, gg, hh, ii, jj -> transform(aa, bb, cc, dd, ff, gg, hh, ii, jj) }.getOrElse { raise(it.reduce(combine)) }
   }
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<NonEmptyList<E>>.parZipOrAccumulate(
@@ -512,9 +512,9 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<NonEmptyList<E
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
   crossinline fj: suspend ScopedRaiseAccumulate<E>.() -> J,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
 ): K =
-  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, fh, fi, fj, f)
+  parZipOrAccumulate(EmptyCoroutineContext, fa, fb, fc, fd, ff, fg, fh, fi, fj, transform)
 
 public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<NonEmptyList<E>>.parZipOrAccumulate(
   context: CoroutineContext,
@@ -527,7 +527,7 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<NonEmptyList<E
   crossinline fh: suspend ScopedRaiseAccumulate<E>.() -> H,
   crossinline fi: suspend ScopedRaiseAccumulate<E>.() -> I,
   crossinline fj: suspend ScopedRaiseAccumulate<E>.() -> J,
-  crossinline f: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
+  crossinline transform: suspend CoroutineScope.(A, B, C, D, F, G, H, I, J) -> K
 ): K =
   parZip(
     context,
@@ -541,6 +541,6 @@ public suspend inline fun <E, A, B, C, D, F, G, H, I, J, K> Raise<NonEmptyList<E
     { either { fi(ScopedRaiseAccumulate(this, this@parZip)) } },
     { either { fj(ScopedRaiseAccumulate(this, this@parZip)) } },
   ) { a, b, c, d, f, g, h, i, j ->
-    Either.zipOrAccumulate(a, b, c, d, f, g, h, i, j) { aa, bb, cc, dd, ff, gg, hh, ii, jj -> f(aa, bb, cc, dd, ff, gg, hh, ii, jj) }.bind()
+    Either.zipOrAccumulate(a, b, c, d, f, g, h, i, j) { aa, bb, cc, dd, ff, gg, hh, ii, jj -> transform(aa, bb, cc, dd, ff, gg, hh, ii, jj) }.bind()
   }
 //endregion

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CyclicBarrierSpec.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/CyclicBarrierSpec.kt
@@ -128,7 +128,7 @@ class CyclicBarrierSpec : StringSpec({
 
       val jobs = (0 until n - 1).map { i ->
         launch(start = CoroutineStart.UNDISPATCHED) {
-          guaranteeCase(barrier::await, exits[i]::complete)
+          guaranteeCase({ barrier.await() }, exits[i]::complete)
         }
       }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmMain/kotlin/arrow/fx/coroutines/ResourceExtensions.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmMain/kotlin/arrow/fx/coroutines/ResourceExtensions.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.newSingleThreadContext
@@ -151,7 +152,7 @@ public fun <A : AutoCloseable> autoCloseable(
  * ```
  * <!--- KNIT example-resourceextensions-04.kt -->
  */
-@OptIn(DelicateCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 @ResourceDSL
 public suspend fun ResourceScope.singleThreadContext(name: String): ExecutorCoroutineDispatcher =
   closeable { newSingleThreadContext(name) }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-bracket-01.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-bracket-01.kt
@@ -3,10 +3,10 @@ package arrow.fx.coroutines.examples.exampleBracket01
 
 import arrow.fx.coroutines.*
 
-class File(url: String) {
+class File(val url: String) {
   fun open(): File = this
   fun close(): Unit {}
-  override fun toString(): String = "This file contains some interesting content!"
+  override fun toString(): String = "This file contains some interesting content from $url!"
 }
 
 suspend fun openFile(uri: String): File = File(uri).open()

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-bracket-02.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-bracket-02.kt
@@ -3,13 +3,13 @@ package arrow.fx.coroutines.examples.exampleBracket02
 
 import arrow.fx.coroutines.*
 
-class File(url: String) {
+class File(val url: String) {
   fun open(): File = this
   fun close(): Unit {}
 }
 
 suspend fun File.content(): String =
-    "This file contains some interesting content!"
+    "This file contains some interesting content from $url!"
 suspend fun openFile(uri: String): File = File(uri).open()
 suspend fun closeFile(file: File): Unit = file.close()
 

--- a/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -43,6 +46,10 @@ kotlin {
       }
     }
   }
+}
+
+tasks.withType<KotlinCompile> {
+  kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
 }
 
 tasks.withType<Test> {

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/STM.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/STM.kt
@@ -250,7 +250,7 @@ public interface STM {
    * suspend fun main() {
    *   //sampleStart
    *   val result = atomically {
-   *     catch({ throw Throwable() }) { e -> "caught" }
+   *     catch({ throw Throwable() }) { _ -> "caught" }
    *   }
    *   //sampleEnd
    *   println("Result $result")
@@ -1202,6 +1202,7 @@ public interface STM {
    *     tarr.transform { it + 1 }
    *   }
    *   //sampleEnd
+   *   println("Result $result")
    * }
    * ```
  * <!--- KNIT example-stm-41.kt -->
@@ -1538,6 +1539,7 @@ public interface STM {
  *
  * Equal to [suspend] just with an [STM] receiver.
  */
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <A> stm(noinline f: STM.() -> A): STM.() -> A = f
 
 /**

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/TArray.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/TArray.kt
@@ -86,6 +86,7 @@ public fun <A> STM.newTArray(xs: Iterable<A>): TArray<A> =
  *     tarr.transform { it + 1 }
  *   }
  *   //sampleEnd
+ *   println("Result $result")
  * }
  * ```
  * <!--- KNIT example-tarray-04.kt -->

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/TVar.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/TVar.kt
@@ -166,6 +166,7 @@ public class TVar<A> internal constructor(a: A) {
    * Internal unsafe (non-suspend) version of read. Used by various other internals and [unsafeRead] to
    *  read the current value respecting its state.
    */
+  @Suppress("UNCHECKED_CAST")
   internal fun readI(): A {
     while (true) {
       ref.value.let { a ->

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/internal/Hamt.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/internal/Hamt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package arrow.fx.stm.internal
 
 import arrow.fx.stm.TVar
@@ -22,7 +24,7 @@ public inline fun <A> STM.lookupHamtWithHash(hmt: Hamt<A>, hash: Int, test: (A) 
     val branches = hamt.branches.read()
     when (val branch = branches[branchInd]) {
       null -> return null
-      is Branch.Leaf -> return@lookupHamtWithHash (branch.value as Array<A>).find(test)
+      is Branch.Leaf -> return (branch.value as Array<A>).find(test)
       is Branch.Branches -> {
         depth = depth.nextDepth()
         hamt = branch.sub

--- a/arrow-libs/fx/arrow-fx-stm/src/jvmTest/kotlin/examples/example-stm-06.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/jvmTest/kotlin/examples/example-stm-06.kt
@@ -6,7 +6,7 @@ import arrow.fx.stm.atomically
 suspend fun main() {
   //sampleStart
   val result = atomically {
-    catch({ throw Throwable() }) { e -> "caught" }
+    catch({ throw Throwable() }) { _ -> "caught" }
   }
   //sampleEnd
   println("Result $result")

--- a/arrow-libs/fx/arrow-fx-stm/src/jvmTest/kotlin/examples/example-stm-41.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/jvmTest/kotlin/examples/example-stm-41.kt
@@ -11,4 +11,5 @@ suspend fun main() {
     tarr.transform { it + 1 }
   }
   //sampleEnd
+  println("Result $result")
 }

--- a/arrow-libs/fx/arrow-fx-stm/src/jvmTest/kotlin/examples/example-tarray-04.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/jvmTest/kotlin/examples/example-tarray-04.kt
@@ -11,4 +11,5 @@ suspend fun main() {
     tarr.transform { it + 1 }
   }
   //sampleEnd
+  println("Result $result")
 }

--- a/arrow-libs/optics/arrow-optics-reflect/src/test/kotlin/arrow/optics/ReflectionTest.kt
+++ b/arrow-libs/optics/arrow-optics-reflect/src/test/kotlin/arrow/optics/ReflectionTest.kt
@@ -11,8 +11,8 @@ import kotlin.test.Test
 data class Person(val name: String, val friends: List<String>)
 
 sealed interface Cutlery
-object Fork : Cutlery
-object Spoon : Cutlery
+data object Fork : Cutlery
+data object Spoon : Cutlery
 
 class ReflectionTest {
   @Test fun lensesForFieldGet() = runTest {
@@ -25,16 +25,16 @@ class ReflectionTest {
   @Test fun lensesForFieldSet() = runTest {
     checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
       val p = Person(nm, fs.toMutableList())
-      val m = Person::name.lens.modify(p) { it.capitalize() }
-      m shouldBe Person(nm.capitalize(), fs)
+      val m = Person::name.lens.modify(p) { it.uppercase() }
+      m shouldBe Person(nm.uppercase(), fs)
     }
   }
 
   @Test fun traversalForListSet() = runTest {
     checkAll(Arb.string(), Arb.list(Arb.string())) { nm, fs ->
       val p = Person(nm, fs)
-      val m = Person::friends.every.modify(p) { it.capitalize() }
-      m shouldBe Person(nm, fs.map { it.capitalize() })
+      val m = Person::friends.every.modify(p) { it.uppercase() }
+      m shouldBe Person(nm, fs.map { it.uppercase() })
     }
   }
 

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Optional.kt
@@ -38,10 +38,10 @@ public fun <S, A> Optional(getOption: (source: S) -> Option<A>, set: (source: S,
  *   }
  * }
  *
- * fun main(args: Array<String>) {
+ * fun main() {
  *   val original = User("arrow-user", None)
  *   val set = User.email.set(original, "arRoW-UsEr@arrow-Kt.IO")
- *   val modified = User.email.modify(set, String::toLowerCase)
+ *   val modified = User.email.modify(set, String::lowercase)
  *   println("original: $original, set: $set, modified: $modified")
  * }
  * ```

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/Traversal.kt
@@ -195,11 +195,11 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
-          combine(f(get1(s)), f(get2(s)))
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
+          combine(map(get1(source)), map(get2(source)))
 
-        override fun modify(s: S, transform: (focus: A) -> B): T =
-          set(transform(get1(s)), transform(get2(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -209,11 +209,11 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
-          combine(combine(f(get1(s)), f(get2(s))), f(get3(s)))
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
+          combine(combine(map(get1(source)), map(get2(source))), map(get3(source)))
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
-          set(f(get1(s)), f(get2(s)), f(get3(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), map(get3(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -224,11 +224,11 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
-          combine(combine(combine(f(get1(s)), f(get2(s))), f(get3(s))), f(get4(s)))
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
+          combine(combine(combine(map(get1(source)), map(get2(source))), map(get3(source))), map(get4(source)))
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
-          set(f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), map(get3(source)), map(get4(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -240,11 +240,11 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
-          combine(combine(combine(f(get1(s)), f(get2(s))), f(get3(s))), f(get5(s)))
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
+          combine(combine(combine(map(get1(source)), map(get2(source))), map(get3(source))), map(get5(source)))
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
-          set(f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), map(get3(source)), map(get4(source)), map(get5(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -257,11 +257,11 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
-          combine(combine(combine(combine(f(get1(s)), f(get2(s))), f(get3(s))), f(get5(s))), f(get6(s)))
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
+          combine(combine(combine(combine(map(get1(source)), map(get2(source))), map(get3(source))), map(get5(source))), map(get6(source)))
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
-          set(f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), map(get3(source)), map(get4(source)), map(get5(source)), map(get6(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -275,14 +275,14 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
           combine(
-            combine(combine(combine(combine(f(get1(s)), f(get2(s))), f(get3(s))), f(get5(s))), f(get6(s))),
-            f(get7(s))
+            combine(combine(combine(combine(map(get1(source)), map(get2(source))), map(get3(source))), map(get5(source))), map(get6(source))),
+            map(get7(source))
           )
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
-          set(f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), f(get7(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), map(get3(source)), map(get4(source)), map(get5(source)), map(get6(source)), map(get7(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -297,18 +297,18 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
           combine(
             combine(
               combine(
-                combine(combine(combine(f(get1(s)), f(get2(s))), f(get3(s))), f(get5(s))),
-                f(get6(s))
-              ), f(get7(s))
-            ), f(get8(s))
+                combine(combine(combine(map(get1(source)), map(get2(source))), map(get3(source))), map(get5(source))),
+                map(get6(source))
+              ), map(get7(source))
+            ), map(get8(source))
           )
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
-          set(f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)), f(get7(s)), f(get8(s)), s)
+        override fun modify(source: S, map: (focus: A) -> B): T =
+          set(map(get1(source)), map(get2(source)), map(get3(source)), map(get4(source)), map(get5(source)), map(get6(source)), map(get7(source)), map(get8(source)), source)
       }
 
     public operator fun <S, T, A, B> invoke(
@@ -324,30 +324,30 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, B, B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
           combine(
             combine(
               combine(
                 combine(
-                  combine(combine(combine(f(get1(s)), f(get2(s))), f(get3(s))), f(get5(s))),
-                  f(get6(s))
-                ), f(get7(s))
-              ), f(get8(s))
-            ), f(get9(s))
+                  combine(combine(combine(map(get1(source)), map(get2(source))), map(get3(source))), map(get5(source))),
+                  map(get6(source))
+                ), map(get7(source))
+              ), map(get8(source))
+            ), map(get9(source))
           )
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
+        override fun modify(source: S, map: (focus: A) -> B): T =
           set(
-            f(get1(s)),
-            f(get2(s)),
-            f(get3(s)),
-            f(get4(s)),
-            f(get5(s)),
-            f(get6(s)),
-            f(get7(s)),
-            f(get8(s)),
-            f(get9(s)),
-            s
+            map(get1(source)),
+            map(get2(source)),
+            map(get3(source)),
+            map(get4(source)),
+            map(get5(source)),
+            map(get6(source)),
+            map(get7(source)),
+            map(get8(source)),
+            map(get9(source)),
+            source
           )
       }
 
@@ -365,35 +365,35 @@ public interface PTraversal<S, T, A, B> {
       set: (B, B, B, B, B, B, B, B, B, B, S) -> T
     ): PTraversal<S, T, A, B> =
       object : PTraversal<S, T, A, B> {
-        override fun <R> foldMap(initial: R, combine: (R, R) -> R, s: S, f: (focus: A) -> R): R =
+        override fun <R> foldMap(initial: R, combine: (R, R) -> R, source: S, map: (focus: A) -> R): R =
           combine(
             combine(
               combine(
                 combine(
                   combine(
                     combine(
-                      combine(combine(f(get1(s)), f(get2(s))), f(get3(s))),
-                      f(get5(s))
-                    ), f(get6(s))
-                  ), f(get7(s))
-                ), f(get8(s))
-              ), f(get9(s))
-            ), f(get10(s))
+                      combine(combine(map(get1(source)), map(get2(source))), map(get3(source))),
+                      map(get5(source))
+                    ), map(get6(source))
+                  ), map(get7(source))
+                ), map(get8(source))
+              ), map(get9(source))
+            ), map(get10(source))
           )
 
-        override fun modify(s: S, f: (focus: A) -> B): T =
+        override fun modify(source: S, map: (focus: A) -> B): T =
           set(
-            f(get1(s)),
-            f(get2(s)),
-            f(get3(s)),
-            f(get4(s)),
-            f(get5(s)),
-            f(get6(s)),
-            f(get7(s)),
-            f(get8(s)),
-            f(get9(s)),
-            f(get10(s)),
-            s
+            map(get1(source)),
+            map(get2(source)),
+            map(get3(source)),
+            map(get4(source)),
+            map(get5(source)),
+            map(get6(source)),
+            map(get7(source)),
+            map(get8(source)),
+            map(get9(source)),
+            map(get10(source)),
+            source
           )
       }
 

--- a/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/predef.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonMain/kotlin/arrow/optics/predef.kt
@@ -2,7 +2,7 @@ package arrow.optics
 
 @Suppress("ClassName")
 internal object EMPTY_VALUE {
-  @Suppress("UNCHECKED_CAST")
+  @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
   inline fun <T> unbox(value: Any?): T =
     if (value === this) null as T else value as T
 }

--- a/arrow-libs/optics/arrow-optics/src/commonTest/kotlin/examples/example-optional-01.kt
+++ b/arrow-libs/optics/arrow-optics/src/commonTest/kotlin/examples/example-optional-01.kt
@@ -15,9 +15,9 @@ data class User(val username: String, val email: Option<String>) {
   }
 }
 
-fun main(args: Array<String>) {
+fun main() {
   val original = User("arrow-user", None)
   val set = User.email.set(original, "arRoW-UsEr@arrow-Kt.IO")
-  val modified = User.email.modify(set, String::toLowerCase)
+  val modified = User.email.modify(set, String::lowercase)
   println("original: $original, set: $set, modified: $modified")
 }

--- a/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Saga.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Saga.kt
@@ -84,6 +84,7 @@ public interface SagaScope {
  * By doing so we can guarantee that any transactional like operations made by the [Saga] will
  * guarantee that it results in the correct state.
  */
+@Suppress("NOTHING_TO_INLINE")
 public inline fun <A> saga(noinline block: suspend SagaScope.() -> A): Saga<A> = block
 
 /** Create a lazy [Saga] that will only run when the [Saga] is invoked. */


### PR DESCRIPTION
This removes every warning in `main` source sets, and most in the Knit examples and `test`s.