### PR TITLE
Remove optional build of `optics-compose`

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -102,10 +102,8 @@ project(":arrow-optics").projectDir = file("arrow-libs/optics/arrow-optics")
 include("arrow-optics-reflect")
 project(":arrow-optics-reflect").projectDir = file("arrow-libs/optics/arrow-optics-reflect")
 
-if (kotlin_version.isNullOrBlank() || "2.0" !in kotlin_version!!) {
-  include("arrow-optics-compose")
-  project(":arrow-optics-compose").projectDir = file("arrow-libs/optics/arrow-optics-compose")
-}
+include("arrow-optics-compose")
+project(":arrow-optics-compose").projectDir = file("arrow-libs/optics/arrow-optics-compose")
 
 include("arrow-optics-ksp-plugin")
 project(":arrow-optics-ksp-plugin").projectDir = file("arrow-libs/optics/arrow-optics-ksp-plugin")


### PR DESCRIPTION
Hopefully the final PR to make things work again in the Kotlin User Projects of the Kotlin team. It seems we had too many `2.0` hardcoded in our build files...