### PR TITLE
Unify SingletonRaise-esque apis and introduce impure builder for raise

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3355,28 +3355,9 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi : java/lang/annotation/Annotation {
 }
 
-public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function0;)V
-	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
-	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun ensure (Z)V
-	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
-	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
+public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/SingletonRaise {
+	public fun <init> (Larrow/core/raise/Raise;Ljava/lang/Object;)V
+	public fun raise ()Ljava/lang/Void;
 }
 
 public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
@@ -3405,67 +3386,6 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/NullableRaise : arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;)V
-	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
-	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public final fun bindAllNullable (Ljava/lang/Iterable;)Ljava/util/List;
-	public final fun bindAllNullable (Ljava/util/Map;)Ljava/util/Map;
-	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun ensure (Z)V
-	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
-	public fun raise (Ljava/lang/Void;)Ljava/lang/Void;
-	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public synthetic fun shift (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun shift (Ljava/lang/Void;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/OptionRaise : arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;)V
-	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
-	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
-	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public final fun bindAllOption (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
-	public final fun bindAllOption (Ljava/lang/Iterable;)Ljava/util/List;
-	public final fun bindAllOption (Ljava/util/Map;)Ljava/util/Map;
-	public final fun bindAllOption (Ljava/util/Set;)Ljava/util/Set;
-	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun ensure (Z)V
-	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun raise (Larrow/core/None;)Ljava/lang/Void;
-	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
-	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public fun shift (Larrow/core/None;)Ljava/lang/Object;
-	public synthetic fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class arrow/core/raise/Raise {
@@ -3561,6 +3481,8 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun getOrElse (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun ignoreErrors (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun impure (Lkotlin/jvm/functions/Function1;)V
 	public static final fun ior (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun iorNel (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static synthetic fun iorNel$default (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/core/Ior;
@@ -3640,6 +3562,38 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public synthetic fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun shift (Ljava/lang/Throwable;)Ljava/lang/Object;
+}
+
+public abstract class arrow/core/raise/SingletonRaise : arrow/core/raise/Raise {
+	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
+	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
+	public fun bind (Larrow/core/Validated;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/EagerEffect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bind (Larrow/core/continuations/Effect;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bindAll (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
+	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
+	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
+	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
+	public final fun bindAllNullable (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun bindAllNullable (Ljava/util/Map;)Ljava/util/Map;
+	public final fun bindAllOption (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
+	public final fun bindAllOption (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun bindAllOption (Ljava/util/Map;)Ljava/util/Map;
+	public final fun bindAllOption (Ljava/util/Set;)Ljava/util/Set;
+	public fun catch (Larrow/core/continuations/Effect;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun ensure (Z)V
+	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun raise ()Ljava/lang/Void;
+	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
+	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun shift (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class arrow/core/raise/Trace {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -425,7 +425,7 @@ public sealed class Option<out A> {
     map: (A, B) -> C
   ): Option<C> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind()) }
+    return option { map(this@Option.bind(), b.bind()) }
   }
 
   @Deprecated(
@@ -441,7 +441,7 @@ public sealed class Option<out A> {
     map: (A, B, C) -> D
   ): Option<D> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind()) }
   }
 
   /**
@@ -562,7 +562,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D) -> E
   ): Option<E> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind()) }
   }
 
   @Deprecated(
@@ -580,7 +580,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D, E) -> F
   ): Option<F> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind(), e.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind(), e.bind()) }
   }
 
   @Deprecated(
@@ -599,7 +599,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D, E, F) -> G
   ): Option<G> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind()) }
   }
 
   @Deprecated(
@@ -619,7 +619,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D, E, F, G) -> H
   ): Option<H> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind()) }
   }
 
   @Deprecated(
@@ -640,7 +640,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D, E, F, G, H) -> I
   ): Option<I> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind(), h.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind(), h.bind()) }
   }
 
   @Deprecated(
@@ -662,7 +662,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D, E, F, G, H, I) -> J
   ): Option<J> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind(), h.bind(), i.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind(), h.bind(), i.bind()) }
   }
 
   @Deprecated(
@@ -685,7 +685,7 @@ public sealed class Option<out A> {
     map: (A, B, C, D, E, F, G, H, I, J) -> K
   ): Option<K> {
     contract { callsInPlace(map, InvocationKind.AT_MOST_ONCE) }
-    return option { map(bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind(), h.bind(), i.bind(), j.bind()) }
+    return option { map(this@Option.bind(), b.bind(), c.bind(), d.bind(), e.bind(), f.bind(), g.bind(), h.bind(), i.bind(), j.bind()) }
   }
 
   /**


### PR DESCRIPTION
Based on a suggestion by @CLOVIS-AI.

Not sure how Arrow handles binary compatibility issues because this introduces some. 
The name impure is not final, but I think it captures the essence of that builder well because it always returns `Unit`, so the action inside must be impure.