### PR TITLE
Make `ExitCase` constructors internal

### DIFF
--- a/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/arrow-fx-coroutines.klib.api
@@ -111,26 +111,20 @@ sealed class <#A: out kotlin/Any?, #B: out kotlin/Any?, #C: out kotlin/Any?> arr
 
 sealed class arrow.fx.coroutines/ExitCase { // arrow.fx.coroutines/ExitCase|null[0]
     final class Cancelled : arrow.fx.coroutines/ExitCase { // arrow.fx.coroutines/ExitCase.Cancelled|null[0]
-        constructor <init>(kotlin.coroutines.cancellation/CancellationException) // arrow.fx.coroutines/ExitCase.Cancelled.<init>|<init>(kotlin.coroutines.cancellation.CancellationException){}[0]
-
         final val exception // arrow.fx.coroutines/ExitCase.Cancelled.exception|{}exception[0]
             final fun <get-exception>(): kotlin.coroutines.cancellation/CancellationException // arrow.fx.coroutines/ExitCase.Cancelled.exception.<get-exception>|<get-exception>(){}[0]
 
         final fun component1(): kotlin.coroutines.cancellation/CancellationException // arrow.fx.coroutines/ExitCase.Cancelled.component1|component1(){}[0]
-        final fun copy(kotlin.coroutines.cancellation/CancellationException = ...): arrow.fx.coroutines/ExitCase.Cancelled // arrow.fx.coroutines/ExitCase.Cancelled.copy|copy(kotlin.coroutines.cancellation.CancellationException){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // arrow.fx.coroutines/ExitCase.Cancelled.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // arrow.fx.coroutines/ExitCase.Cancelled.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // arrow.fx.coroutines/ExitCase.Cancelled.toString|toString(){}[0]
     }
 
     final class Failure : arrow.fx.coroutines/ExitCase { // arrow.fx.coroutines/ExitCase.Failure|null[0]
-        constructor <init>(kotlin/Throwable) // arrow.fx.coroutines/ExitCase.Failure.<init>|<init>(kotlin.Throwable){}[0]
-
         final val failure // arrow.fx.coroutines/ExitCase.Failure.failure|{}failure[0]
             final fun <get-failure>(): kotlin/Throwable // arrow.fx.coroutines/ExitCase.Failure.failure.<get-failure>|<get-failure>(){}[0]
 
         final fun component1(): kotlin/Throwable // arrow.fx.coroutines/ExitCase.Failure.component1|component1(){}[0]
-        final fun copy(kotlin/Throwable = ...): arrow.fx.coroutines/ExitCase.Failure // arrow.fx.coroutines/ExitCase.Failure.copy|copy(kotlin.Throwable){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // arrow.fx.coroutines/ExitCase.Failure.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // arrow.fx.coroutines/ExitCase.Failure.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // arrow.fx.coroutines/ExitCase.Failure.toString|toString(){}[0]

--- a/arrow-libs/fx/arrow-fx-coroutines/api/jvm/arrow-fx-coroutines.api
+++ b/arrow-libs/fx/arrow-fx-coroutines/api/jvm/arrow-fx-coroutines.api
@@ -36,10 +36,7 @@ public abstract class arrow/fx/coroutines/ExitCase {
 }
 
 public final class arrow/fx/coroutines/ExitCase$Cancelled : arrow/fx/coroutines/ExitCase {
-	public fun <init> (Ljava/util/concurrent/CancellationException;)V
 	public final fun component1 ()Ljava/util/concurrent/CancellationException;
-	public final fun copy (Ljava/util/concurrent/CancellationException;)Larrow/fx/coroutines/ExitCase$Cancelled;
-	public static synthetic fun copy$default (Larrow/fx/coroutines/ExitCase$Cancelled;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)Larrow/fx/coroutines/ExitCase$Cancelled;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getException ()Ljava/util/concurrent/CancellationException;
 	public fun hashCode ()I
@@ -56,10 +53,7 @@ public final class arrow/fx/coroutines/ExitCase$Completed : arrow/fx/coroutines/
 }
 
 public final class arrow/fx/coroutines/ExitCase$Failure : arrow/fx/coroutines/ExitCase {
-	public fun <init> (Ljava/lang/Throwable;)V
 	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Throwable;)Larrow/fx/coroutines/ExitCase$Failure;
-	public static synthetic fun copy$default (Larrow/fx/coroutines/ExitCase$Failure;Ljava/lang/Throwable;ILjava/lang/Object;)Larrow/fx/coroutines/ExitCase$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFailure ()Ljava/lang/Throwable;
 	public fun hashCode ()I

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Bracket.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Bracket.kt
@@ -18,8 +18,15 @@ public sealed class ExitCase {
       "ExitCase.Completed"
   }
 
-  public data class Cancelled(val exception: CancellationException) : ExitCase()
-  public data class Failure(val failure: Throwable) : ExitCase()
+  @ConsistentCopyVisibility
+  public data class Cancelled internal constructor(val exception: CancellationException) : ExitCase()
+
+  @ConsistentCopyVisibility
+  public data class Failure internal constructor(val failure: Throwable) : ExitCase() {
+    init {
+      require(failure !is CancellationException) { "Failure must not wrap a CancellationException" }
+    }
+  }
 
   public companion object {
     public fun ExitCase(error: Throwable): ExitCase =


### PR DESCRIPTION
I've checked, and we are not using the constructor anywhere in our source code. I think we can do and simply hide the constructor -- since you should have been using `ExitCase.invoke` anyway.

I think this is a good middle ground for ensuring uses of `ExitCase` are correct, but not removing the type itself.

Fixes  #3814
Closes #3529