### PR TITLE
Fix KDoc of Either's combine method

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -1367,7 +1367,7 @@ public operator fun <A : Comparable<A>, B : Comparable<B>> Either<A, B>.compareT
 /**
  * Combine two [Either] values.
  * If both are [Right] then combine both [B] values using [combineRight] or if both are [Left] then combine both [A] values using [combineLeft],
- * otherwise it returns the `this` or fallbacks to [other] in case `this` is [Left].
+ * otherwise return the sole [Left] value (either `this` or [other]).
  */
 public fun <A, B> Either<A, B>.combine(other: Either<A, B>, combineLeft: (A, A) -> A, combineRight: (B, B) -> B): Either<A, B> =
   when (val one = this) {


### PR DESCRIPTION
`Either.combine`'s method description contains an error. It states:

> "... otherwise it returns the `this` or fallbacks to [other] in case `this` is [Left]"

But the opposite is true: it returns this if this is Left and other if other is Left.