### PR TITLE
Fix incompatible versioning

### DIFF
--- a/arrow-libs/core/arrow-annotations/build.gradle.kts
+++ b/arrow-libs/core/arrow-annotations/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -30,5 +34,11 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.annotations"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }

--- a/arrow-libs/core/arrow-atomic/build.gradle.kts
+++ b/arrow-libs/core/arrow-atomic/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -47,6 +48,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.atomic"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/core/arrow-autoclose/build.gradle.kts
+++ b/arrow-libs/core/arrow-autoclose/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 
@@ -41,6 +43,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.autocloseable"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/core/arrow-cache4k/build.gradle.kts
+++ b/arrow-libs/core/arrow-cache4k/build.gradle.kts
@@ -1,7 +1,11 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
-  `java-library`
+  // `java-library`
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.publish)
   alias(libs.plugins.spotless)
@@ -58,6 +62,12 @@ kotlin {
   // -- Deprecated as of 1.8.20 --
   // iosArm32() // deprecated as of 1.8.20
   // watchosX86()
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
+  }
 }
 
 tasks.named<Jar>("jvmJar").configure {

--- a/arrow-libs/core/arrow-core-high-arity/build.gradle.kts
+++ b/arrow-libs/core/arrow-core-high-arity/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -34,5 +36,11 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.core-high-arity"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }

--- a/arrow-libs/core/arrow-core-retrofit/build.gradle.kts
+++ b/arrow-libs/core/arrow-core-retrofit/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.jvm.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -34,6 +38,13 @@ dependencies {
   testImplementation(libs.kotlinx.serializationJson)
   testImplementation(libs.squareup.retrofit.converter.kotlinxSerialization)
   testImplementation(libs.squareup.moshi.kotlin)
+}
+
+kotlin {
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
+  }
 }
 
 tasks.jar {

--- a/arrow-libs/core/arrow-core-serialization/build.gradle.kts
+++ b/arrow-libs/core/arrow-core-serialization/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -38,6 +42,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.core.serialization"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/core/arrow-core/build.gradle.kts
+++ b/arrow-libs/core/arrow-core/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.Duration
 
@@ -68,6 +69,12 @@ kotlin {
         }
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/core/arrow-eval/build.gradle.kts
+++ b/arrow-libs/core/arrow-eval/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -40,6 +44,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.eval"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/core/arrow-functions/build.gradle.kts
+++ b/arrow-libs/core/arrow-functions/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -43,6 +47,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.continuations"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/fx/arrow-collectors/build.gradle.kts
+++ b/arrow-libs/fx/arrow-collectors/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.time.Duration
 
 plugins {
@@ -57,6 +59,12 @@ kotlin {
         }
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-coroutines/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.time.Duration
 
 
@@ -63,6 +65,12 @@ kotlin {
         }
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
+++ b/arrow-libs/fx/arrow-fx-stm/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 
@@ -49,6 +50,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.fx.stm"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/optics/arrow-optics-compose/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-compose/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 
@@ -73,6 +75,12 @@ kotlin {
         implementation(libs.kotest.property)
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.jvm.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -16,6 +20,11 @@ spotless {
 
 kotlin {
   explicitApi = null
+
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
+  }
 }
 
 apply(from = property("ANIMALSNIFFER_MPP"))

--- a/arrow-libs/optics/arrow-optics-reflect/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-reflect/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.jvm.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -28,6 +32,14 @@ dependencies {
   testImplementation(libs.kotlin.reflect)
   testImplementation(libs.kotest.assertionsCore)
   testImplementation(libs.kotest.property)
+}
+
+kotlin {
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
+  }
 }
 
 tasks.jar {

--- a/arrow-libs/optics/arrow-optics/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -41,6 +45,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.optics"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/arrow-libs/resilience/arrow-resilience/build.gradle.kts
+++ b/arrow-libs/resilience/arrow-resilience/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+
 plugins {
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -38,6 +42,12 @@ kotlin {
         attributes["Automatic-Module-Name"] = "arrow.resilience"
       }
     }
+  }
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class)
+  compilerOptions {
+    (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
+    (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,10 @@ import kotlinx.knit.KnitPluginExtension
 import kotlinx.validation.ExperimentalBCVApi
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
   if (property("version") == "unspecified") {
@@ -32,15 +33,6 @@ allprojects {
     (project.rootProject.properties["kotlin_repo_url"] as? String)?.also { maven(it) }
     google()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-  }
-
-  tasks {
-    withType<KotlinCompile> {
-      compilerOptions {
-        (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
-        (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
The way we set the versions is no longer compatible with the new versions of Kotlin. And arguably, we should have always done it by setting it in the `kotlin.compilerOptions` block, instead of in each separate task.

(This was caught by early tests as part of the Kotlin User Projects run by the Kotlin Q&A team)