### PR TITLE
WIP: Reusable Raise

### DIFF
--- a/arrow-libs/core/arrow-core/src/jvmMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
+++ b/arrow-libs/core/arrow-core/src/jvmMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
@@ -10,7 +10,7 @@ import kotlin.coroutines.cancellation.CancellationException
   "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
   "SEALED_INHERITOR_IN_DIFFERENT_MODULE"
 )
-internal actual class NoTrace actual constructor(raised: Any?, raise: Raise<Any?>) : RaiseCancellationException(raised, raise) {
+internal actual class NoTrace actual constructor(raised: Any?, raise: Raise<*>) : RaiseCancellationException(raised, raise) {
   override fun fillInStackTrace(): Throwable {
     // Prevent Android <= 6.0 bug.
     stackTrace = emptyArray()

--- a/arrow-libs/core/arrow-core/src/nonJvmMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
+++ b/arrow-libs/core/arrow-core/src/nonJvmMain/kotlin/arrow/core/raise/CancellationExceptionNoTrace.kt
@@ -4,4 +4,4 @@ package arrow.core.raise
   "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
   "SEALED_INHERITOR_IN_DIFFERENT_MODULE"
 )
-internal actual class NoTrace actual constructor(raised: Any?, raise: Raise<Any?>) : RaiseCancellationException(raised, raise)
+internal actual class NoTrace actual constructor(raised: Any?, raise: Raise<*>) : RaiseCancellationException(raised, raise)


### PR DESCRIPTION
`reusableRaise` is intended as a scope where one can reuse the same Raise instance for multiple `recoverReused` calls, while also being able to use that raise instance in concurrent contexts such as `async` before `recoverReused` is used. The goal is to allow fewer allocations when using `async` and similar APIs that only throw when you `await` them. The alternative is to use `either` and call `bind` when unpacking is wanted.