### PR TITLE
Optimize the happy path in `parXOrAccumulate`

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -152,13 +152,9 @@ public final class arrow/fx/coroutines/ExitCase$Failure : arrow/fx/coroutines/Ex
 }
 
 public final class arrow/fx/coroutines/FailureValue {
-	public static final field Companion Larrow/fx/coroutines/FailureValue$Companion;
-	public fun <init> (Ljava/lang/Object;)V
-	public final fun getError ()Ljava/lang/Object;
-}
-
-public final class arrow/fx/coroutines/FailureValue$Companion {
+	public static final field INSTANCE Larrow/fx/coroutines/FailureValue;
 	public final fun bindNel (Larrow/core/raise/RaiseAccumulate;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun failureValue (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun mightFail (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -151,6 +151,17 @@ public final class arrow/fx/coroutines/ExitCase$Failure : arrow/fx/coroutines/Ex
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class arrow/fx/coroutines/FailureValue {
+	public static final field Companion Larrow/fx/coroutines/FailureValue$Companion;
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getError ()Ljava/lang/Object;
+}
+
+public final class arrow/fx/coroutines/FailureValue$Companion {
+	public final fun bindNel (Larrow/core/raise/RaiseAccumulate;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun mightFail (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public final class arrow/fx/coroutines/FlowExtensions {
 	public static final fun fixedRate (JZLkotlin/jvm/functions/Function0;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun fixedRate$default (JZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParMap.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParMap.kt
@@ -5,8 +5,8 @@ import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.mapOrAccumulate
 import arrow.core.raise.Raise
-import arrow.fx.coroutines.FailureValue.Companion.bindNel
-import arrow.fx.coroutines.FailureValue.Companion.mightFail
+import arrow.fx.coroutines.FailureValue.bindNel
+import arrow.fx.coroutines.FailureValue.mightFail
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParZipOrAccumulate.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/ParZipOrAccumulate.kt
@@ -3,8 +3,8 @@ package arrow.fx.coroutines
 import arrow.core.NonEmptyList
 import arrow.core.raise.Raise
 import arrow.core.raise.zipOrAccumulate
-import arrow.fx.coroutines.FailureValue.Companion.bindNel
-import arrow.fx.coroutines.FailureValue.Companion.mightFail
+import arrow.fx.coroutines.FailureValue.bindNel
+import arrow.fx.coroutines.FailureValue.mightFail
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/predef.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/predef.kt
@@ -1,5 +1,13 @@
 package arrow.fx.coroutines
 
+import arrow.core.NonEmptyList
+import arrow.core.raise.Raise
+import arrow.core.raise.RaiseAccumulate
+import arrow.core.raise.recover
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 /**
  * Gets current system time in milliseconds since certain moment in the past,
  * only delta between two subsequent calls makes sense.
@@ -9,3 +17,22 @@ package arrow.fx.coroutines
  * For Javascript it relies on `new Date().getTime()`
  */
 public expect fun timeInMillis(): Long
+
+@PublishedApi
+internal class FailureValue(val error: Any?) {
+  @OptIn(ExperimentalContracts::class)
+  companion object {
+    @Suppress("UNCHECKED_CAST")
+    fun <E, T> RaiseAccumulate<E>.bindNel(value: Any?): T =
+      withNel {
+        if (value is FailureValue) raise(value.error as NonEmptyList<E>) else value as T
+      }
+
+    inline fun <E, T> mightFail(block: Raise<E>.() -> T): Any? {
+      contract {
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+      }
+      return recover(block, ::FailureValue)
+    }
+  }
+}


### PR DESCRIPTION
This is done by wrapping raised values in a `FailureValue`, and values of that class are never leaked outside, hence it always denotes that a value was raised.