### PR TITLE
(minor): Slightly Optimize Map.getOrNone

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/map.kt
@@ -496,8 +496,15 @@ public inline fun <K, A, B, C> Map<K, C>.unzip(fc: (Map.Entry<K, C>) -> Pair<A, 
 }
 
 @Suppress("UNCHECKED_CAST")
-public fun <K, V> Map<K, V>.getOrNone(key: K): Option<V> =
-  if (containsKey(key)) Some(get(key) as V) else None
+public fun <K, V> Map<K, V>.getOrNone(key: K): Option<V> {
+  val value = get(key)
+  if (value == null && !containsKey(key)) {
+    return None
+  } else {
+    @Suppress("UNCHECKED_CAST")
+    return Some(value as V)
+  }
+}
 
 /** Combines two maps using [combine] to combine values for the same key. */
 public fun <K, A> Map<K, A>.combine(other: Map<K, A>, combine: (A, A) -> A): Map<K, A> =


### PR DESCRIPTION
I based this implementation on `getOrElseNullable`, which is an internal method in the stdlib. As you can see, it only calls `containsKey` if the value is null, which makes it slightly faster for non-nullable values, and the same speed-ish for nullable ones (conjecture, but clearly it doesn't recalculate hashcode for non-nullable values, which is good, and the only extra instruction for nullable values is just the null check. Realistically, the null check is irrelevant compared to the object allocation, but the hashcode recalculation definitely isn't, since it can be expensive depending on the data structure).