### PR TITLE
Ignore properties in sealed hierarchies where the type changes across children

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/info.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/info.kt
@@ -23,3 +23,9 @@ val String.sealedLensConstructorOverridesOnly
       |                                       ^
       |To generate Lens for a sealed class make sure all children override target properties in constructors.
     """.trimMargin()
+
+val String.sealedLensChangedProperties
+  get() =
+    """
+      |Ignoring $this when generating lenses; the type is not uniform across all children.
+    """.trimMargin()

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/processor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/processor.kt
@@ -8,6 +8,7 @@ import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSTypeParameter
@@ -119,7 +120,13 @@ internal fun evalAnnotatedClass(
         return null
       }
 
-      val propertyNames = properties
+      val (goodProperties, badProperties) = properties.partition { it.sameInChildren(subclasses) }
+
+      badProperties.forEach {
+        logger.info(it.qualifiedNameOrSimpleName.sealedLensChangedProperties, element)
+      }
+
+      val propertyNames = goodProperties
         .map { it.simpleName.asString() }
 
       val nonConstructorOverrides = subclasses
@@ -133,7 +140,7 @@ internal fun evalAnnotatedClass(
         return null
       }
 
-      properties
+      goodProperties
         .map { it.type.resolve().qualifiedString() }
         .zip(propertyNames) { type, name ->
           Focus(
@@ -150,6 +157,15 @@ internal fun evalAnnotatedClass(
     }
   }
 }
+
+fun KSPropertyDeclaration.sameInChildren(subclasses: Sequence<KSClassDeclaration>): Boolean =
+  subclasses.all { subclass ->
+    val property = subclass.getAllProperties().singleOrNull { it.simpleName == this.simpleName }
+    when (property) {
+      null -> false
+      else -> property.type.resolve() == this.type.resolve()
+    }
+  }
 
 internal fun evalAnnotatedDslElement(element: KSClassDeclaration, logger: KSPLogger): Target =
   when {

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
@@ -229,4 +229,31 @@ class LensTests {
       |val r = l != null
       """.compilationFails()
   }
+
+  @Test
+  fun `Lens for sealed class property, ignoring changed types`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |sealed interface Base<out T> {
+      |    val prop: T
+      |
+      |    companion object
+      |}
+      |
+      |@optics
+      |data class Child1(override val prop: String) : Base<String> {
+      |    companion object
+      |}
+      |
+      |@optics
+      |data class Child2(override val prop: Int) : Base<Int> {
+      |    companion object
+      |}
+      |
+      |val l: Lens<Base<String>, String> = Base.prop()
+      |val r = l != null
+      """.compilationFails()
+  }
 }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
@@ -208,4 +208,25 @@ class LensTests {
       |val r = l != null
       """.compilationFails()
   }
+
+  @Test
+  fun `Lens for sealed class property, ignoring changed nullability`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |sealed class LensSealed {
+      |  abstract val property1: String?
+      |  
+      |  data class dataChild1(override val property1: String?) : LensSealed()
+      |  data class dataChild2(override val property1: String?, val number: Int) : LensSealed()
+      |  data class dataChild3(override val property1: String, val enabled: Boolean) : LensSealed()
+      |   
+      |  companion object 
+      |}
+      |
+      |val l: Lens<LensSealed, String>? = LensSealed.property1
+      |val r = l != null
+      """.compilationFails()
+  }
 }


### PR DESCRIPTION
Fixes #3380
Fixes #3381 