### PR TITLE
Correctly escape class names in Optics KSP when a property clashes with a package name

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
@@ -190,7 +190,7 @@ private fun processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): S
   }
 
 private fun resolveClassName(ele: ADT): Pair<String, String> = if (hasPackageCollisions(ele)) {
-  val classNameAlias = ele.sourceClassName.replace(".", "")
+  val classNameAlias = ele.sourceClassName.replace(".", "").replace("`", "").sanitize()
   val aliasImport = "import ${ele.sourceClassName} as $classNameAlias"
   classNameAlias to aliasImport
 } else {

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/utils.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/utils.kt
@@ -13,7 +13,13 @@ fun String.plusIfNotBlank(prefix: String = "", postfix: String = "") =
  * Sanitizes each delimited section if it matches with Kotlin reserved keywords.
  */
 fun KSName.asSanitizedString(delimiter: String = ".", prefix: String = "") =
-  asString().splitToSequence(delimiter).joinToString(delimiter, prefix) { if (it in KOTLIN_KEYWORDS) "`$it`" else it }
+  asString().sanitize(delimiter, prefix)
+
+/**
+ * Sanitizes each delimited section if it matches with Kotlin reserved keywords.
+ */
+fun String.sanitize(delimiter: String = ".", prefix: String = "") =
+  splitToSequence(delimiter).joinToString(delimiter, prefix) { if (it in KOTLIN_KEYWORDS) "`$it`" else it }
 
 private val KOTLIN_KEYWORDS = setOf(
   // Hard keywords

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/DSLTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/DSLTests.kt
@@ -77,6 +77,42 @@ class DSLTests {
   }
 
   @Test
+  fun `DSL for a class in a package including keywords, issue #3134, part 1`() {
+    """
+      |package com.sats.core.data.workouts.models
+      |
+      |$imports
+      |
+      |@optics
+      |data class Source(val program: String) {
+      |  companion object
+      |}
+      |
+      """.compilationSucceeds()
+  }
+
+  /*
+   This test is for a very specific corner case, in which:
+   - The package name includes a Kotlin keyword, so we need to escape them,
+   - There's at least one property which shares name with part of the package,
+     so we need to include an explicit import
+   */
+  @Test
+  fun `DSL for a class in a package including keywords and conflicting fields, issue #3134, part 2`() {
+    """
+      |package com.sats.core.data.workouts.models
+      |
+      |$imports
+      |
+      |@optics
+      |data class Source(val models: String) {
+      |  companion object
+      |}
+      |
+      """.compilationSucceeds()
+  }
+
+  @Test
   fun `DSL works with variance, issue #3057`() {
     """
       |$`package`


### PR DESCRIPTION
Fixes #3134 