### PR TITLE
add arrow-core-serialization SerializersModule

### DIFF
--- a/arrow-libs/core/arrow-core-serialization/api/arrow-core-serialization.api
+++ b/arrow-libs/core/arrow-core-serialization/api/arrow-core-serialization.api
@@ -43,3 +43,7 @@ public final class arrow/core/serialization/OptionSerializer : kotlinx/serializa
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
+public final class arrow/core/serialization/SerializersModuleKt {
+	public static final fun getArrowModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/OptionSerializer.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/OptionSerializer.kt
@@ -2,13 +2,14 @@ package arrow.core.serialization
 
 import arrow.core.Option
 import arrow.core.toOption
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-public class OptionSerializer<T : Any>(
+public class OptionSerializer<T>(
   elementSerializer: KSerializer<T>
 ) : KSerializer<Option<T>> {
   private val nullableSerializer: KSerializer<T?> = elementSerializer.nullable
@@ -20,3 +21,9 @@ public class OptionSerializer<T : Any>(
   override fun deserialize(decoder: Decoder): Option<T> =
     nullableSerializer.deserialize(decoder).toOption()
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+private val <T> KSerializer<T>.nullable get() =
+  @Suppress("UNCHECKED_CAST")
+  if (descriptor.isNullable) (this as KSerializer<T?>)
+  else (this as KSerializer<T & Any>).nullable

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/SerializersModule.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/SerializersModule.kt
@@ -8,5 +8,6 @@ public val ArrowModule: SerializersModule = SerializersModule {
   contextual(Ior::class) { (a, b) -> IorSerializer(a, b) }
   contextual(NonEmptyList::class) { (t) -> NonEmptyListSerializer(t) }
   contextual(NonEmptySet::class) { (t) -> NonEmptySetSerializer(t) }
+  contextual(Option::class) { (t) -> OptionSerializer(t) }
 }
 

--- a/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/SerializersModule.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonMain/kotlin/arrow/core/serialization/SerializersModule.kt
@@ -1,0 +1,12 @@
+package arrow.core.serialization
+
+import arrow.core.*
+import kotlinx.serialization.modules.SerializersModule
+
+public val ArrowModule: SerializersModule = SerializersModule {
+  contextual(Either::class) { (a, b) -> EitherSerializer(a, b) }
+  contextual(Ior::class) { (a, b) -> IorSerializer(a, b) }
+  contextual(NonEmptyList::class) { (t) -> NonEmptyListSerializer(t) }
+  contextual(NonEmptySet::class) { (t) -> NonEmptySetSerializer(t) }
+}
+

--- a/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/BackAgainTest.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/BackAgainTest.kt
@@ -47,11 +47,11 @@ data class NonEmptyListInside<A>(val thing: NonEmptyList<A>)
 @Serializable
 data class NonEmptySetInside<A>(val thing: NonEmptySet<A>)
 
-inline fun <reified T> backAgain(generator: Arb<T>) =
+inline fun <reified T> backAgain(generator: Arb<T>, json: Json = Json) =
   runTest {
     checkAll(generator) { e ->
-      val result = Json.encodeToJsonElement<T>(e)
-      val back = Json.decodeFromJsonElement<T>(result)
+      val result = json.encodeToJsonElement<T>(e)
+      val back = json.decodeFromJsonElement<T>(result)
       back shouldBe e
     }
   }

--- a/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/BackAgainTest.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/BackAgainTest.kt
@@ -12,7 +12,9 @@ import arrow.core.Either
 import arrow.core.Ior
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptySet
+import arrow.core.None
 import arrow.core.Option
+import arrow.core.Some
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
@@ -71,4 +73,12 @@ class BackAgainTest {
     backAgain(Arb.nonEmptyList(Arb.int()).map(::NonEmptyListInside))
   @Test fun backAgainNonEmptySet() =
     backAgain(Arb.nonEmptySet(Arb.int()).map(::NonEmptySetInside))
+
+  // capturing the current functionality of the OptionSerializer
+  @Test fun backAgainFlattensSomeNullToNone() {
+    val container: OptionInside<String?> = OptionInside(Some(null))
+    val result = Json.encodeToJsonElement<OptionInside<String?>>(container)
+    val back = Json.decodeFromJsonElement<OptionInside<String?>>(result)
+    back shouldBe OptionInside(None) // not `container`
+  }
 }

--- a/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/ModuleTest.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/ModuleTest.kt
@@ -1,0 +1,70 @@
+package arrow.core.serialization
+
+import arrow.core.*
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.modules.SerializersModule
+import kotlin.test.Test
+
+
+@Serializable
+data class ContextualEitherInside<A, B>(@Contextual val thing: Either<A, B>)
+
+@Serializable
+data class ContextualIorInside<A, B>(@Contextual val thing: Ior<A, B>)
+
+@Serializable
+data class ContextualNonEmptyListInside<A>(@Contextual val thing: NonEmptyList<A>)
+
+@Serializable
+data class ContextualNonEmptySetInside<A>(@Contextual val thing: NonEmptySet<A>)
+
+class ModuleTest {
+  private val jsonWithModule = Json {
+    serializersModule = SerializersModule {
+      include(ArrowModule)
+    }
+  }
+
+  @Test
+  fun backAgainEither() =
+    backAgain(Arb.either(Arb.string(), Arb.int()), jsonWithModule)
+
+  @Test
+  fun backAgainIor() =
+    backAgain(Arb.ior(Arb.string(), Arb.int()), jsonWithModule)
+
+  @Test
+  fun backAgainNonEmptyList() =
+    backAgain(Arb.nonEmptyList(Arb.int()), jsonWithModule)
+
+  @Test
+  fun backAgainNonEmptySet() =
+    backAgain(Arb.nonEmptySet(Arb.int()), jsonWithModule)
+
+  @Test
+  fun backAgainContextualEither() =
+    backAgain(Arb.either(Arb.string(), Arb.int()).map(::ContextualEitherInside), jsonWithModule)
+
+  @Test
+  fun backAgainContextualIor() =
+    backAgain(Arb.ior(Arb.string(), Arb.int()).map(::ContextualIorInside), jsonWithModule)
+
+  @Test
+  fun backAgainContextualNonEmptyList() =
+    backAgain(Arb.nonEmptyList(Arb.int()).map(::ContextualNonEmptyListInside), jsonWithModule)
+
+  @Test
+  fun backAgainContextualNonEmptySet() =
+    backAgain(Arb.nonEmptySet(Arb.int()).map(::ContextualNonEmptySetInside), jsonWithModule)
+}

--- a/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/ModuleTest.kt
+++ b/arrow-libs/core/arrow-core-serialization/src/commonTest/kotlin/arrow/core/serialization/ModuleTest.kt
@@ -24,6 +24,9 @@ data class ContextualEitherInside<A, B>(@Contextual val thing: Either<A, B>)
 data class ContextualIorInside<A, B>(@Contextual val thing: Ior<A, B>)
 
 @Serializable
+data class ContextualOptionInside<A>(@Contextual val thing: Option<A>)
+
+@Serializable
 data class ContextualNonEmptyListInside<A>(@Contextual val thing: NonEmptyList<A>)
 
 @Serializable
@@ -45,6 +48,10 @@ class ModuleTest {
     backAgain(Arb.ior(Arb.string(), Arb.int()), jsonWithModule)
 
   @Test
+  fun backAgainOption() =
+    backAgain(Arb.option(Arb.string()), jsonWithModule)
+
+  @Test
   fun backAgainNonEmptyList() =
     backAgain(Arb.nonEmptyList(Arb.int()), jsonWithModule)
 
@@ -59,6 +66,10 @@ class ModuleTest {
   @Test
   fun backAgainContextualIor() =
     backAgain(Arb.ior(Arb.string(), Arb.int()).map(::ContextualIorInside), jsonWithModule)
+
+  @Test
+  fun backAgainContextualOption() =
+    backAgain(Arb.option(Arb.string()).map(::ContextualOptionInside), jsonWithModule)
 
   @Test
   fun backAgainContextualNonEmptyList() =


### PR DESCRIPTION
As discussed on [Slack](https://slack-chats.kotlinlang.org/t/18767362/hi-everyone-wave-new-to-kotlin-coming-from-scala-i-m-explori#aa329e2e-1cc5-4ef7-a2a4-49274213b577), this PR adds in an `ArrowModule` to simplify including the arrow serializers in a `SerializersModule {}` definition.

I've also lifted the restriction from `OptionSerializer` as discussed in that thread, but can roll this back if desired.