### PR TITLE
Further improvements for Kotlin Compatibility Testing

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessorOptions.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/OpticsProcessorOptions.kt
@@ -7,7 +7,7 @@ data class OpticsProcessorOptions(
 
   companion object {
     fun from(options: Map<String, String>): OpticsProcessorOptions = OpticsProcessorOptions(
-      useInline = options.getOrDefault("inline", "false").toBooleanStrict(),
+      useInline = options.get("inline")?.toBooleanStrict() ?: false,
     )
   }
 }


### PR DESCRIPTION
This PR fixes some problems which may arise with empty Gradle properties, and correctly sets up Animal Sniffer for Java 1.8 and Android compatibility.

As a result of the incompatibilities found by Animal Sniffer, the minimal Android SDK version has been bumped to 24.