### PR TITLE
Pass Trace transparently through withError

### DIFF
--- a/arrow-libs/core/arrow-core/api/android/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/android/arrow-core.api
@@ -913,7 +913,6 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public final fun complete ()Z
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun isTraced ()Z
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 }
 
@@ -946,6 +945,7 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public final fun getOrAccumulate (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun isTraced ()Z
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
@@ -960,6 +960,7 @@ public abstract interface class arrow/core/raise/Raise {
 	public abstract fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
 	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun isTraced ()Z
 	public abstract fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 }
 
@@ -973,6 +974,7 @@ public final class arrow/core/raise/Raise$DefaultImpls {
 	public static fun bindAll-vcjLgH4 (Larrow/core/raise/Raise;Ljava/util/List;)Ljava/util/List;
 	public static fun invoke (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun isTraced (Larrow/core/raise/Raise;)Z
 }
 
 public class arrow/core/raise/RaiseAccumulate : arrow/core/raise/Accumulate, arrow/core/raise/Raise {
@@ -1101,7 +1103,6 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun tolerant (Larrow/core/raise/Accumulate;Larrow/core/raise/Raise;)Larrow/core/raise/Accumulate;
-	public static final fun withCause (Larrow/core/raise/Traced;Larrow/core/raise/Traced;)Larrow/core/raise/Traced;
 	public static final fun withError (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function9;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function8;)Ljava/lang/Object;
@@ -1137,6 +1138,7 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public final fun bindAllResult (Ljava/util/Set;)Ljava/util/Set;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun isTraced ()Z
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun raise (Ljava/lang/Throwable;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -1169,13 +1171,6 @@ public final class arrow/core/raise/SingletonRaise : arrow/core/raise/Raise {
 	public final fun raise ()Ljava/lang/Void;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/Traced : arrow/core/raise/RaiseCancellationException {
-	public fun <init> (Ljava/lang/Object;Larrow/core/raise/Raise;Larrow/core/raise/Traced;)V
-	public synthetic fun <init> (Ljava/lang/Object;Larrow/core/raise/Raise;Larrow/core/raise/Traced;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCause ()Larrow/core/raise/Traced;
-	public synthetic fun getCause ()Ljava/lang/Throwable;
 }
 
 public final class arrow/core/raise/context/RaiseContextualKt {

--- a/arrow-libs/core/arrow-core/api/arrow-core.klib.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.klib.api
@@ -89,6 +89,8 @@ final class <#A: kotlin/Any?> arrow.core.raise/IorRaise : arrow.core.raise/Raise
 
     final val combineError // arrow.core.raise/IorRaise.combineError|{}combineError[0]
         final fun <get-combineError>(): kotlin/Function2<#A, #A, #A> // arrow.core.raise/IorRaise.combineError.<get-combineError>|<get-combineError>(){}[0]
+    final val isTraced // arrow.core.raise/IorRaise.isTraced|{}isTraced[0]
+        final fun <get-isTraced>(): kotlin/Boolean // arrow.core.raise/IorRaise.isTraced.<get-isTraced>|<get-isTraced>(){}[0]
 
     final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlin.collections/Map<#A1, arrow.core/Either<#A, #B1>>).bindAll(): kotlin.collections/Map<#A1, #B1> // arrow.core.raise/IorRaise.bindAll|bindAll@kotlin.collections.Map<0:0,arrow.core.Either<1:0,0:1>>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlin.collections/Map<#A1, arrow.core/Ior<#A, #B1>>).bindAll(): kotlin.collections/Map<#A1, #B1> // arrow.core.raise/IorRaise.bindAll|bindAll@kotlin.collections.Map<0:0,arrow.core.Ior<1:0,0:1>>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
@@ -318,15 +320,15 @@ final class <#A: out kotlin/Any?> arrow.core/Some : arrow.core/Option<#A> { // a
 final class arrow.core.raise/DefaultRaise : arrow.core.raise/Raise<kotlin/Any?> { // arrow.core.raise/DefaultRaise|null[0]
     constructor <init>(kotlin/Boolean) // arrow.core.raise/DefaultRaise.<init>|<init>(kotlin.Boolean){}[0]
 
-    final val isTraced // arrow.core.raise/DefaultRaise.isTraced|{}isTraced[0]
-        final fun <get-isTraced>(): kotlin/Boolean // arrow.core.raise/DefaultRaise.isTraced.<get-isTraced>|<get-isTraced>(){}[0]
-
     final fun complete(): kotlin/Boolean // arrow.core.raise/DefaultRaise.complete|complete(){}[0]
     final fun raise(kotlin/Any?): kotlin/Nothing // arrow.core.raise/DefaultRaise.raise|raise(kotlin.Any?){}[0]
 }
 
 final class arrow.core.raise/ResultRaise : arrow.core.raise/Raise<kotlin/Throwable> { // arrow.core.raise/ResultRaise|null[0]
     constructor <init>(arrow.core.raise/Raise<kotlin/Throwable>) // arrow.core.raise/ResultRaise.<init>|<init>(arrow.core.raise.Raise<kotlin.Throwable>){}[0]
+
+    final val isTraced // arrow.core.raise/ResultRaise.isTraced|{}isTraced[0]
+        final fun <get-isTraced>(): kotlin/Boolean // arrow.core.raise/ResultRaise.isTraced.<get-isTraced>|<get-isTraced>(){}[0]
 
     final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlin.collections/Map<#A1, arrow.core/Either<kotlin/Throwable, #B1>>).bindAll(): kotlin.collections/Map<#A1, #B1> // arrow.core.raise/ResultRaise.bindAll|bindAll@kotlin.collections.Map<0:0,arrow.core.Either<kotlin.Throwable,0:1>>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (kotlin.collections/Map<#A1, kotlin/Result<#B1>>).bindAll(): kotlin.collections/Map<#A1, #B1> // arrow.core.raise/ResultRaise.bindAll|bindAll@kotlin.collections.Map<0:0,kotlin.Result<0:1>>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
@@ -344,13 +346,6 @@ final class arrow.core.raise/ResultRaise : arrow.core.raise/Raise<kotlin/Throwab
     final inline fun <#A1: kotlin/Any?> recover(kotlin/Function1<arrow.core.raise/ResultRaise, #A1>, kotlin/Function1<kotlin/Throwable, #A1>): #A1 // arrow.core.raise/ResultRaise.recover|recover(kotlin.Function1<arrow.core.raise.ResultRaise,0:0>;kotlin.Function1<kotlin.Throwable,0:0>){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> (kotlin.coroutines/SuspendFunction1<arrow.core.raise/Raise<kotlin/Throwable>, #A1>).bind(): #A1 // arrow.core.raise/ResultRaise.bind|bind@kotlin.coroutines.SuspendFunction1<arrow.core.raise.Raise<kotlin.Throwable>,0:0>(){0§<kotlin.Any?>}[0]
     final suspend fun <#A1: kotlin/Any?> (kotlin.coroutines/SuspendFunction1<arrow.core.raise/Raise<kotlin/Throwable>, #A1>).invoke(): #A1 // arrow.core.raise/ResultRaise.invoke|invoke@kotlin.coroutines.SuspendFunction1<arrow.core.raise.Raise<kotlin.Throwable>,0:0>(){0§<kotlin.Any?>}[0]
-}
-
-final class arrow.core.raise/Traced : arrow.core.raise/RaiseCancellationException { // arrow.core.raise/Traced|null[0]
-    constructor <init>(kotlin/Any?, arrow.core.raise/Raise<kotlin/Any?>, arrow.core.raise/Traced? = ...) // arrow.core.raise/Traced.<init>|<init>(kotlin.Any?;arrow.core.raise.Raise<kotlin.Any?>;arrow.core.raise.Traced?){}[0]
-
-    final val cause // arrow.core.raise/Traced.cause|{}cause[0]
-        final fun <get-cause>(): arrow.core.raise/Traced? // arrow.core.raise/Traced.cause.<get-cause>|<get-cause>(){}[0]
 }
 
 final value class <#A: kotlin/Any?, #B: kotlin/Any?> arrow.core/AtomicMemoizationCache : arrow.core/MemoizationCache<#A, #B> { // arrow.core/AtomicMemoizationCache|null[0]
@@ -721,7 +716,6 @@ final const val arrow.core/NicheAPI // arrow.core/NicheAPI|{}NicheAPI[0]
 final const val arrow.core/RedundantAPI // arrow.core/RedundantAPI|{}RedundantAPI[0]
     final fun <get-RedundantAPI>(): kotlin/String // arrow.core/RedundantAPI.<get-RedundantAPI>|<get-RedundantAPI>(){}[0]
 
-final fun (arrow.core.raise/Traced).arrow.core.raise/withCause(arrow.core.raise/Traced): arrow.core.raise/Traced // arrow.core.raise/withCause|withCause@arrow.core.raise.Traced(arrow.core.raise.Traced){}[0]
 final fun (kotlin/String).arrow.core/escaped(): kotlin/String // arrow.core/escaped|escaped@kotlin.String(){}[0]
 final fun <#A: kotlin/Any> (kotlin/Function1<#A, kotlin/Boolean>).arrow.core/mapNullable(): kotlin/Function1<#A?, kotlin/Boolean> // arrow.core/mapNullable|mapNullable@kotlin.Function1<0:0,kotlin.Boolean>(){0§<kotlin.Any>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?, #C: kotlin/Any?, #D: kotlin/Any?, #E: kotlin/Any?, #F: kotlin/Any?, #G: kotlin/Any?, #H: kotlin/Any?, #I: kotlin/Any?, #J: kotlin/Any?, #K: kotlin/Any?> (kotlin.sequences/Sequence<#A>).arrow.core/zip(kotlin.sequences/Sequence<#B>, kotlin.sequences/Sequence<#C>, kotlin.sequences/Sequence<#D>, kotlin.sequences/Sequence<#E>, kotlin.sequences/Sequence<#F>, kotlin.sequences/Sequence<#G>, kotlin.sequences/Sequence<#H>, kotlin.sequences/Sequence<#I>, kotlin.sequences/Sequence<#J>, kotlin/Function10<#A, #B, #C, #D, #E, #F, #G, #H, #I, #J, #K>): kotlin.sequences/Sequence<#K> // arrow.core/zip|zip@kotlin.sequences.Sequence<0:0>(kotlin.sequences.Sequence<0:1>;kotlin.sequences.Sequence<0:2>;kotlin.sequences.Sequence<0:3>;kotlin.sequences.Sequence<0:4>;kotlin.sequences.Sequence<0:5>;kotlin.sequences.Sequence<0:6>;kotlin.sequences.Sequence<0:7>;kotlin.sequences.Sequence<0:8>;kotlin.sequences.Sequence<0:9>;kotlin.Function10<0:0,0:1,0:2,0:3,0:4,0:5,0:6,0:7,0:8,0:9,0:10>){0§<kotlin.Any?>;1§<kotlin.Any?>;2§<kotlin.Any?>;3§<kotlin.Any?>;4§<kotlin.Any?>;5§<kotlin.Any?>;6§<kotlin.Any?>;7§<kotlin.Any?>;8§<kotlin.Any?>;9§<kotlin.Any?>;10§<kotlin.Any?>}[0]

--- a/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
@@ -913,7 +913,6 @@ public final class arrow/core/raise/DefaultRaise : arrow/core/raise/Raise {
 	public final fun complete ()Z
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun isTraced ()Z
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 }
 
@@ -946,6 +945,7 @@ public final class arrow/core/raise/IorRaise : arrow/core/raise/Raise {
 	public final fun getOrAccumulate (Larrow/core/Either;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun isTraced ()Z
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
@@ -960,6 +960,7 @@ public abstract interface class arrow/core/raise/Raise {
 	public abstract fun bindAll-vcjLgH4 (Ljava/util/List;)Ljava/util/List;
 	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun isTraced ()Z
 	public abstract fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 }
 
@@ -973,6 +974,7 @@ public final class arrow/core/raise/Raise$DefaultImpls {
 	public static fun bindAll-vcjLgH4 (Larrow/core/raise/Raise;Ljava/util/List;)Ljava/util/List;
 	public static fun invoke (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun isTraced (Larrow/core/raise/Raise;)Z
 }
 
 public class arrow/core/raise/RaiseAccumulate : arrow/core/raise/Accumulate, arrow/core/raise/Raise {
@@ -1101,7 +1103,6 @@ public final class arrow/core/raise/RaiseKt {
 	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toResult (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun tolerant (Larrow/core/raise/Accumulate;Larrow/core/raise/Raise;)Larrow/core/raise/Accumulate;
-	public static final fun withCause (Larrow/core/raise/Traced;Larrow/core/raise/Traced;)Larrow/core/raise/Traced;
 	public static final fun withError (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function9;)Ljava/lang/Object;
 	public static final fun zipOrAccumulate (Larrow/core/raise/Raise;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function8;)Ljava/lang/Object;
@@ -1137,6 +1138,7 @@ public final class arrow/core/raise/ResultRaise : arrow/core/raise/Raise {
 	public final fun bindAllResult (Ljava/util/Set;)Ljava/util/Set;
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun isTraced ()Z
 	public synthetic fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public fun raise (Ljava/lang/Throwable;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -1169,13 +1171,6 @@ public final class arrow/core/raise/SingletonRaise : arrow/core/raise/Raise {
 	public final fun raise ()Ljava/lang/Void;
 	public fun raise (Ljava/lang/Object;)Ljava/lang/Void;
 	public final fun recover (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
-public final class arrow/core/raise/Traced : arrow/core/raise/RaiseCancellationException {
-	public fun <init> (Ljava/lang/Object;Larrow/core/raise/Raise;Larrow/core/raise/Traced;)V
-	public synthetic fun <init> (Ljava/lang/Object;Larrow/core/raise/Raise;Larrow/core/raise/Traced;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCause ()Larrow/core/raise/Traced;
-	public synthetic fun getCause ()Ljava/lang/Throwable;
 }
 
 public final class arrow/core/raise/context/RaiseContextualKt {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Builders.kt
@@ -187,6 +187,9 @@ private class IorAccumulate<Error>(
   fun raiseSingle(e: Error): Nothing = raise.raise(EmptyValue.combine(state.get(), e, combineError))
   override fun raise(r: NonEmptyList<Error>) = raiseSingle(r.reduce(combineError))
 
+  @ExperimentalTraceApi
+  override val isTraced: Boolean
+    get() = raise.isTraced
   private val raiseAccumulated = RaiseAccumulate.Error { raise.raise(EmptyValue.unbox(state.get())) }
 
   @ExperimentalRaiseAccumulateApi
@@ -220,6 +223,10 @@ public class SingletonRaise<in E>(private val raise: Raise<Unit>) : Raise<E> {
 
   @RaiseDSL
   override fun raise(r: E): Nothing = raise()
+
+  @ExperimentalTraceApi
+  override val isTraced: Boolean
+    get() = raise.isTraced
 
   @RaiseDSL
   public fun ensure(condition: Boolean) {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -209,6 +209,15 @@ public interface Raise<in Error> {
   public fun raise(r: Error): Nothing
 
   /**
+   * Indicates whether this [Raise] context is traced.
+   * This is used in `withError` to propagate tracing information.
+   * You should override this property if your [Raise] implementation is based on another.
+   */
+  @ExperimentalTraceApi
+  public val isTraced: Boolean
+    get() = false
+
+  /**
    * Invoke an [EagerEffect] inside `this` [Raise] context.
    * Any _logical failure_ is raised in `this` [Raise] context,
    * and thus short-circuits the computation.
@@ -694,6 +703,7 @@ public inline fun <Error, B : Any> Raise<Error>.ensureNotNull(value: B?, raise: 
  * <!--- KNIT example-raise-dsl-11.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
+@OptIn(ExperimentalTraceApi::class)
 @RaiseDSL
 public inline fun <Error, OtherError, A> Raise<Error>.withError(
   transform: (OtherError) -> Error,
@@ -703,7 +713,13 @@ public inline fun <Error, OtherError, A> Raise<Error>.withError(
     callsInPlace(block, EXACTLY_ONCE)
     callsInPlace(transform, AT_MOST_ONCE)
   }
-  recover({ return block() }) { raise(transform(it)) }
+  foldTraced(
+    block = { return block() },
+    catch = { throw it },
+    recover = { _, e -> raise(transform(e)) },
+    transform = { it },
+    isTraced = this.isTraced,
+  )
 }
 
 /**

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Raise.kt
@@ -713,13 +713,7 @@ public inline fun <Error, OtherError, A> Raise<Error>.withError(
     callsInPlace(block, EXACTLY_ONCE)
     callsInPlace(transform, AT_MOST_ONCE)
   }
-  foldTraced(
-    block = { return block() },
-    catch = { throw it },
-    recover = { _, e -> raise(transform(e)) },
-    transform = { it },
-    isTraced = this.isTraced,
-  )
+  return withErrorTraced({ _, e -> transform(e) }, this.isTraced, block)
 }
 
 /**

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
@@ -892,6 +892,10 @@ public open class RaiseAccumulate<Error> @ExperimentalRaiseAccumulateApi constru
 
   override fun raise(r: Error): Nothing = raiseErrorsWith(r)
 
+  @ExperimentalTraceApi
+  override val isTraced: Boolean
+    get() = raise.isTraced
+
   public override fun <K, A> Map<K, Either<Error, A>>.bindAll(): Map<K, A> =
     raise.mapValuesOrAccumulate(this) { it.value.bind() }
 
@@ -1100,6 +1104,10 @@ private class ListAccumulate<Error>(private val raise: Raise<NonEmptyList<Error>
 
   fun raiseSingle(r: Error): Nothing = raise.raise(NonEmptyList(list + r))
   override fun raise(r: NonEmptyList<Error>) = raise.raise(NonEmptyList(list + r.all))
+
+  @ExperimentalTraceApi
+  override val isTraced: Boolean
+    get() = raise.isTraced
 
   // only valid if list is not empty
   // errors are never removed from `list`, so once this is valid, it stays valid

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Trace.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/Trace.kt
@@ -15,14 +15,20 @@ public annotation class ExperimentalTraceApi
 /** Tracing result. Allows to inspect the traces from where raise was called. */
 @ExperimentalTraceApi
 @JvmInline
-public value class Trace(private val exception: CancellationException) {
+public value class Trace(internal val exception: CancellationException) {
+  @DelicateRaiseApi
+  internal fun isTrulyTraced(): Boolean = exception is Traced
+
+  @OptIn(DelicateRaiseApi::class)
+  internal val innerTrace get() = (exception as? Traced)?.trace
+
   /**
    * Returns the stacktrace as a [String]
    *
    * Note, the first line in the stacktrace will be the `RaiseCancellationException`.
    * The users call to `raise` can found in the_second line of the stacktrace.
    */
-  public fun stackTraceToString(): String = (exception.cause ?: exception).stackTraceToString()
+  public fun stackTraceToString(): String = stackTraceToStringImpl()
 
   /**
    * Prints the stacktrace.
@@ -30,8 +36,7 @@ public value class Trace(private val exception: CancellationException) {
    * Note, the first line in the stacktrace will be the `RaiseCancellationException`.
    * The users call to `raise` can found in the_second line of the stacktrace.
    */
-  public fun printStackTrace(): Unit =
-    (exception.cause ?: exception).printStackTrace()
+  public fun printStackTrace(): Unit = printStackTraceImpl()
 
   /**
    * Returns the suppressed exceptions that occurred during cancellation of the surrounding coroutines,
@@ -40,6 +45,17 @@ public value class Trace(private val exception: CancellationException) {
    * When consuming a `Resource` fails due to [Raise.raise] it results in `ExitCase.Cancelled`,
    * if the finalizer then results in a `Throwable` it will be added as a `suppressedException` to the [CancellationException].
    */
-  public fun suppressedExceptions(): List<Throwable> =
-    exception.cause?.suppressedExceptions.orEmpty() + exception.suppressedExceptions
+  public fun suppressedExceptions(): List<Throwable> = buildList { suppressedExceptionsImpl(this@Trace) }
+}
+
+@ExperimentalTraceApi
+private tailrec fun Trace.stackTraceToStringImpl(): String = innerTrace?.stackTraceToStringImpl() ?: exception.stackTraceToString()
+
+@ExperimentalTraceApi
+private tailrec fun Trace.printStackTraceImpl(): Unit = innerTrace?.printStackTraceImpl() ?: exception.printStackTrace()
+
+@ExperimentalTraceApi
+private tailrec fun MutableList<Throwable>.suppressedExceptionsImpl(trace: Trace) {
+  addAll(trace.exception.suppressedExceptions)
+  trace.innerTrace?.let { return suppressedExceptionsImpl(it) }
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/arrow/core/raise/TraceJvmSpec.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/arrow/core/raise/TraceJvmSpec.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.test.runTest
 @OptIn(ExperimentalTraceApi::class)
 class TraceJvmSpec {
   @Test fun canTraceATypedError() = runTest {
-    either<RuntimeException, Nothing> {
+    val _ = merge {
       traced({ raise(RuntimeException("")) }) { traced, raised ->
         // Remove first 2 lines:
         // arrow.core.raise.RaiseCancellationException
@@ -18,6 +18,26 @@ class TraceJvmSpec {
         // java.lang.RuntimeException:
         val exceptionTrace = raised.stackTraceToString().lines().drop(1)
 
+        trace shouldBe exceptionTrace
+      }
+    }
+  }
+
+  @Test fun canTraceAMappedError() = runTest {
+    val _ = merge {
+      traced({
+        withError({ raised: Exception ->
+          // Remove first line:
+          // java.lang.RuntimeException:
+          raised.stackTraceToString().lines().drop(1)
+        }) {
+          raise(RuntimeException(""))
+        }
+      }) { traced, exceptionTrace ->
+        // Remove first 2 lines:
+        // arrow.core.raise.RaiseCancellationException
+        //	at arrow.core.raise.DefaultRaise.raise(Fold.kt:187)
+        val trace = traced.stackTraceToString().lines().drop(2)
         trace shouldBe exceptionTrace
       }
     }

--- a/arrow-libs/fx/arrow-fx-coroutines/api/android/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/android/arrow-fx-coroutines.api
@@ -251,6 +251,7 @@ public final class arrow/fx/coroutines/RaiseScope$DefaultImpls {
 	public static fun bindAll-vcjLgH4 (Larrow/fx/coroutines/RaiseScope;Ljava/util/List;)Ljava/util/List;
 	public static fun invoke (Larrow/fx/coroutines/RaiseScope;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/fx/coroutines/RaiseScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun isTraced (Larrow/fx/coroutines/RaiseScope;)Z
 }
 
 public abstract interface annotation class arrow/fx/coroutines/ResourceDSL : java/lang/annotation/Annotation {

--- a/arrow-libs/fx/arrow-fx-coroutines/api/jvm/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/jvm/arrow-fx-coroutines.api
@@ -251,6 +251,7 @@ public final class arrow/fx/coroutines/RaiseScope$DefaultImpls {
 	public static fun bindAll-vcjLgH4 (Larrow/fx/coroutines/RaiseScope;Ljava/util/List;)Ljava/util/List;
 	public static fun invoke (Larrow/fx/coroutines/RaiseScope;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static fun invoke (Larrow/fx/coroutines/RaiseScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun isTraced (Larrow/fx/coroutines/RaiseScope;)Z
 }
 
 public abstract interface annotation class arrow/fx/coroutines/ResourceDSL : java/lang/annotation/Annotation {


### PR DESCRIPTION
I used a default property this time around. Since we support Java 8 and up, I believe this shouldn't be binary incompatible?