### PR TITLE
Deprecate Iterable#unzip in favor of stdlib method

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -21,6 +21,7 @@ import arrow.typeclasses.SemigroupDeprecation
 import arrow.typeclasses.combine
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmName
+import kotlin.collections.unzip as stdlibUnzip
 
 public inline fun <B, C, D, E> Iterable<B>.zip(
   c: Iterable<C>,
@@ -849,9 +850,7 @@ public fun <A> Iterable<A>.salign(
   ReplaceWith("unzip()", "kotlin.collections.unzip")
 )
 public fun <A, B> Iterable<Pair<A, B>>.unzip(): Pair<List<A>, List<B>> =
-  fold(emptyList<A>() to emptyList()) { (l, r), x ->
-    l + x.first to r + x.second
-  }
+   stdlibUnzip()
 
 /**
  * after applying the given function unzip the resulting structure into its elements.
@@ -876,7 +875,7 @@ public fun <A, B> Iterable<Pair<A, B>>.unzip(): Pair<List<A>, List<B>> =
   ReplaceWith("map(fc).unzip()", "kotlin.collections.unzip")
 )
 public inline fun <A, B, C> Iterable<C>.unzip(fc: (C) -> Pair<A, B>): Pair<List<A>, List<B>> =
-  map(fc).unzip()
+  map(fc).stdlibUnzip()
 
 /**
  * splits a union into its component parts.

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -844,6 +844,10 @@ public fun <A> Iterable<A>.salign(
  * <!--- KNIT example-iterable-11.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
+@Deprecated(
+  "Unzip is being deprecated in favor of the standard library version.\n$NicheAPI",
+  ReplaceWith("unzip()", "kotlin.collections.unzip")
+)
 public fun <A, B> Iterable<Pair<A, B>>.unzip(): Pair<List<A>, List<B>> =
   fold(emptyList<A>() to emptyList()) { (l, r), x ->
     l + x.first to r + x.second
@@ -867,6 +871,10 @@ public fun <A, B> Iterable<Pair<A, B>>.unzip(): Pair<List<A>, List<B>> =
  * <!--- KNIT example-iterable-12.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
+@Deprecated(
+  "Unzip is being deprecated in favor of the standard library version.\n$NicheAPI",
+  ReplaceWith("map(fc).unzip()", "kotlin.collections.unzip")
+)
 public inline fun <A, B, C> Iterable<C>.unzip(fc: (C) -> Pair<A, B>): Pair<List<A>, List<B>> =
   map(fc).unzip()
 

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -10,6 +10,7 @@ import arrow.typeclasses.SemigroupDeprecation
 import arrow.typeclasses.combine
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmStatic
+import kotlin.collections.unzip as stdlibUnzip
 
 public typealias Nel<A> = NonEmptyList<A>
 
@@ -424,11 +425,8 @@ public fun <A, B> NonEmptyList<Pair<A, B>>.unzip(): Pair<NonEmptyList<A>, NonEmp
   this.unzip(::identity)
 
 public fun <A, B, C> NonEmptyList<C>.unzip(f: (C) -> Pair<A, B>): Pair<NonEmptyList<A>, NonEmptyList<B>> =
-  this.map(f).let { nel ->
-    nel.tail.unzip().let {
-      NonEmptyList(nel.head.first, it.first) to
-        NonEmptyList(nel.head.second, it.second)
-    }
+  map(f).stdlibUnzip().let { (l1, l2) ->
+    l1.toNonEmptyListOrNull()!! to l2.toNonEmptyListOrNull()!!
   }
 
 @Deprecated(


### PR DESCRIPTION
From what I can tell the other unzip methods have no equivalent in the stdlib.

NonEmptyList is of course covered by the Iterable#unzip, but still has a use-case because of returning a pair of NonEmptyLists rather than a pair of regular Lists.

This is Iterable#unzip in kotlin 1.9.22:
```kt
public fun <T, R> Iterable<Pair<T, R>>.unzip(): Pair<List<T>, List<R>> {
    val expectedSize = collectionSizeOrDefault(10)
    val listT = ArrayList<T>(expectedSize)
    val listR = ArrayList<R>(expectedSize)
    for (pair in this) {
        listT.add(pair.first)
        listR.add(pair.second)
    }
    return listT to listR
}
```
