### PR TITLE
Fix isos and lenses generation in case of parameters having keywords as names.

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/domain.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/domain.kt
@@ -77,6 +77,10 @@ data class Focus(
   val subclasses: List<String> = emptyList(),
   val classNameWithParameters: String? = className,
 ) {
+  val escapedParamName = paramName.plusIfNotBlank(
+    prefix = "`",
+    postfix = "`",
+  )
   val refinedArguments: List<String>
     get() = refinedType?.arguments?.filter {
       it.type?.resolve()?.declaration is KSTypeParameter

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
@@ -36,9 +36,9 @@ private fun processLensSyntax(ele: ADT, foci: List<Focus>, className: String): S
   return if (ele.typeParameters.isEmpty()) {
     foci.joinToString(separator = "\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Lens<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.lensParamName()}
-    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.lensParamName()}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.lensParamName()}
+    |${ele.visibilityModifierName} inline val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Lens<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
     |
       """.trimMargin()
     }
@@ -47,9 +47,9 @@ private fun processLensSyntax(ele: ADT, foci: List<Focus>, className: String): S
     val joinedTypeParams = ele.typeParameters.joinToString(separator = ",")
     foci.joinToString(separator = "\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.lensParamName()}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.lensParamName()}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.lensParamName()}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
     |
       """.trimMargin()
     }
@@ -86,11 +86,11 @@ private fun processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): S
   if (ele.typeParameters.isEmpty()) {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <__S> $Iso<__S, ${ele.sourceClassName}>.${focus.paramName}: $Iso<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.paramName}: $Lens<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.paramName}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <__S> $Prism<__S, ${ele.sourceClassName}>.${focus.paramName}: $Prism<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.paramName}
-    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.paramName}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.paramName}
+    |${ele.visibilityModifierName} inline val <__S> $Iso<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Iso<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} inline val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Lens<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} inline val <__S> $Prism<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Prism<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
     |
       """.trimMargin()
     }
@@ -102,11 +102,11 @@ private fun processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): S
         else -> focus.refinedArguments.joinToString(separator = ",")
       }
       """
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Iso<__S, $sourceClassNameWithParams>.${focus.paramName}(): $Iso<__S, ${focus.classNameWithParameters}> = this + $className.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.paramName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.paramName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Prism<__S, $sourceClassNameWithParams>.${focus.paramName}(): $Prism<__S, ${focus.classNameWithParameters}> = this + $className.${focus.paramName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.paramName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.paramName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Iso<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Iso<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Prism<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Prism<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
     |
       """.trimMargin()
     }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/iso.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/iso.kt
@@ -9,18 +9,14 @@ private fun OpticsProcessorOptions.processElement(adt: ADT, focus: Focus): Strin
   val sourceClassNameWithParams = "${adt.sourceClassName}${adt.angledTypeParameters}"
   val firstLine = when {
     adt.typeParameters.isEmpty() ->
-      "${adt.visibilityModifierName} $inlineText val ${adt.sourceClassName}.Companion.${focus.paramName}: $Iso<${adt.sourceClassName}, ${focus.className}> $inlineText get()"
+      "${adt.visibilityModifierName} $inlineText val ${adt.sourceClassName}.Companion.${focus.escapedParamName}: $Iso<${adt.sourceClassName}, ${focus.className}> $inlineText get()"
     else ->
-      "${adt.visibilityModifierName} $inlineText fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.paramName}(): $Iso<$sourceClassNameWithParams, ${focus.className}>"
+      "${adt.visibilityModifierName} $inlineText fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.escapedParamName}(): $Iso<$sourceClassNameWithParams, ${focus.className}>"
   }
-  val fineParamName = focus.paramName.plusIfNotBlank(
-    prefix = "`",
-    postfix = "`",
-  )
   return """
   |$firstLine = $Iso(
-  |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.$fineParamName },
-  |  reverseGet = { $fineParamName: ${focus.className} -> ${adt.sourceClassName}($fineParamName) }
+  |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.${focus.escapedParamName} },
+  |  reverseGet = { ${focus.escapedParamName}: ${focus.className} -> ${adt.sourceClassName}(${focus.escapedParamName}) }
   |)
   |
   """.trimMargin()

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
@@ -34,18 +34,13 @@ private fun OpticsProcessorOptions.processElement(adt: ADT, foci: List<Focus>): 
   return foci.joinToString(separator = "\n") { focus ->
     val firstLine = when {
       adt.typeParameters.isEmpty() ->
-        "${adt.visibilityModifierName} $inlineText val ${adt.sourceClassName}.Companion.${focus.lensParamName()}: $Lens<${adt.sourceClassName}, ${focus.className}> $inlineText get()"
+        "${adt.visibilityModifierName} $inlineText val ${adt.sourceClassName}.Companion.${focus.escapedParamName}: $Lens<${adt.sourceClassName}, ${focus.className}> $inlineText get()"
       else ->
-        "${adt.visibilityModifierName} $inlineText fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.lensParamName()}(): $Lens<$sourceClassNameWithParams, ${focus.className}>"
+        "${adt.visibilityModifierName} $inlineText fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.escapedParamName}(): $Lens<$sourceClassNameWithParams, ${focus.className}>"
     }
     """
       |$firstLine = $Lens(
-      |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.${
-      focus.paramName.plusIfNotBlank(
-        prefix = "`",
-        postfix = "`",
-      )
-    } },
+      |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.${focus.escapedParamName} },
       |  set = { ${adt.sourceName}: $sourceClassNameWithParams, value: ${focus.className} ->
       |  ${setBody(focus)}
       |}
@@ -54,5 +49,3 @@ private fun OpticsProcessorOptions.processElement(adt: ADT, foci: List<Focus>): 
     """.trimMargin()
   }
 }
-
-fun Focus.lensParamName(): String = paramName

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/IsoTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/IsoTests.kt
@@ -1,6 +1,7 @@
 package arrow.optics.plugin
 
 import arrow.optics.plugin.internals.noCompanion
+import kotlin.test.Ignore
 import kotlin.test.Test
 
 class IsoTests {
@@ -18,6 +19,31 @@ class IsoTests {
       |val i: Iso<IsoData, String> = IsoData.field1
       |val r = i != null
       """.evals("r" to true)
+  }
+
+  @Test
+  fun `Isos will be generated for value class with parameters having keywords as names`() {
+    """
+      |$`package`
+      |$imports
+      |@optics @JvmInline
+      |value class IsoData(
+      |  val `in`: String
+      |) { companion object }
+      """.compilationSucceeds()
+  }
+
+  @Test
+  @Ignore("Needs fixing joinedTypeParams in processIsoSyntax function")
+  fun `Isos will be generated for generic value class with parameters having keywords as names`() {
+    """
+      |$`package`
+      |$imports
+      |@optics @JvmInline
+      |value class IsoData<T>(
+      |  val `in`: T
+      |) { companion object }
+      """.compilationSucceeds()
   }
 
   @Test

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
@@ -20,6 +20,30 @@ class LensTests {
   }
 
   @Test
+  fun `Lenses will be generated for data class with parameters having keywords as names`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |data class LensData(
+      |  val `in`: String
+      |) { companion object }
+      """.compilationSucceeds()
+  }
+
+  @Test
+  fun `Lenses will be generated for generic data class with parameters having keywords as names`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |data class LensData<T>(
+      |  val `in`: T
+      |) { companion object }
+      """.compilationSucceeds()
+  }
+
+  @Test
   fun `Lenses will be generated for data class with secondary constructors`() {
     """
       |$`package`


### PR DESCRIPTION
Data classes which use parameters that have names which are Kotlin keywords and needs to be escaped fail to compile:
```
data class LensData<T>(
    val `in`: T
) { companion object }
```

This change makes generation of isos an lenses work with such parameters.

There's an additional test added that requires some additional fix in the code which is outside of the scope of this change.