### PR TITLE
Rewrite `OptionDeserializer` for Jackson

### DIFF
--- a/arrow-libs/integrations/arrow-core-jackson/api/arrow-core-jackson.api
+++ b/arrow-libs/integrations/arrow-core-jackson/api/arrow-core-jackson.api
@@ -86,17 +86,21 @@ public final class arrow/integrations/jackson/module/NonEmptyCollectionsModule :
 	public fun setupModule (Lcom/fasterxml/jackson/databind/Module$SetupContext;)V
 }
 
-public final class arrow/integrations/jackson/module/OptionDeserializer : com/fasterxml/jackson/databind/JsonDeserializer, com/fasterxml/jackson/databind/deser/ContextualDeserializer {
-	public fun <init> ()V
-	public fun createContextual (Lcom/fasterxml/jackson/databind/DeserializationContext;Lcom/fasterxml/jackson/databind/BeanProperty;)Lcom/fasterxml/jackson/databind/JsonDeserializer;
-	public fun deserialize (Lcom/fasterxml/jackson/core/JsonParser;Lcom/fasterxml/jackson/databind/DeserializationContext;)Larrow/core/Option;
-	public synthetic fun deserialize (Lcom/fasterxml/jackson/core/JsonParser;Lcom/fasterxml/jackson/databind/DeserializationContext;)Ljava/lang/Object;
-	public fun getEmptyAccessPattern ()Lcom/fasterxml/jackson/databind/util/AccessPattern;
-	public fun getEmptyValue (Lcom/fasterxml/jackson/databind/DeserializationContext;)Larrow/core/Option;
-	public synthetic fun getEmptyValue (Lcom/fasterxml/jackson/databind/DeserializationContext;)Ljava/lang/Object;
-	public fun getNullAccessPattern ()Lcom/fasterxml/jackson/databind/util/AccessPattern;
+public final class arrow/integrations/jackson/module/OptionDeserializer : com/fasterxml/jackson/databind/deser/std/ReferenceTypeDeserializer {
+	public fun <init> (Lcom/fasterxml/jackson/databind/JavaType;Lcom/fasterxml/jackson/databind/deser/ValueInstantiator;Lcom/fasterxml/jackson/databind/jsontype/TypeDeserializer;Lcom/fasterxml/jackson/databind/JsonDeserializer;)V
 	public fun getNullValue (Lcom/fasterxml/jackson/databind/DeserializationContext;)Larrow/core/Option;
 	public synthetic fun getNullValue (Lcom/fasterxml/jackson/databind/DeserializationContext;)Ljava/lang/Object;
+	public fun getReferenced (Larrow/core/Option;)Ljava/lang/Object;
+	public synthetic fun getReferenced (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun referenceValue (Ljava/lang/Object;)Larrow/core/Option;
+	public synthetic fun referenceValue (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun updateReference (Larrow/core/Option;Ljava/lang/Object;)Larrow/core/Option;
+	public synthetic fun updateReference (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class arrow/integrations/jackson/module/OptionDeserializerResolver : com/fasterxml/jackson/databind/deser/Deserializers$Base {
+	public static final field INSTANCE Larrow/integrations/jackson/module/OptionDeserializerResolver;
+	public fun findReferenceDeserializer (Lcom/fasterxml/jackson/databind/type/ReferenceType;Lcom/fasterxml/jackson/databind/DeserializationConfig;Lcom/fasterxml/jackson/databind/BeanDescription;Lcom/fasterxml/jackson/databind/jsontype/TypeDeserializer;Lcom/fasterxml/jackson/databind/JsonDeserializer;)Lcom/fasterxml/jackson/databind/JsonDeserializer;
 }
 
 public final class arrow/integrations/jackson/module/OptionModule : com/fasterxml/jackson/databind/module/SimpleModule {

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/OptionModule.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/OptionModule.kt
@@ -59,7 +59,7 @@ public object OptionDeserializerResolver : Deserializers.Base() {
     config: DeserializationConfig,
     beanDesc: BeanDescription?,
     contentTypeDeserializer: TypeDeserializer?,
-    contentDeserializer: JsonDeserializer<*>?
+    contentDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     if (!Option::class.java.isAssignableFrom(type.rawClass)) return null
     return OptionDeserializer(type, null, contentTypeDeserializer, contentDeserializer)
@@ -122,8 +122,7 @@ public class OptionSerializer : ReferenceTypeSerializer<Option<*>> {
     vts: TypeSerializer?,
     valueSer: JsonSerializer<*>?,
     unwrapper: NameTransformer?,
-  ): ReferenceTypeSerializer<Option<*>> =
-    OptionSerializer(this, prop, vts, valueSer, unwrapper, _suppressableValue, _suppressNulls)
+  ): ReferenceTypeSerializer<Option<*>> = OptionSerializer(this, prop, vts, valueSer, unwrapper, _suppressableValue, _suppressNulls)
 }
 
 public class OptionDeserializer : ReferenceTypeDeserializer<Option<*>> {
@@ -131,11 +130,10 @@ public class OptionDeserializer : ReferenceTypeDeserializer<Option<*>> {
     fullType: JavaType,
     valueInstantiator: ValueInstantiator?,
     typeDeserializer: TypeDeserializer?,
-    jsonDeserializer: JsonDeserializer<*>?
+    jsonDeserializer: JsonDeserializer<*>?,
   ) : super(fullType, valueInstantiator, typeDeserializer, jsonDeserializer)
 
-  override fun withResolved(typeDeser: TypeDeserializer?, valueDeser: JsonDeserializer<*>?): ReferenceTypeDeserializer<Option<*>> =
-    OptionDeserializer(valueType, null, typeDeser, valueDeser)
+  override fun withResolved(typeDeser: TypeDeserializer?, valueDeser: JsonDeserializer<*>?): ReferenceTypeDeserializer<Option<*>> = OptionDeserializer(valueType, null, typeDeser, valueDeser)
 
   override fun getNullValue(ctxt: DeserializationContext?): Option<*> = None
   override fun referenceValue(contents: Any): Option<*> = Some(contents)

--- a/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/DataHelpers.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/DataHelpers.kt
@@ -2,9 +2,17 @@ package arrow.integrations.jackson.module
 
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.string
 
 data class SomeObject(val someString: String, val someInt: Int)
 
 fun Arb.Companion.someObject(): Arb<SomeObject> = Arb.bind(Arb.string(), Arb.int()) { str, int -> SomeObject(str, int) }
+
+data class MapContainer<V>(val value: Map<Key, V>) {
+  enum class Key { First, Second }
+}
+
+fun <V> arbMapContainer(arbValue: Arb<V>): Arb<MapContainer<V>> = Arb.map(Arb.enum<MapContainer.Key>(), arbValue).map { MapContainer<V>(it) }

--- a/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/NonEmptyListModuleTest.kt
@@ -16,8 +16,8 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
 import kotlin.test.Ignore
+import kotlin.test.Test
 
 class NonEmptyListModuleTest {
   private val mapper = ObjectMapper().registerKotlinModule().registerArrowModule()

--- a/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/TestHelper.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/test/kotlin/arrow/integrations/jackson/module/TestHelper.kt
@@ -1,9 +1,13 @@
 package arrow.integrations.jackson.module
 
 import arrow.core.Either
+import arrow.core.Ior
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptySet
 import arrow.core.Option
+import arrow.core.bothIor
+import arrow.core.leftIor
+import arrow.core.rightIor
 import arrow.core.toNonEmptyListOrNull
 import arrow.core.toNonEmptySetOrNull
 import arrow.core.toOption
@@ -11,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.list
@@ -36,3 +41,9 @@ fun <A, B> Arb.Companion.either(left: Arb<A>, right: Arb<B>): Arb<Either<A, B>> 
 fun <A> Arb.Companion.nonEmptyList(a: Arb<A>): Arb<NonEmptyList<A>> = list(a).filter(List<A>::isNotEmpty).map { it.toNonEmptyListOrNull()!! }
 
 fun <A> Arb.Companion.nonEmptySet(a: Arb<A>): Arb<NonEmptySet<A>> = list(a).filter(List<A>::isNotEmpty).map { it.toNonEmptySetOrNull()!! }
+
+fun <L, R> Arb.Companion.ior(arbL: Arb<L>, arbR: Arb<R>): Arb<Ior<L, R>> = Arb.choice(
+  arbitrary { arbL.bind().leftIor() },
+  arbitrary { arbR.bind().rightIor() },
+  arbitrary { (arbL.bind() to arbR.bind()).bothIor() },
+)


### PR DESCRIPTION
This moves `OptionDeserializer` in line with the rest of the implementations; and seems to be much more resilient than before.

Fixes https://github.com/arrow-kt/arrow-integrations/issues/131