### PR TITLE
Remove suspend modifier from ResourceScope.onRelease

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.api
@@ -247,14 +247,13 @@ public final class arrow/fx/coroutines/ResourceKt {
 public abstract interface class arrow/fx/coroutines/ResourceScope : arrow/AutoCloseScope {
 	public abstract fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun install (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onRelease (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onRelease (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun release (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun releaseCase (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class arrow/fx/coroutines/ResourceScope$DefaultImpls {
 	public static fun install (Larrow/fx/coroutines/ResourceScope;Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
-	public static fun onRelease (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun release (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun releaseCase (Larrow/fx/coroutines/ResourceScope;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
@@ -19,11 +19,11 @@ open annotation class arrow.fx.coroutines/ScopeDSL : kotlin/Annotation { // arro
 }
 
 abstract interface arrow.fx.coroutines/ResourceScope : arrow/AutoCloseScope { // arrow.fx.coroutines/ResourceScope|null[0]
+    abstract fun onRelease(kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/ExitCase, kotlin/Unit>) // arrow.fx.coroutines/ResourceScope.onRelease|onRelease(kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.ExitCase,kotlin.Unit>){}[0]
     abstract suspend fun <#A1: kotlin/Any?> (kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/ResourceScope, #A1>).bind(): #A1 // arrow.fx.coroutines/ResourceScope.bind|bind@kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.ResourceScope,0:0>(){0§<kotlin.Any?>}[0]
     abstract suspend fun <#A1: kotlin/Any?> install(kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/AcquireStep, #A1>, kotlin.coroutines/SuspendFunction2<#A1, arrow.fx.coroutines/ExitCase, kotlin/Unit>): #A1 // arrow.fx.coroutines/ResourceScope.install|install(kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.AcquireStep,0:0>;kotlin.coroutines.SuspendFunction2<0:0,arrow.fx.coroutines.ExitCase,kotlin.Unit>){0§<kotlin.Any?>}[0]
     open suspend fun <#A1: kotlin/Any?> (kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/ResourceScope, #A1>).release(kotlin.coroutines/SuspendFunction1<#A1, kotlin/Unit>): #A1 // arrow.fx.coroutines/ResourceScope.release|release@kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.ResourceScope,0:0>(kotlin.coroutines.SuspendFunction1<0:0,kotlin.Unit>){0§<kotlin.Any?>}[0]
     open suspend fun <#A1: kotlin/Any?> (kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/ResourceScope, #A1>).releaseCase(kotlin.coroutines/SuspendFunction2<#A1, arrow.fx.coroutines/ExitCase, kotlin/Unit>): #A1 // arrow.fx.coroutines/ResourceScope.releaseCase|releaseCase@kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.ResourceScope,0:0>(kotlin.coroutines.SuspendFunction2<0:0,arrow.fx.coroutines.ExitCase,kotlin.Unit>){0§<kotlin.Any?>}[0]
-    open suspend fun onRelease(kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/ExitCase, kotlin/Unit>) // arrow.fx.coroutines/ResourceScope.onRelease|onRelease(kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.ExitCase,kotlin.Unit>){}[0]
 }
 
 final class <#A: kotlin/Any?> arrow.fx.coroutines/ScopedRaiseAccumulate : arrow.core.raise/RaiseAccumulate<#A>, kotlinx.coroutines/CoroutineScope { // arrow.fx.coroutines/ScopedRaiseAccumulate|null[0]


### PR DESCRIPTION
This allows it to be called in non-suspending contexts like `runInterruptible` which is important for resource safety when interacting with interruptible Java APIs. It also just doesn't need to be `suspend`, and in fact, it can be the SAM that defines ResourceScope, although that's not implemented here.
This is the only binary breaking change needed for #3518.
I'd really like to get this approved for 2.0, since otherwise we'd have to delay it to 3.0 :(