### PR TITLE
Switch off inlining in optics by default

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessorOptions.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessorOptions.kt
@@ -8,7 +8,7 @@ data class OpticsProcessorOptions(
   companion object {
     fun from(options: Map<String, String>): OpticsProcessorOptions =
       OpticsProcessorOptions(
-        useInline = options.getOrDefault("inline", "true").toBooleanStrict(),
+        useInline = options.getOrDefault("inline", "false").toBooleanStrict(),
       )
   }
 }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/dsl.kt
@@ -1,8 +1,9 @@
 package arrow.optics.plugin.internals
 
+import arrow.optics.plugin.OpticsProcessorOptions
 import com.google.devtools.ksp.getDeclaredProperties
 
-fun generateLensDsl(ele: ADT, optic: DataClassDsl): Snippet {
+fun OpticsProcessorOptions.generateLensDsl(ele: ADT, optic: DataClassDsl): Snippet {
   val (className, import) = resolveClassName(ele)
   return Snippet(
     `package` = ele.packageName,
@@ -12,7 +13,7 @@ fun generateLensDsl(ele: ADT, optic: DataClassDsl): Snippet {
   )
 }
 
-fun generatePrismDsl(ele: ADT, isoOptic: SealedClassDsl): Snippet {
+fun OpticsProcessorOptions.generatePrismDsl(ele: ADT, isoOptic: SealedClassDsl): Snippet {
   val (className, import) = resolveClassName(ele)
   return Snippet(
     `package` = ele.packageName,
@@ -22,7 +23,7 @@ fun generatePrismDsl(ele: ADT, isoOptic: SealedClassDsl): Snippet {
   )
 }
 
-fun generateIsoDsl(ele: ADT, isoOptic: ValueClassDsl): Snippet {
+fun OpticsProcessorOptions.generateIsoDsl(ele: ADT, isoOptic: ValueClassDsl): Snippet {
   val (className, import) = resolveClassName(ele)
   return Snippet(
     `package` = ele.packageName,
@@ -32,13 +33,13 @@ fun generateIsoDsl(ele: ADT, isoOptic: ValueClassDsl): Snippet {
   )
 }
 
-private fun processLensSyntax(ele: ADT, foci: List<Focus>, className: String): String {
+private fun OpticsProcessorOptions.processLensSyntax(ele: ADT, foci: List<Focus>, className: String): String {
   return if (ele.typeParameters.isEmpty()) {
     foci.joinToString(separator = "\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Lens<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Lens<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
     |
       """.trimMargin()
     }
@@ -47,22 +48,22 @@ private fun processLensSyntax(ele: ADT, foci: List<Focus>, className: String): S
     val joinedTypeParams = ele.typeParameters.joinToString(separator = ",")
     foci.joinToString(separator = "\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
     |
       """.trimMargin()
     }
   }
 }
 
-private fun processPrismSyntax(ele: ADT, dsl: SealedClassDsl, className: String): String =
+private fun OpticsProcessorOptions.processPrismSyntax(ele: ADT, dsl: SealedClassDsl, className: String): String =
   if (ele.typeParameters.isEmpty()) {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Prism<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Prism<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Prism<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Prism<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
     |
       """.trimMargin()
     }
@@ -74,23 +75,23 @@ private fun processPrismSyntax(ele: ADT, dsl: SealedClassDsl, className: String)
         else -> focus.refinedArguments.joinToString(separator = ",")
       }
       """
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Prism<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Prism<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Prism<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Prism<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
     |
       """.trimMargin()
     }
   }
 
-private fun processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): String =
+private fun OpticsProcessorOptions.processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): String =
   if (ele.typeParameters.isEmpty()) {
     dsl.foci.joinToString(separator = "\n\n") { focus ->
       """
-    |${ele.visibilityModifierName} inline val <__S> $Iso<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Iso<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Lens<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Prism<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Prism<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
-    |${ele.visibilityModifierName} inline val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> inline get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Iso<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Iso<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Lens<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Lens<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Optional<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Optional<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Prism<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Prism<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
+    |${ele.visibilityModifierName} $inlineText val <__S> $Traversal<__S, ${ele.sourceClassName}>.${focus.escapedParamName}: $Traversal<__S, ${focus.classNameWithParameters}> $inlineText get() = this + $className.${focus.escapedParamName}
     |
       """.trimMargin()
     }
@@ -102,11 +103,11 @@ private fun processIsoSyntax(ele: ADT, dsl: ValueClassDsl, className: String): S
         else -> focus.refinedArguments.joinToString(separator = ",")
       }
       """
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Iso<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Iso<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Prism<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Prism<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
-    |${ele.visibilityModifierName} inline fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Iso<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Iso<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Lens<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Lens<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Optional<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Optional<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Prism<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Prism<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
+    |${ele.visibilityModifierName} $inlineText fun <__S,$joinedTypeParams> $Traversal<__S, $sourceClassNameWithParams>.${focus.escapedParamName}(): $Traversal<__S, ${focus.classNameWithParameters}> = this + $className.${focus.escapedParamName}()
     |
       """.trimMargin()
     }

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/snippets.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/snippets.kt
@@ -8,9 +8,9 @@ internal fun ADT.snippets(options: OpticsProcessorOptions): List<Snippet> =
       is IsoTarget -> options.generateIsos(this, it)
       is PrismTarget -> options.generatePrisms(this, it)
       is LensTarget -> options.generateLenses(this, it)
-      is SealedClassDsl -> generatePrismDsl(this, it)
-      is DataClassDsl -> generateLensDsl(this, it)
-      is ValueClassDsl -> generateIsoDsl(this, it)
+      is SealedClassDsl -> options.generatePrismDsl(this, it)
+      is DataClassDsl -> options.generateLensDsl(this, it)
+      is ValueClassDsl -> options.generateIsoDsl(this, it)
     }
   }
 


### PR DESCRIPTION
Fixes #3500

It seems that the only thing we get from all the `inline` is a bunch of warnings, so it's better to switch it off by default. It's still possible to generate `inline` getters and setter by enabling the corresponding flag.

This PR also fixes the handling of the processor options, which were not completely acknowledged before. In particular, some methods would generate `inline` functions regardless of the options.