### PR TITLE
Make implementation of `HttpRequestSchedule` closer to `HttpRetry`

### DIFF
--- a/arrow-libs/integrations/arrow-resilience-ktor-client/api/android/arrow-resilience-ktor-client.api
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/api/android/arrow-resilience-ktor-client.api
@@ -79,13 +79,13 @@ public final class arrow/resilience/ktor/client/RetryEventData$Failure : arrow/r
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class arrow/resilience/ktor/client/RetryEventData$HttpResponse : arrow/resilience/ktor/client/RetryEventData {
+public final class arrow/resilience/ktor/client/RetryEventData$Response : arrow/resilience/ktor/client/RetryEventData {
 	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun component2 ()I
 	public final fun component3 ()Lio/ktor/client/statement/HttpResponse;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$HttpResponse;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/RetryEventData$Response;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$Response;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$Response;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun exceptionOrNull ()Ljava/lang/Throwable;
 	public fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/api/android/arrow-resilience-ktor-client.api
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/api/android/arrow-resilience-ktor-client.api
@@ -16,26 +16,28 @@ public final class arrow/resilience/ktor/client/HttpCircuitBreaker$Plugin : io/k
 	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule {
-	public static final field Plugin Larrow/resilience/ktor/client/HttpRequestSchedule$Plugin;
-}
-
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$Configuration {
+public final class arrow/resilience/ktor/client/HttpRequestScheduleConfiguration {
 	public fun <init> ()V
 	public final fun modifyRequest (Lkotlin/jvm/functions/Function3;)V
 	public final fun repeat (Larrow/resilience/Schedule;)V
 	public final fun retry (Larrow/resilience/Schedule;)V
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext {
-	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)V
+public final class arrow/resilience/ktor/client/HttpRequestScheduleKt {
+	public static final fun getHttpRequestSchedule ()Lio/ktor/client/plugins/api/ClientPlugin;
+	public static final fun getHttpRequestScheduleEvent ()Lio/ktor/events/EventDefinition;
+	public static final fun schedule (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class arrow/resilience/ktor/client/ModifyRequestContext {
+	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/RetryEventData;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
-	public final fun component2 ()Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;ILjava/lang/Object;)Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;
+	public final fun component2 ()Larrow/resilience/ktor/client/RetryEventData;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/RetryEventData;)Larrow/resilience/ktor/client/ModifyRequestContext;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/RetryEventData;ILjava/lang/Object;)Larrow/resilience/ktor/client/ModifyRequestContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun exceptionOrNull ()Ljava/lang/Throwable;
-	public final fun getLastRetryEventData ()Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;
+	public final fun getLastRetryEventData ()Larrow/resilience/ktor/client/RetryEventData;
 	public final fun getOriginal ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun getRetryCount ()I
@@ -44,38 +46,29 @@ public final class arrow/resilience/ktor/client/HttpRequestSchedule$ModifyReques
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class arrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestPerRequest {
-	public abstract fun invoke (Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract interface class arrow/resilience/ktor/client/ModifyRequestPerRequest {
+	public abstract fun invoke (Larrow/resilience/ktor/client/ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$Plugin : io/ktor/client/plugins/HttpClientPlugin {
-	public final fun getHttpRequestScheduleEvent ()Lio/ktor/events/EventDefinition;
-	public fun getKey ()Lio/ktor/util/AttributeKey;
-	public fun install (Larrow/resilience/ktor/client/HttpRequestSchedule;Lio/ktor/client/HttpClient;)V
-	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
-	public fun prepare (Lkotlin/jvm/functions/Function1;)Larrow/resilience/ktor/client/HttpRequestSchedule;
-	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-}
-
-public abstract interface class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData {
+public abstract interface class arrow/resilience/ktor/client/RetryEventData {
 	public abstract fun exceptionOrNull ()Ljava/lang/Throwable;
 	public abstract fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
 	public abstract fun getRetryCount ()I
 	public abstract fun responseOrNull ()Lio/ktor/client/statement/HttpResponse;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$DefaultImpls {
-	public static fun exceptionOrNull (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)Ljava/lang/Throwable;
-	public static fun responseOrNull (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)Lio/ktor/client/statement/HttpResponse;
+public final class arrow/resilience/ktor/client/RetryEventData$DefaultImpls {
+	public static fun exceptionOrNull (Larrow/resilience/ktor/client/RetryEventData;)Ljava/lang/Throwable;
+	public static fun responseOrNull (Larrow/resilience/ktor/client/RetryEventData;)Lio/ktor/client/statement/HttpResponse;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure : arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData {
+public final class arrow/resilience/ktor/client/RetryEventData$Failure : arrow/resilience/ktor/client/RetryEventData {
 	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun component2 ()I
 	public final fun component3 ()Ljava/lang/Throwable;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure;Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;ILjava/lang/Object;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;)Larrow/resilience/ktor/client/RetryEventData$Failure;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$Failure;Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun exceptionOrNull ()Ljava/lang/Throwable;
 	public final fun getException ()Ljava/lang/Throwable;
@@ -86,13 +79,13 @@ public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventDa
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse : arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData {
+public final class arrow/resilience/ktor/client/RetryEventData$HttpResponse : arrow/resilience/ktor/client/RetryEventData {
 	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun component2 ()I
 	public final fun component3 ()Lio/ktor/client/statement/HttpResponse;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$HttpResponse;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun exceptionOrNull ()Ljava/lang/Throwable;
 	public fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
@@ -101,9 +94,5 @@ public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventDa
 	public fun hashCode ()I
 	public fun responseOrNull ()Lio/ktor/client/statement/HttpResponse;
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class arrow/resilience/ktor/client/HttpRequestScheduleKt {
-	public static final fun schedule (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/api/arrow-resilience-ktor-client.klib.api
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/api/arrow-resilience-ktor-client.klib.api
@@ -6,6 +6,58 @@
 // - Show declarations: true
 
 // Library unique name: <io.arrow-kt:arrow-resilience-ktor-client>
+abstract fun interface arrow.resilience.ktor.client/ModifyRequestPerRequest { // arrow.resilience.ktor.client/ModifyRequestPerRequest|null[0]
+    abstract suspend fun invoke(arrow.resilience.ktor.client/ModifyRequestContext, io.ktor.client.request/HttpRequestBuilder) // arrow.resilience.ktor.client/ModifyRequestPerRequest.invoke|invoke(arrow.resilience.ktor.client.ModifyRequestContext;io.ktor.client.request.HttpRequestBuilder){}[0]
+}
+
+sealed interface arrow.resilience.ktor.client/RetryEventData { // arrow.resilience.ktor.client/RetryEventData|null[0]
+    abstract val request // arrow.resilience.ktor.client/RetryEventData.request|{}request[0]
+        abstract fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.request.<get-request>|<get-request>(){}[0]
+    abstract val retryCount // arrow.resilience.ktor.client/RetryEventData.retryCount|{}retryCount[0]
+        abstract fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
+
+    open fun exceptionOrNull(): kotlin/Throwable? // arrow.resilience.ktor.client/RetryEventData.exceptionOrNull|exceptionOrNull(){}[0]
+    open fun responseOrNull(): io.ktor.client.statement/HttpResponse? // arrow.resilience.ktor.client/RetryEventData.responseOrNull|responseOrNull(){}[0]
+
+    final class Failure : arrow.resilience.ktor.client/RetryEventData { // arrow.resilience.ktor.client/RetryEventData.Failure|null[0]
+        constructor <init>(io.ktor.client.request/HttpRequestBuilder, kotlin/Int, kotlin/Throwable) // arrow.resilience.ktor.client/RetryEventData.Failure.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;kotlin.Throwable){}[0]
+
+        final val exception // arrow.resilience.ktor.client/RetryEventData.Failure.exception|{}exception[0]
+            final fun <get-exception>(): kotlin/Throwable // arrow.resilience.ktor.client/RetryEventData.Failure.exception.<get-exception>|<get-exception>(){}[0]
+        final val request // arrow.resilience.ktor.client/RetryEventData.Failure.request|{}request[0]
+            final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.Failure.request.<get-request>|<get-request>(){}[0]
+        final val retryCount // arrow.resilience.ktor.client/RetryEventData.Failure.retryCount|{}retryCount[0]
+            final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.Failure.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
+
+        final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.Failure.component1|component1(){}[0]
+        final fun component2(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.Failure.component2|component2(){}[0]
+        final fun component3(): kotlin/Throwable // arrow.resilience.ktor.client/RetryEventData.Failure.component3|component3(){}[0]
+        final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., kotlin/Int = ..., kotlin/Throwable = ...): arrow.resilience.ktor.client/RetryEventData.Failure // arrow.resilience.ktor.client/RetryEventData.Failure.copy|copy(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;kotlin.Throwable){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/RetryEventData.Failure.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.Failure.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // arrow.resilience.ktor.client/RetryEventData.Failure.toString|toString(){}[0]
+    }
+
+    final class HttpResponse : arrow.resilience.ktor.client/RetryEventData { // arrow.resilience.ktor.client/RetryEventData.HttpResponse|null[0]
+        constructor <init>(io.ktor.client.request/HttpRequestBuilder, kotlin/Int, io.ktor.client.statement/HttpResponse) // arrow.resilience.ktor.client/RetryEventData.HttpResponse.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
+
+        final val request // arrow.resilience.ktor.client/RetryEventData.HttpResponse.request|{}request[0]
+            final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.HttpResponse.request.<get-request>|<get-request>(){}[0]
+        final val response // arrow.resilience.ktor.client/RetryEventData.HttpResponse.response|{}response[0]
+            final fun <get-response>(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/RetryEventData.HttpResponse.response.<get-response>|<get-response>(){}[0]
+        final val retryCount // arrow.resilience.ktor.client/RetryEventData.HttpResponse.retryCount|{}retryCount[0]
+            final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.HttpResponse.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
+
+        final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.HttpResponse.component1|component1(){}[0]
+        final fun component2(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.HttpResponse.component2|component2(){}[0]
+        final fun component3(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/RetryEventData.HttpResponse.component3|component3(){}[0]
+        final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., kotlin/Int = ..., io.ktor.client.statement/HttpResponse = ...): arrow.resilience.ktor.client/RetryEventData.HttpResponse // arrow.resilience.ktor.client/RetryEventData.HttpResponse.copy|copy(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/RetryEventData.HttpResponse.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.HttpResponse.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // arrow.resilience.ktor.client/RetryEventData.HttpResponse.toString|toString(){}[0]
+    }
+}
+
 final class arrow.resilience.ktor.client/HttpCircuitBreaker { // arrow.resilience.ktor.client/HttpCircuitBreaker|null[0]
     final class Configuration { // arrow.resilience.ktor.client/HttpCircuitBreaker.Configuration|null[0]
         constructor <init>() // arrow.resilience.ktor.client/HttpCircuitBreaker.Configuration.<init>|<init>(){}[0]
@@ -23,98 +75,39 @@ final class arrow.resilience.ktor.client/HttpCircuitBreaker { // arrow.resilienc
     }
 }
 
-final class arrow.resilience.ktor.client/HttpRequestSchedule { // arrow.resilience.ktor.client/HttpRequestSchedule|null[0]
-    abstract fun interface ModifyRequestPerRequest { // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestPerRequest|null[0]
-        abstract suspend fun invoke(arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext, io.ktor.client.request/HttpRequestBuilder) // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestPerRequest.invoke|invoke(arrow.resilience.ktor.client.HttpRequestSchedule.ModifyRequestContext;io.ktor.client.request.HttpRequestBuilder){}[0]
-    }
+final class arrow.resilience.ktor.client/HttpRequestScheduleConfiguration { // arrow.resilience.ktor.client/HttpRequestScheduleConfiguration|null[0]
+    constructor <init>() // arrow.resilience.ktor.client/HttpRequestScheduleConfiguration.<init>|<init>(){}[0]
 
-    sealed interface RetryEventData { // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData|null[0]
-        abstract val request // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.request|{}request[0]
-            abstract fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.request.<get-request>|<get-request>(){}[0]
-        abstract val retryCount // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.retryCount|{}retryCount[0]
-            abstract fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
-
-        open fun exceptionOrNull(): kotlin/Throwable? // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.exceptionOrNull|exceptionOrNull(){}[0]
-        open fun responseOrNull(): io.ktor.client.statement/HttpResponse? // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.responseOrNull|responseOrNull(){}[0]
-
-        final class Failure : arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData { // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure|null[0]
-            constructor <init>(io.ktor.client.request/HttpRequestBuilder, kotlin/Int, kotlin/Throwable) // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;kotlin.Throwable){}[0]
-
-            final val exception // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.exception|{}exception[0]
-                final fun <get-exception>(): kotlin/Throwable // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.exception.<get-exception>|<get-exception>(){}[0]
-            final val request // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.request|{}request[0]
-                final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.request.<get-request>|<get-request>(){}[0]
-            final val retryCount // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.retryCount|{}retryCount[0]
-                final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
-
-            final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.component1|component1(){}[0]
-            final fun component2(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.component2|component2(){}[0]
-            final fun component3(): kotlin/Throwable // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.component3|component3(){}[0]
-            final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., kotlin/Int = ..., kotlin/Throwable = ...): arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.copy|copy(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;kotlin.Throwable){}[0]
-            final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.equals|equals(kotlin.Any?){}[0]
-            final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.hashCode|hashCode(){}[0]
-            final fun toString(): kotlin/String // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.Failure.toString|toString(){}[0]
-        }
-
-        final class HttpResponse : arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData { // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse|null[0]
-            constructor <init>(io.ktor.client.request/HttpRequestBuilder, kotlin/Int, io.ktor.client.statement/HttpResponse) // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
-
-            final val request // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.request|{}request[0]
-                final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.request.<get-request>|<get-request>(){}[0]
-            final val response // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.response|{}response[0]
-                final fun <get-response>(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.response.<get-response>|<get-response>(){}[0]
-            final val retryCount // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.retryCount|{}retryCount[0]
-                final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
-
-            final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.component1|component1(){}[0]
-            final fun component2(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.component2|component2(){}[0]
-            final fun component3(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.component3|component3(){}[0]
-            final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., kotlin/Int = ..., io.ktor.client.statement/HttpResponse = ...): arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.copy|copy(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
-            final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.equals|equals(kotlin.Any?){}[0]
-            final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.hashCode|hashCode(){}[0]
-            final fun toString(): kotlin/String // arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData.HttpResponse.toString|toString(){}[0]
-        }
-    }
-
-    final class Configuration { // arrow.resilience.ktor.client/HttpRequestSchedule.Configuration|null[0]
-        constructor <init>() // arrow.resilience.ktor.client/HttpRequestSchedule.Configuration.<init>|<init>(){}[0]
-
-        final fun <#A2: kotlin/Any?> repeat(arrow.resilience/Schedule<io.ktor.client.statement/HttpResponse, #A2>) // arrow.resilience.ktor.client/HttpRequestSchedule.Configuration.repeat|repeat(arrow.resilience.Schedule<io.ktor.client.statement.HttpResponse,0:0>){0§<kotlin.Any?>}[0]
-        final fun <#A2: kotlin/Any?> retry(arrow.resilience/Schedule<kotlin/Throwable, #A2>) // arrow.resilience.ktor.client/HttpRequestSchedule.Configuration.retry|retry(arrow.resilience.Schedule<kotlin.Throwable,0:0>){0§<kotlin.Any?>}[0]
-        final fun modifyRequest(kotlin.coroutines/SuspendFunction2<arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext, io.ktor.client.request/HttpRequestBuilder, kotlin/Unit>) // arrow.resilience.ktor.client/HttpRequestSchedule.Configuration.modifyRequest|modifyRequest(kotlin.coroutines.SuspendFunction2<arrow.resilience.ktor.client.HttpRequestSchedule.ModifyRequestContext,io.ktor.client.request.HttpRequestBuilder,kotlin.Unit>){}[0]
-    }
-
-    final class ModifyRequestContext { // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext|null[0]
-        constructor <init>(io.ktor.client.request/HttpRequestBuilder, arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData) // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;arrow.resilience.ktor.client.HttpRequestSchedule.RetryEventData){}[0]
-
-        final val lastRetryEventData // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.lastRetryEventData|{}lastRetryEventData[0]
-            final fun <get-lastRetryEventData>(): arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.lastRetryEventData.<get-lastRetryEventData>|<get-lastRetryEventData>(){}[0]
-        final val original // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.original|{}original[0]
-            final fun <get-original>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.original.<get-original>|<get-original>(){}[0]
-        final val request // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.request|{}request[0]
-            final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.request.<get-request>|<get-request>(){}[0]
-        final val retryCount // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.retryCount|{}retryCount[0]
-            final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
-
-        final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.component1|component1(){}[0]
-        final fun component2(): arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.component2|component2(){}[0]
-        final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData = ...): arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.copy|copy(io.ktor.client.request.HttpRequestBuilder;arrow.resilience.ktor.client.HttpRequestSchedule.RetryEventData){}[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.equals|equals(kotlin.Any?){}[0]
-        final fun exceptionOrNull(): kotlin/Throwable? // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.exceptionOrNull|exceptionOrNull(){}[0]
-        final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.hashCode|hashCode(){}[0]
-        final fun responseOrNull(): io.ktor.client.statement/HttpResponse? // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.responseOrNull|responseOrNull(){}[0]
-        final fun toString(): kotlin/String // arrow.resilience.ktor.client/HttpRequestSchedule.ModifyRequestContext.toString|toString(){}[0]
-    }
-
-    final object Plugin : io.ktor.client.plugins/HttpClientPlugin<arrow.resilience.ktor.client/HttpRequestSchedule.Configuration, arrow.resilience.ktor.client/HttpRequestSchedule> { // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin|null[0]
-        final val HttpRequestScheduleEvent // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin.HttpRequestScheduleEvent|{}HttpRequestScheduleEvent[0]
-            final fun <get-HttpRequestScheduleEvent>(): io.ktor.events/EventDefinition<arrow.resilience.ktor.client/HttpRequestSchedule.RetryEventData> // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin.HttpRequestScheduleEvent.<get-HttpRequestScheduleEvent>|<get-HttpRequestScheduleEvent>(){}[0]
-        final val key // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin.key|{}key[0]
-            final fun <get-key>(): io.ktor.util/AttributeKey<arrow.resilience.ktor.client/HttpRequestSchedule> // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin.key.<get-key>|<get-key>(){}[0]
-
-        final fun install(arrow.resilience.ktor.client/HttpRequestSchedule, io.ktor.client/HttpClient) // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin.install|install(arrow.resilience.ktor.client.HttpRequestSchedule;io.ktor.client.HttpClient){}[0]
-        final fun prepare(kotlin/Function1<arrow.resilience.ktor.client/HttpRequestSchedule.Configuration, kotlin/Unit>): arrow.resilience.ktor.client/HttpRequestSchedule // arrow.resilience.ktor.client/HttpRequestSchedule.Plugin.prepare|prepare(kotlin.Function1<arrow.resilience.ktor.client.HttpRequestSchedule.Configuration,kotlin.Unit>){}[0]
-    }
+    final fun <#A1: kotlin/Any?> repeat(arrow.resilience/Schedule<io.ktor.client.statement/HttpResponse, #A1>) // arrow.resilience.ktor.client/HttpRequestScheduleConfiguration.repeat|repeat(arrow.resilience.Schedule<io.ktor.client.statement.HttpResponse,0:0>){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> retry(arrow.resilience/Schedule<kotlin/Throwable, #A1>) // arrow.resilience.ktor.client/HttpRequestScheduleConfiguration.retry|retry(arrow.resilience.Schedule<kotlin.Throwable,0:0>){0§<kotlin.Any?>}[0]
+    final fun modifyRequest(kotlin.coroutines/SuspendFunction2<arrow.resilience.ktor.client/ModifyRequestContext, io.ktor.client.request/HttpRequestBuilder, kotlin/Unit>) // arrow.resilience.ktor.client/HttpRequestScheduleConfiguration.modifyRequest|modifyRequest(kotlin.coroutines.SuspendFunction2<arrow.resilience.ktor.client.ModifyRequestContext,io.ktor.client.request.HttpRequestBuilder,kotlin.Unit>){}[0]
 }
 
-final fun (io.ktor.client.request/HttpRequestBuilder).arrow.resilience.ktor.client/schedule(kotlin/Function1<arrow.resilience.ktor.client/HttpRequestSchedule.Configuration, kotlin/Unit>) // arrow.resilience.ktor.client/schedule|schedule@io.ktor.client.request.HttpRequestBuilder(kotlin.Function1<arrow.resilience.ktor.client.HttpRequestSchedule.Configuration,kotlin.Unit>){}[0]
+final class arrow.resilience.ktor.client/ModifyRequestContext { // arrow.resilience.ktor.client/ModifyRequestContext|null[0]
+    constructor <init>(io.ktor.client.request/HttpRequestBuilder, arrow.resilience.ktor.client/RetryEventData) // arrow.resilience.ktor.client/ModifyRequestContext.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;arrow.resilience.ktor.client.RetryEventData){}[0]
+
+    final val lastRetryEventData // arrow.resilience.ktor.client/ModifyRequestContext.lastRetryEventData|{}lastRetryEventData[0]
+        final fun <get-lastRetryEventData>(): arrow.resilience.ktor.client/RetryEventData // arrow.resilience.ktor.client/ModifyRequestContext.lastRetryEventData.<get-lastRetryEventData>|<get-lastRetryEventData>(){}[0]
+    final val original // arrow.resilience.ktor.client/ModifyRequestContext.original|{}original[0]
+        final fun <get-original>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/ModifyRequestContext.original.<get-original>|<get-original>(){}[0]
+    final val request // arrow.resilience.ktor.client/ModifyRequestContext.request|{}request[0]
+        final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/ModifyRequestContext.request.<get-request>|<get-request>(){}[0]
+    final val retryCount // arrow.resilience.ktor.client/ModifyRequestContext.retryCount|{}retryCount[0]
+        final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/ModifyRequestContext.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
+
+    final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/ModifyRequestContext.component1|component1(){}[0]
+    final fun component2(): arrow.resilience.ktor.client/RetryEventData // arrow.resilience.ktor.client/ModifyRequestContext.component2|component2(){}[0]
+    final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., arrow.resilience.ktor.client/RetryEventData = ...): arrow.resilience.ktor.client/ModifyRequestContext // arrow.resilience.ktor.client/ModifyRequestContext.copy|copy(io.ktor.client.request.HttpRequestBuilder;arrow.resilience.ktor.client.RetryEventData){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/ModifyRequestContext.equals|equals(kotlin.Any?){}[0]
+    final fun exceptionOrNull(): kotlin/Throwable? // arrow.resilience.ktor.client/ModifyRequestContext.exceptionOrNull|exceptionOrNull(){}[0]
+    final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/ModifyRequestContext.hashCode|hashCode(){}[0]
+    final fun responseOrNull(): io.ktor.client.statement/HttpResponse? // arrow.resilience.ktor.client/ModifyRequestContext.responseOrNull|responseOrNull(){}[0]
+    final fun toString(): kotlin/String // arrow.resilience.ktor.client/ModifyRequestContext.toString|toString(){}[0]
+}
+
+final val arrow.resilience.ktor.client/HttpRequestSchedule // arrow.resilience.ktor.client/HttpRequestSchedule|{}HttpRequestSchedule[0]
+    final fun <get-HttpRequestSchedule>(): io.ktor.client.plugins.api/ClientPlugin<arrow.resilience.ktor.client/HttpRequestScheduleConfiguration> // arrow.resilience.ktor.client/HttpRequestSchedule.<get-HttpRequestSchedule>|<get-HttpRequestSchedule>(){}[0]
+final val arrow.resilience.ktor.client/HttpRequestScheduleEvent // arrow.resilience.ktor.client/HttpRequestScheduleEvent|{}HttpRequestScheduleEvent[0]
+    final fun <get-HttpRequestScheduleEvent>(): io.ktor.events/EventDefinition<arrow.resilience.ktor.client/RetryEventData> // arrow.resilience.ktor.client/HttpRequestScheduleEvent.<get-HttpRequestScheduleEvent>|<get-HttpRequestScheduleEvent>(){}[0]
+
+final fun (io.ktor.client.request/HttpRequestBuilder).arrow.resilience.ktor.client/schedule(kotlin/Function1<arrow.resilience.ktor.client/HttpRequestScheduleConfiguration, kotlin/Unit>) // arrow.resilience.ktor.client/schedule|schedule@io.ktor.client.request.HttpRequestBuilder(kotlin.Function1<arrow.resilience.ktor.client.HttpRequestScheduleConfiguration,kotlin.Unit>){}[0]

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/api/arrow-resilience-ktor-client.klib.api
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/api/arrow-resilience-ktor-client.klib.api
@@ -38,23 +38,23 @@ sealed interface arrow.resilience.ktor.client/RetryEventData { // arrow.resilien
         final fun toString(): kotlin/String // arrow.resilience.ktor.client/RetryEventData.Failure.toString|toString(){}[0]
     }
 
-    final class HttpResponse : arrow.resilience.ktor.client/RetryEventData { // arrow.resilience.ktor.client/RetryEventData.HttpResponse|null[0]
-        constructor <init>(io.ktor.client.request/HttpRequestBuilder, kotlin/Int, io.ktor.client.statement/HttpResponse) // arrow.resilience.ktor.client/RetryEventData.HttpResponse.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
+    final class Response : arrow.resilience.ktor.client/RetryEventData { // arrow.resilience.ktor.client/RetryEventData.Response|null[0]
+        constructor <init>(io.ktor.client.request/HttpRequestBuilder, kotlin/Int, io.ktor.client.statement/HttpResponse) // arrow.resilience.ktor.client/RetryEventData.Response.<init>|<init>(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
 
-        final val request // arrow.resilience.ktor.client/RetryEventData.HttpResponse.request|{}request[0]
-            final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.HttpResponse.request.<get-request>|<get-request>(){}[0]
-        final val response // arrow.resilience.ktor.client/RetryEventData.HttpResponse.response|{}response[0]
-            final fun <get-response>(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/RetryEventData.HttpResponse.response.<get-response>|<get-response>(){}[0]
-        final val retryCount // arrow.resilience.ktor.client/RetryEventData.HttpResponse.retryCount|{}retryCount[0]
-            final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.HttpResponse.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
+        final val request // arrow.resilience.ktor.client/RetryEventData.Response.request|{}request[0]
+            final fun <get-request>(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.Response.request.<get-request>|<get-request>(){}[0]
+        final val response // arrow.resilience.ktor.client/RetryEventData.Response.response|{}response[0]
+            final fun <get-response>(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/RetryEventData.Response.response.<get-response>|<get-response>(){}[0]
+        final val retryCount // arrow.resilience.ktor.client/RetryEventData.Response.retryCount|{}retryCount[0]
+            final fun <get-retryCount>(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.Response.retryCount.<get-retryCount>|<get-retryCount>(){}[0]
 
-        final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.HttpResponse.component1|component1(){}[0]
-        final fun component2(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.HttpResponse.component2|component2(){}[0]
-        final fun component3(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/RetryEventData.HttpResponse.component3|component3(){}[0]
-        final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., kotlin/Int = ..., io.ktor.client.statement/HttpResponse = ...): arrow.resilience.ktor.client/RetryEventData.HttpResponse // arrow.resilience.ktor.client/RetryEventData.HttpResponse.copy|copy(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/RetryEventData.HttpResponse.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.HttpResponse.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // arrow.resilience.ktor.client/RetryEventData.HttpResponse.toString|toString(){}[0]
+        final fun component1(): io.ktor.client.request/HttpRequestBuilder // arrow.resilience.ktor.client/RetryEventData.Response.component1|component1(){}[0]
+        final fun component2(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.Response.component2|component2(){}[0]
+        final fun component3(): io.ktor.client.statement/HttpResponse // arrow.resilience.ktor.client/RetryEventData.Response.component3|component3(){}[0]
+        final fun copy(io.ktor.client.request/HttpRequestBuilder = ..., kotlin/Int = ..., io.ktor.client.statement/HttpResponse = ...): arrow.resilience.ktor.client/RetryEventData.Response // arrow.resilience.ktor.client/RetryEventData.Response.copy|copy(io.ktor.client.request.HttpRequestBuilder;kotlin.Int;io.ktor.client.statement.HttpResponse){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience.ktor.client/RetryEventData.Response.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.resilience.ktor.client/RetryEventData.Response.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // arrow.resilience.ktor.client/RetryEventData.Response.toString|toString(){}[0]
     }
 }
 

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/api/jvm/arrow-resilience-ktor-client.api
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/api/jvm/arrow-resilience-ktor-client.api
@@ -79,13 +79,13 @@ public final class arrow/resilience/ktor/client/RetryEventData$Failure : arrow/r
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class arrow/resilience/ktor/client/RetryEventData$HttpResponse : arrow/resilience/ktor/client/RetryEventData {
+public final class arrow/resilience/ktor/client/RetryEventData$Response : arrow/resilience/ktor/client/RetryEventData {
 	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun component2 ()I
 	public final fun component3 ()Lio/ktor/client/statement/HttpResponse;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$HttpResponse;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/RetryEventData$Response;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$Response;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$Response;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun exceptionOrNull ()Ljava/lang/Throwable;
 	public fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/api/jvm/arrow-resilience-ktor-client.api
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/api/jvm/arrow-resilience-ktor-client.api
@@ -16,26 +16,28 @@ public final class arrow/resilience/ktor/client/HttpCircuitBreaker$Plugin : io/k
 	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule {
-	public static final field Plugin Larrow/resilience/ktor/client/HttpRequestSchedule$Plugin;
-}
-
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$Configuration {
+public final class arrow/resilience/ktor/client/HttpRequestScheduleConfiguration {
 	public fun <init> ()V
 	public final fun modifyRequest (Lkotlin/jvm/functions/Function3;)V
 	public final fun repeat (Larrow/resilience/Schedule;)V
 	public final fun retry (Larrow/resilience/Schedule;)V
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext {
-	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)V
+public final class arrow/resilience/ktor/client/HttpRequestScheduleKt {
+	public static final fun getHttpRequestSchedule ()Lio/ktor/client/plugins/api/ClientPlugin;
+	public static final fun getHttpRequestScheduleEvent ()Lio/ktor/events/EventDefinition;
+	public static final fun schedule (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class arrow/resilience/ktor/client/ModifyRequestContext {
+	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/RetryEventData;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
-	public final fun component2 ()Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;ILjava/lang/Object;)Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;
+	public final fun component2 ()Larrow/resilience/ktor/client/RetryEventData;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/RetryEventData;)Larrow/resilience/ktor/client/ModifyRequestContext;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Larrow/resilience/ktor/client/RetryEventData;ILjava/lang/Object;)Larrow/resilience/ktor/client/ModifyRequestContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun exceptionOrNull ()Ljava/lang/Throwable;
-	public final fun getLastRetryEventData ()Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;
+	public final fun getLastRetryEventData ()Larrow/resilience/ktor/client/RetryEventData;
 	public final fun getOriginal ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun getRetryCount ()I
@@ -44,38 +46,29 @@ public final class arrow/resilience/ktor/client/HttpRequestSchedule$ModifyReques
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class arrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestPerRequest {
-	public abstract fun invoke (Larrow/resilience/ktor/client/HttpRequestSchedule$ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract interface class arrow/resilience/ktor/client/ModifyRequestPerRequest {
+	public abstract fun invoke (Larrow/resilience/ktor/client/ModifyRequestContext;Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$Plugin : io/ktor/client/plugins/HttpClientPlugin {
-	public final fun getHttpRequestScheduleEvent ()Lio/ktor/events/EventDefinition;
-	public fun getKey ()Lio/ktor/util/AttributeKey;
-	public fun install (Larrow/resilience/ktor/client/HttpRequestSchedule;Lio/ktor/client/HttpClient;)V
-	public synthetic fun install (Ljava/lang/Object;Lio/ktor/client/HttpClient;)V
-	public fun prepare (Lkotlin/jvm/functions/Function1;)Larrow/resilience/ktor/client/HttpRequestSchedule;
-	public synthetic fun prepare (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-}
-
-public abstract interface class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData {
+public abstract interface class arrow/resilience/ktor/client/RetryEventData {
 	public abstract fun exceptionOrNull ()Ljava/lang/Throwable;
 	public abstract fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
 	public abstract fun getRetryCount ()I
 	public abstract fun responseOrNull ()Lio/ktor/client/statement/HttpResponse;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$DefaultImpls {
-	public static fun exceptionOrNull (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)Ljava/lang/Throwable;
-	public static fun responseOrNull (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData;)Lio/ktor/client/statement/HttpResponse;
+public final class arrow/resilience/ktor/client/RetryEventData$DefaultImpls {
+	public static fun exceptionOrNull (Larrow/resilience/ktor/client/RetryEventData;)Ljava/lang/Throwable;
+	public static fun responseOrNull (Larrow/resilience/ktor/client/RetryEventData;)Lio/ktor/client/statement/HttpResponse;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure : arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData {
+public final class arrow/resilience/ktor/client/RetryEventData$Failure : arrow/resilience/ktor/client/RetryEventData {
 	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun component2 ()I
 	public final fun component3 ()Ljava/lang/Throwable;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure;Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;ILjava/lang/Object;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$Failure;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;)Larrow/resilience/ktor/client/RetryEventData$Failure;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$Failure;Lio/ktor/client/request/HttpRequestBuilder;ILjava/lang/Throwable;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun exceptionOrNull ()Ljava/lang/Throwable;
 	public final fun getException ()Ljava/lang/Throwable;
@@ -86,13 +79,13 @@ public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventDa
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse : arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData {
+public final class arrow/resilience/ktor/client/RetryEventData$HttpResponse : arrow/resilience/ktor/client/RetryEventData {
 	public fun <init> (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)V
 	public final fun component1 ()Lio/ktor/client/request/HttpRequestBuilder;
 	public final fun component2 ()I
 	public final fun component3 ()Lio/ktor/client/statement/HttpResponse;
-	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse;
-	public static synthetic fun copy$default (Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/HttpRequestSchedule$RetryEventData$HttpResponse;
+	public final fun copy (Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
+	public static synthetic fun copy$default (Larrow/resilience/ktor/client/RetryEventData$HttpResponse;Lio/ktor/client/request/HttpRequestBuilder;ILio/ktor/client/statement/HttpResponse;ILjava/lang/Object;)Larrow/resilience/ktor/client/RetryEventData$HttpResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun exceptionOrNull ()Ljava/lang/Throwable;
 	public fun getRequest ()Lio/ktor/client/request/HttpRequestBuilder;
@@ -101,9 +94,5 @@ public final class arrow/resilience/ktor/client/HttpRequestSchedule$RetryEventDa
 	public fun hashCode ()I
 	public fun responseOrNull ()Lio/ktor/client/statement/HttpResponse;
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class arrow/resilience/ktor/client/HttpRequestScheduleKt {
-	public static final fun schedule (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/build.gradle.kts
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
     commonTest {
       dependencies {
         implementation(libs.ktor.test)
+        implementation(libs.ktor.mock)
         implementation(projects.arrowAtomic)
         implementation(libs.bundles.testing)
       }

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/build.gradle.kts
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
 
     commonTest {
       dependencies {
-        implementation(libs.ktor.test)
         implementation(libs.ktor.mock)
         implementation(projects.arrowAtomic)
         implementation(libs.bundles.testing)

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/src/commonMain/kotlin/arrow/resilience/ktor/client/HttpRequestSchedule.kt
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/src/commonMain/kotlin/arrow/resilience/ktor/client/HttpRequestSchedule.kt
@@ -2,20 +2,19 @@ package arrow.resilience.ktor.client
 
 import arrow.resilience.Schedule
 import arrow.resilience.ScheduleStep
-import io.ktor.client.HttpClient
 import io.ktor.client.call.HttpClientCall
-import io.ktor.client.plugins.HttpClientPlugin
-import io.ktor.client.plugins.HttpSend
-import io.ktor.client.plugins.plugin
+import io.ktor.client.plugins.api.ClientPlugin
+import io.ktor.client.plugins.api.Send
+import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 import io.ktor.events.EventDefinition
 import io.ktor.util.AttributeKey
 import io.ktor.utils.io.KtorDsl
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * A plugin that enables the client to retry failed requests according to [arrow.resilience.Schedule].
@@ -42,109 +41,29 @@ import kotlinx.coroutines.delay
  * }
  * ```
  */
-public class HttpRequestSchedule internal constructor(configuration: Configuration) {
-
-  private val repeatSchedule: Schedule<HttpResponse, *> = configuration.repeatSchedule
-  private val retrySchedule: Schedule<Throwable, *> = configuration.retrySchedule
-  private val modifyRequest: ModifyRequestPerRequest = configuration.modifyRequest
-
-  public data class ModifyRequestContext(val original: HttpRequestBuilder, val lastRetryEventData: RetryEventData) {
-    public val request: HttpRequestBuilder = lastRetryEventData.request
-    public val retryCount: Int = lastRetryEventData.retryCount
-
-    public fun responseOrNull(): HttpResponse? = when (lastRetryEventData) {
-      is RetryEventData.Failure -> null
-      is RetryEventData.HttpResponse -> lastRetryEventData.response
+public val HttpRequestSchedule: ClientPlugin<HttpRequestScheduleConfiguration> =
+  createClientPlugin("HttpRequestSchedule", ::HttpRequestScheduleConfiguration) {
+    fun prepareRequest(request: HttpRequestBuilder): HttpRequestBuilder {
+      val subRequest = HttpRequestBuilder().takeFrom(request)
+      request.executionContext.invokeOnCompletion { cause ->
+        val subRequestJob = subRequest.executionContext as CompletableJob
+        if (cause == null) subRequestJob.complete()
+        else subRequestJob.completeExceptionally(cause)
+      }
+      return subRequest
     }
 
-    public fun exceptionOrNull(): Throwable? = when (lastRetryEventData) {
-      is RetryEventData.HttpResponse -> null
-      is RetryEventData.Failure -> lastRetryEventData.exception
-    }
-  }
-
-  public sealed interface RetryEventData {
-    public val request: HttpRequestBuilder
-    public val retryCount: Int
-
-    public fun responseOrNull(): io.ktor.client.statement.HttpResponse? = when (this) {
-      is Failure -> null
-      is HttpResponse -> response
-    }
-
-    public fun exceptionOrNull(): Throwable? = when (this) {
-      is HttpResponse -> null
-      is Failure -> exception
-    }
-
-    public data class HttpResponse(
-      public override val request: HttpRequestBuilder,
-      public override val retryCount: Int,
-      public val response: io.ktor.client.statement.HttpResponse
-    ) : RetryEventData
-
-    public data class Failure(
-      public override val request: HttpRequestBuilder,
-      public override val retryCount: Int,
-      public val exception: Throwable
-    ) : RetryEventData
-  }
-
-  public fun interface ModifyRequestPerRequest {
-    public suspend operator fun invoke(requestContext: ModifyRequestContext, request: HttpRequestBuilder): Unit
-  }
-
-  /**
-   * Contains [HttpRequestSchedule] configurations settings.
-   */
-  @KtorDsl
-  public class Configuration {
-    internal var repeatSchedule: Schedule<HttpResponse, *> = Schedule.recurs(0)
-    internal var retrySchedule: Schedule<Throwable, *> = Schedule.recurs(0)
-    internal var modifyRequest: ModifyRequestPerRequest = ModifyRequestPerRequest { _, _ -> }
-
-    init {
-      @Suppress("MagicNumber")
-      repeatSchedule =
-        Schedule.exponential<HttpResponse>(2.seconds).jittered()
-          .doWhile { request, _ -> request.status.value in 500..599 }
-
-      @Suppress("MagicNumber")
-      retrySchedule =
-        Schedule.exponential<Throwable>(2.seconds).jittered()
-          .and(Schedule.recurs(3))
-    }
-
-    /**
-     * Repeat the request according to the provided Schedule,
-     * the output of the schedule is ignored.
-     */
-    public fun <A> repeat(schedule: Schedule<HttpResponse, A>) {
-      repeatSchedule = schedule
-    }
-
-    public fun <A> retry(schedule: Schedule<Throwable, A>) {
-      retrySchedule = schedule
-    }
-
-    public fun modifyRequest(block: suspend ModifyRequestContext.(HttpRequestBuilder) -> Unit) {
-      modifyRequest = ModifyRequestPerRequest(block)
-    }
-  }
-
-  @Suppress("TooGenericExceptionCaught")
-  internal fun intercept(client: HttpClient) {
-    client.plugin(HttpSend).intercept { request ->
+    on(Send) { request ->
       var retryCount = 0
 
       val modifyRequest: ModifyRequestPerRequest =
-        request.attributes.getOrNull(ModifyRequestPerRequestAttributeKey) ?: modifyRequest
+        request.attributes.getOrNull(ModifyRequestPerRequestAttributeKey) ?: pluginConfig.modifyRequest
 
       var repeatStep: ScheduleStep<HttpResponse, *> =
-        request.attributes.getOrNull(RepeatPerRequestAttributeKey)?.step ?: repeatSchedule.step
+        request.attributes.getOrNull(RepeatPerRequestAttributeKey)?.step ?: pluginConfig.repeatSchedule.step
 
       var retryStep: ScheduleStep<Throwable, *> =
-        request.attributes.getOrNull(RetryPerRequestAttributeKey)?.step ?: retrySchedule.step
+        request.attributes.getOrNull(RetryPerRequestAttributeKey)?.step ?: pluginConfig.retrySchedule.step
 
       var call: HttpClientCall
       var lastRetryData: RetryEventData? = null
@@ -156,7 +75,7 @@ public class HttpRequestSchedule internal constructor(configuration: Configurati
           if (lastRetryData != null) {
             modifyRequest(ModifyRequestContext(request, lastRetryData), subRequest)
           }
-          call = execute(subRequest)
+          call = proceed(subRequest)
           when (val decision = repeatStep(call.response)) {
             is Schedule.Decision.Continue -> {
               if (decision.delay != Duration.ZERO) delay(decision.delay)
@@ -183,40 +102,100 @@ public class HttpRequestSchedule internal constructor(configuration: Configurati
       }
       call
     }
+}
+
+/**
+ * Contains [HttpRequestSchedule] configurations settings.
+ */
+@KtorDsl
+public class HttpRequestScheduleConfiguration {
+  internal var repeatSchedule: Schedule<HttpResponse, *> = Schedule.recurs(0)
+  internal var retrySchedule: Schedule<Throwable, *> = Schedule.recurs(0)
+  internal var modifyRequest: ModifyRequestPerRequest = ModifyRequestPerRequest { _, _ -> }
+
+  init {
+    @Suppress("MagicNumber")
+    repeatSchedule =
+      Schedule.exponential<HttpResponse>(2.seconds).jittered()
+        .doWhile { request, _ -> request.status.value in 500..599 }
+
+    @Suppress("MagicNumber")
+    retrySchedule =
+      Schedule.exponential<Throwable>(2.seconds).jittered()
+        .and(Schedule.recurs(3))
   }
 
-  private fun prepareRequest(request: HttpRequestBuilder): HttpRequestBuilder {
-    val subRequest = HttpRequestBuilder().takeFrom(request)
-    request.executionContext.invokeOnCompletion { cause ->
-      val subRequestJob = subRequest.executionContext as CompletableJob
-      if (cause == null) subRequestJob.complete()
-      else subRequestJob.completeExceptionally(cause)
-    }
-    return subRequest
+  /**
+   * Repeat the request according to the provided Schedule,
+   * the output of the schedule is ignored.
+   */
+  public fun <A> repeat(schedule: Schedule<HttpResponse, A>) {
+    repeatSchedule = schedule
   }
 
-  public companion object Plugin : HttpClientPlugin<Configuration, HttpRequestSchedule> {
-    override val key: AttributeKey<HttpRequestSchedule> = AttributeKey("ScheduleFeature")
-
-    /** Occurs on request retry. */
-    public val HttpRequestScheduleEvent: EventDefinition<RetryEventData> = EventDefinition()
-
-    override fun prepare(block: Configuration.() -> Unit): HttpRequestSchedule {
-      val configuration = Configuration().apply(block)
-      return HttpRequestSchedule(configuration)
-    }
-
-    override fun install(plugin: HttpRequestSchedule, scope: HttpClient) {
-      plugin.intercept(scope)
-    }
+  public fun <A> retry(schedule: Schedule<Throwable, A>) {
+    retrySchedule = schedule
   }
+
+  public fun modifyRequest(block: suspend ModifyRequestContext.(HttpRequestBuilder) -> Unit) {
+    modifyRequest = ModifyRequestPerRequest(block)
+  }
+}
+
+public data class ModifyRequestContext(val original: HttpRequestBuilder, val lastRetryEventData: RetryEventData) {
+  public val request: HttpRequestBuilder = lastRetryEventData.request
+  public val retryCount: Int = lastRetryEventData.retryCount
+
+  public fun responseOrNull(): HttpResponse? = when (lastRetryEventData) {
+    is RetryEventData.Failure -> null
+    is RetryEventData.HttpResponse -> lastRetryEventData.response
+  }
+
+  public fun exceptionOrNull(): Throwable? = when (lastRetryEventData) {
+    is RetryEventData.HttpResponse -> null
+    is RetryEventData.Failure -> lastRetryEventData.exception
+  }
+}
+
+/** Occurs on request retry. */
+public val HttpRequestScheduleEvent: EventDefinition<RetryEventData> = EventDefinition()
+
+public sealed interface RetryEventData {
+  public val request: HttpRequestBuilder
+  public val retryCount: Int
+
+  public fun responseOrNull(): io.ktor.client.statement.HttpResponse? = when (this) {
+    is Failure -> null
+    is HttpResponse -> response
+  }
+
+  public fun exceptionOrNull(): Throwable? = when (this) {
+    is HttpResponse -> null
+    is Failure -> exception
+  }
+
+  public data class HttpResponse(
+    public override val request: HttpRequestBuilder,
+    public override val retryCount: Int,
+    public val response: io.ktor.client.statement.HttpResponse
+  ) : RetryEventData
+
+  public data class Failure(
+    public override val request: HttpRequestBuilder,
+    public override val retryCount: Int,
+    public val exception: Throwable
+  ) : RetryEventData
+}
+
+public fun interface ModifyRequestPerRequest {
+  public suspend operator fun invoke(requestContext: ModifyRequestContext, request: HttpRequestBuilder)
 }
 
 /**
  * Configures the [HttpRequestSchedule] plugin on a per-request level.
  */
-public fun HttpRequestBuilder.schedule(block: HttpRequestSchedule.Configuration.() -> Unit) {
-  val configuration = HttpRequestSchedule.Configuration().apply(block)
+public fun HttpRequestBuilder.schedule(block: HttpRequestScheduleConfiguration.() -> Unit) {
+  val configuration = HttpRequestScheduleConfiguration().apply(block)
   attributes.put(RepeatPerRequestAttributeKey, configuration.repeatSchedule)
   attributes.put(RetryPerRequestAttributeKey, configuration.retrySchedule)
   attributes.put(ModifyRequestPerRequestAttributeKey, configuration.modifyRequest)
@@ -232,4 +211,4 @@ private val RetryPerRequestAttributeKey =
 
 @Suppress("PrivatePropertyName")
 private val ModifyRequestPerRequestAttributeKey =
-  AttributeKey<HttpRequestSchedule.ModifyRequestPerRequest>("ModifyRequestPerRequestAttributeKey")
+  AttributeKey<ModifyRequestPerRequest>("ModifyRequestPerRequestAttributeKey")

--- a/arrow-libs/integrations/arrow-resilience-ktor-client/src/jvmTest/kotlin/arrow/resilience/ktor/client/HttpRequestScheduleTest.kt
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/src/jvmTest/kotlin/arrow/resilience/ktor/client/HttpRequestScheduleTest.kt
@@ -8,51 +8,47 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.get
-import io.ktor.http.HttpStatusCode.Companion.NotFound
-import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
-import io.ktor.server.response.respond
-import io.ktor.server.routing.RoutingContext
-import io.ktor.server.routing.get
-import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.test.runTest
+import java.net.ConnectException
 import kotlin.test.Test
 
 class HttpRequestScheduleTest {
+  class NotFoundExceptionForMocking : Exception()
 
-  fun ApplicationTestBuilder.configureServer(
-    check:  suspend RoutingContext.(counter: Long) -> Unit
-  ): AtomicLong {
+  fun setup(
+    check: suspend (counter: Long) -> Unit,
+    configure: HttpRequestScheduleConfiguration.() -> Unit,
+  ): Pair<AtomicLong, HttpClient> {
     val counter = AtomicLong(0)
-    routing {
-      get("/do") {
+    val engine = MockEngine { _ ->
+      try {
         check(counter.incrementAndGet())
-        call.respond(OK)
+        respond(content = "OK", status = HttpStatusCode.OK)
+      } catch (_: NotFoundExceptionForMocking) {
+        respond(content = "Not Found", status = HttpStatusCode.NotFound)
       }
     }
-    return counter
+    return counter to HttpClient(engine) {
+      install(HttpRequestSchedule, configure)
+    }
   }
-
-  fun ApplicationTestBuilder.configureClient(
-    configure: HttpRequestSchedule.Configuration.() -> Unit
-  ): HttpClient = createClient { install(HttpRequestSchedule, configure) }
 
   val MAX_CHECKS = 19L
 
   @Test fun recurs() = runTest {
     checkAll(Arb.long(0, MAX_CHECKS)) { l ->
       testApplication {
-        val counter = configureServer { }
-        val client = configureClient {
-          repeat(Schedule.recurs(l))
-        }
-
+        val (counter, client) = setup(check = { }) { repeat(Schedule.recurs(l)) }
         val response = client.get("/do")
 
         counter.get() shouldBe l + 1
-        response.status shouldBe OK
+        response.status shouldBe HttpStatusCode.OK
       }
     }
   }
@@ -60,37 +56,31 @@ class HttpRequestScheduleTest {
   @Test fun doWhile() = runTest {
     checkAll(Arb.long(0, MAX_CHECKS)) { l ->
       testApplication {
-        val counter = configureServer { c ->
-          if (c <= l) call.respond(NotFound)
-        }
-        val client = configureClient {
-          repeat(Schedule.doWhile { request, _ -> !request.status.isSuccess() })
-        }
+        val (counter, client) = setup(check = { c ->
+          if (c <= l) throw NotFoundExceptionForMocking()
+        }) { repeat(Schedule.doWhile { request, _ ->
+          !request.status.isSuccess()
+        }) }
 
         val response = client.get("/do")
 
         counter.get() shouldBe l + 1
-        response.status shouldBe OK
+        response.status shouldBe HttpStatusCode.OK
       }
     }
   }
 
-  class NetworkError : Throwable()
-
   @Test fun retry() = runTest {
     checkAll(Arb.long(0, MAX_CHECKS)) { l ->
       testApplication {
-        val counter = configureServer { c ->
-          if (c <= l) throw NetworkError()
-        }
-        val client = configureClient {
-          retry(Schedule.doWhile { throwable, _ -> throwable is NetworkError })
-        }
+        val (counter, client) = setup(check = { c ->
+          if (c <= l) throw ConnectException()
+        }) { retry(Schedule.doWhile { throwable, _ -> throwable is ConnectException }) }
 
         val response = client.get("/do")
 
         counter.get() shouldBe l + 1
-        response.status shouldBe OK
+        response.status shouldBe HttpStatusCode.OK
       }
     }
   }
@@ -98,23 +88,20 @@ class HttpRequestScheduleTest {
   @Test fun schedule() = runTest {
     checkAll(Arb.long(1, MAX_CHECKS)) { l ->
       testApplication {
-        val counter = configureServer { c ->
-          if (c <= l) throw NetworkError()
-        }
-        val client = configureClient {
-          retry(Schedule.recurs(0))
-        }
+        val (counter, client) = setup(check = { c ->
+          if (c <= l) throw ConnectException()
+        }) { retry(Schedule.recurs(0)) }
 
-        shouldThrow<NetworkError> { client.get("/do") }
+        shouldThrow<ConnectException> { client.get("/do") }
 
         val response = client.get("/do") {
           schedule {
-            retry(Schedule.doWhile { throwable, _ -> throwable is NetworkError })
+            retry(Schedule.doWhile { throwable, _ -> throwable is ConnectException })
           }
         }
 
         counter.get() shouldBe l + 1
-        response.status shouldBe OK
+        response.status shouldBe HttpStatusCode.OK
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlinCompileTesting = "0.7.0"
 knit = "0.5.0"
 kspVersion = "2.1.10-1.0.30"
 kotlinxSerialization = "1.8.0"
-ktor = "3.1.0"
+ktor = "3.1.1"
 mockWebServer = "4.12.0"
 retrofit = "2.11.0"
 moshi = "1.15.2"
@@ -44,6 +44,7 @@ cache4k = { module = "io.github.reactivecircus.cache4k:cache4k", version.ref = "
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonModuleKotlin" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-test = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 # required for the convention plugin
 gradlePlugin-kotlin-base = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
This PR does two things:
- Moves the implementation of `HttpRequestSchedule` to the [newer API](https://ktor.io/docs/client-custom-plugins.html) based on `on`. The implementation now follows more closely what is done for `HttpRetry`.
- Updates the tests to actually simulate a failing network request. Before the tests relied on the fact that the exception from the host was propagated with `testApplication`, but now `MockEngine` directly simulates a failing connection.