### PR TITLE
Make AcquireStep delegate to the calling ResourceScope

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/android/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/android/arrow-fx-coroutines.api
@@ -1,5 +1,18 @@
-public final class arrow/fx/coroutines/AcquireStep {
+public final class arrow/fx/coroutines/AcquireStep : arrow/fx/coroutines/ResourceScope {
+	public static final field Companion Larrow/fx/coroutines/AcquireStep$Companion;
 	public static final field INSTANCE Larrow/fx/coroutines/AcquireStep;
+	public fun <init> (Larrow/fx/coroutines/ResourceScope;)V
+	public fun autoClose (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun install (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public fun install (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onClose (Lkotlin/jvm/functions/Function1;)V
+	public fun onRelease (Lkotlin/jvm/functions/Function2;)V
+	public fun release (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun releaseCase (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/fx/coroutines/AcquireStep$Companion {
 }
 
 public final class arrow/fx/coroutines/BracketKt {

--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
@@ -43,6 +43,17 @@ final class arrow.fx.coroutines.await/AwaitAllScope : kotlinx.coroutines/Corouti
     final fun <#A1: kotlin/Any?> async(kotlin.coroutines/CoroutineContext = ..., kotlinx.coroutines/CoroutineStart = ..., kotlin.coroutines/SuspendFunction1<kotlinx.coroutines/CoroutineScope, #A1>): kotlinx.coroutines/Deferred<#A1> // arrow.fx.coroutines.await/AwaitAllScope.async|async(kotlin.coroutines.CoroutineContext;kotlinx.coroutines.CoroutineStart;kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope,0:0>){0§<kotlin.Any?>}[0]
 }
 
+final class arrow.fx.coroutines/AcquireStep : arrow.fx.coroutines/ResourceScope { // arrow.fx.coroutines/AcquireStep|null[0]
+    constructor <init>(arrow.fx.coroutines/ResourceScope) // arrow.fx.coroutines/AcquireStep.<init>|<init>(arrow.fx.coroutines.ResourceScope){}[0]
+
+    final fun onRelease(kotlin.coroutines/SuspendFunction1<arrow.fx.coroutines/ExitCase, kotlin/Unit>) // arrow.fx.coroutines/AcquireStep.onRelease|onRelease(kotlin.coroutines.SuspendFunction1<arrow.fx.coroutines.ExitCase,kotlin.Unit>){}[0]
+
+    final object Companion { // arrow.fx.coroutines/AcquireStep.Companion|null[0]
+        final val INSTANCE // arrow.fx.coroutines/AcquireStep.Companion.INSTANCE|{}INSTANCE[0]
+            final fun <get-INSTANCE>(): arrow.fx.coroutines/AcquireStep // arrow.fx.coroutines/AcquireStep.Companion.INSTANCE.<get-INSTANCE>|<get-INSTANCE>(){}[0]
+    }
+}
+
 final class arrow.fx.coroutines/CountDownLatch { // arrow.fx.coroutines/CountDownLatch|null[0]
     constructor <init>(kotlin/Long) // arrow.fx.coroutines/CountDownLatch.<init>|<init>(kotlin.Long){}[0]
 
@@ -143,8 +154,6 @@ sealed class arrow.fx.coroutines/ExitCase { // arrow.fx.coroutines/ExitCase|null
         final fun toString(): kotlin/String // arrow.fx.coroutines/ExitCase.Completed.toString|toString(){}[0]
     }
 }
-
-final object arrow.fx.coroutines/AcquireStep // arrow.fx.coroutines/AcquireStep|null[0]
 
 final val arrow.fx.coroutines/errorOrNull // arrow.fx.coroutines/errorOrNull|@arrow.fx.coroutines.ExitCase{}errorOrNull[0]
     final fun (arrow.fx.coroutines/ExitCase).<get-errorOrNull>(): kotlin/Throwable? // arrow.fx.coroutines/errorOrNull.<get-errorOrNull>|<get-errorOrNull>@arrow.fx.coroutines.ExitCase(){}[0]

--- a/arrow-libs/fx/arrow-fx-coroutines/api/jvm/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/jvm/arrow-fx-coroutines.api
@@ -1,5 +1,18 @@
-public final class arrow/fx/coroutines/AcquireStep {
+public final class arrow/fx/coroutines/AcquireStep : arrow/fx/coroutines/ResourceScope {
+	public static final field Companion Larrow/fx/coroutines/AcquireStep$Companion;
 	public static final field INSTANCE Larrow/fx/coroutines/AcquireStep;
+	public fun <init> (Larrow/fx/coroutines/ResourceScope;)V
+	public fun autoClose (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun install (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
+	public fun install (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onClose (Lkotlin/jvm/functions/Function1;)V
+	public fun onRelease (Lkotlin/jvm/functions/Function2;)V
+	public fun release (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun releaseCase (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class arrow/fx/coroutines/AcquireStep$Companion {
 }
 
 public final class arrow/fx/coroutines/BracketKt {


### PR DESCRIPTION
Also deprecate AcquireStep so it may be removed in the future

This preserves source and binary compatibility perfectly, but is a little overkill. We could instead deprecate-and-hide `install` and introduce a non-AcquireStep version of it. This would technically break source compatibility if anyone used `this` to refer to `AcquireStep`, but I find that very very unlikely. 
I know nothing about klib compatibility btw, and it's showing a break there, but I'm not sure what that entails.