### PR TITLE
Introduce `Raise` in `onRightBind` and `onLeftBind`

### DIFF
--- a/arrow-libs/core/arrow-core/api/android/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/android/arrow-core.api
@@ -74,7 +74,8 @@ public abstract class arrow/core/Either {
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun mapLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun onLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public final fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public final synthetic fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public final fun onRight (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
 	public final fun swap ()Larrow/core/Either;
 	public final fun toIor ()Larrow/core/Ior;
 	public fun toString ()Ljava/lang/String;

--- a/arrow-libs/core/arrow-core/api/android/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/android/arrow-core.api
@@ -74,8 +74,9 @@ public abstract class arrow/core/Either {
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun mapLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun onLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public final synthetic fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public final fun onRight (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
+	public final fun onLeftBind (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
+	public final fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public final fun onRightBind (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
 	public final fun swap ()Larrow/core/Either;
 	public final fun toIor ()Larrow/core/Ior;
 	public fun toString ()Ljava/lang/String;

--- a/arrow-libs/core/arrow-core/api/arrow-core.klib.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.klib.api
@@ -526,6 +526,7 @@ sealed class <#A: out kotlin/Any?, #B: out kotlin/Any?> arrow.core/Either { // a
     final inline fun isRight(kotlin/Function1<#B, kotlin/Boolean>): kotlin/Boolean // arrow.core/Either.isRight|isRight(kotlin.Function1<1:1,kotlin.Boolean>){}[0]
     final inline fun onLeft(kotlin/Function1<#A, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onLeft|onLeft(kotlin.Function1<1:0,kotlin.Unit>){}[0]
     final inline fun onRight(kotlin/Function1<#B, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onRight|onRight(kotlin.Function1<1:1,kotlin.Unit>){}[0]
+    final inline fun onRight(kotlin/Function2<arrow.core.raise/Raise<#A>, #B, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onRight|onRight(kotlin.Function2<arrow.core.raise.Raise<1:0>,1:1,kotlin.Unit>){}[0]
     open fun toString(): kotlin/String // arrow.core/Either.toString|toString(){}[0]
 
     final class <#A1: out kotlin/Any?> Left : arrow.core/Either<#A1, kotlin/Nothing> { // arrow.core/Either.Left|null[0]

--- a/arrow-libs/core/arrow-core/api/arrow-core.klib.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.klib.api
@@ -525,8 +525,9 @@ sealed class <#A: out kotlin/Any?, #B: out kotlin/Any?> arrow.core/Either { // a
     final inline fun isLeft(kotlin/Function1<#A, kotlin/Boolean>): kotlin/Boolean // arrow.core/Either.isLeft|isLeft(kotlin.Function1<1:0,kotlin.Boolean>){}[0]
     final inline fun isRight(kotlin/Function1<#B, kotlin/Boolean>): kotlin/Boolean // arrow.core/Either.isRight|isRight(kotlin.Function1<1:1,kotlin.Boolean>){}[0]
     final inline fun onLeft(kotlin/Function1<#A, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onLeft|onLeft(kotlin.Function1<1:0,kotlin.Unit>){}[0]
+    final inline fun onLeftBind(kotlin/Function2<arrow.core.raise/Raise<#A>, #A, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onLeftBind|onLeftBind(kotlin.Function2<arrow.core.raise.Raise<1:0>,1:0,kotlin.Unit>){}[0]
     final inline fun onRight(kotlin/Function1<#B, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onRight|onRight(kotlin.Function1<1:1,kotlin.Unit>){}[0]
-    final inline fun onRight(kotlin/Function2<arrow.core.raise/Raise<#A>, #B, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onRight|onRight(kotlin.Function2<arrow.core.raise.Raise<1:0>,1:1,kotlin.Unit>){}[0]
+    final inline fun onRightBind(kotlin/Function2<arrow.core.raise/Raise<#A>, #B, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.onRightBind|onRightBind(kotlin.Function2<arrow.core.raise.Raise<1:0>,1:1,kotlin.Unit>){}[0]
     open fun toString(): kotlin/String // arrow.core/Either.toString|toString(){}[0]
 
     final class <#A1: out kotlin/Any?> Left : arrow.core/Either<#A1, kotlin/Nothing> { // arrow.core/Either.Left|null[0]

--- a/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
@@ -74,7 +74,8 @@ public abstract class arrow/core/Either {
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun mapLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun onLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public final fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public final synthetic fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public final fun onRight (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
 	public final fun swap ()Larrow/core/Either;
 	public final fun toIor ()Larrow/core/Ior;
 	public fun toString ()Ljava/lang/String;

--- a/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
@@ -74,8 +74,9 @@ public abstract class arrow/core/Either {
 	public final fun map (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun mapLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
 	public final fun onLeft (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public final synthetic fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
-	public final fun onRight (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
+	public final fun onLeftBind (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
+	public final fun onRight (Lkotlin/jvm/functions/Function1;)Larrow/core/Either;
+	public final fun onRightBind (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
 	public final fun swap ()Larrow/core/Either;
 	public final fun toIor ()Larrow/core/Ior;
 	public fun toString ()Ljava/lang/String;

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
@@ -81,6 +81,20 @@ class EitherTest {
   }
 
   @Test
+  fun tapMayRaise() = runTest {
+    checkAll(Arb.either(Arb.long(), Arb.int())) { either ->
+      var effect = 0
+      val res = either.onRight { effect += 1 ; raise(100L) }
+      val expected = when (either) {
+        is Left -> 0
+        is Right -> 1
+      }
+      effect shouldBe expected
+      res.shouldBeInstanceOf<Left<Long>>()
+    }
+  }
+
+  @Test
   fun tapLeftAppliesEffects() = runTest {
     checkAll(Arb.either(Arb.long(), Arb.int())) { either ->
       var effect = 0

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
@@ -84,7 +84,7 @@ class EitherTest {
   fun tapMayRaise() = runTest {
     checkAll(Arb.either(Arb.long(), Arb.int())) { either ->
       var effect = 0
-      val res = either.onRight { effect += 1 ; raise(100L) }
+      val res = either.onRightBind { effect += 1 ; raise(100L) }
       val expected = when (either) {
         is Left -> 0
         is Right -> 1
@@ -105,6 +105,23 @@ class EitherTest {
       }
       effect shouldBe expected
       res shouldBe either
+    }
+  }
+
+  @Test
+  fun tapLeftMayRaise() = runTest {
+    checkAll(Arb.either(Arb.long(), Arb.int())) { either ->
+      var effect = 0
+      val res = either.onLeftBind { effect += 1 ; raise(100L) }
+      val expected = when (either) {
+        is Left -> 1
+        is Right -> 0
+      }
+      effect shouldBe expected
+      when (either){
+        is Left -> res shouldBe Left(100L)
+        is Right -> res shouldBe either
+      }
     }
   }
 

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-27.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-27.kt
@@ -5,8 +5,5 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(1).onRight { print(it) } shouldBe Either.Right(1)
-
-  val x: Either<String, Int> = Either.Right(2)
-  x.onRight { raise("hello") } shouldBe Either.Left("hello")
+  Either.Right(1).onRight(::println) shouldBe Either.Right(1)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-27.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-27.kt
@@ -5,5 +5,8 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(1).onRight(::println) shouldBe Either.Right(1)
+  Either.Right(1).onRight { print(it) } shouldBe Either.Right(1)
+
+  val x: Either<String, Int> = Either.Right(2)
+  x.onRight { raise("hello") } shouldBe Either.Left("hello")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-28.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-28.kt
@@ -5,5 +5,8 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Left(2).onLeft(::println) shouldBe Either.Left(2)
+  Either.Right(1).onRightBind { print(it) } shouldBe Either.Right(1)
+
+  val x: Either<String, Int> = Either.Right(2)
+  x.onRightBind { raise("hello") } shouldBe Either.Left("hello")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-29.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-29.kt
@@ -5,6 +5,5 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(12).getOrNull() shouldBe 12
-  Either.Left(12).getOrNull() shouldBe null
+  Either.Left(2).onLeft(::println) shouldBe Either.Left(2)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-30.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-30.kt
@@ -5,6 +5,8 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(12).leftOrNull() shouldBe null
-  Either.Left(12).leftOrNull() shouldBe 12
+  Either.Left(2).onLeftBind { println(it) } shouldBe Either.Left(2)
+
+  val x: Either<String, Int> = Either.Left("hello")
+  x.onLeftBind { raise("bye") } shouldBe Either.Left("bye")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-31.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-31.kt
@@ -2,11 +2,9 @@
 package arrow.core.examples.exampleEither31
 
 import arrow.core.Either
-import arrow.core.Some
-import arrow.core.None
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Right(12).getOrNone() shouldBe Some(12)
-  Either.Left(12).getOrNone() shouldBe None
+  Either.Right(12).getOrNull() shouldBe 12
+  Either.Left(12).getOrNull() shouldBe null
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-32.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-32.kt
@@ -2,9 +2,9 @@
 package arrow.core.examples.exampleEither32
 
 import arrow.core.Either
-import arrow.core.getOrElse
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Left(12) getOrElse { it + 5 } shouldBe 17
+  Either.Right(12).leftOrNull() shouldBe null
+  Either.Left(12).leftOrNull() shouldBe 12
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-33.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-33.kt
@@ -1,11 +1,12 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither33
 
-import arrow.core.Either.Left
-import arrow.core.Either.Right
-import arrow.core.merge
+import arrow.core.Either
+import arrow.core.Some
+import arrow.core.None
+import io.kotest.matchers.shouldBe
 
 fun test() {
-  Right(12).merge() // Result: 12
-  Left(12).merge() // Result: 12
+  Either.Right(12).getOrNone() shouldBe Some(12)
+  Either.Left(12).getOrNone() shouldBe None
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-34.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-34.kt
@@ -2,11 +2,9 @@
 package arrow.core.examples.exampleEither34
 
 import arrow.core.Either
-import arrow.core.recover
+import arrow.core.getOrElse
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  val error: Either<String, Int> = Either.Left("error")
-  val fallback: Either<Nothing, Int> = error.recover { it.length }
-  fallback shouldBe Either.Right(5)
+  Either.Left(12) getOrElse { it + 5 } shouldBe 17
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-35.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-35.kt
@@ -1,12 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither35
 
-import arrow.core.Either
-import arrow.core.recover
-import io.kotest.matchers.shouldBe
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.merge
 
 fun test() {
-  val error: Either<String, Int> = Either.Left("error")
-  val listOfErrors: Either<List<Char>, Int> = error.recover { raise(it.toList()) }
-  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
+  Right(12).merge() // Result: 12
+  Left(12).merge() // Result: 12
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-37.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-37.kt
@@ -1,5 +1,5 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
-package arrow.core.examples.exampleEither36
+package arrow.core.examples.exampleEither37
 
 import arrow.core.Either
 import arrow.core.recover
@@ -7,6 +7,6 @@ import io.kotest.matchers.shouldBe
 
 fun test() {
   val error: Either<String, Int> = Either.Left("error")
-  val fallback: Either<Nothing, Int> = error.recover { it.length }
-  fallback shouldBe Either.Right(5)
+  val listOfErrors: Either<List<Char>, Int> = error.recover { raise(it.toList()) }
+  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-38.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-38.kt
@@ -1,0 +1,22 @@
+// This file was automatically generated from Either.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleEither38
+
+import arrow.core.Either
+import arrow.core.catch
+import arrow.core.shouldThrow
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
+
+  val caught: Either<Nothing, Int> = left.catch { _: RuntimeException -> 1 }
+  val failure: Either<String, Int> = left.catch { _: RuntimeException -> raise("failure") }
+
+  shouldThrow<RuntimeException> {
+    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
+    Unit
+  }
+
+  caught shouldBe Either.Right(1)
+  failure shouldBe Either.Left("failure")
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
@@ -65,4 +65,12 @@ class EitherKnitTest {
     arrow.core.examples.exampleEither36.test()
   }
 
+  @Test fun exampleEither37() = runTest {
+    arrow.core.examples.exampleEither37.test()
+  }
+
+  @Test fun exampleEither38() = runTest {
+    arrow.core.examples.exampleEither38.test()
+  }
+
 }


### PR DESCRIPTION
This fixes the original goal of #3639 of being able to check for errors in the middle of a chain of calls, by allowing `raise`ing in `onRight`.

```kotlin
fun failOnMoreConditionsWithBindMap(): Either<String, Int> =
    randomNumber()
        .onRight { ensure(it != 10) { "Number 10 also not allowed" } }
        .map { it + 100 }
```

IMO this way of looking at this point requires a much smaller change to our API (just generalizing a function type). We should not try to account for all possible ways of working on `either` in every possible chain.