### PR TITLE
Use guaranteeCase in CircuitBreaker instead of addSuppressed

### DIFF
--- a/arrow-libs/resilience/arrow-resilience/build.gradle.kts
+++ b/arrow-libs/resilience/arrow-resilience/build.gradle.kts
@@ -6,9 +6,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
-        api(projects.arrowCore)
-        implementation(libs.coroutines.core)
-        implementation(projects.arrowExceptionUtils)
+        implementation(projects.arrowFxCoroutines)
       }
     }
     commonTest {


### PR DESCRIPTION
Part of the effort to unify `addSuppressed` usages, this delegates to `guaranteeCase`; as a nice bonus, the code is cleaner!