### PR TITLE
De-duplicate class names in `arrow-optics` and `arrow-optics-compose`

### DIFF
--- a/arrow-libs/optics/arrow-optics-compose/api/android/arrow-optics-compose.api
+++ b/arrow-libs/optics/arrow-optics-compose/api/android/arrow-optics-compose.api
@@ -1,16 +1,16 @@
-public final class arrow/optics/CopyKt {
+public final class arrow/optics/ComposeCopyKt {
 	public static final fun update (Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function1;)V
 	public static final fun updateCopy (Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function1;)V
 	public static final fun updateCopy (Lkotlinx/coroutines/flow/MutableStateFlow;Lkotlin/jvm/functions/Function1;)V
 }
 
-public final class arrow/optics/FlowKt {
+public final class arrow/optics/ComposeFlowKt {
 	public static final fun optic (Lkotlinx/coroutines/flow/MutableStateFlow;Larrow/optics/PLens;)Lkotlinx/coroutines/flow/MutableStateFlow;
 	public static final fun optic (Lkotlinx/coroutines/flow/SharedFlow;Larrow/optics/PLens;)Lkotlinx/coroutines/flow/SharedFlow;
 	public static final fun optic (Lkotlinx/coroutines/flow/StateFlow;Larrow/optics/PLens;)Lkotlinx/coroutines/flow/StateFlow;
 }
 
-public final class arrow/optics/StateKt {
+public final class arrow/optics/ComposeStateKt {
 	public static final fun optic (Landroidx/compose/runtime/MutableState;Larrow/optics/PLens;)Landroidx/compose/runtime/MutableState;
 	public static final fun optic (Landroidx/compose/runtime/State;Larrow/optics/PLens;)Landroidx/compose/runtime/State;
 }

--- a/arrow-libs/optics/arrow-optics-compose/api/jvm/arrow-optics-compose.api
+++ b/arrow-libs/optics/arrow-optics-compose/api/jvm/arrow-optics-compose.api
@@ -1,16 +1,16 @@
-public final class arrow/optics/CopyKt {
+public final class arrow/optics/ComposeCopyKt {
 	public static final fun update (Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function1;)V
 	public static final fun updateCopy (Landroidx/compose/runtime/MutableState;Lkotlin/jvm/functions/Function1;)V
 	public static final fun updateCopy (Lkotlinx/coroutines/flow/MutableStateFlow;Lkotlin/jvm/functions/Function1;)V
 }
 
-public final class arrow/optics/FlowKt {
+public final class arrow/optics/ComposeFlowKt {
 	public static final fun optic (Lkotlinx/coroutines/flow/MutableStateFlow;Larrow/optics/PLens;)Lkotlinx/coroutines/flow/MutableStateFlow;
 	public static final fun optic (Lkotlinx/coroutines/flow/SharedFlow;Larrow/optics/PLens;)Lkotlinx/coroutines/flow/SharedFlow;
 	public static final fun optic (Lkotlinx/coroutines/flow/StateFlow;Larrow/optics/PLens;)Lkotlinx/coroutines/flow/StateFlow;
 }
 
-public final class arrow/optics/StateKt {
+public final class arrow/optics/ComposeStateKt {
 	public static final fun optic (Landroidx/compose/runtime/MutableState;Larrow/optics/PLens;)Landroidx/compose/runtime/MutableState;
 	public static final fun optic (Landroidx/compose/runtime/State;Larrow/optics/PLens;)Landroidx/compose/runtime/State;
 }

--- a/arrow-libs/optics/arrow-optics-compose/src/commonMain/kotlin/arrow/optics/Copy.kt
+++ b/arrow-libs/optics/arrow-optics-compose/src/commonMain/kotlin/arrow/optics/Copy.kt
@@ -1,9 +1,12 @@
+@file:JvmName("ComposeCopyKt")
+
 package arrow.optics
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.snapshots.Snapshot
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlin.jvm.JvmName
 
 /**
  * Modifies the value in this [MutableState]

--- a/arrow-libs/optics/arrow-optics-compose/src/commonMain/kotlin/arrow/optics/Flow.kt
+++ b/arrow-libs/optics/arrow-optics-compose/src/commonMain/kotlin/arrow/optics/Flow.kt
@@ -1,3 +1,5 @@
+@file:JvmName("ComposeFlowKt")
+
 package arrow.optics
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -5,6 +7,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.jvm.JvmName
 
 /**
  * Exposes the values of [this] through the optic.

--- a/arrow-libs/optics/arrow-optics-compose/src/commonMain/kotlin/arrow/optics/State.kt
+++ b/arrow-libs/optics/arrow-optics-compose/src/commonMain/kotlin/arrow/optics/State.kt
@@ -1,7 +1,10 @@
+@file:JvmName("ComposeStateKt")
+
 package arrow.optics
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
+import kotlin.jvm.JvmName
 
 /**
  * Exposes the value of [this] through the optic.


### PR DESCRIPTION
Fixes #3447