### PR TITLE
Keep Jackson ABI intact

### DIFF
--- a/arrow-libs/integrations/arrow-core-jackson/api/arrow-core-jackson.api
+++ b/arrow-libs/integrations/arrow-core-jackson/api/arrow-core-jackson.api
@@ -91,12 +91,14 @@ public final class arrow/integrations/jackson/module/NonEmptyCollectionsModule :
 
 public final class arrow/integrations/jackson/module/NonEmptyListDeserializer : tools/jackson/databind/deser/std/StdDeserializer {
 	public fun <init> (Ltools/jackson/databind/JavaType;)V
+	public fun <init> (Ltools/jackson/databind/JavaType;Ltools/jackson/databind/jsontype/TypeDeserializer;Ltools/jackson/databind/ValueDeserializer;)V
 	public synthetic fun deserialize (Ltools/jackson/core/JsonParser;Ltools/jackson/databind/DeserializationContext;)Ljava/lang/Object;
 	public fun deserialize-L4fWQpE (Ltools/jackson/core/JsonParser;Ltools/jackson/databind/DeserializationContext;)Ljava/util/List;
 }
 
 public final class arrow/integrations/jackson/module/NonEmptySetDeserializer : tools/jackson/databind/deser/std/StdDeserializer {
 	public fun <init> (Ltools/jackson/databind/JavaType;)V
+	public fun <init> (Ltools/jackson/databind/JavaType;Ltools/jackson/databind/jsontype/TypeDeserializer;Ltools/jackson/databind/ValueDeserializer;)V
 	public synthetic fun deserialize (Ltools/jackson/core/JsonParser;Ltools/jackson/databind/DeserializationContext;)Ljava/lang/Object;
 	public fun deserialize-OZgIoXQ (Ltools/jackson/core/JsonParser;Ltools/jackson/databind/DeserializationContext;)Ljava/util/Set;
 }

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
@@ -49,13 +49,13 @@ public object NonEmptyCollectionSerializerResolver : Serializers.Base() {
   ): ValueSerializer<*>? = when {
     NonEmptyCollection::class.java.isAssignableFrom(type.rawClass) ->
       IndexedListSerializer(type.contentType, false, elementTypeSerializer, elementValueSerializer)
+
     else -> null
   }
 }
 
 public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
-  override fun hasDeserializerFor(config: DeserializationConfig, valueType: Class<*>): Boolean =
-    NonEmptyList::class.java.isAssignableFrom(valueType) || NonEmptySet::class.java.isAssignableFrom(valueType)
+  override fun hasDeserializerFor(config: DeserializationConfig, valueType: Class<*>): Boolean = NonEmptyList::class.java.isAssignableFrom(valueType) || NonEmptySet::class.java.isAssignableFrom(valueType)
 
   override fun findCollectionDeserializer(
     type: CollectionType,
@@ -82,7 +82,7 @@ public class NonEmptyListDeserializer(
   private val elementTypeDeserializer: TypeDeserializer?,
   private val elementDeserializer: ValueDeserializer<*>?,
 ) : StdDeserializer<NonEmptyList<*>>(NonEmptyList::class.java) {
-  public constructor(contentType: JavaType): this(contentType, null, null)
+  public constructor(contentType: JavaType) : this(contentType, null, null)
 
   @OptIn(PotentiallyUnsafeNonEmptyOperation::class)
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): NonEmptyList<*>? {
@@ -95,13 +95,12 @@ public class NonEmptyListDeserializer(
   }
 }
 
-
 public class NonEmptySetDeserializer(
   private val contentType: JavaType,
   private val elementTypeDeserializer: TypeDeserializer?,
   private val elementDeserializer: ValueDeserializer<*>?,
 ) : StdDeserializer<NonEmptySet<*>>(NonEmptySet::class.java) {
-  public constructor(contentType: JavaType): this(contentType, null, null)
+  public constructor(contentType: JavaType) : this(contentType, null, null)
 
   @OptIn(PotentiallyUnsafeNonEmptyOperation::class)
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): NonEmptySet<*>? {

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
@@ -50,8 +50,10 @@ public object NonEmptyCollectionSerializerResolver : Serializers.Base() {
   ): ValueSerializer<*>? = when {
     NonEmptyList::class.java.isAssignableFrom(type.rawClass) ->
       IndexedListSerializer(type.contentType, false, elementTypeSerializer, elementValueSerializer)
+
     NonEmptySet::class.java.isAssignableFrom(type.rawClass) ->
       CollectionSerializer(type.contentType, false, elementTypeSerializer, elementValueSerializer)
+
     else -> null
   }
 }

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
@@ -19,12 +19,12 @@ import tools.jackson.databind.SerializationContext
 import tools.jackson.databind.ValueDeserializer
 import tools.jackson.databind.ValueSerializer
 import tools.jackson.databind.deser.Deserializers
-import tools.jackson.databind.deser.std.ContainerDeserializerBase
 import tools.jackson.databind.deser.std.StdDeserializer
 import tools.jackson.databind.jsontype.TypeDeserializer
 import tools.jackson.databind.jsontype.TypeSerializer
 import tools.jackson.databind.module.SimpleModule
 import tools.jackson.databind.ser.Serializers
+import tools.jackson.databind.ser.jdk.IndexedListSerializer
 import tools.jackson.databind.ser.std.StdSerializer
 import tools.jackson.databind.type.CollectionType
 import tools.jackson.databind.type.TypeBindings
@@ -47,19 +47,20 @@ public object NonEmptyCollectionSerializerResolver : Serializers.Base() {
     elementTypeSerializer: TypeSerializer?,
     elementValueSerializer: ValueSerializer<Any>?,
   ): ValueSerializer<*>? = when {
-    NonEmptyCollection::class.java.isAssignableFrom(type.rawClass) -> NonEmptyCollectionSerializer
+    NonEmptyCollection::class.java.isAssignableFrom(type.rawClass) ->
+      IndexedListSerializer(type.contentType, false, elementTypeSerializer, elementValueSerializer)
     else -> null
   }
 }
 
 public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
-  override fun hasDeserializerFor(config: DeserializationConfig, valueType: Class<*>): Boolean = NonEmptyList::class.java.isAssignableFrom(valueType) ||
-    NonEmptySet::class.java.isAssignableFrom(valueType)
+  override fun hasDeserializerFor(config: DeserializationConfig, valueType: Class<*>): Boolean =
+    NonEmptyList::class.java.isAssignableFrom(valueType) || NonEmptySet::class.java.isAssignableFrom(valueType)
 
   override fun findCollectionDeserializer(
     type: CollectionType,
     config: DeserializationConfig,
-    beanDescRef: BeanDescription.Supplier?,
+    beanDescRef: BeanDescription.Supplier,
     elementTypeDeserializer: TypeDeserializer?,
     elementDeserializer: ValueDeserializer<*>?,
   ): ValueDeserializer<*>? = when {
@@ -69,6 +70,7 @@ public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
   }
 }
 
+@Deprecated("Use IndexedListSerializer instead")
 public object NonEmptyCollectionSerializer : StdSerializer<NonEmptyCollection<*>>(NonEmptyCollection::class.java) {
   override fun serialize(value: NonEmptyCollection<*>, gen: JsonGenerator, provider: SerializationContext) {
     provider.writeValue(gen, value.toList())
@@ -80,6 +82,8 @@ public class NonEmptyListDeserializer(
   private val elementTypeDeserializer: TypeDeserializer?,
   private val elementDeserializer: ValueDeserializer<*>?,
 ) : StdDeserializer<NonEmptyList<*>>(NonEmptyList::class.java) {
+  public constructor(contentType: JavaType): this(contentType, null, null)
+
   @OptIn(PotentiallyUnsafeNonEmptyOperation::class)
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): NonEmptyList<*>? {
     val bindings = TypeBindings.create(ArrayList::class.java, contentType)
@@ -91,11 +95,14 @@ public class NonEmptyListDeserializer(
   }
 }
 
+
 public class NonEmptySetDeserializer(
   private val contentType: JavaType,
   private val elementTypeDeserializer: TypeDeserializer?,
   private val elementDeserializer: ValueDeserializer<*>?,
 ) : StdDeserializer<NonEmptySet<*>>(NonEmptySet::class.java) {
+  public constructor(contentType: JavaType): this(contentType, null, null)
+
   @OptIn(PotentiallyUnsafeNonEmptyOperation::class)
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): NonEmptySet<*>? {
     val bindings = TypeBindings.create(LinkedHashSet::class.java, contentType)

--- a/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
+++ b/arrow-libs/integrations/arrow-core-jackson/src/main/kotlin/arrow/integrations/jackson/module/NonEmptyCollections.kt
@@ -24,6 +24,7 @@ import tools.jackson.databind.jsontype.TypeDeserializer
 import tools.jackson.databind.jsontype.TypeSerializer
 import tools.jackson.databind.module.SimpleModule
 import tools.jackson.databind.ser.Serializers
+import tools.jackson.databind.ser.jdk.CollectionSerializer
 import tools.jackson.databind.ser.jdk.IndexedListSerializer
 import tools.jackson.databind.ser.std.StdSerializer
 import tools.jackson.databind.type.CollectionType
@@ -47,9 +48,10 @@ public object NonEmptyCollectionSerializerResolver : Serializers.Base() {
     elementTypeSerializer: TypeSerializer?,
     elementValueSerializer: ValueSerializer<Any>?,
   ): ValueSerializer<*>? = when {
-    NonEmptyCollection::class.java.isAssignableFrom(type.rawClass) ->
+    NonEmptyList::class.java.isAssignableFrom(type.rawClass) ->
       IndexedListSerializer(type.contentType, false, elementTypeSerializer, elementValueSerializer)
-
+    NonEmptySet::class.java.isAssignableFrom(type.rawClass) ->
+      CollectionSerializer(type.contentType, false, elementTypeSerializer, elementValueSerializer)
     else -> null
   }
 }
@@ -70,7 +72,7 @@ public object NonEmptyCollectionDeserializerResolver : Deserializers.Base() {
   }
 }
 
-@Deprecated("Use IndexedListSerializer instead")
+@Deprecated("Use IndexedListSerializer or CollectionSerializer instead")
 public object NonEmptyCollectionSerializer : StdSerializer<NonEmptyCollection<*>>(NonEmptyCollection::class.java) {
   override fun serialize(value: NonEmptyCollection<*>, gen: JsonGenerator, provider: SerializationContext) {
     provider.writeValue(gen, value.toList())


### PR DESCRIPTION
I forgot to update the `.abi` files, and missed that I had removed a public constructor. This PR brings it back.