### PR TITLE
fix(optics): resolve name shadowing when property is named 'arrow' (#3789)

### DIFF
--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/domain.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/domain.kt
@@ -3,6 +3,7 @@
 package arrow.optics.plugin.internals
 
 import arrow.optics.plugin.companionObject
+import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
@@ -119,6 +120,20 @@ const val Iso = "arrow.optics.Iso"
 const val Optional = "arrow.optics.Optional"
 const val Prism = "arrow.optics.Prism"
 const val Traversal = "arrow.optics.Traversal"
+
+fun ADT.resolveTypeName(type: String): Pair<String, String> = if (hasTypeCollisions(type)) {
+  val typeName = type.substringAfterLast('.')
+  val typeAlias = "ArrowOptics$typeName"
+  val aliasImport = "import $type as $typeAlias"
+  typeAlias to aliasImport
+} else {
+  type to ""
+}
+
+private fun ADT.hasTypeCollisions(type: String): Boolean = declaration.getDeclaredProperties().let { properties ->
+  val firstSegment = type.substringBefore('.')
+  properties.any { it.simpleName.asString() == firstSegment }
+}
 
 data class Snippet(
   val `package`: String,

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/main/kotlin/arrow/optics/plugin/internals/lenses.kt
@@ -2,13 +2,17 @@ package arrow.optics.plugin.internals
 
 import arrow.optics.plugin.OpticsProcessorOptions
 
-internal fun OpticsProcessorOptions.generateLenses(ele: ADT, target: LensTarget) = Snippet(
-  `package` = ele.packageName,
-  name = ele.simpleName,
-  content = processElement(ele, target.foci),
-)
+internal fun OpticsProcessorOptions.generateLenses(ele: ADT, target: LensTarget): Snippet {
+  val (lensType, lensImport) = ele.resolveTypeName(Lens)
+  return Snippet(
+    `package` = ele.packageName,
+    name = ele.simpleName,
+    content = processElement(ele, target.foci, lensType),
+    imports = setOf(lensImport).filter { it.isNotBlank() }.toSet(),
+  )
+}
 
-private fun OpticsProcessorOptions.processElement(adt: ADT, foci: List<Focus>): String {
+private fun OpticsProcessorOptions.processElement(adt: ADT, foci: List<Focus>, lensType: String): String {
   val sourceClassNameWithParams = "${adt.sourceClassName}${adt.angledTypeParameterNames}"
 
   val setBody = { focus: Focus ->
@@ -30,12 +34,12 @@ private fun OpticsProcessorOptions.processElement(adt: ADT, foci: List<Focus>): 
   return foci.joinToString(separator = "\n") { focus ->
     val firstLine = when {
       adt.typeParameters.isEmpty() ->
-        "${adt.visibilityModifierName} $inlineText val ${adt.sourceClassName}.Companion.${focus.escapedParamName}: $Lens<${adt.sourceClassName}, ${focus.className}> $inlineText get()"
+        "${adt.visibilityModifierName} $inlineText val ${adt.sourceClassName}.Companion.${focus.escapedParamName}: $lensType<${adt.sourceClassName}, ${focus.className}> $inlineText get()"
       else ->
-        "${adt.visibilityModifierName} $inlineText fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.escapedParamName}(): $Lens<$sourceClassNameWithParams, ${focus.className}>"
+        "${adt.visibilityModifierName} $inlineText fun ${adt.angledTypeParameters} ${adt.sourceClassName}.Companion.${focus.escapedParamName}(): $lensType<$sourceClassNameWithParams, ${focus.className}>"
     }
     """
-      |$firstLine = $Lens(
+      |$firstLine = $lensType(
       |  get = { ${adt.sourceName}: $sourceClassNameWithParams -> ${adt.sourceName}.${focus.escapedParamName} },
       |  set = { ${adt.sourceName}: $sourceClassNameWithParams, value: ${focus.className} ->
       |  ${setBody(focus)}

--- a/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
+++ b/arrow-libs/optics/arrow-optics-ksp-plugin/src/test/kotlin/arrow/optics/plugin/LensTests.kt
@@ -308,4 +308,21 @@ class LensTests {
       |val r = l != null
       """.compilationFails()
   }
+
+  @Test
+  fun `Lenses will be generated for data class with property named arrow (issue #3789)`() {
+    """
+      |$`package`
+      |$imports
+      |@optics
+      |data class AutoLambdaData(
+      |  val leftBrace: String = "",
+      |  val arrow: String = "->",
+      |  val rightBrace: String = ""
+      |) { companion object }
+      |
+      |val lens: Lens<AutoLambdaData, String> = AutoLambdaData.arrow
+      |val r = lens != null
+      """.evals("r" to true)
+  }
 }


### PR DESCRIPTION
## Overview
This PR fixes the compilation error occurring when a data class has a property named `arrow`.

## Problem
In the generated optics code, the compiler confuses the `arrow` package with the property name, leading to an `Unresolved reference`.

## Changes
- Introduced `resolveTypeName` in `domain.kt` to detect collisions between property names and package/type segments.
- Automatically generates alias imports (e.g., `import arrow.optics.Lens as ArrowOpticsLens`) when a collision is detected.
- Applied this logic to `Lens`, `Optional`, `Prism`, `Traversal`, and `Iso`.

## Fixed Issue
Closes #3789