### PR TITLE
Test and fix for Map.combine()

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
@@ -502,7 +502,7 @@ public fun <K, V> Map<K, V>.getOrNone(key: K): Option<V> =
 /** Combines two maps using [combine] to combine values for the same key. */
 public fun <K, A> Map<K, A>.combine(other: Map<K, A>, combine: (A, A) -> A): Map<K, A> =
   if (size < other.size) fold(other) { my, (k, b) -> my + Pair(k, my[k]?.let { combine(b, it) } ?: b) }
-  else other.fold(this@combine) { my, (k, a) -> my + Pair(k, my[k]?.let { combine(a, it) } ?: a) }
+  else other.fold(this@combine) { my, (k, a) -> my + Pair(k, my[k]?.let { combine(it, a) } ?: a) }
 
 public inline fun <K, A, B> Map<K, A>.fold(initial: B, operation: (acc: B, Map.Entry<K, A>) -> B): B {
   var accumulator = initial

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
@@ -42,10 +42,10 @@ class MapKTest {
       )
     )
 
-  // In addition to verifying monoid laws, we need to test the property of order-preservation
-  // when delegating to the nested monoid. Since the nested monoid is not necessarily
-  // commutative, preserving the order of parameters is essential.
-  @Test fun nestingMonoids() = runTest {
+  // In addition to verifying monoid laws, we must test the property of order-preservation
+  // when delegating to the nested monoid operation. Since a monoid's associative operation
+  // is not necessarily commutative, preserving the order of parameters is essential.
+  @Test fun orderPreservationInNestedCombine() = runTest {
     checkAll(
       // The range of keys and map sizes are chosen to allow for varying maps sizes, while ensuring key conflicts.
       // Consider that minSize is inclusive while maxSize is exclusive.
@@ -53,7 +53,7 @@ class MapKTest {
       Arb.map(Arb.int(1, 2), Arb.string(), minSize = 1, maxSize = 3),
     ) { map1, map2 ->
 
-      // Note using string concatenation which is not-commutative
+      // Notice that string concatenation is non-commutative.
       val result = map1.combine(map2, String::plus)
       map1.keys.intersect(map2.keys).forEach { key ->
         val expectedValue = map1[key].plus(map2[key])

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/MapKTest.kt
@@ -26,6 +26,7 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.pair
+import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -40,6 +41,27 @@ class MapKTest {
         Arb.map(Arb.int(), Arb.intSmall(), maxSize = 10)
       )
     )
+
+  // In addition to verifying monoid laws, we need to test the property of order-preservation
+  // when delegating to the nested monoid. Since the nested monoid is not necessarily
+  // commutative, preserving the order of parameters is essential.
+  @Test fun nestingMonoids() = runTest {
+    checkAll(
+      // The range of keys and map sizes are chosen to allow for varying maps sizes, while ensuring key conflicts.
+      // Consider that minSize is inclusive while maxSize is exclusive.
+      Arb.map(Arb.int(1, 2), Arb.string(), minSize = 1, maxSize = 3),
+      Arb.map(Arb.int(1, 2), Arb.string(), minSize = 1, maxSize = 3),
+    ) { map1, map2 ->
+
+      // Note using string concatenation which is not-commutative
+      val result = map1.combine(map2, String::plus)
+      map1.keys.intersect(map2.keys).forEach { key ->
+        val expectedValue = map1[key].plus(map2[key])
+        result[key] shouldBe expectedValue
+      }
+    }
+  }
+
 
   @Test fun alignMaps() = runTest {
       checkAll(


### PR DESCRIPTION
Fixes #3591

The existing test covers monoid laws but does not verify delegation to the nested monoid's `combine` function, which is why the bug went unnoticed.

This PR provides a property-based test that verifies the property of order-preservation when `Map.combine()` delegates. The test fails with the existing implementation. The PR also includes a fix that makes it pass.

I'm happy to refine the PR to better align with the project's style and conventions.
