### PR TITLE
Detect Raise leaks at compile-time

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3591,6 +3591,7 @@ public abstract interface annotation class arrow/core/raise/RaiseDSL : java/lang
 }
 
 public final class arrow/core/raise/RaiseKt {
+	public static final field PotentialRaiseLeak Ljava/lang/String;
 	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _foldUnsafe (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -3638,7 +3639,15 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun merge (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun nullable (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun nullableFunction (Lkotlin/jvm/functions/Function1;)Lkotlin/Function;
+	public static final fun nullableLazy (Lkotlin/jvm/functions/Function1;)Lkotlin/Lazy;
+	public static final fun nullableSequence (Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
+	public static final fun nullableUnsafe (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun option (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun optionFunction (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun optionLazy (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun optionSequence (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public static final fun optionUnsafe (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
 	public static final fun orNull (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun orNull (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun raisedOrRethrow (Ljava/util/concurrent/CancellationException;Larrow/core/raise/DefaultRaise;)Ljava/lang/Object;
@@ -3647,6 +3656,10 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
 	public static final fun recover (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
 	public static final fun result (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun resultFunction (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun resultLazy (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun resultSequence (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun resultUnsafe (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun toEither (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public static final fun toEither (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toIor (Lkotlin/jvm/functions/Function1;)Larrow/core/Ior;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -23,6 +23,11 @@ import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
+public const val PotentialRaiseLeak: String = """Returning a lazy computation or closure from 'fold' breaks the context scope, and may lead to leaked exceptions on later execution.
+  Make sure all calls to 'raise' and 'bind' occur within the lifecycle of nullable { }, either { } or similar builders.
+   
+  See Arrow documentation on 'Typed errors' for further information."""
+
 /**
  * Runs a computation [block] using [Raise], and return its outcome as [Either].
  * - [Either.Right] represents success,
@@ -36,6 +41,9 @@ import kotlin.jvm.JvmName
 public inline fun <Error, A> either(@BuilderInference block: Raise<Error>.() -> A): Either<Error, A> =
   fold({ block.invoke(this) }, { Either.Left(it) }, { Either.Right(it) })
 
+public inline fun <A> nullableUnsafe(block: NullableRaise.() -> A): A? =
+  merge { block(NullableRaise(this)) }
+
 /**
  * Runs a computation [block] using [Raise], and return its outcome as nullable type,
  * where `null` represents logical failure.
@@ -48,8 +56,39 @@ public inline fun <Error, A> either(@BuilderInference block: Raise<Error>.() -> 
  * @see NullableRaise.ignoreErrors By default, `nullable` only allows raising `null`.
  * Calling [ignoreErrors][NullableRaise.ignoreErrors] inside `nullable` allows to raise any error, which will be returned to the caller as if `null` was raised.
  */
+@OverloadResolutionByLambdaReturnType
 public inline fun <A> nullable(block: NullableRaise.() -> A): A? =
-  merge { block(NullableRaise(this)) }
+  nullableUnsafe(block)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("nullableUnsafe(block)"),
+)
+@JvmName("nullableFunction")
+public inline fun nullable(block: NullableRaise.() -> Function<*>): Function<*>? =
+  error(PotentialRaiseLeak)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("nullableUnsafe(block)"),
+)
+@JvmName("nullableLazy")
+public inline fun nullable(block: NullableRaise.() -> Lazy<*>): Lazy<*>? =
+  error(PotentialRaiseLeak)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("nullableUnsafe(block)"),
+)
+@JvmName("nullableSequence")
+public inline fun nullable(block: NullableRaise.() -> Sequence<*>): Sequence<*>? =
+  error(PotentialRaiseLeak)
+
+public inline fun <A> resultUnsafe(block: ResultRaise.() -> A): Result<A> =
+  fold({ block(ResultRaise(this)) }, Result.Companion::failure, Result.Companion::failure, Result.Companion::success)
 
 /**
  * Runs a computation [block] using [Raise], and return its outcome as [Result].
@@ -58,8 +97,39 @@ public inline fun <A> nullable(block: NullableRaise.() -> A): A? =
  * Read more about running a [Raise] computation in the
  * [Arrow docs](https://arrow-kt.io/learn/typed-errors/working-with-typed-errors/#running-and-inspecting-results).
  */
+@OverloadResolutionByLambdaReturnType
 public inline fun <A> result(block: ResultRaise.() -> A): Result<A> =
-  fold({ block(ResultRaise(this)) }, Result.Companion::failure, Result.Companion::failure, Result.Companion::success)
+  resultUnsafe(block)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("resultUnsafe(block)"),
+)
+@JvmName("resultFunction")
+public inline fun result(block: ResultRaise.() -> Function<*>): Result<Function<*>> =
+  error(PotentialRaiseLeak)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("resultUnsafe(block)"),
+)
+@JvmName("resultLazy")
+public inline fun result(block: ResultRaise.() -> Lazy<*>): Result<Lazy<*>> =
+  error(PotentialRaiseLeak)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("resultUnsafe(block)"),
+)
+@JvmName("resultSequence")
+public inline fun result(block: ResultRaise.() -> Sequence<*>): Result<Sequence<*>> =
+  error(PotentialRaiseLeak)
+
+public inline fun <A> optionUnsafe(block: OptionRaise.() -> A): Option<A> =
+  fold({ block(OptionRaise(this)) }, ::identity, ::Some)
 
 /**
  * Runs a computation [block] using [Raise], and return its outcome as [Option].
@@ -71,8 +141,36 @@ public inline fun <A> result(block: ResultRaise.() -> A): Result<A> =
  * Read more about running a [Raise] computation in the
  * [Arrow docs](https://arrow-kt.io/learn/typed-errors/working-with-typed-errors/#running-and-inspecting-results).
  */
+@OverloadResolutionByLambdaReturnType
 public inline fun <A> option(block: OptionRaise.() -> A): Option<A> =
-  fold({ block(OptionRaise(this)) }, ::identity, ::Some)
+  optionUnsafe(block)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("optionUnsafe(block)"),
+)
+@JvmName("optionFunction")
+public inline fun option(block: OptionRaise.() -> Function<*>): Option<Function<*>> =
+  error(PotentialRaiseLeak)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("optionUnsafe(block)"),
+)
+@JvmName("optionLazy")
+public inline fun option(block: OptionRaise.() -> Lazy<*>): Option<Lazy<*>> =
+  error(PotentialRaiseLeak)
+
+@Deprecated(
+  PotentialRaiseLeak,
+  level = DeprecationLevel.ERROR,
+  replaceWith = ReplaceWith("optionUnsafe(block)"),
+)
+@JvmName("optionSequence")
+public inline fun option(block: OptionRaise.() -> Sequence<*>): Option<Sequence<*>> =
+  error(PotentialRaiseLeak)
 
 /**
  * Runs a computation [block] using [Raise], and return its outcome as [Ior].

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Fold.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Fold.kt
@@ -135,18 +135,7 @@ public inline fun <Error, A, B> fold(
     callsInPlace(recover, AT_MOST_ONCE)
     callsInPlace(transform, AT_MOST_ONCE)
   }
-  return foldUnsafe(block, catch, recover) {
-    if (it is Function<*> || it is Lazy<*> || it is Sequence<*>)
-      throw IllegalStateException(
-        """
-  Returning a lazy computation or closure from 'fold' breaks the context scope, and may lead to leaked exceptions on later execution.
-  Make sure all calls to 'raise' and 'bind' occur within the lifecycle of nullable { }, either { } or similar builders.
- 
-  See Arrow documentation on 'Typed errors' for further information.
-  """.trimIndent()
-      )
-    transform(it)
-  }
+  return foldUnsafe(block, catch, recover, transform)
 }
 
 /**

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/NullableSpec.kt
@@ -146,15 +146,14 @@ class NullableSpec : StringSpec({
   }
 
   "Detects potential leaked exceptions" {
+    @Suppress("DEPRECATION_ERROR")
     shouldThrow<IllegalStateException> {
       nullable { lazy { raise(null) } }
     }
   }
 
   "Unsafe leakage of exceptions" {
-    val l: Lazy<Int> = foldUnsafe<String, Lazy<Int>, Lazy<Int>?>(
-      { lazy { raise("problem") } }, { throw it }, { null }, { it }
-    ).shouldNotBeNull()
+    val l: Lazy<Int> = nullableUnsafe { lazy { raise(null) } }.shouldNotBeNull()
     shouldThrow<IllegalStateException> {
       l.value
     }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/OptionSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/OptionSpec.kt
@@ -4,8 +4,10 @@ import arrow.core.None
 import arrow.core.Some
 import arrow.core.some
 import arrow.core.toOption
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.int
@@ -35,7 +37,7 @@ class OptionSpec : StringSpec({
 
   "short circuit option" {
     @Suppress("UNREACHABLE_CODE")
-    option {
+    option<Nothing> {
       ensureNotNull<Int>(null)
       throw IllegalStateException("This should not be executed")
     } shouldBe None
@@ -47,5 +49,19 @@ class OptionSpec : StringSpec({
       val two = Some(2).bind()
       one + two
     } shouldBe Some(3)
+  }
+
+  "Detects potential leaked exceptions" {
+    @Suppress("DEPRECATION_ERROR")
+    shouldThrow<IllegalStateException> {
+      option { lazy { raise(None) } }
+    }
+  }
+
+  "Unsafe leakage of exceptions" {
+    val l: Lazy<Int> = optionUnsafe { lazy { raise(None) } }.shouldBeInstanceOf<Some<Lazy<Int>>>().value
+    shouldThrow<IllegalStateException> {
+      l.value
+    }
   }
 })


### PR DESCRIPTION
Fixes #3391

Note that `@OverloadResolutionByLambdaReturnType` is currently very limited. So limited, in fact, that it doesn't support calls with multiple lambdas, and it doesn't support calls where the lambdas have type parameter usages (other than the type parameter being the return type). Also, one has to explicitly provide a type argument of `Nothing` now when a lambda would return such, but I think that's such a niche use case that it won't show up anywhere other than our test code.
I had been pulling my hair out trying to get `@OverloadResolutionByLambdaReturnType` to work for this case, so fair warning for any of you that wish to explore this further. I think this change shouldn't break any code that previously worked (other than code of the form `nullable { throw Exception()`)