### PR TITLE
Run K2 using 2.0.0-Beta2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -179,7 +179,7 @@ jobs:
       - name: jvmTest (K2 enabled)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: "jvmTest -Pkotlin_version=2.0.0-dev-7674 -Pkotlin_repo_url=https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap -Pkotlin_language_version=2.0 -Pkotlin_api_version=2.0"
+          arguments: "jvmTest -Pkotlin_version=2.0.0-Beta2 -Pkotlin_language_version=2.0 -Pkotlin_api_version=2.0"
 
       - name: Upload reports
         if: failure()

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -179,7 +179,7 @@ jobs:
       - name: jvmTest (K2 enabled)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: "jvmTest -Pkotlin_version=2.0.0-Beta2 -Pkotlin_language_version=2.0 -Pkotlin_api_version=2.0"
+          arguments: "jvmTest -Pkotlin_version=2.0.0-Beta2 -Pksp_version=2.0.0-Beta2-1.0.16 -Pkotlin_language_version=2.0 -Pkotlin_api_version=2.0"
 
       - name: Upload reports
         if: failure()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencyResolutionManagement {
   @Suppress("LocalVariableName") val kotlin_repo_url: String? by settings
   @Suppress("LocalVariableName") val kotlin_version: String? by settings
+  @Suppress("LocalVariableName") val ksp_version: String? by settings
 
   repositories {
     mavenCentral()
@@ -32,6 +33,10 @@ dependencyResolutionManagement {
       if (!kotlin_version.isNullOrBlank()) {
         println("Overriding Kotlin version with $kotlin_version")
         version("kotlin", kotlin_version!!)
+      }
+      if (!ksp_version.isNullOrBlank()) {
+        println("Overriding KSP version with $ksp_version")
+        version("kspVersion", ksp_version!!)
       }
     }
   }


### PR DESCRIPTION
I think we should stop tracking the `-dev` versions of 2.0, and just use the beta's, since this is what our users are ultimately going to see