### PR TITLE
Safeguard for leaked 'raise' or 'bind'

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3584,6 +3584,7 @@ public abstract interface annotation class arrow/core/raise/RaiseDSL : java/lang
 public final class arrow/core/raise/RaiseKt {
 	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun _foldUnsafe (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Fold.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Fold.kt
@@ -135,6 +135,37 @@ public inline fun <Error, A, B> fold(
     callsInPlace(recover, AT_MOST_ONCE)
     callsInPlace(transform, AT_MOST_ONCE)
   }
+  return foldUnsafe(block, catch, recover) {
+    if (it is Function<*> || it is Lazy<*> || it is Sequence<*>)
+      throw IllegalStateException(
+        """
+  Returning a lazy computation or closure from 'fold' breaks the context scope, and may lead to leaked exceptions on later execution.
+  Make sure all calls to 'raise' and 'bind' occur within the lifecycle of nullable { }, either { } or similar builders.
+ 
+  See Arrow documentation on 'Typed errors' for further information.
+  """.trimIndent()
+      )
+    transform(it)
+  }
+}
+
+/**
+ * Similar to [fold], but does *not* check for
+ * potential lazy return types which break the
+ * [Raise] context barrier.
+ */
+@JvmName("_foldUnsafe")
+public inline fun <Error, A, B> foldUnsafe(
+  @BuilderInference block: Raise<Error>.() -> A,
+  catch: (throwable: Throwable) -> B,
+  recover: (error: Error) -> B,
+  transform: (value: A) -> B,
+): B {
+  contract {
+    callsInPlace(catch, AT_MOST_ONCE)
+    callsInPlace(recover, AT_MOST_ONCE)
+    callsInPlace(transform, AT_MOST_ONCE)
+  }
   val raise = DefaultRaise(false)
   return try {
     val res = block(raise)
@@ -237,10 +268,10 @@ internal expect open class CancellationExceptionNoTrace() : CancellationExceptio
 
 private class RaiseLeakedException : IllegalStateException(
   """
-  raise or bind was called outside of its DSL scope, and the DSL Scoped operator was leaked
-  This is kind of usage is incorrect, make sure all calls to raise or bind occur within the lifecycle of effect { }, either { } or similar builders.
+  'raise' or 'bind' was leaked outside of its context scope.
+  Make sure all calls to 'raise' and 'bind' occur within the lifecycle of nullable { }, either { } or similar builders.
  
-  See: Effect documentation for additional information.
+  See Arrow documentation on 'Typed errors' for further information.
   """.trimIndent()
 )
 

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
@@ -718,6 +718,7 @@ class EffectSpec : StringSpec({
     }
   }
 
+  /*
   "shift leaked results in RaiseLeakException" {
     effect {
       suspend { raise("failure") }
@@ -727,6 +728,7 @@ class EffectSpec : StringSpec({
       },
       { unreachable() }) { f -> f() }
   }
+  */
 
   "shift leaked results in RaiseLeakException with exception" {
     shouldThrow<IllegalStateException> {

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EffectSpec.kt
@@ -743,7 +743,7 @@ class EffectSpec : StringSpec({
         },
         { fail("Cannot be here") }
       ) { fail("Cannot be here") }
-    }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+    }.message shouldStartWith "'raise' or 'bind' was leaked"
   }
 
   "shift leaked results in RaiseLeakException after raise" {
@@ -758,7 +758,7 @@ class EffectSpec : StringSpec({
           it shouldBe "Boom!"
           leak.await().invoke()
         }) { fail("Cannot be here") }
-    }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+    }.message shouldStartWith "'raise' or 'bind' was leaked"
   }
 
   "mapError - raise and transform error" {

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -2,7 +2,9 @@ package arrow.core.raise
 
 import arrow.core.Either
 import arrow.core.Some
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.boolean
@@ -141,5 +143,20 @@ class NullableSpec : StringSpec({
       val two = 2.bind()
       one + two
     } shouldBe 3
+  }
+
+  "Detects potential leaked exceptions" {
+    shouldThrow<IllegalStateException> {
+      nullable { lazy { raise(null) } }
+    }
+  }
+
+  "Unsafe leakage of exceptions" {
+    val l: Lazy<Int> = foldUnsafe<String, Lazy<Int>, Lazy<Int>?>(
+      { lazy { raise("problem") } }, { throw it }, { null }, { it }
+    ).shouldNotBeNull()
+    shouldThrow<IllegalStateException> {
+      l.value
+    }
   }
 })

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/StructuredConcurrencySpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/StructuredConcurrencySpec.kt
@@ -234,7 +234,7 @@ class StructuredConcurrencySpec : StringSpec({
               .fold({ fail("shift was never awaited, so it never took effect") }, ::identity)
           shiftedAsync.await()
         }
-      }.message shouldStartWith "raise or bind was called outside of its DSL scope"
+      }.message shouldStartWith "'raise' or 'bind' was leaked"
     }
   }
 })


### PR DESCRIPTION
This should be accompanied with a text in the Arrow docs.

It would be great to also detect `Deferred` or `Flow` from `kotlinx.coroutines`, but this doesn't seem like a good enough reason to add a dependency on those.