### PR TITLE
fix(autoclose): close `Closeable`s in reversed order

### DIFF
--- a/arrow-libs/core/arrow-autoclose/src/commonMain/kotlin/arrow/AutoCloseScope.kt
+++ b/arrow-libs/core/arrow-autoclose/src/commonMain/kotlin/arrow/AutoCloseScope.kt
@@ -98,7 +98,7 @@ internal class DefaultAutoCloseScope : AutoCloseScope {
     }
 
   fun close(error: Throwable?): Nothing? {
-    return finalizers.get().fold(error) { acc, function ->
+    return finalizers.get().asReversed().fold(error) { acc, function ->
       acc.add(runCatching { function.invoke(error) }.exceptionOrNull())
     }?.let { throw it }
   }

--- a/arrow-libs/core/arrow-autoclose/src/commonTest/kotlin/arrow/AutoCloseTest.kt
+++ b/arrow-libs/core/arrow-autoclose/src/commonTest/kotlin/arrow/AutoCloseTest.kt
@@ -169,6 +169,7 @@ class AutoCloseTest {
     closed.receive() shouldBe res3
     closed.receive() shouldBe res2
     closed.receive() shouldBe res1
+    closed.cancel()
   }
 
   @OptIn(ExperimentalStdlibApi::class)

--- a/arrow-libs/core/arrow-autoclose/src/commonTest/kotlin/arrow/AutoCloseTest.kt
+++ b/arrow-libs/core/arrow-autoclose/src/commonTest/kotlin/arrow/AutoCloseTest.kt
@@ -78,7 +78,7 @@ class AutoCloseTest {
     }
 
     e shouldBe error
-    e.suppressedExceptions shouldBe listOf(error2, error3)
+    e.suppressedExceptions shouldBe listOf(error3, error2)
     promise.await() shouldBe error
     wasActive.await() shouldBe true
     res.isActive() shouldBe false


### PR DESCRIPTION
Fix #3386