### PR TITLE
AutoClose and Resource rehaul/cleanup

### DIFF
--- a/arrow-libs/core/arrow-autoclose/api/arrow-autoclose.api
+++ b/arrow-libs/core/arrow-autoclose/api/arrow-autoclose.api
@@ -1,6 +1,6 @@
 public abstract interface class arrow/AutoCloseScope {
-	public abstract fun autoClose (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public abstract fun install (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public abstract fun onClose (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class arrow/AutoCloseScope$DefaultImpls {
@@ -8,6 +8,7 @@ public final class arrow/AutoCloseScope$DefaultImpls {
 }
 
 public final class arrow/AutoCloseScopeKt {
+	public static final fun autoClose (Larrow/AutoCloseScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static final fun autoCloseScope (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
@@ -16,10 +17,22 @@ public final class arrow/AutoCloseableExtensionsKt {
 }
 
 public final class arrow/DefaultAutoCloseScope : arrow/AutoCloseScope {
-	public fun <init> ()V
-	public fun autoClose (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public final fun close (Ljava/lang/Throwable;)Ljava/lang/Void;
+	public static final synthetic fun box-impl (Ljava/util/concurrent/atomic/AtomicReference;)Larrow/DefaultAutoCloseScope;
+	public static final fun closeAll-impl (Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Throwable;)V
+	public static fun constructor-impl (Ljava/util/concurrent/atomic/AtomicReference;)Ljava/util/concurrent/atomic/AtomicReference;
+	public static synthetic fun constructor-impl$default (Ljava/util/concurrent/atomic/AtomicReference;ILkotlin/jvm/internal/DefaultConstructorMarker;)Ljava/util/concurrent/atomic/AtomicReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/concurrent/atomic/AtomicReference;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/concurrent/atomic/AtomicReference;)I
 	public fun install (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public static fun install-impl (Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public fun onClose (Lkotlin/jvm/functions/Function1;)V
+	public static fun onClose-impl (Ljava/util/concurrent/atomic/AtomicReference;Lkotlin/jvm/functions/Function1;)V
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/concurrent/atomic/AtomicReference;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/concurrent/atomic/AtomicReference;
 }
 
 public final class arrow/ThrowIfFatalKt {

--- a/arrow-libs/core/arrow-autoclose/src/commonMain/kotlin/arrow/AutoCloseScope.kt
+++ b/arrow-libs/core/arrow-autoclose/src/commonMain/kotlin/arrow/AutoCloseScope.kt
@@ -74,6 +74,7 @@ public inline fun <A> autoCloseScope(block: AutoCloseScope.() -> A): A = with(De
 public interface AutoCloseScope {
   public fun onClose(release: (Throwable?) -> Unit)
 
+  @ExperimentalStdlibApi
   public fun <A : AutoCloseable> install(autoCloseable: A): A =
     autoCloseable.also { onClose { autoCloseable.close() } }
 }

--- a/arrow-libs/core/arrow-autoclose/src/jvmMain/kotlin/arrow/throwIfFatal.kt
+++ b/arrow-libs/core/arrow-autoclose/src/jvmMain/kotlin/arrow/throwIfFatal.kt
@@ -1,10 +1,8 @@
 package arrow
 
-import kotlin.coroutines.cancellation.CancellationException
-
 @PublishedApi
 internal actual fun Throwable.throwIfFatal(): Throwable =
   when(this) {
-    is VirtualMachineError, is ThreadDeath, is InterruptedException, is LinkageError, is CancellationException -> throw this
+    is VirtualMachineError, is ThreadDeath, is InterruptedException, is LinkageError -> throw this
     else -> this
   }

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -5,6 +5,7 @@ public final class arrow/fx/coroutines/AcquireStep {
 public final class arrow/fx/coroutines/BracketKt {
 	public static final fun bracket (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun bracketCase (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getThrowableOrNull (Larrow/fx/coroutines/ExitCase;)Ljava/lang/Throwable;
 	public static final fun guarantee (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun guaranteeCase (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun onCancel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -30,7 +31,7 @@ public final class arrow/fx/coroutines/CyclicBarrierCancellationException : java
 	public fun <init> ()V
 }
 
-public abstract class arrow/fx/coroutines/ExitCase {
+public abstract interface class arrow/fx/coroutines/ExitCase {
 	public static final field Companion Larrow/fx/coroutines/ExitCase$Companion;
 }
 
@@ -51,6 +52,8 @@ public final class arrow/fx/coroutines/ExitCase$Companion {
 
 public final class arrow/fx/coroutines/ExitCase$Completed : arrow/fx/coroutines/ExitCase {
 	public static final field INSTANCE Larrow/fx/coroutines/ExitCase$Completed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -238,25 +241,54 @@ public final class arrow/fx/coroutines/ResourceExtensionsKt {
 public final class arrow/fx/coroutines/ResourceKt {
 	public static final fun allocated (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun asFlow (Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun install (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun resource (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
 	public static final fun resource (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
-	public static final fun resourceScope (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun resourceScope (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun use (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class arrow/fx/coroutines/ResourceScope : arrow/AutoCloseScope {
 	public abstract fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun install (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onRelease (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onClose (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun onRelease (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun release (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun releaseCase (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/fx/coroutines/ResourceScope$DefaultImpls {
+	public static fun bind (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun install (Larrow/fx/coroutines/ResourceScope;Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
-	public static fun onRelease (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onClose (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function1;)V
 	public static fun release (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun releaseCase (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/fx/coroutines/ResourceScopeImpl : arrow/fx/coroutines/ResourceScope {
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun bind-impl (Ljava/util/concurrent/atomic/AtomicReference;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun box-impl (Ljava/util/concurrent/atomic/AtomicReference;)Larrow/fx/coroutines/ResourceScopeImpl;
+	public static final fun cancelAll-impl (Ljava/util/concurrent/atomic/AtomicReference;Larrow/fx/coroutines/ExitCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun constructor-impl (Ljava/util/concurrent/atomic/AtomicReference;)Ljava/util/concurrent/atomic/AtomicReference;
+	public static synthetic fun constructor-impl$default (Ljava/util/concurrent/atomic/AtomicReference;ILkotlin/jvm/internal/DefaultConstructorMarker;)Ljava/util/concurrent/atomic/AtomicReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/concurrent/atomic/AtomicReference;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/concurrent/atomic/AtomicReference;)I
+	public fun install (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public static fun install-impl (Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public fun onClose (Lkotlin/jvm/functions/Function1;)V
+	public static fun onClose-impl (Ljava/util/concurrent/atomic/AtomicReference;Lkotlin/jvm/functions/Function1;)V
+	public fun onRelease (Lkotlin/jvm/functions/Function2;)V
+	public static fun onRelease-impl (Ljava/util/concurrent/atomic/AtomicReference;Lkotlin/jvm/functions/Function2;)V
+	public fun release (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun release-impl (Ljava/util/concurrent/atomic/AtomicReference;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun releaseCase (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun releaseCase-impl (Ljava/util/concurrent/atomic/AtomicReference;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/concurrent/atomic/AtomicReference;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/concurrent/atomic/AtomicReference;
 }
 
 public abstract interface annotation class arrow/fx/coroutines/ScopeDSL : java/lang/annotation/Annotation {

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -477,9 +477,7 @@ internal value class ResourceScopeImpl(
 
   suspend fun cancelAll(exitCase: ExitCase): Unit = withContext(NonCancellable) {
     finalizers.value.fold(exitCase.throwableOrNull) { acc, finalizer ->
-      val e = runCatching { finalizer(exitCase) }.exceptionOrNull()
-      println("Adding $e with $acc")
-      acc.add(e)
+      acc.add(runCatching { finalizer(exitCase) }.exceptionOrNull())
     }?.let { throw it }
   }
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -475,9 +475,11 @@ internal value class ResourceScopeImpl(
   override fun onRelease(release: suspend (ExitCase) -> Unit) =
     finalizers.update(release::prependTo)
 
-  suspend fun cancelAll(exitCase: ExitCase): Unit = withContext(NonCancellable) {
-    finalizers.value.fold(exitCase.throwableOrNull) { acc, finalizer ->
-      acc.add(runCatching { finalizer(exitCase) }.exceptionOrNull())
+  suspend fun cancelAll(exitCase: ExitCase) {
+    withContext(NonCancellable) {
+      finalizers.value.fold(exitCase.throwableOrNull) { acc, finalizer ->
+        acc.add(runCatching { finalizer(exitCase) }.exceptionOrNull())
+      }
     }?.let { throw it }
   }
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -1,15 +1,13 @@
 package arrow.fx.coroutines
 
-import arrow.autoCloseScope
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.raise.either
 import arrow.fx.coroutines.ExitCase.Companion.ExitCase
 import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -31,7 +29,6 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import kotlin.random.Random
 import kotlin.test.Test
 
 class ResourceTest {
@@ -599,7 +596,7 @@ class ResourceTest {
       }
 
       exception shouldBe original
-      exception.suppressedExceptions.firstOrNull().shouldNotBeNull() shouldBe suppressed
+      exception.suppressedExceptions.shouldHaveSingleElement(suppressed)
       released.await().shouldBeTypeOf<ExitCase.Failure>()
     }
   }
@@ -629,7 +626,7 @@ class ResourceTest {
       }
 
       exception shouldBe cancellation
-      exception.suppressedExceptions.firstOrNull().shouldNotBeNull() shouldBe suppressed
+      exception.suppressedExceptions.shouldHaveSingleElement(suppressed)
       released.await().shouldBeTypeOf<ExitCase.Cancelled>()
     }
   }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-04.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-04.kt
@@ -3,6 +3,7 @@ package arrow.fx.coroutines.examples.exampleResource04
 
 import arrow.fx.coroutines.ResourceScope
 import arrow.fx.coroutines.Resource
+import arrow.fx.coroutines.install
 import arrow.fx.coroutines.resource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-05.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-05.kt
@@ -2,6 +2,7 @@
 package arrow.fx.coroutines.examples.exampleResource05
 
 import arrow.fx.coroutines.ResourceScope
+import arrow.fx.coroutines.install
 import arrow.fx.coroutines.resourceScope
 import arrow.fx.coroutines.parZip
 import kotlinx.coroutines.Dispatchers

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-06.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-06.kt
@@ -1,6 +1,7 @@
 // This file was automatically generated from Resource.kt by Knit tool. Do not edit.
 package arrow.fx.coroutines.examples.exampleResource06
 
+import arrow.fx.coroutines.install
 import arrow.fx.coroutines.resourceScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-07.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/examples/example-resource-07.kt
@@ -1,6 +1,7 @@
 // This file was automatically generated from Resource.kt by Knit tool. Do not edit.
 package arrow.fx.coroutines.examples.exampleResource07
 
+import arrow.fx.coroutines.install
 import arrow.fx.coroutines.resource
 import arrow.fx.coroutines.resourceScope
 


### PR DESCRIPTION
This PR simplifies the implementations of `AutoCloseScope` and `ResourceScope` and allows some of their functions to be `inline`. It also makes `onRelease` not suspending.