### PR TITLE
Proposal: Remove top-level fold in favor of recover et al

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -127,6 +127,7 @@ public final class arrow/core/EitherKt {
 public final class arrow/core/EmptyValue {
 	public static final field INSTANCE Larrow/core/EmptyValue;
 	public final fun combine (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public final fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun unbox (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -993,8 +994,6 @@ public abstract interface annotation class arrow/core/raise/RaiseDSL : java/lang
 }
 
 public final class arrow/core/raise/RaiseKt {
-	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -127,7 +127,6 @@ public final class arrow/core/EitherKt {
 public final class arrow/core/EmptyValue {
 	public static final field INSTANCE Larrow/core/EmptyValue;
 	public final fun combine (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public final fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun unbox (Ljava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
@@ -516,10 +516,9 @@ public inline fun <Error, A, B> Raise<Error>.mapOrAccumulate(
   var error: Any? = EmptyValue
   val results = ArrayList<B>(iterable.collectionSizeOrDefault(10))
   for (item in iterable) {
-    fold<NonEmptyList<Error>, B, Unit>(
-      { transform(RaiseAccumulate(this), item) },
-      { errors -> error = combine(error, errors.reduce(combine), combine) },
-      { results.add(it) }
+    recover(
+      { results.add(transform(RaiseAccumulate(this), item)) },
+      { errors -> error = combine(error, errors.reduce(combine), combine) }
     )
   }
   return if (error === EmptyValue) results else raise(unbox<Error>(error))
@@ -540,10 +539,9 @@ public inline fun <Error, A, B> Raise<NonEmptyList<Error>>.mapOrAccumulate(
   val error = mutableListOf<Error>()
   val results = ArrayList<B>(iterable.collectionSizeOrDefault(10))
   for (item in iterable) {
-    fold<NonEmptyList<Error>, B, Unit>(
-      { transform(RaiseAccumulate(this), item) },
-      { errors -> error.addAll(errors) },
-      { results.add(it) }
+    recover(
+      { results.add(transform(RaiseAccumulate(this), item)) },
+      error::addAll
     )
   }
   return error.toNonEmptyListOrNull()?.let { raise(it) } ?: results
@@ -577,10 +575,9 @@ public inline fun <Error, A, B> Raise<NonEmptyList<Error>>.mapOrAccumulate(
   val error = mutableListOf<Error>()
   val results = HashSet<B>(nonEmptySet.collectionSizeOrDefault(10))
   for (item in nonEmptySet) {
-    fold<NonEmptyList<Error>, B, Unit>(
-      { transform(RaiseAccumulate(this), item) },
-      { errors -> error.addAll(errors) },
-      { results.add(it) }
+    recover(
+      { results.add(transform(RaiseAccumulate(this), item)) },
+      error::addAll
     )
   }
   return error.toNonEmptyListOrNull()?.let { raise(it) } ?: requireNotNull(results.toNonEmptySetOrNull())

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/predef.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/predef.kt
@@ -1,11 +1,9 @@
 package arrow.core.raise
 
-import arrow.core.identity
+suspend fun <A> Effect<Nothing, A>.value(): A = merge()
 
-suspend fun <A> Effect<Nothing, A>.value(): A = fold(::identity, ::identity)
+suspend fun <E, A> Effect<E, A>.runCont(): Any? = merge()
 
-suspend fun <E, A> Effect<E, A>.runCont(): Any? = fold(::identity, ::identity)
+fun <A> EagerEffect<Nothing, A>.value(): A = merge()
 
-fun <A> EagerEffect<Nothing, A>.value(): A = fold(::identity, ::identity)
-
-fun <E, A> EagerEffect<E, A>.runCont(): Any? = fold(::identity, ::identity)
+fun <E, A> EagerEffect<E, A>.runCont(): Any? = merge()


### PR DESCRIPTION
I've been thinking about the need for a `transform` lambda for top-level `fold` for raise. I understand that it makes sense for there to be a `transform` in the happy path if we're thinking of a `Raise<E>.() -> A` as an `Effect`, i.e as a proper data type, but I think the mental model surrounding `Raise` seems to be more around error handlers than it is about representing a data type that can succeed and fail. I think looking at all the raise builders other than fold makes that very clear, because none of them take any transformation parameter for the happy path. That's because a transformation is just a last step of the calculation inside our `Raise<E>.() -> A` block, so we can always very idiomatically do such a transformation inside the block with no cost. I see how `Effect.fold` is very idiomatic though, and it makes since for it to have a `transform`

When removing the `transform` lambda, it made it visible that perhaps top-level fold shouldn't exist, instead being replaced by recover, which matches the mental model of raise providing error handling strategies. This PR does that, and perhaps one can see how some of Arrow's own code becomes clearer. I understand however that maybe the `fold` ship has already sailed!