### PR TITLE
Introducing Arrow Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![StackOverflow](https://img.shields.io/badge/arrow--kt-grey.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/arrow-kt)
 [![Twitter](https://img.shields.io/twitter/follow/arrow_kt?color=blue&style=flat)](https://twitter.com/arrow_kt)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Arrow%20Guru-006BFF)](https://gurubase.io/g/arrow)
 
 Λrrow is a library for Typed Functional Programming in Kotlin.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Arrow Guru](https://gurubase.io/g/arrow) to Gurubase. Arrow Guru uses the data from this repo and data from the [docs](http://arrow-kt.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Arrow Guru", which highlights that Arrow now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Arrow Guru in Gurubase, just let me know that's totally fine.
