### PR TITLE
Prevent error accumulation in `withNel` when RCE caught

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/raise/RaiseAccumulate.kt
@@ -873,20 +873,22 @@ public inline fun <Error, A, R> accumulate(
 @Suppress("DEPRECATION")
 @SubclassOptInRequired(ExperimentalRaiseAccumulateApi::class)
 public open class RaiseAccumulate<Error> @ExperimentalRaiseAccumulateApi constructor(
-  accumulate: Accumulate<Error>, private val raiseErrorsWith: (Error) -> Nothing
+  accumulate: Accumulate<Error>,
+  @Deprecated("use withNel instead", level = DeprecationLevel.WARNING)
+  public val raise: Raise<NonEmptyList<Error>>,
+  private val raiseErrorsWith: (Error) -> Nothing
 ) : Accumulate<Error> by accumulate, Raise<Error> {
+  @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+  @ExperimentalRaiseAccumulateApi
+  public constructor(accumulate: Accumulate<Error>, raiseErrorsWith: (Error) -> Nothing): this(accumulate, RaiseNel(accumulate), raiseErrorsWith)
+
   @OptIn(ExperimentalRaiseAccumulateApi::class)
-  public constructor(raise: Raise<NonEmptyList<Error>>) : this(raise, mutableListOf<Error>())
+  public constructor(raise: Raise<NonEmptyList<Error>>) : this(ListAccumulate(raise))
 
   @ExperimentalRaiseAccumulateApi
-  private constructor(raise: Raise<NonEmptyList<Error>>, list: MutableList<Error>) :
-    this(ListAccumulate(raise, list), { raise.raise(NonEmptyList(list + it)) })
+  private constructor(listAccumulate: ListAccumulate<Error>) : this(listAccumulate, listAccumulate, listAccumulate::raiseSingle)
 
   override fun raise(r: Error): Nothing = raiseErrorsWith(r)
-
-  @OptIn(ExperimentalRaiseAccumulateApi::class)
-  @Deprecated("use withNel instead", level = DeprecationLevel.WARNING)
-  public val raise: Raise<NonEmptyList<Error>> = RaiseNel(this)
 
   public override fun <K, A> Map<K, Either<Error, A>>.bindAll(): Map<K, A> =
     raise.mapValuesOrAccumulate(this) { it.value.bind() }
@@ -1027,7 +1029,12 @@ public open class RaiseAccumulate<Error> @ExperimentalRaiseAccumulateApi constru
     recover: (error: Error) -> A,
   ): A {
     contract { callsInPlace(block, AT_MOST_ONCE) }
-    return (this as Accumulate<Error>).recover(block, recover)
+    val accumulate = this
+    return arrow.core.raise.recover({
+      withNel {
+        block(RaiseAccumulate(accumulate, this, ::raise))
+      }
+    }, recover)
   }
 
   @ExperimentalRaiseAccumulateApi
@@ -1087,10 +1094,12 @@ private class RaiseNel<Error>(private val accumulate: Accumulate<Error>) : Raise
 }
 
 @OptIn(ExperimentalRaiseAccumulateApi::class)
-private class ListAccumulate<Error>(
-  private val raise: Raise<NonEmptyList<Error>>,
-  private val list: MutableList<Error>
-) : Accumulate<Error> {
+private class ListAccumulate<Error>(private val raise: Raise<NonEmptyList<Error>>) : Accumulate<Error>, Raise<NonEmptyList<Error>> {
+  private val list: MutableList<Error> = mutableListOf()
+
+  fun raiseSingle(r: Error): Nothing = raise.raise(NonEmptyList(list + r))
+  override fun raise(r: NonEmptyList<Error>) = raise.raise(NonEmptyList(list + r.all))
+
   // only valid if list is not empty
   // errors are never removed from `list`, so once this is valid, it stays valid
   private val error = Error { raise.raise(NonEmptyList(list)) }
@@ -1165,21 +1174,8 @@ public interface Accumulate<Error> {
 public inline fun <Error, A> Accumulate<Error>.accumulating(block: RaiseAccumulate<Error>.() -> A): Value<A> {
   contract { callsInPlace(block, AT_MOST_ONCE) }
   return merge {
-    recover({ Ok(block(RaiseAccumulate(tolerant(this@merge), ::raise))) }, ::accumulate)
+    recover({ Ok(block(RaiseAccumulate(tolerant(this@merge), this) { raise(it.nel()) })) }, ::accumulateAll)
   }
-}
-
-@ExperimentalRaiseAccumulateApi
-@RaiseDSL
-public inline fun <Error, A> Accumulate<Error>.recover(
-  block: RaiseAccumulate<Error>.() -> A,
-  recover: (error: Error) -> A,
-): A {
-  contract { callsInPlace(block, AT_MOST_ONCE) }
-  val accumulate = this
-  return arrow.core.raise.recover({
-    block(RaiseAccumulate(accumulate, ::raise))
-  }, recover)
 }
 
 @ExperimentalRaiseAccumulateApi

--- a/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/RaiseAccumulateSpec.kt
+++ b/arrow-libs/core/arrow-core/src/commonTest/kotlin/arrow/core/raise/RaiseAccumulateSpec.kt
@@ -94,4 +94,53 @@ class RaiseAccumulateSpec {
     } shouldBe nonEmptyListOf("nonfatal").left()
     reachedEnd shouldBe true
   }
+
+  @Test fun tryCatchRecoverRaise() = runTest {
+     accumulate(::merge) {
+      try {
+        accumulate(1)
+        raise(2)
+      } catch (_: Throwable) { }
+      raise(3)
+    } shouldBe nonEmptyListOf(1, 3)
+  }
+
+  @Test fun tryCatchRecoverRaiseInsideAccumulating() = runTest {
+    accumulate(::merge) {
+      accumulating {
+        try {
+          accumulate(1)
+          raise(2)
+        } catch (_: Throwable) { }
+        raise(3)
+      }
+    } shouldBe nonEmptyListOf(1, 3)
+  }
+
+  @Test fun tryCatchRecoverRaiseWithNel() = runTest {
+    accumulate(::merge) {
+      try {
+        withNel {
+          accumulate(1)
+          raise(nonEmptyListOf(2, 4))
+        }
+      } catch (_: Throwable) { }
+      raise(3)
+    } shouldBe nonEmptyListOf(1, 3)
+  }
+
+  @Test fun tryCatchRecoverRaiseWithNelInsideAccumulating() = runTest {
+    accumulate(::merge) {
+      accumulating {
+        try {
+          withNel {
+            accumulate(1)
+            raise(nonEmptyListOf(2, 4))
+          }
+        } catch (_: Throwable) {
+        }
+        raise(3)
+      }
+    } shouldBe nonEmptyListOf(1, 3)
+  }
 }


### PR DESCRIPTION
This is a precedent set by `ior`, which was carried over into `iorAccumulate` and by extension `accumulate` itself. This further extends this rule to `withNel`. The previous behaviour was surprising since a user might expect `ra.withNel { raise(foo.nel()) }` to be equivalent to `ra.raise(foo)` (where `ra: RaiseAccumulate`), but that wasn't true in the presence of `try-catch`. 