### PR TITLE
Use macOS 14 runner

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,7 +42,7 @@ jobs:
           path: '**/build/reports/**'
 
   ios_watchos:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 60
 
     steps:
@@ -130,7 +130,7 @@ jobs:
           file_pattern: arrow-libs/**/*.kt
 
   macos_tvos:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
According to [this blog post](https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/) this can have a huge impact in our build times