### PR TITLE
Unify SingletonRaise-esque APIs, and add impure

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -854,8 +854,8 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi : java/lang/annotation/Annotation {
 }
 
-public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/SingletonRaise, arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;Ljava/lang/Object;)V
+public abstract class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/SingletonRaise, arrow/core/raise/Raise {
+	public fun <init> ()V
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -865,7 +865,6 @@ public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/Singlet
 	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun raise ()Ljava/lang/Void;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recoverIgnoreErrors (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
@@ -966,7 +965,7 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun getOrElse (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun ignoreErrors (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun ignoreErrors (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun impure (Lkotlin/jvm/functions/Function1;)V
 	public static final fun ior (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun iorNel (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -576,7 +576,7 @@ public final class arrow/core/OptionKt {
 	public static final fun flatten (Larrow/core/Option;)Larrow/core/Option;
 	public static final fun getOrElse (Larrow/core/Option;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static final fun none ()Larrow/core/Option;
-	public static final fun recover (Larrow/core/Option;Lkotlin/jvm/functions/Function2;)Larrow/core/Option;
+	public static final fun recover (Larrow/core/Option;Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun some (Ljava/lang/Object;)Larrow/core/Option;
 	public static final fun toMap (Larrow/core/Option;)Ljava/util/Map;
 	public static final fun toOption (Ljava/lang/Object;)Larrow/core/Option;
@@ -854,9 +854,20 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi : java/lang/annotation/Annotation {
 }
 
-public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/SingletonRaise {
+public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/SingletonRaise, arrow/core/raise/Raise {
 	public fun <init> (Larrow/core/raise/Raise;Ljava/lang/Object;)V
+	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
+	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
+	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
+	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun raise ()Ljava/lang/Void;
+	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
+	public final fun recoverIgnoreErrors (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
@@ -1027,16 +1038,9 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public abstract class arrow/core/raise/SingletonRaise : arrow/core/raise/Raise {
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
+public abstract class arrow/core/raise/SingletonRaise {
 	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
 	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
 	public final fun bindAllNullable (Ljava/lang/Iterable;)Ljava/util/List;
 	public final fun bindAllNullable (Ljava/util/List;)Ljava/util/List;
 	public final fun bindAllNullable (Ljava/util/Map;)Ljava/util/Map;
@@ -1048,10 +1052,7 @@ public abstract class arrow/core/raise/SingletonRaise : arrow/core/raise/Raise {
 	public final fun ensure (Z)V
 	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun raise ()Ljava/lang/Void;
-	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -854,22 +854,9 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi : java/lang/annotation/Annotation {
 }
 
-public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function0;)V
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
-	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
-	public final fun ensure (Z)V
-	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
+public final class arrow/core/raise/IgnoreErrorsRaise : arrow/core/raise/SingletonRaise {
+	public fun <init> (Larrow/core/raise/Raise;Ljava/lang/Object;)V
+	public fun raise ()Ljava/lang/Void;
 }
 
 public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
@@ -892,53 +879,6 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/NullableRaise : arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;)V
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
-	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
-	public final fun bindAllNullable (Ljava/lang/Iterable;)Ljava/util/List;
-	public final fun bindAllNullable (Ljava/util/Map;)Ljava/util/Map;
-	public final fun ensure (Z)V
-	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
-	public fun raise (Ljava/lang/Void;)Ljava/lang/Void;
-	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/OptionRaise : arrow/core/raise/Raise {
-	public fun <init> (Larrow/core/raise/Raise;)V
-	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
-	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
-	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
-	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
-	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
-	public final fun bindAllOption (Ljava/lang/Iterable;)Ljava/util/List;
-	public final fun bindAllOption (Ljava/util/List;)Ljava/util/List;
-	public final fun bindAllOption (Ljava/util/Map;)Ljava/util/Map;
-	public final fun bindAllOption (Ljava/util/Set;)Ljava/util/Set;
-	public final fun ensure (Z)V
-	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun raise (Larrow/core/None;)Ljava/lang/Void;
-	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
-	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public abstract interface class arrow/core/raise/Raise {
@@ -1015,6 +955,8 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun getOrElse (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun getOrNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun ignoreErrors (Larrow/core/raise/Raise;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun impure (Lkotlin/jvm/functions/Function1;)V
 	public static final fun ior (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static final fun iorNel (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;
 	public static synthetic fun iorNel$default (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/core/Ior;
@@ -1083,6 +1025,34 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun raise (Ljava/lang/Throwable;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract class arrow/core/raise/SingletonRaise : arrow/core/raise/Raise {
+	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
+	public final fun bind (Larrow/core/Option;)Ljava/lang/Object;
+	public final fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun bindAll (Ljava/lang/Iterable;)Ljava/util/List;
+	public fun bindAll (Ljava/util/Map;)Ljava/util/Map;
+	public fun bindAll-1TN0_VU (Ljava/util/Set;)Ljava/util/Set;
+	public fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
+	public final fun bindAllNullable (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun bindAllNullable (Ljava/util/List;)Ljava/util/List;
+	public final fun bindAllNullable (Ljava/util/Map;)Ljava/util/Map;
+	public final fun bindAllNullable (Ljava/util/Set;)Ljava/util/Set;
+	public final fun bindAllOption (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun bindAllOption (Ljava/util/List;)Ljava/util/List;
+	public final fun bindAllOption (Ljava/util/Map;)Ljava/util/Map;
+	public final fun bindAllOption (Ljava/util/Set;)Ljava/util/Set;
+	public final fun ensure (Z)V
+	public final fun ensureNotNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun ignoreErrors (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun raise ()Ljava/lang/Void;
+	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
+	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class arrow/core/raise/Trace {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -3,7 +3,7 @@ package arrow.core
 
 import arrow.core.raise.EagerEffect
 import arrow.core.raise.Effect
-import arrow.core.raise.OptionRaise
+import arrow.core.raise.SingletonRaise
 import arrow.core.raise.option
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -563,10 +563,10 @@ public inline fun <T> Option<T>.getOrElse(default: () -> T): T {
 public fun <T> T?.toOption(): Option<T> = this?.let { Some(it) } ?: None
 
 /** Run the [Effect] by returning [Option] of [A], or [None] if raised with [None]. */
-public suspend fun <A> Effect<None, A>.toOption(): Option<A> = option { invoke() }
+public suspend fun <A> Effect<None, A>.toOption(): Option<A> = option { ignoreErrors { invoke() } }
 
 /** Run the [EagerEffect] by returning [Option] of [A], or [None] if raised with [None]. */
-public fun <A> EagerEffect<None, A>.toOption(): Option<A> = option { invoke() }
+public fun <A> EagerEffect<None, A>.toOption(): Option<A> = option { ignoreErrors { invoke() } }
 
 public fun <A> A.some(): Option<A> = Some(this)
 
@@ -671,8 +671,8 @@ public operator fun <A : Comparable<A>> Option<A>.compareTo(other: Option<A>): I
  * <!--- KNIT example-option-22.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
-public inline fun <A> Option<A>.recover(recover: OptionRaise.(None) -> A): Option<A> =
+public inline fun <A> Option<A>.recover(recover: SingletonRaise.() -> A): Option<A> =
   when (this@recover) {
-    is None -> option { recover(this, None) }
+    is None -> option { recover() }
     is Some -> this@recover
   }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -136,7 +136,7 @@ public inline fun <Error, A> iorNel(noinline combineError: (NonEmptyList<Error>,
  */
 public inline fun impure(block: SingletonRaise.() -> Unit) {
   contract { callsInPlace(block, InvocationKind.AT_MOST_ONCE) }
-  return merge { ignoreErrors({}, block) }
+  return merge { ignoreErrors({ Unit }, block) }
 }
 
 /**

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -14,7 +14,6 @@ import arrow.core.recover
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind.AT_MOST_ONCE
-import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmMultifileClass
@@ -665,6 +664,13 @@ public inline fun <Error, OtherError, A> Raise<Error>.withError(
   return recover(block) { raise(transform(it)) }
 }
 
+@RaiseDSL
+public inline fun <Error, A> Raise<Error>.ignoreErrors(value: Error, @BuilderInference block: SingletonRaise<Any?>.() -> A): A {
+  contract {
+    callsInPlace(block, AT_MOST_ONCE)
+  }
+  return block(IgnoreErrorsRaise(this, value))
+}
 /**
  * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [A].
  * Does not distinguish between normal results and errors, thus you can consider

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -665,7 +665,7 @@ public inline fun <Error, OtherError, A> Raise<Error>.withError(
 }
 
 @RaiseDSL
-public inline fun <Error, A> Raise<Error>.ignoreErrors(value: Error, @BuilderInference block: SingletonRaise<Any?>.() -> A): A {
+public inline fun <Error, A> Raise<Error>.ignoreErrors(value: Error, @BuilderInference block: IgnoreErrorsRaise<*>.() -> A): A {
   contract {
     callsInPlace(block, AT_MOST_ONCE)
   }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -665,12 +665,16 @@ public inline fun <Error, OtherError, A> Raise<Error>.withError(
 }
 
 @RaiseDSL
-public inline fun <Error, A> Raise<Error>.ignoreErrors(value: Error, @BuilderInference block: IgnoreErrorsRaise<*>.() -> A): A {
+public inline fun <Error, A> Raise<Error>.ignoreErrors(crossinline raise: () -> Error, block: IgnoreErrorsRaise.() -> A): A {
   contract {
+    callsInPlace(raise, AT_MOST_ONCE)
     callsInPlace(block, AT_MOST_ONCE)
   }
-  return block(IgnoreErrorsRaise(this, value))
+  return block(object : IgnoreErrorsRaise() {
+    override fun raise(): Nothing = this@ignoreErrors.raise(raise())
+  })
 }
+
 /**
  * Execute the [Raise] context function resulting in [A] or any _logical error_ of type [A].
  * Does not distinguish between normal results and errors, thus you can consider

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -69,14 +69,6 @@ class NullableSpec {
     } shouldBe "1"
   }
 
-  @Test fun bindingEitherInNullable() = runTest {
-    nullable {
-      val number = Either.Right("s".length)
-      val string = number.map(Int::toString).bind()
-      string
-    } shouldBe "1"
-  }
-
   @Test fun bindingEitherInNullableIgnoreErrors() = runTest {
     nullable {
       val number = Either.Right("s".length) as Either<Boolean, Int>
@@ -126,13 +118,6 @@ class NullableSpec {
       }.bind()
       string
     } shouldBe null
-  }
-
-  @Test fun eitherOfNothingAndSomethingCanBeBound() = runTest {
-    nullable {
-      val either: Either<Nothing, Int> = Either.Right(4)
-      either.bind() + 3
-    } shouldBe 7
   }
 
   @Test fun recoverWorksAsExpected() = runTest {


### PR DESCRIPTION
Based on a suggestion by @CLOVIS-AI. This is a followup from #3305 
The name `impure` is not final, but I think it captures the essence of that builder well because it always returns `Unit`, so the action inside must be impure.

@CLOVIS-AI gave this example of a function that uses `impure`
```kotlin
fun MutableSet<AccessRight>.addRightsForUser(user: User) = impure {
    ensure(…)
    ensure(…)

    add(AccessRight(…, user))
}
```