### PR TITLE
Add accumulate function to IorRaise

### DIFF
--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -895,6 +895,7 @@ public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi
 
 public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public fun <init> (Lkotlin/jvm/functions/Function2;Ljava/util/concurrent/atomic/AtomicReference;Larrow/core/raise/Raise;)V
+	public final fun accumulate (Ljava/lang/Object;)V
 	public fun bind (Larrow/core/Either;)Ljava/lang/Object;
 	public final fun bind (Larrow/core/Ior;)Ljava/lang/Object;
 	public fun bind (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -909,6 +910,7 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public final fun bindAllIor (Ljava/util/Set;)Ljava/util/Set;
 	public final fun combine (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getCombineError ()Lkotlin/jvm/functions/Function2;
+	public final fun getOrAccumulate (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -287,7 +287,7 @@ public class ResultRaise(private val raise: Raise<Throwable>) : Raise<Throwable>
     recover: (Throwable) -> A,
   ): A = result(block).fold(
     onSuccess = { it },
-    onFailure =  { recover(it) }
+    onFailure = { recover(it) }
   )
 }
 
@@ -303,6 +303,13 @@ public class IorRaise<Error> @PublishedApi internal constructor(
   @Suppress("UNCHECKED_CAST")
   @PublishedApi
   internal fun combine(e: Error): Error = state.updateAndGet { EmptyValue.combine(it, e, combineError) } as Error
+
+  @RaiseDSL
+  public fun accumulate(value: Error): Unit = Ior.Both(value, Unit).bind()
+
+  @RaiseDSL
+  public fun <A> Either<Error, A>.getOrAccumulate(recover: (Error) -> A): A =
+    fold(ifLeft = { Ior.Both(it, recover(it)) }, ifRight = { Ior.Right(it) }).bind()
 
   @RaiseDSL
   @JvmName("bindAllIor")

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/IorSpec.kt
@@ -2,6 +2,8 @@ package arrow.core.raise
 
 import arrow.core.Either
 import arrow.core.Ior
+import arrow.core.left
+import arrow.core.right
 import arrow.core.test.nonEmptyList
 import arrow.core.toIorNel
 import io.kotest.assertions.throwables.shouldThrow
@@ -153,5 +155,26 @@ class IorSpec {
       val two = Ior.Both("ErrorTwo", 2).toIorNel().bind()
       one + two
     } shouldBe Ior.Both(listOf("ErrorOne", "ErrorTwo"), 3)
+  }
+
+  @Test fun accumulateErrorManually() {
+    ior(String::plus) {
+      accumulate("nonfatal")
+      "output"
+    } shouldBe Ior.Both("nonfatal", "output")
+  }
+
+  @Test fun getOrAccumulateRightEither() {
+    ior(String::plus) {
+      val result = "success".right().getOrAccumulate { "failed" }
+      "output: $result"
+    } shouldBe Ior.Right("output: success")
+  }
+
+  @Test fun getOrAccumulateLeftEither() {
+    ior(String::plus) {
+      val result = "nonfatal".left().getOrAccumulate { "failed" }
+      "output: $result"
+    } shouldBe Ior.Both("nonfatal", "output: failed")
   }
 }


### PR DESCRIPTION
Used to combine errors into the IorRaise state and trigger a Both output in a more convenient way. Previously the only mechanism to do this was to call `bind()` on an `Ior.Both`.