### PR TITLE
Non-empty collections for Jackson

### DIFF
--- a/arrow-libs/integrations/arrow-core-jackson/api/arrow-core-jackson.api
+++ b/arrow-libs/integrations/arrow-core-jackson/api/arrow-core-jackson.api
@@ -59,6 +59,33 @@ public final class arrow/integrations/jackson/module/IorSerializerResolver : com
 	public fun findSerializer (Lcom/fasterxml/jackson/databind/SerializationConfig;Lcom/fasterxml/jackson/databind/JavaType;Lcom/fasterxml/jackson/databind/BeanDescription;)Lcom/fasterxml/jackson/databind/JsonSerializer;
 }
 
+public final class arrow/integrations/jackson/module/NonEmptyCollectionDeserializer : com/fasterxml/jackson/databind/deser/std/StdDeserializer {
+	public fun <init> (Lcom/fasterxml/jackson/databind/JavaType;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)V
+	public fun deserialize (Lcom/fasterxml/jackson/core/JsonParser;Lcom/fasterxml/jackson/databind/DeserializationContext;)Larrow/core/NonEmptyCollection;
+	public synthetic fun deserialize (Lcom/fasterxml/jackson/core/JsonParser;Lcom/fasterxml/jackson/databind/DeserializationContext;)Ljava/lang/Object;
+}
+
+public final class arrow/integrations/jackson/module/NonEmptyCollectionDeserializerResolver : com/fasterxml/jackson/databind/deser/Deserializers$Base {
+	public static final field INSTANCE Larrow/integrations/jackson/module/NonEmptyCollectionDeserializerResolver;
+	public fun findCollectionDeserializer (Lcom/fasterxml/jackson/databind/type/CollectionType;Lcom/fasterxml/jackson/databind/DeserializationConfig;Lcom/fasterxml/jackson/databind/BeanDescription;Lcom/fasterxml/jackson/databind/jsontype/TypeDeserializer;Lcom/fasterxml/jackson/databind/JsonDeserializer;)Lcom/fasterxml/jackson/databind/JsonDeserializer;
+}
+
+public final class arrow/integrations/jackson/module/NonEmptyCollectionSerializer : com/fasterxml/jackson/databind/ser/std/StdSerializer {
+	public static final field INSTANCE Larrow/integrations/jackson/module/NonEmptyCollectionSerializer;
+	public fun serialize (Larrow/core/NonEmptyCollection;Lcom/fasterxml/jackson/core/JsonGenerator;Lcom/fasterxml/jackson/databind/SerializerProvider;)V
+	public synthetic fun serialize (Ljava/lang/Object;Lcom/fasterxml/jackson/core/JsonGenerator;Lcom/fasterxml/jackson/databind/SerializerProvider;)V
+}
+
+public final class arrow/integrations/jackson/module/NonEmptyCollectionSerializerResolver : com/fasterxml/jackson/databind/ser/Serializers$Base {
+	public static final field INSTANCE Larrow/integrations/jackson/module/NonEmptyCollectionSerializerResolver;
+	public fun findCollectionSerializer (Lcom/fasterxml/jackson/databind/SerializationConfig;Lcom/fasterxml/jackson/databind/type/CollectionType;Lcom/fasterxml/jackson/databind/BeanDescription;Lcom/fasterxml/jackson/databind/jsontype/TypeSerializer;Lcom/fasterxml/jackson/databind/JsonSerializer;)Lcom/fasterxml/jackson/databind/JsonSerializer;
+}
+
+public final class arrow/integrations/jackson/module/NonEmptyCollectionsModule : com/fasterxml/jackson/databind/module/SimpleModule {
+	public fun <init> ()V
+	public fun setupModule (Lcom/fasterxml/jackson/databind/Module$SetupContext;)V
+}
+
 public final class arrow/integrations/jackson/module/OptionDeserializer : com/fasterxml/jackson/databind/JsonDeserializer, com/fasterxml/jackson/databind/deser/ContextualDeserializer {
 	public fun <init> ()V
 	public fun createContextual (Lcom/fasterxml/jackson/databind/DeserializationContext;Lcom/fasterxml/jackson/databind/BeanProperty;)Lcom/fasterxml/jackson/databind/JsonDeserializer;

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/ArrowModule.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/ArrowModule.kt
@@ -6,9 +6,7 @@ public fun ObjectMapper.registerArrowModule(
   eitherModuleConfig: EitherModuleConfig = EitherModuleConfig("left", "right"),
   iorModuleConfig: IorModuleConfig = IorModuleConfig("left", "right"),
 ): ObjectMapper = registerModules(
-  // no longer required, as they are value classes
-  // NonEmptyListModule,
-  // NonEmptySetModule,
+  NonEmptyCollectionsModule(),
   OptionModule,
   EitherModule(eitherModuleConfig.leftFieldName, eitherModuleConfig.rightFieldName),
   IorModule(iorModuleConfig.leftFieldName, iorModuleConfig.rightFieldName),

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
@@ -1,0 +1,80 @@
+package arrow.integrations.jackson.module
+
+import arrow.core.NonEmptyCollection
+import arrow.core.NonEmptyList
+import arrow.core.NonEmptySet
+import arrow.core.toNonEmptyListOrNull
+import arrow.core.toNonEmptySetOrNull
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.json.PackageVersion
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializationConfig
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.deser.Deserializers
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.databind.type.CollectionType
+
+public class NonEmptyCollectionsModule : SimpleModule(NonEmptyCollectionsModule::class.java.name, PackageVersion.VERSION) {
+  override fun setupModule(context: SetupContext) {
+    super.setupModule(context)
+    context.addSerializers(NonEmptyCollectionSerializerResolver)
+    context.addDeserializers(NonEmptyCollectionDeserializerResolver)
+  }
+}
+
+public object NonEmptyCollectionSerializerResolver : Serializers.Base() {
+  override fun findCollectionSerializer(
+    config: SerializationConfig,
+    type: CollectionType,
+    beanDesc: BeanDescription?,
+    elementTypeSerializer: TypeSerializer?,
+    elementValueSerializer: JsonSerializer<Any>?
+  ): JsonSerializer<*>? = when {
+    NonEmptyCollection::class.java.isAssignableFrom(type.rawClass) -> NonEmptyCollectionSerializer
+    else -> null
+  }
+}
+
+public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
+  override fun findCollectionDeserializer(
+    type: CollectionType,
+    config: DeserializationConfig,
+    beanDesc: BeanDescription?,
+    elementTypeDeserializer: TypeDeserializer?,
+    elementDeserializer: JsonDeserializer<*>?
+  ): JsonDeserializer<*>? = when {
+    NonEmptyList::class.java.isAssignableFrom(type.rawClass) ->
+      NonEmptyCollectionDeserializer(type.contentType, NonEmptyList::class.java) { it.toNonEmptyListOrNull() }
+    NonEmptySet::class.java.isAssignableFrom(type.rawClass) ->
+      NonEmptyCollectionDeserializer(type.contentType, NonEmptySet::class.java) { it.toNonEmptySetOrNull() }
+    else -> null
+  }
+}
+
+public object NonEmptyCollectionSerializer: StdSerializer<NonEmptyCollection<*>>(NonEmptyCollection::class.java) {
+  override fun serialize(value: NonEmptyCollection<*>, gen: JsonGenerator, provider: SerializerProvider) {
+    provider.defaultSerializeValue(value.toList(), gen)
+  }
+}
+
+public class NonEmptyCollectionDeserializer<T: NonEmptyCollection<*>>(
+  private val contentType: JavaType,
+  klass: Class<T>,
+  private val converter: (List<*>) -> T?
+) : StdDeserializer<T>(klass) {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T? {
+    val collection = CollectionType.construct(ArrayList::class.java, contentType)
+    return converter(ctxt.readValue(p, collection))
+  }
+}

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
@@ -39,7 +39,7 @@ public object NonEmptyCollectionSerializerResolver : Serializers.Base() {
     type: CollectionType,
     beanDesc: BeanDescription?,
     elementTypeSerializer: TypeSerializer?,
-    elementValueSerializer: JsonSerializer<Any>?
+    elementValueSerializer: JsonSerializer<Any>?,
   ): JsonSerializer<*>? = when {
     NonEmptyCollection::class.java.isAssignableFrom(type.rawClass) -> NonEmptyCollectionSerializer
     else -> null
@@ -52,7 +52,7 @@ public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
     config: DeserializationConfig,
     beanDesc: BeanDescription?,
     elementTypeDeserializer: TypeDeserializer?,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? = when {
     NonEmptyList::class.java.isAssignableFrom(type.rawClass) ->
       NonEmptyCollectionDeserializer(type.contentType, NonEmptyList::class.java) { it.toNonEmptyListOrNull() }
@@ -62,16 +62,16 @@ public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
   }
 }
 
-public object NonEmptyCollectionSerializer: StdSerializer<NonEmptyCollection<*>>(NonEmptyCollection::class.java) {
+public object NonEmptyCollectionSerializer : StdSerializer<NonEmptyCollection<*>>(NonEmptyCollection::class.java) {
   override fun serialize(value: NonEmptyCollection<*>, gen: JsonGenerator, provider: SerializerProvider) {
     provider.defaultSerializeValue(value.toList(), gen)
   }
 }
 
-public class NonEmptyCollectionDeserializer<T: NonEmptyCollection<*>>(
+public class NonEmptyCollectionDeserializer<T : NonEmptyCollection<*>>(
   private val contentType: JavaType,
   klass: Class<T>,
-  private val converter: (List<*>) -> T?
+  private val converter: (List<*>) -> T?,
 ) : StdDeserializer<T>(klass) {
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T? {
     val collection = CollectionType.construct(ArrayList::class.java, contentType)

--- a/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
@@ -19,9 +19,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.Ignore
 
-@Ignore
 class NonEmptyListModuleTest {
-  private val mapper = ObjectMapper().registerKotlinModule()
+  private val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
 
   @Test
   fun `serializing NonEmptyList should be the same as serializing the underlying list`() = runTest {
@@ -54,13 +53,11 @@ class NonEmptyListModuleTest {
     }
   }
 
-  @Test
+  @Test @Ignore
   fun `serializing NonEmptyList in an object should round trip`() = runTest {
-    data class Wrapper(val nel: Nel<SomeObject>)
-
-    checkAll(arbitrary { Wrapper(Arb.nonEmptyList(Arb.someObject()).bind()) }) { wrapper ->
+    checkAll(arbitrary { WrapperWithList(Arb.nonEmptyList(Arb.someObject()).bind()) }) { wrapper ->
       val encoded: String = mapper.writeValueAsString(wrapper)
-      val decoded: Wrapper = mapper.readValue(encoded, Wrapper::class.java)
+      val decoded: WrapperWithList = mapper.readValue(encoded, WrapperWithList::class.java)
 
       decoded shouldBe wrapper
     }
@@ -78,3 +75,5 @@ class NonEmptyListModuleTest {
     }
   }
 }
+
+data class WrapperWithList(val nel: Nel<SomeObject>)

--- a/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/NonEmptySetModuleTest.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/NonEmptySetModuleTest.kt
@@ -18,9 +18,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 
-@Ignore
 class NonEmptySetModuleTest {
-  private val mapper = ObjectMapper().registerKotlinModule()
+  private val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()
 
   @Test
   fun `serializing NonEmptySet should be the same as serializing the underlying set`() = runTest {
@@ -57,13 +56,11 @@ class NonEmptySetModuleTest {
     }
   }
 
-  @Test
+  @Test @Ignore
   fun `serializing NonEmptySet in an object should round trip`() = runTest {
-    data class Wrapper(val nel: NonEmptySet<SomeObject>)
-
-    checkAll(arbitrary { Wrapper(Arb.nonEmptySet(Arb.someObject()).bind()) }) { wrapper ->
+    checkAll(arbitrary { WrapperWithSet(Arb.nonEmptySet(Arb.someObject()).bind()) }) { wrapper ->
       val encoded: String = mapper.writeValueAsString(wrapper)
-      val decoded: Wrapper = mapper.readValue(encoded, Wrapper::class.java)
+      val decoded: WrapperWithSet = mapper.readValue(encoded, WrapperWithSet::class.java)
 
       decoded shouldBe wrapper
     }
@@ -81,3 +78,5 @@ class NonEmptySetModuleTest {
     }
   }
 }
+
+data class WrapperWithSet(val nel: NonEmptySet<SomeObject>)


### PR DESCRIPTION
This adds serializers for non-empty collections for the Jackson integration module.

Note than nested fields still fail because of the [Kotlin compiler bug](https://youtrack.jetbrains.com/issue/KT-52706/Bad-signature-for-generic-value-classes-with-substituted-type-parameter) which also affects #3557.