### PR TITLE
added retryRaise and retryEither functions

### DIFF
--- a/arrow-libs/resilience/arrow-resilience/api/arrow-resilience.api
+++ b/arrow-libs/resilience/arrow-resilience/api/arrow-resilience.api
@@ -252,8 +252,11 @@ public final class arrow/resilience/Schedule$Decision$Done : arrow/resilience/Sc
 
 public final class arrow/resilience/ScheduleKt {
 	public static final fun retry-4AuOtiA (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun retry-YL6hcnA (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun retryEither-4AuOtiA (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retryOrElse-aZo8_V4 (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retryOrElseEither-aZo8_V4 (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun retryRaise-4AuOtiA (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/resilience/common/Platform : java/lang/Enum {

--- a/arrow-libs/resilience/arrow-resilience/src/commonTest/kotlin/arrow/resilience/ScheduleTest.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonTest/kotlin/arrow/resilience/ScheduleTest.kt
@@ -3,9 +3,10 @@ package arrow.resilience
 import arrow.atomic.AtomicLong
 import arrow.atomic.updateAndGet
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import arrow.resilience.Schedule.Decision.Continue
 import arrow.resilience.Schedule.Decision.Done
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -27,7 +28,6 @@ internal data class SideEffect(var counter: Int = 0) {
   }
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @ExperimentalTime
 @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
 class ScheduleTest {
@@ -280,6 +280,56 @@ class ScheduleTest {
 
     result.fold({ assertEquals(ex, it) }, { fail("The impossible happened") })
   }
+
+  @Test
+  fun retryRaiseIsStackSafe(): TestResult = runTest {
+    val count = AtomicLong(0)
+    val iterations = stackSafeIteration().toLong()
+
+    suspend fun increment() {
+      count.incrementAndGet()
+    }
+
+    val result = Schedule.recurs<CustomError>(iterations).retryRaise {
+      increment()
+      raise(CustomError)
+    }
+
+    assertTrue { result is Either.Left }
+    assertEquals(iterations + 1, count.get())
+  }
+
+  @Test
+  fun retryRaiseSucceedsIfErrorIsNotRaised(): TestResult = runTest {
+    val result = Schedule.recurs<CustomError>(0).retryRaise { 1 }
+
+    assertTrue { result is Either.Right && result.value == 1 }
+  }
+
+  @Test
+  fun retryEitherIsStackSafe(): TestResult = runTest {
+    val count = AtomicLong(0)
+    val iterations = stackSafeIteration().toLong()
+
+    suspend fun increment() {
+      count.incrementAndGet()
+    }
+
+    val result = Schedule.recurs<CustomError>(iterations).retryEither {
+      increment()
+      CustomError.left()
+    }
+
+    assertTrue { result is Either.Left }
+    assertEquals(iterations + 1, count.get())
+  }
+
+  @Test
+  fun retryEitherSucceedsIfErrorIsNotRaised(): TestResult = runTest {
+    val result = Schedule.recurs<CustomError>(0).retryEither { 1.right() }
+
+    assertTrue { result is Either.Right && result.value == 1 }
+  }
 }
 
 fun <A, B> Schedule.Decision<A, B>.delay(): Duration? = when (this) {
@@ -355,3 +405,5 @@ private suspend fun <B> checkRepeat(schedule: Schedule<Long, List<B>>, expected:
 
   assertContentEquals(expected, result)
 }
+
+private object CustomError


### PR DESCRIPTION
Hey, with the latest API, it is easy to write Either version of the retry function. I think it could be quite useful. 
I based the implementation on 
`public suspend fun <A> Schedule<Throwable, *>.retry(action: suspend () -> A): A`