### PR TITLE
Deprecate `unweave`

### DIFF
--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Iterable.kt
@@ -817,6 +817,7 @@ public fun <A> Iterable<A>.interleave(other: Iterable<A>): List<A> =
  * ```
  * <!--- KNIT example-iterable-15.kt -->
  */
+@Deprecated("To be removed due to unclear semantics. Please report use cases at https://github.com/arrow-kt/arrow/issues/3675.")
 public fun <A, B> Iterable<A>.unweave(ffa: (A) -> Iterable<B>): List<B> =
   split()?.let { (fa, a) ->
     ffa(a).interleave(fa.unweave(ffa))

--- a/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
+++ b/arrow-libs/core/arrow-core/src/commonMain/kotlin/arrow/core/Sequence.kt
@@ -681,6 +681,7 @@ public fun <A, B, C> Sequence<C>.unalign(fa: (C) -> Ior<A, B>): Pair<Sequence<A>
  * ```
  * <!--- KNIT example-sequence-13.kt -->
  */
+@Deprecated("To be removed due to unclear semantics. Please report use cases at https://github.com/arrow-kt/arrow/issues/3675.")
 public fun <A, B> Sequence<A>.unweave(ffa: (A) -> Sequence<B>): Sequence<B> =
   split()?.let { (fa, a) ->
     ffa(a).interleave(fa.unweave(ffa))


### PR DESCRIPTION
Nobody seems to understand what it does, and the usage is non-existent.

Fixes #3675