### PR TITLE
Use AutoCloseScope in SuspendApp

### DIFF
--- a/arrow-libs/suspendapp/suspendapp/build.gradle.kts
+++ b/arrow-libs/suspendapp/suspendapp/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
     commonMain {
       dependencies {
         api(libs.coroutines.core)
+        implementation(projects.arrowAutoclose)
       }
     }
   }

--- a/arrow-libs/suspendapp/suspendapp/src/commonMain/kotlin/arrow/continuations/Process.kt
+++ b/arrow-libs/suspendapp/suspendapp/src/commonMain/kotlin/arrow/continuations/Process.kt
@@ -1,17 +1,18 @@
 package arrow.continuations
 
+import arrow.AutoCloseScope
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 
 /** KMP constructor for [Process]. */
-internal expect fun process(): Process
+internal expect fun AutoCloseScope.process(): Process
 
 /**
  * [Process] offers a common API to work with our application's process, installing signal handlers,
  * shutdown hooks, running scopes in our process (runBlocking), and exiting the process.
  */
 @OptIn(ExperimentalStdlibApi::class)
-internal interface Process : AutoCloseable {
+internal interface Process {
   fun onSigTerm(block: suspend (code: Int) -> Unit)
 
   fun onSigInt(block: suspend (code: Int) -> Unit)
@@ -27,6 +28,4 @@ internal interface Process : AutoCloseable {
   fun runScope(context: CoroutineContext, block: suspend CoroutineScope.() -> Unit)
 
   fun exit(code: Int): Nothing
-
-  override fun close()
 }

--- a/arrow-libs/suspendapp/suspendapp/src/commonMain/kotlin/arrow/continuations/SuspendApp.kt
+++ b/arrow-libs/suspendapp/suspendapp/src/commonMain/kotlin/arrow/continuations/SuspendApp.kt
@@ -1,5 +1,6 @@
 package arrow.continuations
 
+import arrow.autoCloseScope
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
@@ -19,36 +20,35 @@ import kotlinx.coroutines.*
  *   regardless of finalizers.
  * @param block the lambda of the actual application.
  */
-@OptIn(ExperimentalStdlibApi::class)  // 'use' in stdlib < 2.0
 public fun SuspendApp(
   context: CoroutineContext = Dispatchers.Default,
   uncaught: (Throwable) -> Unit = Throwable::printStackTrace,
   timeout: Duration = Duration.INFINITE,
   block: suspend CoroutineScope.() -> Unit,
-): Unit =
-  process().use { env ->
-    env.runScope(context) {
-      val result = supervisorScope {
-        val app =
-          async(start = CoroutineStart.LAZY, block = block)
-        val unregister =
-          env.onShutdown {
-            withTimeout(timeout) {
-              app.cancel(SuspendAppShutdown)
-              app.join()
-            }
+): Unit = autoCloseScope {
+  val env = process()
+  env.runScope(context) {
+    val result = supervisorScope {
+      val app =
+        async(start = CoroutineStart.LAZY, block = block)
+      val unregister =
+        env.onShutdown {
+          withTimeout(timeout) {
+            app.cancel(SuspendAppShutdown())
+            app.join()
           }
-        runCatching { app.await() }
-          .also { unregister() }
-      }
-      result.fold({ env.exit(0) }) { e ->
-        if (e !is SuspendAppShutdown) {
-          uncaught(e)
-          env.exit(-1)
         }
+      runCatching { app.await() }
+        .also { unregister() }
+    }
+    result.fold({ env.exit(0) }) { e ->
+      if (e !is SuspendAppShutdown) {
+        uncaught(e)
+        env.exit(-1)
       }
     }
   }
+}
 
-/** Marker type so track shutdown signal */
-private object SuspendAppShutdown : CancellationException("SuspendApp shutting down.")
+/** Marker type to track shutdown signal */
+private class SuspendAppShutdown : CancellationException("SuspendApp shutting down.")

--- a/arrow-libs/suspendapp/suspendapp/src/jsMain/kotlin/arrow/continuations/Enviroment.js.kt
+++ b/arrow-libs/suspendapp/suspendapp/src/jsMain/kotlin/arrow/continuations/Enviroment.js.kt
@@ -1,5 +1,6 @@
 package arrow.continuations
 
+import arrow.AutoCloseScope
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -17,7 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.promise
 import kotlinx.coroutines.withContext
 
-internal actual fun process(): Process = JsProcess
+internal actual fun AutoCloseScope.process(): Process = JsProcess
 
 private object JsProcess : Process {
   override fun onShutdown(block: suspend () -> Unit): () -> Unit {
@@ -65,8 +66,6 @@ private object JsProcess : Process {
     js("process.exit(code)")
     error("process.exit() should have exited...")
   }
-
-  override fun close(): Unit = Unit
 }
 
 private inline fun Process.exitAfter(code: Int, block: () -> Unit): Unit =

--- a/arrow-libs/suspendapp/suspendapp/src/jvmMain/kotlin/arrow/continuations/Enviroment.jvm.kt
+++ b/arrow-libs/suspendapp/suspendapp/src/jvmMain/kotlin/arrow/continuations/Enviroment.jvm.kt
@@ -1,5 +1,6 @@
 package arrow.continuations
 
+import arrow.AutoCloseScope
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.system.exitProcess
@@ -8,7 +9,7 @@ import kotlinx.coroutines.runBlocking
 import sun.misc.Signal
 import sun.misc.SignalHandler
 
-internal actual fun process(): Process = JvmProcess
+internal actual fun AutoCloseScope.process(): Process = JvmProcess
 
 private object JvmProcess : Process {
   override fun onShutdown(block: suspend () -> Unit): () -> Unit {
@@ -59,6 +60,4 @@ private object JvmProcess : Process {
     runBlocking(context, block)
 
   override fun exit(code: Int): Nothing = exitProcess(code)
-
-  override fun close(): Unit = Unit
 }

--- a/arrow-libs/suspendapp/suspendapp/src/wasmJsMain/kotlin/arrow/continuations/Enviroment.js.kt
+++ b/arrow-libs/suspendapp/suspendapp/src/wasmJsMain/kotlin/arrow/continuations/Enviroment.js.kt
@@ -1,5 +1,9 @@
+@file:Suppress("API_NOT_AVAILABLE")
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
 package arrow.continuations
 
+import arrow.AutoCloseScope
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -17,7 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.promise
 import kotlinx.coroutines.withContext
 
-internal actual fun process(): Process = JsProcess
+internal actual fun AutoCloseScope.process(): Process = JsProcess
 
 private object JsProcess : Process {
   override fun onShutdown(block: suspend () -> Unit): () -> Unit {
@@ -65,8 +69,6 @@ private object JsProcess : Process {
     jsExit(code)
     error("process.exit() should have exited...")
   }
-
-  override fun close(): Unit = Unit
 }
 
 private inline fun Process.exitAfter(code: Int, block: () -> Unit): Unit =
@@ -78,6 +80,7 @@ private inline fun Process.exitAfter(code: Int, block: () -> Unit): Unit =
     exit(-1)
   }
 
+@Suppress("unused")
 private fun processOn(signal: String, provide: () -> Promise<JsAny?>) {
   js(
     """
@@ -87,6 +90,7 @@ private fun processOn(signal: String, provide: () -> Promise<JsAny?>) {
   )
 }
 
+@Suppress("unused")
 private fun jsExit(code: Int) {
   js("process.exit(code);")
 }


### PR DESCRIPTION
As part of the effort to unify usages of `addSuppressed`, `SuspendApp` now delegates to `autoCloseScope`.