### PR TITLE
Add attempt builder as an imperative alternative to `recover`

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -1040,6 +1040,7 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _foldUnsafe (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun attempt (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
 	public static final fun catch (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
@@ -1089,6 +1090,7 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun traced (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun valueOrEmpty (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun withError (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function9;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function8;)Ljava/lang/Object;

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/EagerEffectSpec.kt
@@ -293,4 +293,25 @@ class EagerEffectSpec {
         .get() shouldBe i
     }
   }
+
+  @Test fun attemptSuccess() = runTest {
+    checkAll(Arb.int()) { i ->
+      run { attempt<Nothing> { return@run i } } shouldBe i
+    }
+  }
+
+  @Test fun attemptRaise() = runTest {
+    checkAll(Arb.int(), Arb.string()) { i, s ->
+      run {
+        attempt { raise(i) } shouldBe i
+        s
+      } shouldBe s
+    }
+  }
+
+  @Test fun attemptNested() = runTest {
+    checkAll(Arb.int()) { i ->
+      attempt { attempt<Nothing> { raise(i) } } shouldBe i
+    }
+  }
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-13.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-raise-dsl-13.kt
@@ -1,0 +1,23 @@
+// This file was automatically generated from Raise.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleRaiseDsl13
+
+import arrow.core.getOrElse
+import arrow.core.raise.attempt
+import arrow.core.raise.either
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+val foo = either { if (Random.nextBoolean()) raise("failed") else 42 }
+
+fun test() {
+  either {
+    val msg = attempt { return@either foo.bind() }
+    raise(msg.toList())
+  } shouldBe foo.mapLeft(String::toList)
+
+  run {
+    attempt { return@run foo.bind() }
+    1
+  } shouldBe foo.getOrElse { 1 }
+}
+

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/RaiseKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/RaiseKnitTest.kt
@@ -49,4 +49,8 @@ class RaiseKnitTest {
     arrow.core.examples.exampleRaiseDsl12.test()
   }
 
+  @Test fun exampleRaiseDsl13() = runTest {
+    arrow.core.examples.exampleRaiseDsl13.test()
+  }
+
 }


### PR DESCRIPTION
I couldn't add this in `main` because it conflicted with a deprecated method, and so it wasn't useable inside of other `Raise` instances. Perhaps if there's a better name than `attempt`, then this change can be backported.