### PR TITLE
Allow specifying a more concrete Throwable type for retrying

### DIFF
--- a/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Schedule.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Schedule.kt
@@ -484,7 +484,8 @@ public suspend inline fun <Input, Output, A, reified E : Throwable> Schedule<E, 
         }
 
         is Done ->
-          if (NonFatal(e)) Either.Left(orElse(e, decision.output)) else throw e
+          if (NonFatal(e)) return Either.Left(orElse(e, decision.output))
+          else throw e
       }
     }
   }

--- a/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Schedule.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Schedule.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.retry
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmName
 import kotlin.math.pow
 import kotlin.random.Random
 import kotlin.time.Duration
@@ -420,6 +421,7 @@ public suspend fun <A> Schedule<Throwable, *>.retry(action: suspend () -> A): A 
  * Retries [action] only when [E] has occurred, otherwise it immediately retries the other exception.
  * It will throw the last [E] if the [Schedule] is exhausted, and ignores the output of the [Schedule].
  */
+@JvmName("retryReified")
 public suspend inline fun <A, reified E : Throwable> Schedule<E, *>.retry(action: suspend () -> A): A =
   retryOrElse<A, Any?, E>(action) { e, _ -> throw e }
 
@@ -438,6 +440,7 @@ public suspend fun <Input, Output> Schedule<Throwable, Output>.retryOrElse(
  * If the [Schedule] is exhausted,
  * it will invoke [orElse] with the last [E] and the output of the [Schedule] to produce a fallback [Input] value.
  */
+@JvmName("retryOrElseReified")
 public suspend inline fun <Input, Output, reified E : Throwable> Schedule<E, Output>.retryOrElse(
   action: suspend () -> Input,
   orElse: suspend (Throwable, Output) -> Input
@@ -461,6 +464,7 @@ public suspend fun <Input, Output, A> Schedule<Throwable, Output>.retryOrElseEit
  * it will invoke [orElse] with the last [E] and the output of the [Schedule] to produce a fallback value of [A].
  * Returns [Either] with the fallback value if the [Schedule] is exhausted, or the successful result of [action].
  */
+@JvmName("retryOrElseEitherReified")
 public suspend inline fun <Input, Output, A, reified E : Throwable> Schedule<E, Output>.retryOrElseEither(
   action: suspend () -> Input,
   orElse: suspend (E, Output) -> A

--- a/arrow-libs/resilience/arrow-resilience/src/commonTest/kotlin/arrow/resilience/FlowTest.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonTest/kotlin/arrow/resilience/FlowTest.kt
@@ -79,12 +79,5 @@ class FlowTest {
   }
 }
 
-inline fun <A> assertThrowable(executable: () -> A): Throwable {
-  val a = try {
-    executable.invoke()
-  } catch (e: Throwable) {
-    e
-  }
-
-  return if (a is Throwable) a else fail("Expected an exception but found: $a")
-}
+inline fun assertThrowable(executable: () -> Unit): Throwable =
+  assertThrows<Throwable>(executable)

--- a/arrow-libs/resilience/arrow-resilience/src/commonTest/kotlin/arrow/resilience/ScheduleTest.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonTest/kotlin/arrow/resilience/ScheduleTest.kt
@@ -9,7 +9,6 @@ import arrow.resilience.Schedule.Decision.Continue
 import arrow.resilience.Schedule.Decision.Done
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import kotlin.math.pow
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -269,13 +268,47 @@ class ScheduleTest {
       .doUntil { _, output -> output > 50.0.milliseconds }
       .doUntil { input, _ -> input is IllegalStateException }
 
-    val result: Either<Throwable, Unit> = withTimeout(10.seconds) {
-      schedule.retryOrElseEither({
-        throw ex
-      }, { t, _ -> t })
-    }
+    val result: Either<Throwable, Unit> = schedule.retryOrElseEither({
+      throw ex
+    }, { t, _ -> t })
 
     result.fold({ assertEquals(ex, it) }, { fail("The impossible happened") })
+  }
+
+  @Test
+  fun rethrowsUnmatchedException(): TestResult = runTest {
+    val ex = Throwable("Hello")
+
+    val e = assertThrowable {
+      Schedule.forever<IllegalStateException>()
+        .retry { throw ex }
+    }
+    assertEquals(ex, e)
+  }
+
+  @Test
+  fun captureException(): TestResult = runTest {
+    val ex = IllegalStateException("Hello")
+    val buffer = mutableListOf<IllegalStateException>()
+
+    assertThrows<IllegalStateException> {
+      Schedule.recurs<IllegalStateException>(2)
+        .log { e, _ -> buffer.add(e) }
+        .retry { throw ex }
+    }
+
+    assertEquals(listOf(ex, ex), buffer)
+  }
+
+  @Test
+  fun retriesMatchedException(): TestResult = runTest {
+    val ex = IllegalStateException("Hello")
+    var count = 0
+
+    val i = Schedule.forever<IllegalStateException>()
+      .retry { if (count++ == 0) throw ex else 1 }
+
+    assertEquals(1, i)
   }
 
   @Test
@@ -401,3 +434,13 @@ private suspend fun <B> checkRepeat(schedule: Schedule<Long, List<B>>, expected:
 }
 
 private object CustomError
+
+inline fun <reified A : Throwable> assertThrows(executable: () -> Unit): A {
+  val a = try {
+    executable.invoke()
+  } catch (e: Throwable) {
+    e
+  }
+
+  return if (a is A) a else fail("Expected an exception but found: $a")
+}


### PR DESCRIPTION
Small use-case I came across several times, and I stumbled across it again. This PR allows specifying concrete types for retrying. I.e.

```kotlin
Schedule.exponential<PSQLException>(...)
  .and(Schedule.recurs(5))
  .doWhile { e: PSQLExeption, _ -> e.isRetryable() }
  .retry {
    exposedTransaction { doDatabaseStuff() }
  }
```


TODO
 - [ ] Write test cases
 - [x] Broke something, investigate