### PR TITLE
`validate` for `Either`

### DIFF
--- a/arrow-libs/core/arrow-core/api/android/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/android/arrow-core.api
@@ -78,6 +78,7 @@ public abstract class arrow/core/Either {
 	public final fun swap ()Larrow/core/Either;
 	public final fun toIor ()Larrow/core/Ior;
 	public fun toString ()Ljava/lang/String;
+	public final fun validate (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
 }
 
 public final class arrow/core/Either$Companion {

--- a/arrow-libs/core/arrow-core/api/arrow-core.klib.api
+++ b/arrow-libs/core/arrow-core/api/arrow-core.klib.api
@@ -519,6 +519,7 @@ sealed class <#A: out kotlin/Any?, #B: out kotlin/Any?> arrow.core/Either { // a
     final fun leftOrNull(): #A? // arrow.core/Either.leftOrNull|leftOrNull(){}[0]
     final fun swap(): arrow.core/Either<#B, #A> // arrow.core/Either.swap|swap(){}[0]
     final fun toIor(): arrow.core/Ior<#A, #B> // arrow.core/Either.toIor|toIor(){}[0]
+    final fun validate(kotlin/Function2<arrow.core.raise/Raise<#A>, #B, kotlin/Unit>): arrow.core/Either<#A, #B> // arrow.core/Either.validate|validate(kotlin.Function2<arrow.core.raise.Raise<1:0>,1:1,kotlin.Unit>){}[0]
     final inline fun <#A1: kotlin/Any?> fold(kotlin/Function1<#A, #A1>, kotlin/Function1<#B, #A1>): #A1 // arrow.core/Either.fold|fold(kotlin.Function1<1:0,0:0>;kotlin.Function1<1:1,0:0>){0§<kotlin.Any?>}[0]
     final inline fun <#A1: kotlin/Any?> map(kotlin/Function1<#B, #A1>): arrow.core/Either<#A, #A1> // arrow.core/Either.map|map(kotlin.Function1<1:1,0:0>){0§<kotlin.Any?>}[0]
     final inline fun <#A1: kotlin/Any?> mapLeft(kotlin/Function1<#A, #A1>): arrow.core/Either<#A1, #B> // arrow.core/Either.mapLeft|mapLeft(kotlin.Function1<1:0,0:0>){0§<kotlin.Any?>}[0]

--- a/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
+++ b/arrow-libs/core/arrow-core/api/jvm/arrow-core.api
@@ -78,6 +78,7 @@ public abstract class arrow/core/Either {
 	public final fun swap ()Larrow/core/Either;
 	public final fun toIor ()Larrow/core/Ior;
 	public fun toString ()Ljava/lang/String;
+	public final fun validate (Lkotlin/jvm/functions/Function2;)Larrow/core/Either;
 }
 
 public final class arrow/core/Either$Companion {

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -795,7 +795,7 @@ public sealed class Either<out A, out B> {
    */
   public fun validate(validation: Raise<@UnsafeVariance A>.(B) -> Unit): Either<A, B> = when (this) {
     is Left -> this
-    is Right -> either { validation(value) ; value }
+    is Right -> fold({ validation(value) }, { Left(it) }, { this })
   }
 
   /**

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -9,6 +9,7 @@ import arrow.core.Either.Right
 import arrow.core.Either.Right.Companion.unit
 import arrow.core.raise.Raise
 import arrow.core.raise.either
+import arrow.core.raise.fold
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Either.kt
@@ -773,6 +773,32 @@ public sealed class Either<out A, out B> {
   public fun getOrNone(): Option<B> = fold({ None }, { Some(it) })
 
   /**
+   * Runs some [validation], expressed as a lambda that may [raise], on [Right] values.
+   * If the [validation] is successful, the value is left unchanged.
+   * The main use case is in combination with [ensure] and other validation functions.
+   *
+   * ```kotlin
+   * import arrow.core.Either
+   * import arrow.core.raise.ensure
+   * import io.kotest.matchers.shouldBe
+   *
+   * fun test() {
+   *   val one: Either<String, Int> = Either.Right(1)
+   *   one.validate { ensure(it > 0) { "negative" } } shouldBe one
+   *
+   *   val zero: Either<String, Int> = Either.Right(0)
+   *   zero.validate { ensure(it > 0) { "negative" } } shouldBe Either.Left("negative")
+   * }
+   * ```
+   * <!--- KNIT example-either-32.kt -->
+   * <!--- TEST lines.isEmpty() -->
+   */
+  public fun validate(validation: Raise<@UnsafeVariance A>.(B) -> Unit): Either<A, B> = when (this) {
+    is Left -> this
+    is Right -> either { validation(value) ; value }
+  }
+
+  /**
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
   public data class Left<out A> constructor(val value: A) : Either<A, Nothing>() {
@@ -1331,7 +1357,7 @@ public fun <A, B> Either<A, Either<A, B>>.flatten(): Either<A, B> =
  *   Either.Left(12) getOrElse { it + 5 } shouldBe 17
  * }
  * ```
- * <!--- KNIT example-either-32.kt -->
+ * <!--- KNIT example-either-33.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 public inline infix fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
@@ -1356,7 +1382,7 @@ public inline infix fun <A, B> Either<A, B>.getOrElse(default: (A) -> B): B {
  *   Left(12).merge() // Result: 12
  * }
  * ```
- * <!--- KNIT example-either-33.kt -->
+ * <!--- KNIT example-either-34.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 public fun <A> Either<A, A>.merge(): A =
@@ -1428,7 +1454,7 @@ public fun <E> E.leftNel(): EitherNel<E, Nothing> =
  *   fallback shouldBe Either.Right(5)
  * }
  * ```
- * <!--- KNIT example-either-34.kt -->
+ * <!--- KNIT example-either-35.kt -->
  * <!--- TEST lines.isEmpty() -->
  *
  * When shifting a new error [EE] into the [Either.Left] channel,
@@ -1445,7 +1471,7 @@ public fun <E> E.leftNel(): EitherNel<E, Nothing> =
  *   listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
  * }
  * ```
- * <!--- KNIT example-either-35.kt -->
+ * <!--- KNIT example-either-36.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @OptIn(ExperimentalTypeInference::class)
@@ -1483,7 +1509,7 @@ public inline fun <E, EE, A> Either<E, A>.recover(@BuilderInference recover: Rai
  *   failure shouldBe Either.Left("failure")
  * }
  * ```
- * <!--- KNIT example-either-36.kt -->
+ * <!--- KNIT example-either-37.kt -->
  * <!--- TEST lines.isEmpty() -->
  */
 @OptIn(ExperimentalTypeInference::class)

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/EitherTest.kt
@@ -2,6 +2,7 @@ package arrow.core
 
 import arrow.core.Either.Left
 import arrow.core.Either.Right
+import arrow.core.raise.ensure
 import arrow.core.test.either
 import arrow.core.test.intSmall
 import arrow.core.test.laws.MonoidLaws
@@ -1024,6 +1025,18 @@ class EitherTest {
             enel shouldBe e
           }
         }
+      }
+    }
+  }
+
+  @Test
+  fun validateWorks() = runTest {
+    checkAll(Arb.either(Arb.string(), Arb.int())) { e ->
+      e.validate { /* nothing */ } shouldBe e
+      e.validate { raise("problem") }.shouldBeInstanceOf<Left<String>>()
+      e.validate { ensure(it > 0) { "negative" } } shouldBe when (e) {
+        is Right -> if (e.value > 0) e else "negative".left()
+        is Left -> e
       }
     }
   }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-32.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-32.kt
@@ -2,9 +2,13 @@
 package arrow.core.examples.exampleEither32
 
 import arrow.core.Either
-import arrow.core.getOrElse
+import arrow.core.raise.ensure
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  Either.Left(12) getOrElse { it + 5 } shouldBe 17
+  val one: Either<String, Int> = Either.Right(1)
+  one.validate { ensure(it > 0) { "negative" } } shouldBe one
+
+  val zero: Either<String, Int> = Either.Right(0)
+  zero.validate { ensure(it > 0) { "negative" } } shouldBe Either.Left("negative")
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-33.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-33.kt
@@ -1,11 +1,10 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither33
 
-import arrow.core.Either.Left
-import arrow.core.Either.Right
-import arrow.core.merge
+import arrow.core.Either
+import arrow.core.getOrElse
+import io.kotest.matchers.shouldBe
 
 fun test() {
-  Right(12).merge() // Result: 12
-  Left(12).merge() // Result: 12
+  Either.Left(12) getOrElse { it + 5 } shouldBe 17
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-34.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-34.kt
@@ -1,12 +1,11 @@
 // This file was automatically generated from Either.kt by Knit tool. Do not edit.
 package arrow.core.examples.exampleEither34
 
-import arrow.core.Either
-import arrow.core.recover
-import io.kotest.matchers.shouldBe
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.merge
 
 fun test() {
-  val error: Either<String, Int> = Either.Left("error")
-  val fallback: Either<Nothing, Int> = error.recover { it.length }
-  fallback shouldBe Either.Right(5)
+  Right(12).merge() // Result: 12
+  Left(12).merge() // Result: 12
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-35.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-35.kt
@@ -7,6 +7,6 @@ import io.kotest.matchers.shouldBe
 
 fun test() {
   val error: Either<String, Int> = Either.Left("error")
-  val listOfErrors: Either<List<Char>, Int> = error.recover { raise(it.toList()) }
-  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
+  val fallback: Either<Nothing, Int> = error.recover { it.length }
+  fallback shouldBe Either.Right(5)
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-36.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-36.kt
@@ -2,21 +2,11 @@
 package arrow.core.examples.exampleEither36
 
 import arrow.core.Either
-import arrow.core.catch
-import arrow.core.shouldThrow
+import arrow.core.recover
 import io.kotest.matchers.shouldBe
 
 fun test() {
-  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
-
-  val caught: Either<Nothing, Int> = left.catch { _: RuntimeException -> 1 }
-  val failure: Either<String, Int> = left.catch { _: RuntimeException -> raise("failure") }
-
-  shouldThrow<RuntimeException> {
-    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
-    Unit
-  }
-
-  caught shouldBe Either.Right(1)
-  failure shouldBe Either.Left("failure")
+  val error: Either<String, Int> = Either.Left("error")
+  val listOfErrors: Either<List<Char>, Int> = error.recover { raise(it.toList()) }
+  listOfErrors shouldBe Either.Left(listOf('e', 'r', 'r', 'o', 'r'))
 }

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-37.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/example-either-37.kt
@@ -1,0 +1,22 @@
+// This file was automatically generated from Either.kt by Knit tool. Do not edit.
+package arrow.core.examples.exampleEither37
+
+import arrow.core.Either
+import arrow.core.catch
+import arrow.core.shouldThrow
+import io.kotest.matchers.shouldBe
+
+fun test() {
+  val left: Either<Throwable, Int> = Either.catch { throw RuntimeException("Boom!") }
+
+  val caught: Either<Nothing, Int> = left.catch { _: RuntimeException -> 1 }
+  val failure: Either<String, Int> = left.catch { _: RuntimeException -> raise("failure") }
+
+  shouldThrow<RuntimeException> {
+    val caught2: Either<Nothing, Int> = left.catch { _: IllegalStateException -> 1 }
+    Unit
+  }
+
+  caught shouldBe Either.Right(1)
+  failure shouldBe Either.Left("failure")
+}

--- a/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
+++ b/arrow-libs/core/arrow-core/src/jvmTest/kotlin/examples/test/EitherKnitTest.kt
@@ -65,4 +65,8 @@ class EitherKnitTest {
     arrow.core.examples.exampleEither36.test()
   }
 
+  @Test fun exampleEither37() = runTest {
+    arrow.core.examples.exampleEither37.test()
+  }
+
 }


### PR DESCRIPTION
Fixes #3639
Closes #3711

This is the result of the discussion in #3711 (it was easier for me to create a new PR than to rollback all the changes there). This PR introduces a single `validate` function that runs a `Raise` block on `Right` values, but leaves them unchanged until something `raise`s. This seems quite effective in combination with `ensure` to write one-liners:

```kotlin
fun failOnMoreConditionsWithBindMap(): Either<String, Int> =
    randomNumber()
        .validate { ensure(it != 10) { "Number 10 also not allowed" } }
        .map { it + 100 }
```