### PR TITLE
Improvements to STM + do not expose internal members

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -3593,7 +3593,6 @@ public abstract interface annotation class arrow/core/raise/RaiseDSL : java/lang
 public final class arrow/core/raise/RaiseKt {
 	public static final fun _fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _foldOrThrow (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun _foldUnsafe (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun _merge (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun catch (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;

--- a/arrow-libs/fx/arrow-fx-stm/api/arrow-fx-stm.api
+++ b/arrow-libs/fx/arrow-fx-stm/api/arrow-fx-stm.api
@@ -239,64 +239,6 @@ public final class arrow/fx/stm/internal/BlockedIndefinitely : java/lang/Throwab
 	public fun <init> ()V
 }
 
-public abstract class arrow/fx/stm/internal/Branch {
-}
-
-public final class arrow/fx/stm/internal/Branch$Branches : arrow/fx/stm/internal/Branch {
-	public fun <init> (Larrow/fx/stm/internal/Hamt;)V
-	public final fun component1 ()Larrow/fx/stm/internal/Hamt;
-	public final fun copy (Larrow/fx/stm/internal/Hamt;)Larrow/fx/stm/internal/Branch$Branches;
-	public static synthetic fun copy$default (Larrow/fx/stm/internal/Branch$Branches;Larrow/fx/stm/internal/Hamt;ILjava/lang/Object;)Larrow/fx/stm/internal/Branch$Branches;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getSub ()Larrow/fx/stm/internal/Hamt;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class arrow/fx/stm/internal/Branch$Leaf : arrow/fx/stm/internal/Branch {
-	public fun <init> (I[Ljava/lang/Object;)V
-	public final fun component1 ()I
-	public final fun component2 ()[Ljava/lang/Object;
-	public final fun copy (I[Ljava/lang/Object;)Larrow/fx/stm/internal/Branch$Leaf;
-	public static synthetic fun copy$default (Larrow/fx/stm/internal/Branch$Leaf;I[Ljava/lang/Object;ILjava/lang/Object;)Larrow/fx/stm/internal/Branch$Leaf;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHash ()I
-	public final fun getValue ()[Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class arrow/fx/stm/internal/Hamt {
-	public static final field Companion Larrow/fx/stm/internal/Hamt$Companion;
-	public fun <init> (Larrow/fx/stm/TVar;)V
-	public final fun component1 ()Larrow/fx/stm/TVar;
-	public final fun copy (Larrow/fx/stm/TVar;)Larrow/fx/stm/internal/Hamt;
-	public static synthetic fun copy$default (Larrow/fx/stm/internal/Hamt;Larrow/fx/stm/TVar;ILjava/lang/Object;)Larrow/fx/stm/internal/Hamt;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBranches ()Larrow/fx/stm/TVar;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class arrow/fx/stm/internal/Hamt$Companion {
-	public final fun new (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class arrow/fx/stm/internal/HamtKt {
-	public static final field ARR_SIZE I
-	public static final field DEPTH_STEP I
-	public static final field MASK I
-	public static final fun alterHamtWithHash (Larrow/fx/stm/STM;Larrow/fx/stm/internal/Hamt;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Z
-	public static final fun atDepth (II)I
-	public static final fun clearHamt (Larrow/fx/stm/STM;Larrow/fx/stm/internal/Hamt;)V
-	public static final fun index (I)I
-	public static final fun indexAtDepth (II)I
-	public static final fun lookupHamtWithHash (Larrow/fx/stm/STM;Larrow/fx/stm/internal/Hamt;ILkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun newHamt (Larrow/fx/stm/STM;)Larrow/fx/stm/internal/Hamt;
-	public static final fun nextDepth (I)I
-	public static final fun pair (Larrow/fx/stm/STM;IILarrow/fx/stm/internal/Branch;ILarrow/fx/stm/internal/Branch;)Larrow/fx/stm/internal/Hamt;
-}
-
 public final class arrow/fx/stm/internal/RetryException : java/lang/Throwable {
 	public static final field INSTANCE Larrow/fx/stm/internal/RetryException;
 	public fun fillInStackTrace ()Ljava/lang/Throwable;

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/STM.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/STM.kt
@@ -310,7 +310,7 @@ public interface STM {
    * - When committing the value inside the [TVar], at the time of calling [write], has to be the
    *   same as the current value otherwise the transaction will retry
    */
-  public fun <A> TVar<A>.write(a: A): Unit
+  public fun <A> TVar<A>.write(a: A)
 
   /**
    * Modify the value of a [TVar]
@@ -683,7 +683,7 @@ public interface STM {
    *
    * @see TSemaphore.tryAcquire for a version that does not retry.
    */
-  public fun TSemaphore.acquire(n: Int): Unit {
+  public fun TSemaphore.acquire(n: Int) {
     val curr = v.read()
     check(curr - n >= 0)
     v.write(curr - n)
@@ -1103,7 +1103,7 @@ public interface STM {
    *
    * > This function has to access both [TVar]'s and thus may lead to increased contention, use sparingly.
    */
-  public fun <A> TQueue<A>.removeAll(pred: (A) -> Boolean): Unit {
+  public fun <A> TQueue<A>.removeAll(pred: (A) -> Boolean) {
     reads.modify { it.filter(pred) }
     writes.modify { it.filter(pred) }
   }
@@ -1332,7 +1332,7 @@ public interface STM {
    * ```
  * <!--- KNIT example-stm-46.kt -->
    */
-  public fun <K, V> TMap<K, V>.insert(k: K, v: V): Unit {
+  public fun <K, V> TMap<K, V>.insert(k: K, v: V) {
     alterHamtWithHash(hamt, hashFn(k), { it.first == k }) { k to v }
   }
 
@@ -1397,8 +1397,8 @@ public interface STM {
    * ```
  * <!--- KNIT example-stm-49.kt -->
    */
-  public fun <K, V> TMap<K, V>.update(k: K, fn: (V) -> V): Unit {
-    alterHamtWithHash(hamt, hashFn(k), { it.first == k }) { it?.second?.let(fn)?.let { k to it } }
+  public fun <K, V> TMap<K, V>.update(k: K, fn: (V) -> V) {
+    alterHamtWithHash(hamt, hashFn(k), { it.first == k }) { it?.second?.let(fn)?.let { r -> k to r } }
   }
 
   /**
@@ -1420,7 +1420,7 @@ public interface STM {
    * ```
  * <!--- KNIT example-stm-50.kt -->
    */
-  public fun <K, V> TMap<K, V>.remove(k: K): Unit {
+  public fun <K, V> TMap<K, V>.remove(k: K) {
     alterHamtWithHash(hamt, hashFn(k), { it.first == k }) { null }
   }
 
@@ -1466,7 +1466,7 @@ public interface STM {
    * ```
  * <!--- KNIT example-stm-52.kt -->
    */
-  public fun <A> TSet<A>.insert(a: A): Unit {
+  public fun <A> TSet<A>.insert(a: A) {
     alterHamtWithHash(hamt, hashFn(a), { it == a }) { a }
   }
 
@@ -1509,7 +1509,7 @@ public interface STM {
    * ```
  * <!--- KNIT example-stm-54.kt -->
    */
-  public fun <A> TSet<A>.remove(a: A): Unit {
+  public fun <A> TSet<A>.remove(a: A) {
     alterHamtWithHash(hamt, hashFn(a), { it == a }) { null }
   }
 }

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/internal/Impl.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/internal/Impl.kt
@@ -87,8 +87,11 @@ internal class STMFrame(private val parent: STMFrame? = null) : STM {
    *
    * If we have not seen this variable before we add a read which stores it in the read set as well.
    */
-  override fun <A> TVar<A>.write(a: A): Unit =
-    accessMap[this as TVar<Any?>]?.update(a) ?: readI().let { accessMap[this] = Entry(it, a) }
+  @Suppress("UNCHECKED_CAST")
+  override fun <A> TVar<A>.write(a: A) {
+    this as TVar<Any?>
+    accessMap[this]?.update(a) ?: readI().let { accessMap[this] = Entry(it, a) }
+  }
 
   internal fun validate(): Boolean =
     accessMap.all { (tv, entry) -> tv.value === entry.initialVal }

--- a/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/internal/Impl.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/commonMain/kotlin/arrow/fx/stm/internal/Impl.kt
@@ -10,7 +10,7 @@ import kotlin.coroutines.Continuation
  * A STMFrame keeps the reads and writes performed by a transaction.
  * It may have a parent which is only used for read lookups.
  */
-internal class STMFrame(val parent: STMFrame? = null) : STM {
+internal class STMFrame(private val parent: STMFrame? = null) : STM {
 
   class Entry(var initialVal: Any?, var newVal: Any?) {
     object NO_CHANGE
@@ -19,7 +19,7 @@ internal class STMFrame(val parent: STMFrame? = null) : STM {
     fun isWrite(): Boolean =
       newVal !== NO_CHANGE
 
-    fun update(v: Any?): Unit {
+    fun update(v: Any?) {
       newVal = if (initialVal === v) NO_CHANGE else v
     }
 
@@ -31,7 +31,7 @@ internal class STMFrame(val parent: STMFrame? = null) : STM {
   /**
    * Helper to search the entire hierarchy for stored previous reads
    */
-  private fun readVar(v: TVar<Any?>): Any? =
+  private fun readVar(v: TVar<Any?>): Any =
     accessMap[v]?.getValue() ?: parent?.readVar(v) ?: Entry.NOT_PRESENT
 
   override fun retry(): Nothing = throw RetryException
@@ -56,18 +56,18 @@ internal class STMFrame(val parent: STMFrame? = null) : STM {
         //  If we are already invalid here there is no point in continuing.
         if (frame.validate()) {
           this@STMFrame.merge(frame)
-          return@runLocal res as A
+          return res
         }
       } catch (ignored: RetryException) {
         if (frame.validate()) {
           this@STMFrame.mergeReads(frame)
-          return@runLocal onRetry()
+          return onRetry()
         }
       } catch (e: Throwable) {
         // An invalid frame retries even if it throws, so our sub-frame also needs to handle this correctly
         if (frame.validate()) {
           this@STMFrame.mergeReads(frame)
-          return@runLocal onError(e)
+          return onError(e)
         }
       }
     }
@@ -139,11 +139,11 @@ internal class STMFrame(val parent: STMFrame? = null) : STM {
     return true
   }
 
-  private fun mergeReads(other: STMFrame): Unit {
+  private fun mergeReads(other: STMFrame) {
     accessMap.putAll(other.accessMap.filter { (_, e) -> e.isWrite().not() })
   }
 
-  private fun merge(other: STMFrame): Unit {
+  private fun merge(other: STMFrame) {
     accessMap.putAll(other.accessMap)
   }
 }
@@ -188,7 +188,7 @@ internal class STMTransaction<A>(val f: STM.() -> A) {
         if (frame.accessMap.isEmpty()) throw BlockedIndefinitely()
 
         val registered = mutableListOf<TVar<Any?>>()
-        suspendCancellableCoroutine<Unit> susp@{ k ->
+        suspendCancellableCoroutine susp@{ k ->
           cont.set(k)
 
           frame.accessMap

--- a/arrow-libs/fx/arrow-fx-stm/src/jvmMain/kotlin/arrow/fx/stm/internal/RetryException.kt
+++ b/arrow-libs/fx/arrow-fx-stm/src/jvmMain/kotlin/arrow/fx/stm/internal/RetryException.kt
@@ -1,5 +1,6 @@
 package arrow.fx.stm.internal
 
 public actual object RetryException : Throwable("Arrow STM Retry. This should always be caught by arrow internally. Please report this as a bug if that is not the case!") {
+  private fun readResolve(): Any = RetryException
   override fun fillInStackTrace(): Throwable { return this }
 }


### PR DESCRIPTION
I was doing a bit of ABI cleanup, and I figured out a way to remove some duplication in the STM code, and increase the type safety (we no longer hold `Array<Any?>` but `Array<A>` in the HAMT tree).