### PR TITLE
`Eval` for `suspend` functions

### DIFF
--- a/arrow-libs/core/arrow-eval/api/android/arrow-eval.api
+++ b/arrow-libs/core/arrow-eval/api/android/arrow-eval.api
@@ -1,15 +1,18 @@
-public abstract class arrow/eval/Eval {
+public abstract class arrow/eval/Eval : arrow/eval/SuspendEval {
 	public static final field Companion Larrow/eval/Eval$Companion;
 	public static final fun always (Lkotlin/jvm/functions/Function0;)Larrow/eval/Eval$Always;
 	public final fun coflatMap (Lkotlin/jvm/functions/Function1;)Larrow/eval/Eval;
 	public static final fun defer (Lkotlin/jvm/functions/Function0;)Larrow/eval/Eval;
 	public final fun flatMap (Lkotlin/jvm/functions/Function1;)Larrow/eval/Eval;
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
 	public final fun invoke ()Ljava/lang/Object;
 	public static final fun later (Lkotlin/jvm/functions/Function0;)Larrow/eval/Eval$Later;
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/eval/Eval;
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
 	public abstract fun memoize ()Larrow/eval/Eval;
 	public static final fun now (Ljava/lang/Object;)Larrow/eval/Eval;
 	public static final fun raise (Ljava/lang/Throwable;)Larrow/eval/Eval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public abstract fun value ()Ljava/lang/Object;
 }
@@ -21,6 +24,7 @@ public final class arrow/eval/Eval$Always : arrow/eval/Eval {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -42,15 +46,19 @@ public final class arrow/eval/Eval$Defer : arrow/eval/Eval {
 	public final fun getThunk ()Lkotlin/jvm/functions/Function0;
 	public fun hashCode ()I
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
 
-public abstract class arrow/eval/Eval$FlatMap : arrow/eval/Eval {
+public abstract class arrow/eval/Eval$FlatMap : arrow/eval/Eval, arrow/eval/SuspendEval$AbstractFlatMap {
 	public fun <init> ()V
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public abstract fun run (Ljava/lang/Object;)Larrow/eval/Eval;
+	public fun runSuspend (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start ()Larrow/eval/Eval;
+	public fun startSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -64,6 +72,7 @@ public final class arrow/eval/Eval$Later : arrow/eval/Eval, kotlin/Lazy {
 	public fun hashCode ()I
 	public fun isInitialized ()Z
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -79,6 +88,7 @@ public final class arrow/eval/Eval$Now : arrow/eval/Eval, kotlin/Lazy {
 	public fun hashCode ()I
 	public fun isInitialized ()Z
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -101,5 +111,132 @@ public final class arrow/eval/EvalKt {
 	public static final fun zip (Larrow/eval/Eval;Larrow/eval/Eval;Larrow/eval/Eval;Larrow/eval/Eval;Lkotlin/jvm/functions/Function4;)Larrow/eval/Eval;
 	public static final fun zip (Larrow/eval/Eval;Larrow/eval/Eval;Larrow/eval/Eval;Lkotlin/jvm/functions/Function3;)Larrow/eval/Eval;
 	public static final fun zip (Larrow/eval/Eval;Larrow/eval/Eval;Lkotlin/jvm/functions/Function2;)Larrow/eval/Eval;
+}
+
+public abstract interface class arrow/eval/SuspendEval {
+	public static final field Companion Larrow/eval/SuspendEval$Companion;
+	public static fun always (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Always;
+	public static fun defer (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval;
+	public abstract fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun later (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Later;
+	public abstract fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public abstract fun memoize ()Larrow/eval/SuspendEval;
+	public static fun now (Ljava/lang/Object;)Larrow/eval/SuspendEval;
+	public static fun raise (Ljava/lang/Throwable;)Larrow/eval/SuspendEval;
+	public abstract fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class arrow/eval/SuspendEval$AbstractDefer : arrow/eval/SuspendEval {
+	public abstract fun getThunk ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class arrow/eval/SuspendEval$AbstractDefer$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval$AbstractDefer;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval$AbstractDefer;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public abstract interface class arrow/eval/SuspendEval$AbstractFlatMap : arrow/eval/SuspendEval {
+	public abstract fun runSuspend (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/eval/SuspendEval$AbstractFlatMap$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval$AbstractFlatMap;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval$AbstractFlatMap;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public abstract interface class arrow/eval/SuspendEval$AbstractMemoize : arrow/eval/SuspendEval {
+	public abstract fun getEval ()Larrow/eval/SuspendEval;
+	public abstract fun getResult ()Larrow/core/Option;
+	public abstract fun setResult (Larrow/core/Option;)V
+}
+
+public final class arrow/eval/SuspendEval$AbstractMemoize$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval$AbstractMemoize;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval$AbstractMemoize;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public final class arrow/eval/SuspendEval$Always : arrow/eval/SuspendEval {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Always;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Always;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/eval/SuspendEval$Always;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/eval/SuspendEval$Companion {
+	public final fun always (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Always;
+	public final fun defer (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval;
+	public final fun later (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Later;
+	public final fun now (Ljava/lang/Object;)Larrow/eval/SuspendEval;
+	public final fun raise (Ljava/lang/Throwable;)Larrow/eval/SuspendEval;
+}
+
+public final class arrow/eval/SuspendEval$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public final class arrow/eval/SuspendEval$Defer : arrow/eval/SuspendEval$AbstractDefer {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Defer;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Defer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/eval/SuspendEval$Defer;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun getThunk ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class arrow/eval/SuspendEval$FlatMap : arrow/eval/SuspendEval$AbstractFlatMap {
+	public fun <init> ()V
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun runSuspend (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/eval/SuspendEval$Later : arrow/eval/SuspendEval {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Later;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Later;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/eval/SuspendEval$Later;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public final fun getResult ()Larrow/core/Option;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setResult (Larrow/core/Option;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/eval/SuspendEval$Memoize : arrow/eval/SuspendEval$AbstractMemoize {
+	public fun <init> (Larrow/eval/SuspendEval;)V
+	public final fun component1 ()Larrow/eval/SuspendEval;
+	public final fun copy (Larrow/eval/SuspendEval;)Larrow/eval/SuspendEval$Memoize;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Memoize;Larrow/eval/SuspendEval;ILjava/lang/Object;)Larrow/eval/SuspendEval$Memoize;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun getEval ()Larrow/eval/SuspendEval;
+	public fun getResult ()Larrow/core/Option;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setResult (Larrow/core/Option;)V
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/arrow-libs/core/arrow-eval/api/arrow-eval.klib.api
+++ b/arrow-libs/core/arrow-eval/api/arrow-eval.klib.api
@@ -6,7 +6,111 @@
 // - Show declarations: true
 
 // Library unique name: <io.arrow-kt:arrow-eval>
-sealed class <#A: out kotlin/Any?> arrow.eval/Eval { // arrow.eval/Eval|null[0]
+sealed interface <#A: out kotlin/Any?> arrow.eval/SuspendEval { // arrow.eval/SuspendEval|null[0]
+    abstract fun memoize(): arrow.eval/SuspendEval<#A> // arrow.eval/SuspendEval.memoize|memoize(){}[0]
+    abstract suspend fun run(): #A // arrow.eval/SuspendEval.run|run(){}[0]
+    open fun <#A1: kotlin/Any?> flatMapSuspend(kotlin.coroutines/SuspendFunction1<#A, arrow.eval/SuspendEval<#A1>>): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.flatMapSuspend|flatMapSuspend(kotlin.coroutines.SuspendFunction1<1:0,arrow.eval.SuspendEval<0:0>>){0§<kotlin.Any?>}[0]
+    open fun <#A1: kotlin/Any?> mapSuspend(kotlin.coroutines/SuspendFunction1<#A, #A1>): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.mapSuspend|mapSuspend(kotlin.coroutines.SuspendFunction1<1:0,0:0>){0§<kotlin.Any?>}[0]
+
+    abstract interface <#A1: kotlin/Any?> AbstractMemoize : arrow.eval/SuspendEval<#A1> { // arrow.eval/SuspendEval.AbstractMemoize|null[0]
+        abstract val eval // arrow.eval/SuspendEval.AbstractMemoize.eval|{}eval[0]
+            abstract fun <get-eval>(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.AbstractMemoize.eval.<get-eval>|<get-eval>(){}[0]
+
+        abstract var result // arrow.eval/SuspendEval.AbstractMemoize.result|{}result[0]
+            abstract fun <get-result>(): arrow.core/Option<#A1> // arrow.eval/SuspendEval.AbstractMemoize.result.<get-result>|<get-result>(){}[0]
+            abstract fun <set-result>(arrow.core/Option<#A1>) // arrow.eval/SuspendEval.AbstractMemoize.result.<set-result>|<set-result>(arrow.core.Option<1:0>){}[0]
+    }
+
+    abstract interface <#A1: out kotlin/Any?> AbstractDefer : arrow.eval/SuspendEval<#A1> { // arrow.eval/SuspendEval.AbstractDefer|null[0]
+        abstract val thunk // arrow.eval/SuspendEval.AbstractDefer.thunk|{}thunk[0]
+            abstract fun <get-thunk>(): kotlin.coroutines/SuspendFunction0<arrow.eval/SuspendEval<#A1>> // arrow.eval/SuspendEval.AbstractDefer.thunk.<get-thunk>|<get-thunk>(){}[0]
+    }
+
+    abstract interface <#A1: out kotlin/Any?> AbstractFlatMap : arrow.eval/SuspendEval<#A1> { // arrow.eval/SuspendEval.AbstractFlatMap|null[0]
+        abstract suspend fun <#A2: kotlin/Any?> runSuspend(#A2): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.AbstractFlatMap.runSuspend|runSuspend(0:0){0§<kotlin.Any?>}[0]
+        abstract suspend fun <#A2: kotlin/Any?> startSuspend(): arrow.eval/SuspendEval<#A2> // arrow.eval/SuspendEval.AbstractFlatMap.startSuspend|startSuspend(){0§<kotlin.Any?>}[0]
+    }
+
+    abstract class <#A1: out kotlin/Any?> FlatMap : arrow.eval/SuspendEval.AbstractFlatMap<#A1> { // arrow.eval/SuspendEval.FlatMap|null[0]
+        constructor <init>() // arrow.eval/SuspendEval.FlatMap.<init>|<init>(){}[0]
+
+        abstract suspend fun <#A2: kotlin/Any?> runSuspend(#A2): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.FlatMap.runSuspend|runSuspend(0:0){0§<kotlin.Any?>}[0]
+        abstract suspend fun <#A2: kotlin/Any?> startSuspend(): arrow.eval/SuspendEval<#A2> // arrow.eval/SuspendEval.FlatMap.startSuspend|startSuspend(){0§<kotlin.Any?>}[0]
+        open fun memoize(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.FlatMap.memoize|memoize(){}[0]
+        open fun toString(): kotlin/String // arrow.eval/SuspendEval.FlatMap.toString|toString(){}[0]
+        open suspend fun run(): #A1 // arrow.eval/SuspendEval.FlatMap.run|run(){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> Memoize : arrow.eval/SuspendEval.AbstractMemoize<#A1> { // arrow.eval/SuspendEval.Memoize|null[0]
+        constructor <init>(arrow.eval/SuspendEval<#A1>) // arrow.eval/SuspendEval.Memoize.<init>|<init>(arrow.eval.SuspendEval<1:0>){}[0]
+
+        final val eval // arrow.eval/SuspendEval.Memoize.eval|{}eval[0]
+            final fun <get-eval>(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.Memoize.eval.<get-eval>|<get-eval>(){}[0]
+
+        final var result // arrow.eval/SuspendEval.Memoize.result|{}result[0]
+            final fun <get-result>(): arrow.core/Option<#A1> // arrow.eval/SuspendEval.Memoize.result.<get-result>|<get-result>(){}[0]
+            final fun <set-result>(arrow.core/Option<#A1>) // arrow.eval/SuspendEval.Memoize.result.<set-result>|<set-result>(arrow.core.Option<1:0>){}[0]
+
+        final fun component1(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.Memoize.component1|component1(){}[0]
+        final fun copy(arrow.eval/SuspendEval<#A1> = ...): arrow.eval/SuspendEval.Memoize<#A1> // arrow.eval/SuspendEval.Memoize.copy|copy(arrow.eval.SuspendEval<1:0>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.eval/SuspendEval.Memoize.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.eval/SuspendEval.Memoize.hashCode|hashCode(){}[0]
+        final fun memoize(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.Memoize.memoize|memoize(){}[0]
+        final fun toString(): kotlin/String // arrow.eval/SuspendEval.Memoize.toString|toString(){}[0]
+        final suspend fun run(): #A1 // arrow.eval/SuspendEval.Memoize.run|run(){}[0]
+    }
+
+    final class <#A1: out kotlin/Any?> Always : arrow.eval/SuspendEval<#A1> { // arrow.eval/SuspendEval.Always|null[0]
+        constructor <init>(kotlin.coroutines/SuspendFunction0<#A1>) // arrow.eval/SuspendEval.Always.<init>|<init>(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+
+        final fun copy(kotlin.coroutines/SuspendFunction0<#A1> = ...): arrow.eval/SuspendEval.Always<#A1> // arrow.eval/SuspendEval.Always.copy|copy(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.eval/SuspendEval.Always.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.eval/SuspendEval.Always.hashCode|hashCode(){}[0]
+        final fun memoize(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.Always.memoize|memoize(){}[0]
+        final fun toString(): kotlin/String // arrow.eval/SuspendEval.Always.toString|toString(){}[0]
+        final suspend fun run(): #A1 // arrow.eval/SuspendEval.Always.run|run(){}[0]
+    }
+
+    final class <#A1: out kotlin/Any?> Defer : arrow.eval/SuspendEval.AbstractDefer<#A1> { // arrow.eval/SuspendEval.Defer|null[0]
+        constructor <init>(kotlin.coroutines/SuspendFunction0<arrow.eval/SuspendEval<#A1>>) // arrow.eval/SuspendEval.Defer.<init>|<init>(kotlin.coroutines.SuspendFunction0<arrow.eval.SuspendEval<1:0>>){}[0]
+
+        final val thunk // arrow.eval/SuspendEval.Defer.thunk|{}thunk[0]
+            final fun <get-thunk>(): kotlin.coroutines/SuspendFunction0<arrow.eval/SuspendEval<#A1>> // arrow.eval/SuspendEval.Defer.thunk.<get-thunk>|<get-thunk>(){}[0]
+
+        final fun component1(): kotlin.coroutines/SuspendFunction0<arrow.eval/SuspendEval<#A1>> // arrow.eval/SuspendEval.Defer.component1|component1(){}[0]
+        final fun copy(kotlin.coroutines/SuspendFunction0<arrow.eval/SuspendEval<#A1>> = ...): arrow.eval/SuspendEval.Defer<#A1> // arrow.eval/SuspendEval.Defer.copy|copy(kotlin.coroutines.SuspendFunction0<arrow.eval.SuspendEval<1:0>>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.eval/SuspendEval.Defer.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.eval/SuspendEval.Defer.hashCode|hashCode(){}[0]
+        final fun memoize(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.Defer.memoize|memoize(){}[0]
+        final fun toString(): kotlin/String // arrow.eval/SuspendEval.Defer.toString|toString(){}[0]
+        final suspend fun run(): #A1 // arrow.eval/SuspendEval.Defer.run|run(){}[0]
+    }
+
+    final class <#A1: out kotlin/Any?> Later : arrow.eval/SuspendEval<#A1> { // arrow.eval/SuspendEval.Later|null[0]
+        constructor <init>(kotlin.coroutines/SuspendFunction0<#A1>) // arrow.eval/SuspendEval.Later.<init>|<init>(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+
+        final var result // arrow.eval/SuspendEval.Later.result|{}result[0]
+            final fun <get-result>(): arrow.core/Option<#A1> // arrow.eval/SuspendEval.Later.result.<get-result>|<get-result>(){}[0]
+            final fun <set-result>(arrow.core/Option<#A1>) // arrow.eval/SuspendEval.Later.result.<set-result>|<set-result>(arrow.core.Option<1:0>){}[0]
+
+        final fun copy(kotlin.coroutines/SuspendFunction0<#A1> = ...): arrow.eval/SuspendEval.Later<#A1> // arrow.eval/SuspendEval.Later.copy|copy(kotlin.coroutines.SuspendFunction0<1:0>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // arrow.eval/SuspendEval.Later.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // arrow.eval/SuspendEval.Later.hashCode|hashCode(){}[0]
+        final fun memoize(): arrow.eval/SuspendEval<#A1> // arrow.eval/SuspendEval.Later.memoize|memoize(){}[0]
+        final fun toString(): kotlin/String // arrow.eval/SuspendEval.Later.toString|toString(){}[0]
+        final suspend fun run(): #A1 // arrow.eval/SuspendEval.Later.run|run(){}[0]
+    }
+
+    final object Companion { // arrow.eval/SuspendEval.Companion|null[0]
+        final fun <#A2: kotlin/Any?> now(#A2): arrow.eval/SuspendEval<#A2> // arrow.eval/SuspendEval.Companion.now|now(0:0){0§<kotlin.Any?>}[0]
+        final fun raise(kotlin/Throwable): arrow.eval/SuspendEval<kotlin/Nothing> // arrow.eval/SuspendEval.Companion.raise|raise(kotlin.Throwable){}[0]
+        final inline fun <#A2: kotlin/Any?> always(crossinline kotlin.coroutines/SuspendFunction0<#A2>): arrow.eval/SuspendEval.Always<#A2> // arrow.eval/SuspendEval.Companion.always|always(kotlin.coroutines.SuspendFunction0<0:0>){0§<kotlin.Any?>}[0]
+        final inline fun <#A2: kotlin/Any?> defer(crossinline kotlin.coroutines/SuspendFunction0<arrow.eval/SuspendEval<#A2>>): arrow.eval/SuspendEval<#A2> // arrow.eval/SuspendEval.Companion.defer|defer(kotlin.coroutines.SuspendFunction0<arrow.eval.SuspendEval<0:0>>){0§<kotlin.Any?>}[0]
+        final inline fun <#A2: kotlin/Any?> later(crossinline kotlin.coroutines/SuspendFunction0<#A2>): arrow.eval/SuspendEval.Later<#A2> // arrow.eval/SuspendEval.Companion.later|later(kotlin.coroutines.SuspendFunction0<0:0>){0§<kotlin.Any?>}[0]
+    }
+}
+
+sealed class <#A: out kotlin/Any?> arrow.eval/Eval : arrow.eval/SuspendEval<#A> { // arrow.eval/Eval|null[0]
     abstract fun memoize(): arrow.eval/Eval<#A> // arrow.eval/Eval.memoize|memoize(){}[0]
     abstract fun value(): #A // arrow.eval/Eval.value|value(){}[0]
     final fun <#A1: kotlin/Any?> flatMap(kotlin/Function1<#A, arrow.eval/Eval<#A1>>): arrow.eval/Eval<#A1> // arrow.eval/Eval.flatMap|flatMap(kotlin.Function1<1:0,arrow.eval.Eval<0:0>>){0§<kotlin.Any?>}[0]
@@ -14,8 +118,9 @@ sealed class <#A: out kotlin/Any?> arrow.eval/Eval { // arrow.eval/Eval|null[0]
     final inline fun <#A1: kotlin/Any?> coflatMap(crossinline kotlin/Function1<arrow.eval/Eval<#A>, #A1>): arrow.eval/Eval<#A1> // arrow.eval/Eval.coflatMap|coflatMap(kotlin.Function1<arrow.eval.Eval<1:0>,0:0>){0§<kotlin.Any?>}[0]
     final inline fun <#A1: kotlin/Any?> map(crossinline kotlin/Function1<#A, #A1>): arrow.eval/Eval<#A1> // arrow.eval/Eval.map|map(kotlin.Function1<1:0,0:0>){0§<kotlin.Any?>}[0]
     open fun toString(): kotlin/String // arrow.eval/Eval.toString|toString(){}[0]
+    open suspend fun run(): #A // arrow.eval/Eval.run|run(){}[0]
 
-    abstract class <#A1: out kotlin/Any?> FlatMap : arrow.eval/Eval<#A1> { // arrow.eval/Eval.FlatMap|null[0]
+    abstract class <#A1: out kotlin/Any?> FlatMap : arrow.eval/Eval<#A1>, arrow.eval/SuspendEval.AbstractFlatMap<#A1> { // arrow.eval/Eval.FlatMap|null[0]
         constructor <init>() // arrow.eval/Eval.FlatMap.<init>|<init>(){}[0]
 
         abstract fun <#A2: kotlin/Any?> run(#A2): arrow.eval/Eval<#A1> // arrow.eval/Eval.FlatMap.run|run(0:0){0§<kotlin.Any?>}[0]
@@ -23,6 +128,8 @@ sealed class <#A: out kotlin/Any?> arrow.eval/Eval { // arrow.eval/Eval|null[0]
         open fun memoize(): arrow.eval/Eval<#A1> // arrow.eval/Eval.FlatMap.memoize|memoize(){}[0]
         open fun toString(): kotlin/String // arrow.eval/Eval.FlatMap.toString|toString(){}[0]
         open fun value(): #A1 // arrow.eval/Eval.FlatMap.value|value(){}[0]
+        open suspend fun <#A2: kotlin/Any?> runSuspend(#A2): arrow.eval/Eval<#A1> // arrow.eval/Eval.FlatMap.runSuspend|runSuspend(0:0){0§<kotlin.Any?>}[0]
+        open suspend fun <#A2: kotlin/Any?> startSuspend(): arrow.eval/Eval<#A2> // arrow.eval/Eval.FlatMap.startSuspend|startSuspend(){0§<kotlin.Any?>}[0]
     }
 
     final class <#A1: out kotlin/Any?> Always : arrow.eval/Eval<#A1> { // arrow.eval/Eval.Always|null[0]

--- a/arrow-libs/core/arrow-eval/api/jvm/arrow-eval.api
+++ b/arrow-libs/core/arrow-eval/api/jvm/arrow-eval.api
@@ -1,15 +1,18 @@
-public abstract class arrow/eval/Eval {
+public abstract class arrow/eval/Eval : arrow/eval/SuspendEval {
 	public static final field Companion Larrow/eval/Eval$Companion;
 	public static final fun always (Lkotlin/jvm/functions/Function0;)Larrow/eval/Eval$Always;
 	public final fun coflatMap (Lkotlin/jvm/functions/Function1;)Larrow/eval/Eval;
 	public static final fun defer (Lkotlin/jvm/functions/Function0;)Larrow/eval/Eval;
 	public final fun flatMap (Lkotlin/jvm/functions/Function1;)Larrow/eval/Eval;
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
 	public final fun invoke ()Ljava/lang/Object;
 	public static final fun later (Lkotlin/jvm/functions/Function0;)Larrow/eval/Eval$Later;
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/eval/Eval;
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
 	public abstract fun memoize ()Larrow/eval/Eval;
 	public static final fun now (Ljava/lang/Object;)Larrow/eval/Eval;
 	public static final fun raise (Ljava/lang/Throwable;)Larrow/eval/Eval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public abstract fun value ()Ljava/lang/Object;
 }
@@ -21,6 +24,7 @@ public final class arrow/eval/Eval$Always : arrow/eval/Eval {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -42,15 +46,19 @@ public final class arrow/eval/Eval$Defer : arrow/eval/Eval {
 	public final fun getThunk ()Lkotlin/jvm/functions/Function0;
 	public fun hashCode ()I
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
 
-public abstract class arrow/eval/Eval$FlatMap : arrow/eval/Eval {
+public abstract class arrow/eval/Eval$FlatMap : arrow/eval/Eval, arrow/eval/SuspendEval$AbstractFlatMap {
 	public fun <init> ()V
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public abstract fun run (Ljava/lang/Object;)Larrow/eval/Eval;
+	public fun runSuspend (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start ()Larrow/eval/Eval;
+	public fun startSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -64,6 +72,7 @@ public final class arrow/eval/Eval$Later : arrow/eval/Eval, kotlin/Lazy {
 	public fun hashCode ()I
 	public fun isInitialized ()Z
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -79,6 +88,7 @@ public final class arrow/eval/Eval$Now : arrow/eval/Eval, kotlin/Lazy {
 	public fun hashCode ()I
 	public fun isInitialized ()Z
 	public fun memoize ()Larrow/eval/Eval;
+	public synthetic fun memoize ()Larrow/eval/SuspendEval;
 	public fun toString ()Ljava/lang/String;
 	public fun value ()Ljava/lang/Object;
 }
@@ -101,5 +111,132 @@ public final class arrow/eval/EvalKt {
 	public static final fun zip (Larrow/eval/Eval;Larrow/eval/Eval;Larrow/eval/Eval;Larrow/eval/Eval;Lkotlin/jvm/functions/Function4;)Larrow/eval/Eval;
 	public static final fun zip (Larrow/eval/Eval;Larrow/eval/Eval;Larrow/eval/Eval;Lkotlin/jvm/functions/Function3;)Larrow/eval/Eval;
 	public static final fun zip (Larrow/eval/Eval;Larrow/eval/Eval;Lkotlin/jvm/functions/Function2;)Larrow/eval/Eval;
+}
+
+public abstract interface class arrow/eval/SuspendEval {
+	public static final field Companion Larrow/eval/SuspendEval$Companion;
+	public static fun always (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Always;
+	public static fun defer (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval;
+	public abstract fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun later (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Later;
+	public abstract fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public abstract fun memoize ()Larrow/eval/SuspendEval;
+	public static fun now (Ljava/lang/Object;)Larrow/eval/SuspendEval;
+	public static fun raise (Ljava/lang/Throwable;)Larrow/eval/SuspendEval;
+	public abstract fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class arrow/eval/SuspendEval$AbstractDefer : arrow/eval/SuspendEval {
+	public abstract fun getThunk ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class arrow/eval/SuspendEval$AbstractDefer$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval$AbstractDefer;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval$AbstractDefer;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public abstract interface class arrow/eval/SuspendEval$AbstractFlatMap : arrow/eval/SuspendEval {
+	public abstract fun runSuspend (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/eval/SuspendEval$AbstractFlatMap$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval$AbstractFlatMap;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval$AbstractFlatMap;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public abstract interface class arrow/eval/SuspendEval$AbstractMemoize : arrow/eval/SuspendEval {
+	public abstract fun getEval ()Larrow/eval/SuspendEval;
+	public abstract fun getResult ()Larrow/core/Option;
+	public abstract fun setResult (Larrow/core/Option;)V
+}
+
+public final class arrow/eval/SuspendEval$AbstractMemoize$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval$AbstractMemoize;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval$AbstractMemoize;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public final class arrow/eval/SuspendEval$Always : arrow/eval/SuspendEval {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Always;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Always;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/eval/SuspendEval$Always;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/eval/SuspendEval$Companion {
+	public final fun always (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Always;
+	public final fun defer (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval;
+	public final fun later (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Later;
+	public final fun now (Ljava/lang/Object;)Larrow/eval/SuspendEval;
+	public final fun raise (Ljava/lang/Throwable;)Larrow/eval/SuspendEval;
+}
+
+public final class arrow/eval/SuspendEval$DefaultImpls {
+	public static fun flatMapSuspend (Larrow/eval/SuspendEval;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public static fun mapSuspend (Larrow/eval/SuspendEval;Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+}
+
+public final class arrow/eval/SuspendEval$Defer : arrow/eval/SuspendEval$AbstractDefer {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Defer;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Defer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/eval/SuspendEval$Defer;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun getThunk ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class arrow/eval/SuspendEval$FlatMap : arrow/eval/SuspendEval$AbstractFlatMap {
+	public fun <init> ()V
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun runSuspend (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/eval/SuspendEval$Later : arrow/eval/SuspendEval {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Larrow/eval/SuspendEval$Later;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Later;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Larrow/eval/SuspendEval$Later;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public final fun getResult ()Larrow/core/Option;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setResult (Larrow/core/Option;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class arrow/eval/SuspendEval$Memoize : arrow/eval/SuspendEval$AbstractMemoize {
+	public fun <init> (Larrow/eval/SuspendEval;)V
+	public final fun component1 ()Larrow/eval/SuspendEval;
+	public final fun copy (Larrow/eval/SuspendEval;)Larrow/eval/SuspendEval$Memoize;
+	public static synthetic fun copy$default (Larrow/eval/SuspendEval$Memoize;Larrow/eval/SuspendEval;ILjava/lang/Object;)Larrow/eval/SuspendEval$Memoize;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun flatMapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun getEval ()Larrow/eval/SuspendEval;
+	public fun getResult ()Larrow/core/Option;
+	public fun hashCode ()I
+	public fun mapSuspend (Lkotlin/jvm/functions/Function2;)Larrow/eval/SuspendEval;
+	public fun memoize ()Larrow/eval/SuspendEval;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setResult (Larrow/core/Option;)V
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/arrow-libs/core/arrow-eval/src/commonMain/kotlin/arrow/eval/SuspendEval.kt
+++ b/arrow-libs/core/arrow-eval/src/commonMain/kotlin/arrow/eval/SuspendEval.kt
@@ -1,0 +1,212 @@
+package arrow.eval
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
+import arrow.core.getOrElse
+import arrow.eval.Eval.Now
+import kotlin.jvm.JvmStatic
+
+public sealed interface SuspendEval<out A> {
+  public companion object {
+    @JvmStatic
+    public fun <A> now(a: A): SuspendEval<A> = Eval.now(a)
+
+    @JvmStatic
+    public inline fun <A> later(crossinline f: suspend () -> A): Later<A> =
+      Later { f() }
+
+    @JvmStatic
+    public inline fun <A> always(crossinline f: suspend () -> A): Always<A> =
+      Always { f() }
+
+    @JvmStatic
+    public inline fun <A> defer(crossinline f: suspend () -> SuspendEval<A>): SuspendEval<A> =
+      Defer { f() }
+
+    @JvmStatic
+    public fun raise(t: Throwable): SuspendEval<Nothing> =
+      defer { throw t }
+
+    private tailrec suspend fun <A> collapse(fa: SuspendEval<A>): SuspendEval<A> =
+      when (fa) {
+        is AbstractDefer -> collapse(fa.thunk())
+        is AbstractFlatMap ->
+          object : FlatMap<A>() {
+            override suspend fun <S> startSuspend(): SuspendEval<S> = fa.startSuspend()
+            override suspend fun <S> runSuspend(s: S): SuspendEval<A> = collapse1(fa.runSuspend(s))
+          }
+        else -> fa
+      }
+
+    // Enforce tailrec call to collapse inside compute loop
+    private suspend fun <A> collapse1(fa: SuspendEval<A>): SuspendEval<A> = collapse(fa)
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun <A> evaluate(e: SuspendEval<A>): A = run {
+      var curr: SuspendEval<Any?> = e
+      val fs: MutableList<suspend (Any?) -> SuspendEval<Any?>> = mutableListOf()
+
+      fun addToMemo(m: AbstractMemoize<Any?>): (Any?) -> SuspendEval<Any?> = {
+        m.result = Some(it)
+        now(it)
+      }
+
+      loop@ while (true) {
+        when (curr) {
+          is AbstractFlatMap -> {
+            val currComp = curr as AbstractFlatMap<A>
+            currComp.startSuspend<A>().let { cc ->
+              when (cc) {
+                is AbstractFlatMap -> {
+                  curr = cc.startSuspend<A>()
+                  fs.add(0, currComp::runSuspend)
+                  fs.add(0, cc::runSuspend)
+                }
+
+                is AbstractMemoize -> {
+                  cc.result.fold(
+                    {
+                      curr = cc.eval
+                      fs.add(0, currComp::runSuspend)
+                      fs.add(0, addToMemo(cc as AbstractMemoize<Any?>))
+                    },
+                    {
+                      curr = Now(it)
+                      fs.add(0, currComp::runSuspend)
+                    }
+                  )
+                }
+
+                else -> {
+                  curr = currComp.runSuspend(cc.run())
+                }
+              }
+            }
+          }
+
+          is AbstractMemoize -> {
+            val currComp = curr as AbstractMemoize<Any?>
+            val eval = currComp.eval
+            currComp.result.fold(
+              {
+                curr = eval
+                fs.add(0, addToMemo(currComp))
+              },
+              {
+                if (fs.isNotEmpty()) {
+                  curr = fs[0](it)
+                  fs.removeAt(0)
+                }
+              }
+            )
+          }
+
+          else ->
+            if (fs.isNotEmpty()) {
+              curr = fs[0](curr.run())
+              fs.removeAt(0)
+            } else {
+              break@loop
+            }
+        }
+      }
+
+      return curr.run() as A
+    }
+  }
+
+  public suspend fun run(): A
+
+  public fun memoize(): SuspendEval<A>
+
+  public fun <B> mapSuspend(f: suspend (A) -> B): SuspendEval<B> =
+    flatMapSuspend { a -> Now(f(a)) }
+
+  @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE", "UNCHECKED_CAST")
+  public fun <B> flatMapSuspend(f: suspend (A) -> SuspendEval<B>): SuspendEval<B> =
+    when (this) {
+      is AbstractFlatMap<A> -> object : FlatMap<B>() {
+        override suspend fun <S> startSuspend(): SuspendEval<S> = (this@SuspendEval).startSuspend()
+
+        // @IgnoreJRERequirement
+        override suspend fun <S> runSuspend(s: S): SuspendEval<B> =
+          object : FlatMap<B>() {
+            override suspend fun <S1> startSuspend(): SuspendEval<S1> = (this@SuspendEval).runSuspend(s) as SuspendEval<S1>
+            override suspend fun <S1> runSuspend(s1: S1): SuspendEval<B> = f(s1 as A)
+          }
+      }
+      is AbstractDefer<A> -> object : FlatMap<B>() {
+        override suspend fun <S> startSuspend(): SuspendEval<S> = this@SuspendEval.thunk() as SuspendEval<S>
+        override suspend fun <S> runSuspend(s: S): SuspendEval<B> = f(s as A)
+      }
+      else -> object : FlatMap<B>() {
+        override suspend fun <S> startSuspend(): Eval<S> = this@SuspendEval as Eval<S>
+        override suspend fun <S> runSuspend(s: S): SuspendEval<B> = f(s as A)
+      }
+    }
+
+  public data class Later<out A>(private val f: suspend () -> A) : SuspendEval<A> {
+    var result: Option<@UnsafeVariance A> = None
+
+    override suspend fun run(): A = result.getOrElse {
+      f().also { result = Some(it) }
+    }
+
+    override fun memoize(): SuspendEval<A> = this
+
+    override fun toString(): String =
+      "SuspendEval.Later(f)"
+  }
+
+  public data class Always<out A>(private val f: suspend () -> A) : SuspendEval<A> {
+    override suspend fun run(): A = f()
+    override fun memoize(): SuspendEval<A> = Later(f)
+
+    override fun toString(): String =
+      "SuspendEval.Always(f)"
+  }
+
+  public interface AbstractDefer<out A>: SuspendEval<A> {
+    public val thunk: suspend () -> SuspendEval<A>
+  }
+
+  public data class Defer<out A>(override val thunk: suspend () -> SuspendEval<A>) : AbstractDefer<A> {
+    override fun memoize(): SuspendEval<A> = Memoize(this)
+    override suspend fun run(): A = collapse(this).run()
+
+    override fun toString(): String =
+      "SuspendEval.Defer(thunk)"
+  }
+
+  public interface AbstractFlatMap<out A> : SuspendEval<A> {
+    public suspend fun <S> startSuspend(): SuspendEval<S>
+    public suspend fun <S> runSuspend(s: S): SuspendEval<A>
+  }
+
+  public abstract class FlatMap<out A> : AbstractFlatMap<A> {
+    public abstract override suspend fun <S> startSuspend(): SuspendEval<S>
+    public abstract override suspend fun <S> runSuspend(s: S): SuspendEval<A>
+    override fun memoize(): SuspendEval<A> = Memoize(this)
+    override suspend fun run(): A = evaluate(this)
+
+    override fun toString(): String =
+      "Eval.FlatMap(..)"
+  }
+
+  public interface AbstractMemoize<A> : SuspendEval<A> {
+    public val eval: SuspendEval<A>
+    public var result: Option<A>
+  }
+
+  public data class Memoize<A>(override val eval: SuspendEval<A>) : AbstractMemoize<A> {
+    override var result: Option<A> = None
+    override fun memoize(): SuspendEval<A> = this
+    override suspend fun run(): A = result.getOrElse {
+      evaluate(eval).also { result = Some(it) }
+    }
+
+    override fun toString(): String =
+      "Eval.Memoize($eval)"
+  }
+}

--- a/arrow-libs/core/arrow-eval/src/commonTest/kotlin/arrow/eval/SuspendEvalTest.kt
+++ b/arrow-libs/core/arrow-eval/src/commonTest/kotlin/arrow/eval/SuspendEvalTest.kt
@@ -1,0 +1,151 @@
+package arrow.eval
+
+import arrow.platform.stackSafeIteration
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal data class SuspendSideEffect(var counter: Int = 0) {
+  suspend fun increment() {
+    counter++
+  }
+}
+
+private fun recur(limit: Int, sideEffect: SuspendSideEffect): suspend (Int) -> SuspendEval<Int> {
+  return { num ->
+    if (num <= limit) {
+      sideEffect.increment()
+      SuspendEval.defer {
+        recur(limit, sideEffect).invoke(num + 1)
+      }
+    } else {
+      Eval.now(-1)
+    }
+  }
+}
+
+class SuspendEvalTest {
+  @Test
+  fun mapWrappedValue() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = Eval.now(0)
+      .mapSuspend { sideEffect.increment(); it + 1 }
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 2
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 3
+  }
+
+  @Test
+  fun laterEvaluatesOnce() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.later { sideEffect.increment(); sideEffect.counter }
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+  }
+
+  @Test
+  fun laterMemoizes() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.later { sideEffect.increment(); sideEffect.counter }.memoize()
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+  }
+
+  @Test
+  fun alwaysEvaluatesMany() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.always { sideEffect.increment(); sideEffect.counter }
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 2
+    sideEffect.counter shouldBe 2
+    mapped.run() shouldBe 3
+    sideEffect.counter shouldBe 3
+  }
+
+  @Test
+  fun alwaysMemoizes() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.always { sideEffect.increment(); sideEffect.counter }.memoize()
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+  }
+
+  @Test
+  fun deferShouldLazilyEvaluateOtherVals() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.defer {
+      sideEffect.increment()
+      SuspendEval.later { sideEffect.increment(); sideEffect.counter }
+    }
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 2
+    sideEffect.counter shouldBe 2
+    mapped.run() shouldBe 4
+    sideEffect.counter shouldBe 4
+    mapped.run() shouldBe 6
+    sideEffect.counter shouldBe 6
+  }
+
+  @Test
+  fun deferShouldMemoizeLater() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.defer {
+      sideEffect.increment()
+      SuspendEval.later { sideEffect.increment(); sideEffect.counter }
+    }.memoize()
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 2
+    sideEffect.counter shouldBe 2
+    mapped.run() shouldBe 2
+    sideEffect.counter shouldBe 2
+    mapped.run() shouldBe 2
+    sideEffect.counter shouldBe 2
+  }
+
+  @Test
+  fun deferShouldMemoizeNow() = runTest {
+    val sideEffect = SuspendSideEffect()
+    val mapped = SuspendEval.defer {
+      sideEffect.increment()
+      Eval.now(sideEffect.counter)
+    }.memoize()
+    sideEffect.counter shouldBe 0
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+    mapped.run() shouldBe 1
+    sideEffect.counter shouldBe 1
+  }
+
+  @Test
+  fun flatMapShouldNotBlowTheStack() = runTest {
+    val limit = stackSafeIteration()
+    val sideEffect = SuspendSideEffect()
+    val flatMapped = Eval.now(0).flatMapSuspend(recur(limit, sideEffect))
+    sideEffect.counter shouldBe 0
+    flatMapped.run() shouldBe -1
+    sideEffect.counter shouldBe limit + 1
+  }
+}


### PR DESCRIPTION
Coming from [this Slack thread](https://kotlinlang.slack.com/archives/C5UPMM0A0/p1741261169119059)

This brings a version of `Eval` which wraps `suspend` functions. The approach is very similar to the one in `arrow-collectors`, in which `SuspendEval` becomes a supertype of `Eval`. This allows freely mixing `SuspendEval` with `Eval` to get a `SuspendEval`, or use just `Eval` to keep `Eval`s.