### PR TITLE
Fix crosswalk ordering logic

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -882,7 +882,7 @@ public fun <A, B> Iterable<A>.crosswalk(f: (A) -> Iterable<B>): List<List<B>> =
       ior.fold(
         { listOf(it) },
         ::identity,
-        { l, r -> listOf(l) + r }
+        { l, r -> r + l }
       )
     }
   }
@@ -893,19 +893,13 @@ public fun <A, K, V> Iterable<A>.crosswalkMap(f: (A) -> Map<K, V>): Map<K, List<
       ior.fold(
         { listOf(it) },
         ::identity,
-        { l, r -> listOf(l) + r }
+        { l, r -> r + l }
       )
     }
   }
 
 public fun <A, B> Iterable<A>.crosswalkNull(f: (A) -> B?): List<B>? =
-  fold<A, List<B>?>(emptyList()) { bs, a ->
-    Ior.fromNullables(f(a), bs)?.fold(
-      { listOf(it) },
-      ::identity,
-      { l, r -> listOf(l) + r }
-    )
-  }
+  mapNotNull(f).takeIf { it.isNotEmpty() || !this.any() }
 
 public operator fun <A : Comparable<A>> Iterable<A>.compareTo(other: Iterable<A>): Int =
   align(other) { ior -> ior.fold({ 1 }, { -1 }, { a1, a2 -> a1.compareTo(a2) }) }

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/IterableTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/IterableTest.kt
@@ -559,9 +559,8 @@ class IterableTest {
       val transarr: List<(Int) -> Int> = incr.map { i -> { it + i } }
 
       val expected = mutableListOf<List<Int>>()
-      val arev = a.reversed()
       transarr.forEach { t ->
-        arev.map { t(it) }.takeIf { it.isNotEmpty() }
+        a.map { t(it) }.takeIf { it.isNotEmpty() }
           ?.let(expected::add)
       }
 
@@ -590,7 +589,17 @@ class IterableTest {
     checkAll(Arb.list(Arb.int(), 0..10), Arb.pair(Arb.int(1..1000), Arb.int())) { a, mod ->
       fun trans(i: Int) = if (i % mod.first == 0) i + mod.second else null
 
-      val expected = a.reversed().mapNotNull(::trans)
+      var expected: MutableList<Int>? = if (a.isEmpty()) mutableListOf() else null
+      a.forEach { n ->
+        val result = trans(n)
+        if (result != null) {
+          if (expected == null) {
+            expected = mutableListOf(result)
+          } else {
+            expected.add(result)
+          }
+        }
+      }
       a.crosswalkNull(::trans) shouldBe expected
     }
   }


### PR DESCRIPTION
This PR addresses the crosswalk-related implementation problems discovered during the review of #3040:

- Fix ordering issue in crosswalk: Corrects the fold operation to preserve original element order instead of reversing it
- Fix crosswalkNull behavior: Ensures proper null handling and return type behavior according to the expected semantics

