### PR TITLE
Make `HttpCircuitBreaker` aware of `expectSuccess`

### DIFF
--- a/arrow-libs/integrations/arrow-resilience-ktor-client/src/jvmTest/kotlin/arrow/resilience/ktor/client/HttpRequestScheduleTest.kt
+++ b/arrow-libs/integrations/arrow-resilience-ktor-client/src/jvmTest/kotlin/arrow/resilience/ktor/client/HttpRequestScheduleTest.kt
@@ -1,6 +1,9 @@
+@file:Suppress("API_NOT_AVAILABLE")
+
 package arrow.resilience.ktor.client
 
 import arrow.atomic.AtomicLong
+import arrow.resilience.CircuitBreaker
 import arrow.resilience.Schedule
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.common.reflection.bestName
@@ -12,12 +15,15 @@ import io.kotest.property.checkAll
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.test.runTest
 import java.net.ConnectException
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
 
 class HttpRequestScheduleTest {
   class NotFoundExceptionForMocking : Exception()
@@ -98,14 +104,64 @@ class HttpRequestScheduleTest {
       response.status shouldBe HttpStatusCode.OK
     }
   }
+
+  val EXPECT_SUCCESS_MAX_FAILURES = 4
+
+  fun expectSuccessSetup(
+    expectSuccess: Boolean
+  ): Pair<AtomicLong, HttpClient> {
+    val counter = AtomicLong(0)
+    val mockEngine =
+      MockEngine {
+        counter.incrementAndGet()
+        respondError(status = HttpStatusCode.InternalServerError)
+      }
+
+    val client =
+      HttpClient(mockEngine) {
+        install(HttpCircuitBreaker) {
+          circuitBreaker(
+            resetTimeout = 15.seconds,
+            maxFailures = EXPECT_SUCCESS_MAX_FAILURES
+          )
+        }
+        this.expectSuccess = expectSuccess
+      }
+
+    return counter to client
+  }
+
+  @Test
+  fun `HTTP server errors trip the Circuit Breaker if expectSuccess is true`() =
+    runTest {
+      val (counter, client) = expectSuccessSetup(expectSuccess = true)
+      (0.. EXPECT_SUCCESS_MAX_FAILURES).forEach { _ ->
+        shouldThrow<ServerResponseException> {
+          client.get("/test")
+        }
+      }
+      shouldThrow<CircuitBreaker.ExecutionRejected> {
+        client.get("/test")
+      }
+      counter.get() shouldBe EXPECT_SUCCESS_MAX_FAILURES + 1
+    }
+
+  @Test
+  fun `HTTP server errors do not trip the Circuit Breaker if expectSuccess is false`() =
+    runTest {
+      val (counter, client) = expectSuccessSetup(expectSuccess = false)
+      val _ = client.get("/test")
+      counter.get() shouldBe 1
+    }
 }
 
 // copied from Kotest so we can inline it
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrow(block: () -> Any?): T {
   assertionCounter.inc()
   val expectedExceptionClass = T::class
   val thrownThrowable = try {
-    block()
+    val _ = block()
     null  // Can't throw failure here directly, as it would be caught by the catch clause, and it's an AssertionError, which is a special case
   } catch (thrown: Throwable) {
     thrown


### PR DESCRIPTION
This PR makes the Ktor Client plugin aware of whether the request should check for success or not. If `expectSuccess = true`, then any non-2XX status codes would be taken as problematic.

Fixes #3844