### PR TITLE
Do not run flaky tests on corresponding platforms

### DIFF
--- a/arrow-libs/core/arrow-cache4k/build.gradle.kts
+++ b/arrow-libs/core/arrow-cache4k/build.gradle.kts
@@ -44,12 +44,15 @@ kotlin {
   jvm {
     withJava()
   }
-
   js(IR) {
     browser()
     nodejs()
   }
-
+  // @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class) wasmJs {
+  //   browser()
+  //   nodejs()
+  //   d8()
+  // }
   // Native: https://kotlinlang.org/docs/native-target-support.html
   // -- Tier 1 --
   linuxX64()

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
@@ -9,6 +9,7 @@ import arrow.core.test.map2
 import arrow.core.test.map3
 import arrow.core.test.option
 import arrow.core.test.testLaws
+import arrow.platform.test.FlakyOnJs
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.maps.shouldBeEmpty
@@ -714,7 +715,7 @@ class MapKTest {
     }
   }
 
-  @Test fun mapValuesOrAccumulateAccumulates() = runTest {
+  @Test @FlakyOnJs fun mapValuesOrAccumulateAccumulates() = runTest {
     checkAll(
       Arb.map(Arb.int(), Arb.int(), minSize = 1, maxSize = 30)
     ) { xs ->

--- a/arrow-libs/core/arrow-platform/api/arrow-platform.api
+++ b/arrow-libs/core/arrow-platform/api/arrow-platform.api
@@ -16,3 +16,6 @@ public final class arrow/platform/PlatformKt {
 	public static final fun stackSafeIteration ()I
 }
 
+public abstract interface annotation class arrow/platform/test/NonFlakyOnThisPlatform : java/lang/annotation/Annotation {
+}
+

--- a/arrow-libs/core/arrow-platform/api/arrow-platform.klib.api
+++ b/arrow-libs/core/arrow-platform/api/arrow-platform.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <io.arrow-kt:arrow-platform>
+open annotation class arrow.platform.test/NonFlakyOnThisPlatform : kotlin/Annotation { // arrow.platform.test/NonFlakyOnThisPlatform|null[0]
+    constructor <init>() // arrow.platform.test/NonFlakyOnThisPlatform.<init>|<init>(){}[0]
+}
+
 final enum class arrow.platform/Platform : kotlin/Enum<arrow.platform/Platform> { // arrow.platform/Platform|null[0]
     enum entry JS // arrow.platform/Platform.JS|null[0]
     enum entry JVM // arrow.platform/Platform.JVM|null[0]

--- a/arrow-libs/core/arrow-platform/build.gradle.kts
+++ b/arrow-libs/core/arrow-platform/build.gradle.kts
@@ -25,6 +25,17 @@ kotlin {
     commonMain {
       dependencies {
         implementation(libs.kotlin.stdlib)
+        implementation(libs.kotlin.testAnnotations)
+      }
+    }
+    jvmMain {
+      dependencies {
+        implementation(libs.kotlin.testJUnit5)
+      }
+    }
+    jsMain {
+      dependencies {
+        implementation(libs.kotlin.test)
       }
     }
   }
@@ -41,5 +52,6 @@ kotlin {
   compilerOptions {
     (project.rootProject.properties["kotlin_language_version"] as? String)?.also { languageVersion = KotlinVersion.fromVersion(it) }
     (project.rootProject.properties["kotlin_api_version"] as? String)?.also { apiVersion = KotlinVersion.fromVersion(it) }
+    freeCompilerArgs.add("-Xexpect-actual-classes")
   }
 }

--- a/arrow-libs/core/arrow-platform/src/commonMain/kotlin/arrow/platform/test/Flaky.kt
+++ b/arrow-libs/core/arrow-platform/src/commonMain/kotlin/arrow/platform/test/Flaky.kt
@@ -1,0 +1,7 @@
+package arrow.platform.test
+
+public annotation class NonFlakyOnThisPlatform
+
+public expect annotation class FlakyOnJvm()
+public expect annotation class FlakyOnJs()
+public expect annotation class FlakyOnNative()

--- a/arrow-libs/core/arrow-platform/src/jsMain/kotlin/arrow/platform/test/Flaky.kt
+++ b/arrow-libs/core/arrow-platform/src/jsMain/kotlin/arrow/platform/test/Flaky.kt
@@ -1,0 +1,5 @@
+package arrow.platform.test
+
+public actual typealias FlakyOnJvm = NonFlakyOnThisPlatform
+public actual typealias FlakyOnJs = kotlin.test.Ignore
+public actual typealias FlakyOnNative = NonFlakyOnThisPlatform

--- a/arrow-libs/core/arrow-platform/src/jvmMain/kotlin/arrow/platform/test/Flaky.kt
+++ b/arrow-libs/core/arrow-platform/src/jvmMain/kotlin/arrow/platform/test/Flaky.kt
@@ -1,0 +1,5 @@
+package arrow.platform.test
+
+public actual typealias FlakyOnJvm = org.junit.jupiter.api.Disabled
+public actual typealias FlakyOnJs = NonFlakyOnThisPlatform
+public actual typealias FlakyOnNative = NonFlakyOnThisPlatform

--- a/arrow-libs/core/arrow-platform/src/nativeMain/kotlin/arrow/platform/test/Flaky.kt
+++ b/arrow-libs/core/arrow-platform/src/nativeMain/kotlin/arrow/platform/test/Flaky.kt
@@ -1,0 +1,5 @@
+package arrow.platform.test
+
+public actual typealias FlakyOnJvm = NonFlakyOnThisPlatform
+public actual typealias FlakyOnJs = NonFlakyOnThisPlatform
+public actual typealias FlakyOnNative = kotlin.test.Ignore

--- a/arrow-libs/core/arrow-platform/src/wasmJsMain/kotlin/arrow/platform/test/Flaky.kt
+++ b/arrow-libs/core/arrow-platform/src/wasmJsMain/kotlin/arrow/platform/test/Flaky.kt
@@ -1,0 +1,5 @@
+package arrow.platform.test
+
+public actual typealias FlakyOnJvm = NonFlakyOnThisPlatform
+public actual typealias FlakyOnJs = NonFlakyOnThisPlatform
+public actual typealias FlakyOnNative = NonFlakyOnThisPlatform

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ParMapTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonTest/kotlin/arrow/fx/coroutines/ParMapTest.kt
@@ -7,6 +7,7 @@ import arrow.core.NonEmptyList
 import arrow.core.left
 import arrow.core.raise.either
 import arrow.platform.stackSafeIteration
+import arrow.platform.test.FlakyOnJs
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -50,7 +51,7 @@ class ParMapTest {
     ).parMap { it.invoke() }
   }
 
-  @Test fun parTraverseResultsInTheCorrectError() = runTestUsingDefaultDispatcher {
+  @Test @FlakyOnJs fun parTraverseResultsInTheCorrectError() = runTestUsingDefaultDispatcher {
     checkAll(
       Arb.int(min = 10, max = 20),
       Arb.int(min = 1, max = 9),

--- a/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/arrow/fx/coroutines/RaceNJvmTest.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/jvmTest/kotlin/arrow/fx/coroutines/RaceNJvmTest.kt
@@ -2,6 +2,7 @@ package arrow.fx.coroutines
 
 import arrow.core.Either
 import arrow.core.identity
+import arrow.platform.test.FlakyOnJvm
 import io.kotest.matchers.should
 import io.kotest.matchers.string.shouldStartWith
 import kotlin.test.Test
@@ -67,7 +68,7 @@ class RaceNJvmTest {
   fun race2ReturnsToOriginalContextOnFailureRight(): Unit =
       race2ReturnsToOriginalContextOnFailure(true)
 
-  @Test
+  @Test @FlakyOnJvm
   fun firstRacerOutOf2AlwaysWinsOnASingleThread(): Unit =
       runBlocking(Dispatchers.Default) {
         resourceScope {

--- a/arrow-libs/optics/arrow-optics-compose/build.gradle.kts
+++ b/arrow-libs/optics/arrow-optics-compose/build.gradle.kts
@@ -37,7 +37,11 @@ kotlin {
     browser()
     nodejs()
   }
-  @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class) wasmJs()
+  @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class) wasmJs {
+    browser()
+    nodejs()
+    d8()
+  }
   androidTarget()
   // Native: https://kotlinlang.org/docs/native-target-support.html
   // -- Tier 1 --

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 animalSniffer = "1.7.2"
-arrowGradleConfig = "0.12.0-rc.24"
+arrowGradleConfig = "0.12.0-rc.25"
 coroutines = "1.9.0"
 classgraph = "4.8.179"
 dokka = "2.0.0"
@@ -31,6 +31,8 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
+kotlin-testAnnotations = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common" }
+kotlin-testJUnit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 kotlinx-knit = { module = "org.jetbrains.kotlinx:kotlinx-knit", version.ref = "knit" }
 kotlinx-serializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinx-serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }


### PR DESCRIPTION
Fixes #3523
Fixes #3520
Fixes #3519
Fixes #3471 

This PR introduces a few annotations in the somehow-internal `arrow-platform` package which allows setting a test as disabled in only one platform. This should alleviate our current problems with flaky test.