### PR TITLE
optimize NonEmptyList

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -857,7 +857,7 @@ public final class arrow/core/NonEmptyCollection$DefaultImpls {
 
 public final class arrow/core/NonEmptyList : kotlin/collections/AbstractList, arrow/core/NonEmptyCollection {
 	public static final field Companion Larrow/core/NonEmptyList$Companion;
-	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Iterable;)V
 	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun align (Larrow/core/NonEmptyList;)Larrow/core/NonEmptyList;
 	public final fun coflatMap (Lkotlin/jvm/functions/Function1;)Larrow/core/NonEmptyList;
@@ -909,6 +909,7 @@ public final class arrow/core/NonEmptyList$Companion {
 	public final fun fromList (Ljava/util/List;)Larrow/core/Option;
 	public final fun fromListUnsafe (Ljava/util/List;)Larrow/core/NonEmptyList;
 	public final fun getUnit ()Larrow/core/NonEmptyList;
+	public final synthetic fun unsafeOf (Ljava/util/List;)Larrow/core/NonEmptyList;
 }
 
 public final class arrow/core/NonEmptyListKt {


### PR DESCRIPTION
- update the constructor:
  - store `all` instead of `head` + `tail` -> `head` and `tail` are simply derivatives of `all`
  - change the second param of ctor to `Iterable`
- replace `tail` with `all` to simplify the implementation of some functions, and also improve the perf (avoid unnecessary collection copying)