### PR TITLE
Add finer-grained validation for determining the symbols to defer during symbol processing

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessor.kt
@@ -14,7 +14,9 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.validate
 
 class OpticsProcessor(
@@ -27,7 +29,15 @@ class OpticsProcessor(
     val (resolved, deferred) = resolver
       .getSymbolsWithAnnotation("arrow.optics.optics")
       .filterIsInstance<KSClassDeclaration>()
-      .partition { it.validate() }
+      .partition {
+        it.validate { _, element ->
+          when (element) {
+            is KSAnnotation -> false
+            is KSFunctionDeclaration -> false
+            else -> true
+          }
+        }
+      }
     resolved.forEach(::processClass)
 
     // If types used by the annotated class are by other processors,

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
@@ -60,6 +60,34 @@ class LensTests {
   }
 
   @Test
+  fun `Lenses are generated for data class referencing its own lenses for type inference`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |data class UsingLens(val field: String) {
+      |  fun getLens() = UsingLens.field
+      |  companion object
+      |}
+      |
+      |val i: Lens<UsingLens, String> = UsingLens.field
+      |val r = i != null
+    """.evals("r" to true)
+  }
+
+  @Test
+  fun `Lenses are not generated for unresolved types`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |data class InvalidType(val field: Foo) {
+      |  companion object
+      |}
+    """.compilationFails()
+  }
+
+  @Test
   fun `Lenses which mentions imported elements`() {
     """
       |$`package`


### PR DESCRIPTION
This addresses an issue introduced here: https://github.com/arrow-kt/arrow/pull/3537#issuecomment-2573056265

Essentially, at the moment, processing for any candidate class for optics is "deferred" when "validation" fails - essentially when any type in the class definition is not resolved. Unfortunately, this causes issues when these types are dependent on the lenses-to-be-generated themselves, such as in the following example:

```kotlin
@optics
data class UsingLens(val field: String) {
  fun getLens() = UsingLens.field // Return type of the function is dependent on the lens
  companion object
}
```

While this class obviously has unresolved types, these do not impact code generation of optics. Ideally, we should limit the validation to only check the validity of the types involved in the generated lenses. The best place for this would probably be in the `Focus` class after generating the ADT, but I could not get this to work very neatly without changing code everywhere.

Instead, I implemented a simpler, "best effort" approach where I skip validation for irrelevant declarations/nodes, such as functions and annotations. This is not perfect, and still causes the validation to be "too strict", but might be a good initial step.

The approach suggested in the other thread - to defer classes once and actually process them on a second pass - does not work, as KSP will stop processing symbols when there is no other processor to defer symbols _to_.