### PR TITLE
Add Arrow Version Catalog module

### DIFF
--- a/arrow-libs/version-catalog/README.MD
+++ b/arrow-libs/version-catalog/README.MD
@@ -1,0 +1,27 @@
+# Arrow Version Catalog
+
+## settings.gradle.kts
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("arrow") {
+            from("io.arrow-kt:arrow-version-catalog:2.1.2")
+        }
+    }
+}
+```
+
+## build.gradle.kts
+
+```kotlin
+dependencies {
+    implementation(arrow.autoclose)
+    implementation(arrow.core)
+    implementation(arrow.fx.coroutines)
+    etc
+}
+```

--- a/arrow-libs/version-catalog/build.gradle.kts
+++ b/arrow-libs/version-catalog/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    `version-catalog`
+}
+
+catalog {
+    versionCatalog {
+        version("arrow", project.version.toString())
+
+        library("annotations", "io.arrow-kt", "arrow-annotations").versionRef("arrow")
+        library("atomic", "io.arrow-kt", "arrow-atomic").versionRef("arrow")
+        library("autoclose", "io.arrow-kt", "arrow-autoclose").versionRef("arrow")
+        library("cache4k", "io.arrow-kt", "arrow-cache4k").versionRef("arrow")
+        library("collectors", "io.arrow-kt", "arrow-collectors").versionRef("arrow")
+        library("core", "io.arrow-kt", "arrow-core").versionRef("arrow")
+        library("core-high-arity", "io.arrow-kt", "arrow-core-high-arity").versionRef("arrow")
+        library("core-jackson", "io.arrow-kt", "arrow-core-jackson").versionRef("arrow")
+        library("core-retrofit", "io.arrow-kt", "arrow-core-retrofit").versionRef("arrow")
+        library("core-serialization", "io.arrow-kt", "arrow-core-serialization").versionRef("arrow")
+        library("eval", "io.arrow-kt", "arrow-eval").versionRef("arrow")
+        library("functions", "io.arrow-kt", "arrow-functions").versionRef("arrow")
+        library("fx-coroutines", "io.arrow-kt", "arrow-fx-coroutines").versionRef("arrow")
+        library("fx-stm", "io.arrow-kt", "arrow-fx-stm").versionRef("arrow")
+        library("optics", "io.arrow-kt", "arrow-optics").versionRef("arrow")
+        library("optics-compose", "io.arrow-kt", "arrow-optics-compose").versionRef("arrow")
+        library("optics-ksp-plugin", "io.arrow-kt", "arrow-optics-ksp-plugin").versionRef("arrow")
+        library("optics-reflect", "io.arrow-kt", "arrow-optics-reflect").versionRef("arrow")
+        library("resilience", "io.arrow-kt", "arrow-resilience").versionRef("arrow")
+        library("resilience-ktor-client", "io.arrow-kt", "arrow-resilience-ktor-client").versionRef("arrow")
+        library("suspendapp", "io.arrow-kt", "suspendapp").versionRef("arrow")
+        library("suspendapp-ktor", "io.arrow-kt", "suspendapp-ktor").versionRef("arrow")
+    }
+}

--- a/arrow-libs/version-catalog/gradle.properties
+++ b/arrow-libs/version-catalog/gradle.properties
@@ -1,0 +1,2 @@
+POM_NAME=Arrow Version Catalog
+POM_DESCRIPTION=Version catalog for Arrow Kotlin libraries

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -139,6 +139,9 @@ project(":arrow-raise-ktor-server").projectDir = file("arrow-libs/integrations/a
 include("arrow-stack")
 project(":arrow-stack").projectDir = file("arrow-libs/stack")
 
+include("arrow-version-catalog")
+project(":arrow-version-catalog").projectDir = file("arrow-libs/version-catalog")
+
 develocity {
   buildScan {
     termsOfUseUrl = "https://gradle.com/terms-of-service"


### PR DESCRIPTION
Introduced a new module for managing version catalogs for Arrow Kotlin libraries. This includes updates to `settings.gradle.kts`, a `build.gradle.kts` configuration, and a README file with setup instructions. The catalog simplifies dependency management for various Arrow libraries.