### PR TITLE
Mark `AutoCloseScope` and `SagaScope` as subclass opt-in

### DIFF
--- a/arrow-libs/core/arrow-autoclose/api/arrow-autoclose.klib.api
+++ b/arrow-libs/core/arrow-autoclose/api/arrow-autoclose.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <io.arrow-kt:arrow-autoclose>
+open annotation class arrow/AutoCloseImplementation : kotlin/Annotation { // arrow/AutoCloseImplementation|null[0]
+    constructor <init>() // arrow/AutoCloseImplementation.<init>|<init>(){}[0]
+}
+
 abstract interface arrow/AutoCloseScope { // arrow/AutoCloseScope|null[0]
     abstract fun onClose(kotlin/Function1<kotlin/Throwable?, kotlin/Unit>) // arrow/AutoCloseScope.onClose|onClose(kotlin.Function1<kotlin.Throwable?,kotlin.Unit>){}[0]
     open fun <#A1: kotlin/Any?> autoClose(kotlin/Function0<#A1>, kotlin/Function2<#A1, kotlin/Throwable?, kotlin/Unit>): #A1 // arrow/AutoCloseScope.autoClose|autoClose(kotlin.Function0<0:0>;kotlin.Function2<0:0,kotlin.Throwable?,kotlin.Unit>){0§<kotlin.Any?>}[0]

--- a/arrow-libs/core/arrow-autoclose/api/jvm/arrow-autoclose.api
+++ b/arrow-libs/core/arrow-autoclose/api/jvm/arrow-autoclose.api
@@ -1,3 +1,6 @@
+public abstract interface annotation class arrow/AutoCloseImplementation : java/lang/annotation/Annotation {
+}
+
 public abstract interface class arrow/AutoCloseScope {
 	public abstract fun autoClose (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public abstract fun install (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;

--- a/arrow-libs/core/arrow-autoclose/src/commonMain/kotlin/arrow/AutoCloseScope.kt
+++ b/arrow-libs/core/arrow-autoclose/src/commonMain/kotlin/arrow/AutoCloseScope.kt
@@ -83,6 +83,11 @@ public inline fun <A> autoCloseScope(block: AutoCloseScope.() -> A): A {
   }
 }
 
+@Target(AnnotationTarget.CLASS)
+@RequiresOptIn
+public annotation class AutoCloseImplementation
+
+@SubclassOptInRequired(AutoCloseImplementation::class)
 public interface AutoCloseScope {
   public fun onClose(release: (Throwable?) -> Unit)
 
@@ -97,6 +102,7 @@ public interface AutoCloseScope {
     autoCloseable.also { onClose { autoCloseable.close() } }
 }
 
+@OptIn(AutoCloseImplementation::class)
 @PublishedApi
 internal class DefaultAutoCloseScope : AutoCloseScope {
   private val finalizers = Atomic(emptyList<(Throwable?) -> Unit>())

--- a/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-libs/fx/arrow-fx-coroutines/src/commonMain/kotlin/arrow/fx/coroutines/Resource.kt
@@ -2,6 +2,7 @@
 
 package arrow.fx.coroutines
 
+import arrow.AutoCloseImplementation
 import arrow.AutoCloseScope
 import arrow.atomic.Atomic
 import arrow.atomic.update
@@ -289,6 +290,7 @@ public typealias Resource<A> = suspend ResourceScope.() -> A
 @Deprecated("Don't refer to this type. It'll be removed in the future.", level = DeprecationLevel.WARNING)
 public object AcquireStep
 
+@SubclassOptInRequired(AutoCloseImplementation::class)
 @ResourceDSL
 public interface ResourceScope : AutoCloseScope {
 
@@ -476,6 +478,7 @@ public suspend fun <A> Resource<A>.allocate(): Pair<A, suspend (ExitCase) -> Uni
   bind() to this::cancelAll
 }
 
+@OptIn(AutoCloseImplementation::class)
 internal class ResourceScopeImpl : ResourceScope {
   private val finalizers: Atomic<List<suspend (ExitCase) -> Unit>> = Atomic(emptyList())
   override fun onRelease(release: suspend (ExitCase) -> Unit) {

--- a/arrow-libs/resilience/arrow-resilience/api/arrow-resilience.klib.api
+++ b/arrow-libs/resilience/arrow-resilience/api/arrow-resilience.klib.api
@@ -10,6 +10,10 @@ open annotation class arrow.resilience/SagaDSLMarker : kotlin/Annotation { // ar
     constructor <init>() // arrow.resilience/SagaDSLMarker.<init>|<init>(){}[0]
 }
 
+open annotation class arrow.resilience/SagaImplementation : kotlin/Annotation { // arrow.resilience/SagaImplementation|null[0]
+    constructor <init>() // arrow.resilience/SagaImplementation.<init>|<init>(){}[0]
+}
+
 abstract fun interface <#A: in kotlin/Any?, #B: out kotlin/Any?> arrow.resilience/Schedule { // arrow.resilience/Schedule|null[0]
     open val step // arrow.resilience/Schedule.step|{}step[0]
         open fun <get-step>(): kotlin.coroutines/SuspendFunction1<#A, arrow.resilience/Schedule.Decision<#A, #B>> // arrow.resilience/Schedule.step.<get-step>|<get-step>(){}[0]

--- a/arrow-libs/resilience/arrow-resilience/api/jvm/arrow-resilience.api
+++ b/arrow-libs/resilience/arrow-resilience/api/jvm/arrow-resilience.api
@@ -114,6 +114,9 @@ public final class arrow/resilience/SagaBuilder : arrow/resilience/SagaScope {
 public abstract interface annotation class arrow/resilience/SagaDSLMarker : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class arrow/resilience/SagaImplementation : java/lang/annotation/Annotation {
+}
+
 public final class arrow/resilience/SagaKt {
 	public static final fun saga (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
 	public static final fun saga (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;

--- a/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Saga.kt
+++ b/arrow-libs/resilience/arrow-resilience/src/commonMain/kotlin/arrow/resilience/Saga.kt
@@ -55,7 +55,12 @@ import kotlin.coroutines.cancellation.CancellationException
  */
 public typealias Saga<A> = suspend SagaScope.() -> A
 
+@Target(AnnotationTarget.CLASS)
+@RequiresOptIn
+public annotation class SagaImplementation
+
 /** DSL that enables the [Saga] pattern in a `suspend` DSL. */
+@SubclassOptInRequired(SagaImplementation::class)
 @SagaDSLMarker
 public interface SagaScope {
 
@@ -120,6 +125,7 @@ public suspend fun <A> Saga<A>.transact(): A {
 public object SagaActionStep
 
 // Internal implementation of the `saga { }` builder.
+@OptIn(SagaImplementation::class)
 @PublishedApi
 internal class SagaBuilder(
   private val stack: Atomic<List<suspend () -> Unit>> = Atomic(emptyList())


### PR DESCRIPTION
I think these are the main ones that deserve `SubclassOptInRequired`. For `Raise` we actually describe how to subclass it, so it doesn't make sense to require the opt-in.

Fixes #3811