### PR TITLE
Unify handling of addSuppressed

### DIFF
--- a/arrow-libs/resilience/arrow-resilience/api/android/arrow-resilience.api
+++ b/arrow-libs/resilience/arrow-resilience/api/android/arrow-resilience.api
@@ -89,7 +89,6 @@ public final class arrow/resilience/CircuitBreaker$State$Open : arrow/resilience
 	public fun getOpeningStrategy ()Larrow/resilience/CircuitBreaker$OpeningStrategy;
 	public final fun getResetTimeout-UwyO8pc ()J
 	public final fun getStartedAt ()Lkotlin/time/TimeMark;
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -108,7 +107,7 @@ public final class arrow/resilience/SagaBuilder : arrow/resilience/SagaScope {
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun saga (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final synthetic fun totalCompensation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun totalCompensation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class arrow/resilience/SagaDSLMarker : java/lang/annotation/Annotation {

--- a/arrow-libs/resilience/arrow-resilience/api/arrow-resilience.klib.api
+++ b/arrow-libs/resilience/arrow-resilience/api/arrow-resilience.klib.api
@@ -205,7 +205,6 @@ final class arrow.resilience/CircuitBreaker { // arrow.resilience/CircuitBreaker
                 final fun <get-startedAt>(): kotlin.time/TimeMark // arrow.resilience/CircuitBreaker.State.Open.startedAt.<get-startedAt>|<get-startedAt>(){}[0]
 
             final fun equals(kotlin/Any?): kotlin/Boolean // arrow.resilience/CircuitBreaker.State.Open.equals|equals(kotlin.Any?){}[0]
-            final fun hashCode(): kotlin/Int // arrow.resilience/CircuitBreaker.State.Open.hashCode|hashCode(){}[0]
             final fun toString(): kotlin/String // arrow.resilience/CircuitBreaker.State.Open.toString|toString(){}[0]
         }
     }

--- a/arrow-libs/resilience/arrow-resilience/api/jvm/arrow-resilience.api
+++ b/arrow-libs/resilience/arrow-resilience/api/jvm/arrow-resilience.api
@@ -89,7 +89,6 @@ public final class arrow/resilience/CircuitBreaker$State$Open : arrow/resilience
 	public fun getOpeningStrategy ()Larrow/resilience/CircuitBreaker$OpeningStrategy;
 	public final fun getResetTimeout-UwyO8pc ()J
 	public final fun getStartedAt ()Lkotlin/time/TimeMark;
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -108,7 +107,7 @@ public final class arrow/resilience/SagaBuilder : arrow/resilience/SagaScope {
 	public fun bind (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun invoke (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun saga (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final synthetic fun totalCompensation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun totalCompensation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class arrow/resilience/SagaDSLMarker : java/lang/annotation/Annotation {


### PR DESCRIPTION
Only behaviour change is that `guaranteeCase` now matches the behaviour of `resourceScope` in that `guaranteeCase({ throw e }) { throw CancellationException() }` Now throws `e` with the cancellation suppressed. 

The logic is spelled-out on purpose, to make editing easier in the future. In particular, we might want to deprioritize `CancellationException`.