### PR TITLE
Expose a few operations from `NonEmpty` collections to Java

### DIFF
--- a/arrow-libs/core/arrow-core/api/android/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/android/arrow-core.api
@@ -435,6 +435,10 @@ public final class arrow/core/NonEmptyList : arrow/core/NonEmptyCollection, java
 	public fun map-0-xjo5U (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static fun mapIndexed-0-xjo5U (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public fun mapIndexed-0-xjo5U (Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptyList;
+	public static final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptyList;
+	public static final fun of-0-xjo5U (Ljava/lang/Iterable;)Ljava/util/List;
+	public static final fun of-9knGJv4 (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/List;
 	public static final fun padZip-YfahJLU (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun padZip-vcjLgH4 (Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 	public synthetic fun plus (Ljava/lang/Iterable;)Larrow/core/NonEmptyCollection;
@@ -456,6 +460,7 @@ public final class arrow/core/NonEmptyList : arrow/core/NonEmptyCollection, java
 	public static fun subList-impl (Ljava/util/List;II)Ljava/util/List;
 	public fun toArray ()[Ljava/lang/Object;
 	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun toList ()Ljava/util/List;
 	public static final fun toList-impl (Ljava/util/List;)Ljava/util/List;
 	public fun toNonEmptyList-1X0FA-Y ()Ljava/util/List;
 	public static fun toNonEmptyList-1X0FA-Y (Ljava/util/List;)Ljava/util/List;
@@ -480,6 +485,10 @@ public final class arrow/core/NonEmptyList : arrow/core/NonEmptyCollection, java
 
 public final class arrow/core/NonEmptyList$Companion {
 	public final fun getUnit-1X0FA-Y ()Ljava/util/List;
+	public final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptyList;
+	public final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptyList;
+	public final fun of-0-xjo5U (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun of-9knGJv4 (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/List;
 }
 
 public final class arrow/core/NonEmptyListKt {
@@ -503,6 +512,7 @@ public final class arrow/core/NonEmptyListKt {
 }
 
 public final class arrow/core/NonEmptySet : arrow/core/NonEmptyCollection, java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Larrow/core/NonEmptySet$Companion;
 	public fun add (Ljava/lang/Object;)Z
 	public fun addAll (Ljava/util/Collection;)Z
 	public static final synthetic fun box-impl (Ljava/util/Set;)Larrow/core/NonEmptySet;
@@ -539,6 +549,10 @@ public final class arrow/core/NonEmptySet : arrow/core/NonEmptyCollection, java/
 	public fun map-0-xjo5U (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static fun mapIndexed-0-xjo5U (Ljava/util/Set;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public fun mapIndexed-0-xjo5U (Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptySet;
+	public static final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptySet;
+	public static final fun of-J9TPrxk (Ljava/lang/Iterable;)Ljava/util/Set;
+	public static final fun of-rU2te6o (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/Set;
 	public synthetic fun plus (Ljava/lang/Iterable;)Larrow/core/NonEmptyCollection;
 	public synthetic fun plus (Ljava/lang/Object;)Larrow/core/NonEmptyCollection;
 	public fun plus-J9TPrxk (Ljava/lang/Iterable;)Ljava/util/Set;
@@ -555,12 +569,21 @@ public final class arrow/core/NonEmptySet : arrow/core/NonEmptyCollection, java/
 	public static fun toNonEmptyList-1X0FA-Y (Ljava/util/Set;)Ljava/util/List;
 	public fun toNonEmptySet-5sCjGKo ()Ljava/util/Set;
 	public static fun toNonEmptySet-5sCjGKo (Ljava/util/Set;)Ljava/util/Set;
+	public final fun toSet ()Ljava/util/Set;
+	public static final fun toSet-impl (Ljava/util/Set;)Ljava/util/Set;
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/util/Set;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/util/Set;
 	public synthetic fun zip (Larrow/core/NonEmptyCollection;)Larrow/core/NonEmptyCollection;
 	public fun zip-0-xjo5U (Larrow/core/NonEmptyCollection;)Ljava/util/List;
 	public static fun zip-0-xjo5U (Ljava/util/Set;Larrow/core/NonEmptyCollection;)Ljava/util/List;
+}
+
+public final class arrow/core/NonEmptySet$Companion {
+	public final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptySet;
+	public final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptySet;
+	public final fun of-J9TPrxk (Ljava/lang/Iterable;)Ljava/util/Set;
+	public final fun of-rU2te6o (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/Set;
 }
 
 public final class arrow/core/NonEmptySetKt {

--- a/arrow-libs/core/arrow-core/api/arrow-core.klib.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.klib.api
@@ -412,6 +412,9 @@ final value class <#A: out kotlin/Any?> arrow.core/NonEmptyList : arrow.core/Non
     final object Companion { // arrow.core/NonEmptyList.Companion|null[0]
         final val unit // arrow.core/NonEmptyList.Companion.unit|{}unit[0]
             final fun <get-unit>(): arrow.core/NonEmptyList<kotlin/Unit> // arrow.core/NonEmptyList.Companion.unit.<get-unit>|<get-unit>(){}[0]
+
+        final fun <#A2: kotlin/Any?> of(#A2, kotlin/Array<out #A2>...): arrow.core/NonEmptyList<#A2> // arrow.core/NonEmptyList.Companion.of|of(0:0;kotlin.Array<out|0:0>...){0§<kotlin.Any?>}[0]
+        final fun <#A2: kotlin/Any?> of(kotlin.collections/Iterable<#A2>): arrow.core/NonEmptyList<#A2> // arrow.core/NonEmptyList.Companion.of|of(kotlin.collections.Iterable<0:0>){0§<kotlin.Any?>}[0]
     }
 
     // Targets: [js]
@@ -443,7 +446,13 @@ final value class <#A: out kotlin/Any?> arrow.core/NonEmptySet : arrow.core/NonE
     final fun lastOrNull(): #A // arrow.core/NonEmptySet.lastOrNull|lastOrNull(){}[0]
     final fun plus(#A): arrow.core/NonEmptySet<#A> // arrow.core/NonEmptySet.plus|plus(1:0){}[0]
     final fun plus(kotlin.collections/Iterable<#A>): arrow.core/NonEmptySet<#A> // arrow.core/NonEmptySet.plus|plus(kotlin.collections.Iterable<1:0>){}[0]
+    final fun toSet(): kotlin.collections/Set<#A> // arrow.core/NonEmptySet.toSet|toSet(){}[0]
     final fun toString(): kotlin/String // arrow.core/NonEmptySet.toString|toString(){}[0]
+
+    final object Companion { // arrow.core/NonEmptySet.Companion|null[0]
+        final fun <#A2: kotlin/Any?> of(#A2, kotlin/Array<out #A2>...): arrow.core/NonEmptySet<#A2> // arrow.core/NonEmptySet.Companion.of|of(0:0;kotlin.Array<out|0:0>...){0§<kotlin.Any?>}[0]
+        final fun <#A2: kotlin/Any?> of(kotlin.collections/Iterable<#A2>): arrow.core/NonEmptySet<#A2> // arrow.core/NonEmptySet.Companion.of|of(kotlin.collections.Iterable<0:0>){0§<kotlin.Any?>}[0]
+    }
 
     // Targets: [js]
     final fun asJsReadonlySetView(): kotlin.js.collections/JsReadonlySet<#A> // arrow.core/NonEmptySet.asJsReadonlySetView|asJsReadonlySetView(){}[0]

--- a/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
@@ -435,6 +435,10 @@ public final class arrow/core/NonEmptyList : arrow/core/NonEmptyCollection, java
 	public fun map-0-xjo5U (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static fun mapIndexed-0-xjo5U (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public fun mapIndexed-0-xjo5U (Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptyList;
+	public static final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptyList;
+	public static final fun of-0-xjo5U (Ljava/lang/Iterable;)Ljava/util/List;
+	public static final fun of-9knGJv4 (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/List;
 	public static final fun padZip-YfahJLU (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun padZip-vcjLgH4 (Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 	public synthetic fun plus (Ljava/lang/Iterable;)Larrow/core/NonEmptyCollection;
@@ -456,6 +460,7 @@ public final class arrow/core/NonEmptyList : arrow/core/NonEmptyCollection, java
 	public static fun subList-impl (Ljava/util/List;II)Ljava/util/List;
 	public fun toArray ()[Ljava/lang/Object;
 	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun toList ()Ljava/util/List;
 	public static final fun toList-impl (Ljava/util/List;)Ljava/util/List;
 	public fun toNonEmptyList-1X0FA-Y ()Ljava/util/List;
 	public static fun toNonEmptyList-1X0FA-Y (Ljava/util/List;)Ljava/util/List;
@@ -480,6 +485,10 @@ public final class arrow/core/NonEmptyList : arrow/core/NonEmptyCollection, java
 
 public final class arrow/core/NonEmptyList$Companion {
 	public final fun getUnit-1X0FA-Y ()Ljava/util/List;
+	public final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptyList;
+	public final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptyList;
+	public final fun of-0-xjo5U (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun of-9knGJv4 (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/List;
 }
 
 public final class arrow/core/NonEmptyListKt {
@@ -503,6 +512,7 @@ public final class arrow/core/NonEmptyListKt {
 }
 
 public final class arrow/core/NonEmptySet : arrow/core/NonEmptyCollection, java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Larrow/core/NonEmptySet$Companion;
 	public fun add (Ljava/lang/Object;)Z
 	public fun addAll (Ljava/util/Collection;)Z
 	public static final synthetic fun box-impl (Ljava/util/Set;)Larrow/core/NonEmptySet;
@@ -539,6 +549,10 @@ public final class arrow/core/NonEmptySet : arrow/core/NonEmptyCollection, java/
 	public fun map-0-xjo5U (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static fun mapIndexed-0-xjo5U (Ljava/util/Set;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public fun mapIndexed-0-xjo5U (Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptySet;
+	public static final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptySet;
+	public static final fun of-J9TPrxk (Ljava/lang/Iterable;)Ljava/util/Set;
+	public static final fun of-rU2te6o (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/Set;
 	public synthetic fun plus (Ljava/lang/Iterable;)Larrow/core/NonEmptyCollection;
 	public synthetic fun plus (Ljava/lang/Object;)Larrow/core/NonEmptyCollection;
 	public fun plus-J9TPrxk (Ljava/lang/Iterable;)Ljava/util/Set;
@@ -555,12 +569,21 @@ public final class arrow/core/NonEmptySet : arrow/core/NonEmptyCollection, java/
 	public static fun toNonEmptyList-1X0FA-Y (Ljava/util/Set;)Ljava/util/List;
 	public fun toNonEmptySet-5sCjGKo ()Ljava/util/Set;
 	public static fun toNonEmptySet-5sCjGKo (Ljava/util/Set;)Ljava/util/Set;
+	public final fun toSet ()Ljava/util/Set;
+	public static final fun toSet-impl (Ljava/util/Set;)Ljava/util/Set;
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/util/Set;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/util/Set;
 	public synthetic fun zip (Larrow/core/NonEmptyCollection;)Larrow/core/NonEmptyCollection;
 	public fun zip-0-xjo5U (Larrow/core/NonEmptyCollection;)Ljava/util/List;
 	public static fun zip-0-xjo5U (Ljava/util/Set;Larrow/core/NonEmptyCollection;)Ljava/util/List;
+}
+
+public final class arrow/core/NonEmptySet$Companion {
+	public final fun of (Ljava/lang/Iterable;)Larrow/core/NonEmptySet;
+	public final fun of (Ljava/lang/Object;[Ljava/lang/Object;)Larrow/core/NonEmptySet;
+	public final fun of-J9TPrxk (Ljava/lang/Iterable;)Ljava/util/Set;
+	public final fun of-rU2te6o (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/util/Set;
 }
 
 public final class arrow/core/NonEmptySetKt {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptyList.kt
@@ -1,4 +1,5 @@
-@file:OptIn(ExperimentalTypeInference::class, ExperimentalContracts::class)
+@file:OptIn(ExperimentalTypeInference::class, ExperimentalContracts::class, ExperimentalStdlibApi::class)
+@file:Suppress("API_NOT_AVAILABLE")
 
 package arrow.core
 
@@ -7,8 +8,10 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.experimental.ExperimentalTypeInference
+import kotlin.jvm.JvmExposeBoxed
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
+import kotlin.jvm.JvmStatic
 import kotlin.collections.unzip as stdlibUnzip
 
 public typealias Nel<A> = NonEmptyList<A>
@@ -170,6 +173,7 @@ public value class NonEmptyList<out E> @PublishedApi internal constructor(
 
   override fun isEmpty(): Boolean = false
 
+  @JvmExposeBoxed
   public fun toList(): List<E> = all
 
   public override val head: E
@@ -251,6 +255,14 @@ public value class NonEmptyList<out E> @PublishedApi internal constructor(
     @PublishedApi
     internal val unit: NonEmptyList<Unit> =
       nonEmptyListOf(Unit)
+
+    @JvmStatic @JvmExposeBoxed
+    public fun <E> of(head: E, vararg t: E): NonEmptyList<E> =
+      nonEmptyListOf(head, *t)
+
+    @JvmStatic @JvmExposeBoxed
+    public fun <E> of(values: Iterable<E>): NonEmptyList<E> =
+      values.toNonEmptyListOrThrow()
   }
 
   public fun <T> zip(other: NonEmptyList<T>): NonEmptyList<Pair<E, T>> =

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/NonEmptySet.kt
@@ -1,11 +1,13 @@
-@file:OptIn(ExperimentalTypeInference::class)
+@file:OptIn(ExperimentalTypeInference::class, ExperimentalStdlibApi::class)
+@file:Suppress("API_NOT_AVAILABLE")
 
 package arrow.core
 
 import arrow.core.raise.RaiseAccumulate
 import kotlin.experimental.ExperimentalTypeInference
+import kotlin.jvm.JvmExposeBoxed
 import kotlin.jvm.JvmInline
-import kotlin.jvm.JvmName
+import kotlin.jvm.JvmStatic
 
 @JvmInline
 public value class NonEmptySet<out E> internal constructor(
@@ -21,6 +23,9 @@ public value class NonEmptySet<out E> internal constructor(
     NonEmptySet(this.elements + element)
 
   override fun isEmpty(): Boolean = false
+
+  @JvmExposeBoxed
+  public fun toSet(): Set<E> = elements
 
   override val head: E get() = elements.first()
 
@@ -53,6 +58,16 @@ public value class NonEmptySet<out E> internal constructor(
 
   override fun <T> zip(other: NonEmptyCollection<T>): NonEmptyList<Pair<E, T>> =
     NonEmptyList(elements.zip(other))
+
+  public companion object {
+    @JvmStatic @JvmExposeBoxed
+    public fun <E> of(head: E, vararg t: E): NonEmptySet<E> =
+      nonEmptySetOf(head, *t)
+
+    @JvmStatic @JvmExposeBoxed
+    public fun <E> of(values: Iterable<E>): NonEmptySet<E> =
+      values.toNonEmptySetOrThrow()
+  }
 }
 
 public inline fun <Error, E, T> NonEmptySet<E>.mapOrAccumulate(


### PR DESCRIPTION
This allows using the basic API (transformation back and forth the maybe-empty versions) from Java. This in turn may allow some libraries to work better with Arrow.