### PR TITLE
Remove incorrect and misleading returns(null) contracts

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -489,8 +489,8 @@ public sealed class Either<out A, out B> {
    */
   public fun isLeft(): Boolean {
     contract {
-      returns(true) implies (this@Either is Left<A>)
-      returns(false) implies (this@Either is Right<B>)
+      returns(true) implies (this@Either is Left)
+      returns(false) implies (this@Either is Right)
     }
     return this@Either is Left<A>
   }
@@ -500,8 +500,8 @@ public sealed class Either<out A, out B> {
    */
   public fun isRight(): Boolean {
     contract {
-      returns(true) implies (this@Either is Right<B>)
-      returns(false) implies (this@Either is Left<A>)
+      returns(true) implies (this@Either is Right)
+      returns(false) implies (this@Either is Left)
     }
     return this@Either is Right<B>
   }
@@ -529,7 +529,7 @@ public sealed class Either<out A, out B> {
    */
   public inline fun isLeft(predicate: (A) -> Boolean): Boolean {
     contract {
-      returns(true) implies (this@Either is Left<A>)
+      returns(true) implies (this@Either is Left)
       callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
     }
     return this@Either is Left<A> && predicate(value)
@@ -558,7 +558,7 @@ public sealed class Either<out A, out B> {
    */
   public inline fun isRight(predicate: (B) -> Boolean): Boolean {
     contract {
-      returns(true) implies (this@Either is Right<B>)
+      returns(true) implies (this@Either is Right)
       callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
     }
     return this@Either is Right<B> && predicate(value)
@@ -724,8 +724,7 @@ public sealed class Either<out A, out B> {
    */
   public fun getOrNull(): B? {
     contract {
-      returns(null) implies (this@Either is Left<A>)
-      returnsNotNull() implies (this@Either is Right<B>)
+      returnsNotNull() implies (this@Either is Right)
     }
     return getOrElse { null }
   }
@@ -747,8 +746,7 @@ public sealed class Either<out A, out B> {
    */
   public fun leftOrNull(): A? {
     contract {
-      returnsNotNull() implies (this@Either is Left<A>)
-      returns(null) implies (this@Either is Right<B>)
+      returnsNotNull() implies (this@Either is Left)
     }
     return fold(::identity) { null }
   }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Ior.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Ior.kt
@@ -51,8 +51,8 @@ public sealed class Ior<out A, out B> {
    */
   public fun isLeft(): Boolean {
     contract {
-      returns(true) implies (this@Ior is Ior.Left<A>)
-      returns(false) implies (this@Ior is Ior.Right<B> || this@Ior is Ior.Both<A, B>)
+      returns(true) implies (this@Ior is Left)
+      returns(false) implies (this@Ior is Right || this@Ior is Both)
     }
     return this@Ior is Ior.Left<A>
   }
@@ -75,8 +75,8 @@ public sealed class Ior<out A, out B> {
    */
   public fun isRight(): Boolean {
     contract {
-      returns(true) implies (this@Ior is Ior.Right<B>)
-      returns(false) implies (this@Ior is Ior.Left<A> || this@Ior is Ior.Both<A, B>)
+      returns(true) implies (this@Ior is Right)
+      returns(false) implies (this@Ior is Left || this@Ior is Both)
     }
     return this@Ior is Ior.Right<B>
   }
@@ -98,8 +98,8 @@ public sealed class Ior<out A, out B> {
    */
   public fun isBoth(): Boolean {
     contract {
-      returns(false) implies (this@Ior is Ior.Right<B> || this@Ior is Ior.Left<A>)
-      returns(true) implies (this@Ior is Ior.Both<A, B>)
+      returns(false) implies (this@Ior is Right || this@Ior is Left)
+      returns(true) implies (this@Ior is Both)
     }
     return this@Ior is Ior.Both<A, B>
   }
@@ -263,8 +263,7 @@ public sealed class Ior<out A, out B> {
 
   public fun getOrNull(): B? {
     contract {
-      returns(null) implies (this@Ior is Left<A>)
-      returnsNotNull() implies ((this@Ior is Right<B>) || (this@Ior is Both<A, B>))
+      returnsNotNull() implies (this@Ior is Right || this@Ior is Both)
     }
     return fold({ null }, { it }, { _, b -> b })
   }
@@ -290,8 +289,7 @@ public sealed class Ior<out A, out B> {
    */
   public fun leftOrNull(): A? {
     contract {
-      returns(null) implies (this@Ior is Right<B>)
-      returnsNotNull() implies ((this@Ior is Left<A>) || (this@Ior is Both<A, B>))
+      returnsNotNull() implies (this@Ior is Left || this@Ior is Both)
     }
     return fold({ it }, { null }, { a, _ -> a })
   }
@@ -337,8 +335,8 @@ public sealed class Ior<out A, out B> {
    */
   public inline fun isLeft(predicate: (A) -> Boolean): Boolean {
     contract {
-      returns(true) implies (this@Ior is Left<A>)
-      returns(false) implies (this@Ior is Right<B> || this@Ior is Both<A, B>)
+      returns(true) implies (this@Ior is Left)
+      returns(false) implies (this@Ior is Right || this@Ior is Both)
       callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
     }
     return this@Ior is Left<A> && predicate(value)
@@ -363,8 +361,8 @@ public sealed class Ior<out A, out B> {
    */
   public inline fun isRight(predicate: (B) -> Boolean): Boolean {
     contract {
-      returns(true) implies (this@Ior is Right<B>)
-      returns(false) implies (this@Ior is Left<A> || this@Ior is Both<A, B>)
+      returns(true) implies (this@Ior is Right)
+      returns(false) implies (this@Ior is Left || this@Ior is Both)
       callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
     }
     return this@Ior is Right<B> && predicate(value)
@@ -390,8 +388,8 @@ public sealed class Ior<out A, out B> {
    */
   public inline fun isBoth(leftPredicate: (A) -> Boolean, rightPredicate: (B) -> Boolean): Boolean {
     contract {
-      returns(true) implies (this@Ior is Both<A, B>)
-      returns(false) implies (this@Ior is Left<A> || this@Ior is Right<B>)
+      returns(true) implies (this@Ior is Both)
+      returns(false) implies (this@Ior is Left || this@Ior is Right)
       callsInPlace(leftPredicate, InvocationKind.AT_MOST_ONCE)
       callsInPlace(rightPredicate, InvocationKind.AT_MOST_ONCE)
     }

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Option.kt
@@ -382,7 +382,7 @@ public sealed class Option<out A> {
    */
   public fun isNone(): Boolean {
     contract {
-      returns(false) implies (this@Option is Some<A>)
+      returns(false) implies (this@Option is Some)
       returns(true) implies (this@Option is None)
     }
     return this@Option is None
@@ -394,7 +394,7 @@ public sealed class Option<out A> {
    */
   public fun isSome(): Boolean {
     contract {
-      returns(true) implies (this@Option is Some<A>)
+      returns(true) implies (this@Option is Some)
       returns(false) implies (this@Option is None)
     }
     return this@Option is Some<A>
@@ -426,7 +426,7 @@ public sealed class Option<out A> {
   public inline fun isSome(predicate: (A) -> Boolean): Boolean {
     contract {
       callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
-      returns(true) implies (this@Option is Some<A>)
+      returns(true) implies (this@Option is Some)
     }
     return this@Option is Some<A> && predicate(value)
   }
@@ -448,8 +448,7 @@ public sealed class Option<out A> {
    */
   public fun getOrNull(): A? {
     contract {
-      returns(null) implies (this@Option is None)
-      returnsNotNull() implies (this@Option is Some<A>)
+      returnsNotNull() implies (this@Option is Some)
     }
     return getOrElse { null }
   }


### PR DESCRIPTION
First discovered on Slack by Huib Donkers.

Luckily, `returns` contracts are broken when consumed from third-party library anyways. Also, Arrow's current Kotlin version has a bug that doesn't smart case based on those contracts lol. Regardless, with that bug fixed, this code would produce a CCE:
```kotlin
val either: Either<String, Int?> = Right(null)
if (either.gon() == null) {
  val left: Either.Left<*> = either
  left.value
}
```
Simply, `returns(null)` shouldn't actually imply that the either is `Left`, since it might be `Right(null)`. When this [feature request](https://youtrack.jetbrains.com/issue/KT-43798/Cannot-check-for-instance-of-erased-type-inside-contracts-for-generics) is implemented, we can put back the contract as the more complicated `returns(null) implies (this@Either is Left || this@Either is Right<Nothing?>)` and we can update the current contract as well to be `returnsNotNull() implies (this@Either is Right<B & Any>)`.

I also cleaned up other similar contracts 