### PR TITLE
Flag new 2.0 APIs as experimental

### DIFF
--- a/arrow-libs/core/arrow-core-high-arity/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
+++ b/arrow-libs/core/arrow-core-high-arity/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalTypeInference::class, ExperimentalContracts::class)
+@file:OptIn(ExperimentalTypeInference::class, ExperimentalContracts::class, ExperimentalRaiseAccumulateApi::class)
 @file:JvmMultifileClass
 @file:JvmName("RaiseHighArityKt")
 

--- a/arrow-libs/core/arrow-core/api/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.api
@@ -892,6 +892,9 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 public abstract interface annotation class arrow/core/raise/DelicateRaiseApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class arrow/core/raise/ExperimentalRaiseAccumulateApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class arrow/core/raise/ExperimentalTraceApi : java/lang/annotation/Annotation {
 }
 

--- a/arrow-libs/core/arrow-core/api/arrow-core.klib.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.klib.api
@@ -10,6 +10,10 @@ open annotation class arrow.core.raise/DelicateRaiseApi : kotlin/Annotation { //
     constructor <init>() // arrow.core.raise/DelicateRaiseApi.<init>|<init>(){}[0]
 }
 
+open annotation class arrow.core.raise/ExperimentalRaiseAccumulateApi : kotlin/Annotation { // arrow.core.raise/ExperimentalRaiseAccumulateApi|null[0]
+    constructor <init>() // arrow.core.raise/ExperimentalRaiseAccumulateApi.<init>|<init>(){}[0]
+}
+
 open annotation class arrow.core.raise/ExperimentalTraceApi : kotlin/Annotation { // arrow.core.raise/ExperimentalTraceApi|null[0]
     constructor <init>() // arrow.core.raise/ExperimentalTraceApi.<init>|<init>(){}[0]
 }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/RaiseAccumulateSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/RaiseAccumulateSpec.kt
@@ -1,3 +1,4 @@
+@file:OptIn(ExperimentalRaiseAccumulateApi::class)
 package arrow.core.raise
 
 import arrow.core.NonEmptyList

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -279,3 +279,6 @@ public final class arrow/fx/coroutines/await/AwaitAllScopeKt {
 	public static final fun awaitAll (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface annotation class arrow/fx/coroutines/await/ExperimentalAwaitAllApi : java/lang/annotation/Annotation {
+}
+

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <io.arrow-kt:arrow-fx-coroutines>
+open annotation class arrow.fx.coroutines.await/ExperimentalAwaitAllApi : kotlin/Annotation { // arrow.fx.coroutines.await/ExperimentalAwaitAllApi|null[0]
+    constructor <init>() // arrow.fx.coroutines.await/ExperimentalAwaitAllApi.<init>|<init>(){}[0]
+}
+
 open annotation class arrow.fx.coroutines/ResourceDSL : kotlin/Annotation { // arrow.fx.coroutines/ResourceDSL|null[0]
     constructor <init>() // arrow.fx.coroutines/ResourceDSL.<init>|<init>(){}[0]
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/await/AwaitAllScope.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/await/AwaitAllScope.kt
@@ -6,15 +6,23 @@ import kotlinx.coroutines.async as coroutinesAsync
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.InternalForInheritanceCoroutinesApi
 import kotlinx.coroutines.awaitAll as coroutinesAwaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING, message = "This API is work-in-progress and is subject to change.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+public annotation class ExperimentalAwaitAllApi
+
+@ExperimentalAwaitAllApi
 public suspend fun <A> awaitAll(
   block: suspend AwaitAllScope.() -> A
 ): A = coroutineScope { block(AwaitAllScope(this)) }
 
+@ExperimentalAwaitAllApi
 public suspend fun <A> CoroutineScope.awaitAll(
   block: suspend AwaitAllScope.() -> A
 ): A = block(AwaitAllScope(this))
@@ -61,6 +69,7 @@ public class AwaitAllScope(
     return Await(deferred)
   }
 
+  @OptIn(InternalForInheritanceCoroutinesApi::class)
   private inner class Await<T>(
     private val deferred: Deferred<T>
   ): Deferred<T> by deferred {


### PR DESCRIPTION
Since we are not 100% sure of the API, I thought it would be useful to mark those experimental for one or two releases.